### PR TITLE
fix quantization range initialization in case of 1 scale channel to a…

### DIFF
--- a/nncf/quantization/init_range.py
+++ b/nncf/quantization/init_range.py
@@ -80,6 +80,9 @@ def expand_like(input_: torch.Tensor, scale_shape: List[int]):
 def split_into_channels(input_: np.ndarray, scale_shape: List[int]) -> List[np.ndarray]:
     channel_count, channel_dim_idx = get_channel_count_and_dim_idx(scale_shape)
     channel_first_tensor = np.moveaxis(input_, channel_dim_idx, 0)
+    if channel_count == 1:
+        return [channel_first_tensor]
+
     ret_list = []
     for i in range(channel_count):
         ret_list.append(channel_first_tensor[i, ...])


### PR DESCRIPTION
…void initialization only by single slice of data (data[0]) and ignoring the other (data[1], data[2],.....)

fix quantization range initialization in case of 1 scale channel to avoid initialization only by single slice of data (data[0]) and ignoring the other (data[1], data[2],.....)