### PR TITLE
Fix bug with export to Q/DQ

### DIFF
--- a/nncf/quantization/layers.py
+++ b/nncf/quantization/layers.py
@@ -318,8 +318,7 @@ class SymmetricQuantizer(BaseQuantizer):
                         y_zero_point - y_zero_point[0], torch.zeros_like(y_zero_point)):
                     y_scale, y_zero_point = y_scale[0], y_zero_point[0]
                     return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
-                else:
-                    raise RuntimeError("PyTorch export to ONNX doesn't support per_channel quantization")
+                raise RuntimeError("PyTorch export to ONNX doesn't support per_channel quantization")
             return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
         if self._export_mode == QuantizerExportMode.FAKE_QUANTIZE:
             return ExportQuantizeToFakeQuantize.apply(x, self.levels, input_low, input_high, input_low, input_high)
@@ -412,8 +411,7 @@ class AsymmetricQuantizer(BaseQuantizer):
                         y_zero_point - y_zero_point[0], torch.zeros_like(y_zero_point)):
                     y_scale, y_zero_point = y_scale[0], y_zero_point[0]
                     return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
-                else:
-                    raise RuntimeError("PyTorch export to ONNX doesn't support per_channel quantization")
+                raise RuntimeError("PyTorch export to ONNX doesn't support per_channel quantization")
         if self._export_mode == QuantizerExportMode.FAKE_QUANTIZE:
             return ExportQuantizeToFakeQuantize.apply(x, self.levels,
                                                       input_low_tuned, input_high_tuned,

--- a/nncf/quantization/layers.py
+++ b/nncf/quantization/layers.py
@@ -318,8 +318,8 @@ class SymmetricQuantizer(BaseQuantizer):
                         y_zero_point - y_zero_point[0], torch.zeros_like(y_zero_point)):
                     y_scale, y_zero_point = y_scale[0], y_zero_point[0]
                     return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
-                raise RuntimeError(
-                    "PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization")
+                raise RuntimeError("""PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear
+                     doesn't support per channel quantization""")
             return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
         if self._export_mode == QuantizerExportMode.FAKE_QUANTIZE:
             return ExportQuantizeToFakeQuantize.apply(x, self.levels, input_low, input_high, input_low, input_high)
@@ -412,8 +412,8 @@ class AsymmetricQuantizer(BaseQuantizer):
                         y_zero_point - y_zero_point[0], torch.zeros_like(y_zero_point)):
                     y_scale, y_zero_point = y_scale[0], y_zero_point[0]
                     return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
-                raise RuntimeError(
-                    "PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization")
+                raise RuntimeError("""PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear
+                     doesn't support per channel quantization""")
             return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
         if self._export_mode == QuantizerExportMode.FAKE_QUANTIZE:
             return ExportQuantizeToFakeQuantize.apply(x, self.levels,

--- a/nncf/quantization/layers.py
+++ b/nncf/quantization/layers.py
@@ -318,7 +318,8 @@ class SymmetricQuantizer(BaseQuantizer):
                         y_zero_point - y_zero_point[0], torch.zeros_like(y_zero_point)):
                     y_scale, y_zero_point = y_scale[0], y_zero_point[0]
                     return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
-                raise RuntimeError("PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization")
+                raise RuntimeError(
+                    "PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization")
             return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
         if self._export_mode == QuantizerExportMode.FAKE_QUANTIZE:
             return ExportQuantizeToFakeQuantize.apply(x, self.levels, input_low, input_high, input_low, input_high)
@@ -411,7 +412,9 @@ class AsymmetricQuantizer(BaseQuantizer):
                         y_zero_point - y_zero_point[0], torch.zeros_like(y_zero_point)):
                     y_scale, y_zero_point = y_scale[0], y_zero_point[0]
                     return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
-                raise RuntimeError("PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization")
+                raise RuntimeError(
+                    "PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization")
+            return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
         if self._export_mode == QuantizerExportMode.FAKE_QUANTIZE:
             return ExportQuantizeToFakeQuantize.apply(x, self.levels,
                                                       input_low_tuned, input_high_tuned,

--- a/nncf/quantization/layers.py
+++ b/nncf/quantization/layers.py
@@ -318,7 +318,7 @@ class SymmetricQuantizer(BaseQuantizer):
                         y_zero_point - y_zero_point[0], torch.zeros_like(y_zero_point)):
                     y_scale, y_zero_point = y_scale[0], y_zero_point[0]
                     return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
-                raise RuntimeError("PyTorch export to ONNX doesn't support per_channel quantization")
+                raise RuntimeError("PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization")
             return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
         if self._export_mode == QuantizerExportMode.FAKE_QUANTIZE:
             return ExportQuantizeToFakeQuantize.apply(x, self.levels, input_low, input_high, input_low, input_high)
@@ -411,7 +411,7 @@ class AsymmetricQuantizer(BaseQuantizer):
                         y_zero_point - y_zero_point[0], torch.zeros_like(y_zero_point)):
                     y_scale, y_zero_point = y_scale[0], y_zero_point[0]
                     return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
-                raise RuntimeError("PyTorch export to ONNX doesn't support per_channel quantization")
+                raise RuntimeError("PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization")
         if self._export_mode == QuantizerExportMode.FAKE_QUANTIZE:
             return ExportQuantizeToFakeQuantize.apply(x, self.levels,
                                                       input_low_tuned, input_high_tuned,

--- a/nncf/quantization/layers.py
+++ b/nncf/quantization/layers.py
@@ -318,8 +318,8 @@ class SymmetricQuantizer(BaseQuantizer):
                         y_zero_point - y_zero_point[0], torch.zeros_like(y_zero_point)):
                     y_scale, y_zero_point = y_scale[0], y_zero_point[0]
                     return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
-                raise RuntimeError("""PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear
-                     doesn't support per channel quantization""")
+                raise RuntimeError("PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear "
+                                   "doesn't support per channel quantization")
             return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
         if self._export_mode == QuantizerExportMode.FAKE_QUANTIZE:
             return ExportQuantizeToFakeQuantize.apply(x, self.levels, input_low, input_high, input_low, input_high)
@@ -412,8 +412,8 @@ class AsymmetricQuantizer(BaseQuantizer):
                         y_zero_point - y_zero_point[0], torch.zeros_like(y_zero_point)):
                     y_scale, y_zero_point = y_scale[0], y_zero_point[0]
                     return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
-                raise RuntimeError("""PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear
-                     doesn't support per channel quantization""")
+                raise RuntimeError("PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear "
+                                   "doesn't support per channel quantization")
             return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
         if self._export_mode == QuantizerExportMode.FAKE_QUANTIZE:
             return ExportQuantizeToFakeQuantize.apply(x, self.levels,

--- a/nncf/quantization/quantize_functions.py
+++ b/nncf/quantization/quantize_functions.py
@@ -153,19 +153,15 @@ def get_scale_zp_from_input_low_input_high(level_low, level_high, input_low, inp
     y_scale = (input_high - input_low) / (level_high - level_low)
     y_zero_point = (level_low * input_high - level_high * input_low) / (input_high - input_low)
 
-    if level_low < 0:
-        level_low = torch.ones([1]).to(torch.int8) * level_low
-        level_high = torch.ones([1]).to(torch.int8) * level_high
-        level_low = level_low.to(y_zero_point.device)
-        level_high = level_high.to(y_zero_point.device)
-        y_zero_point = min(max(level_low, (y_zero_point.to(torch.int8))), level_high)
-    else:
-        level_low = torch.ones([1]).to(torch.uint8) * level_low
-        level_high = torch.ones([1]).to(torch.uint8) * level_high
-        level_low = level_low.to(y_zero_point.device)
-        level_high = level_high.to(y_zero_point.device)
-        y_zero_point = min(max(level_low, (y_zero_point.to(torch.uint8))), level_high)
+    type_ = torch.int8 if level_low < 0 else torch.uint8
+    level_low *= torch.ones_like(y_zero_point).to(type_)
+    level_high *= torch.ones_like(y_zero_point).to(type_)
+    level_low = level_low.to(y_zero_point.device)
+    level_high = level_high.to(y_zero_point.device)
+    y_zero_point = torch.min(torch.max(level_low, y_zero_point.to(type_)), level_high)
 
+    y_scale = torch.squeeze(y_scale)
+    y_zero_point = torch.squeeze(y_zero_point)
     return y_scale, y_zero_point
 
 

--- a/tests/quantization/test_onnx_export.py
+++ b/tests/quantization/test_onnx_export.py
@@ -123,8 +123,8 @@ def test_onnx_export_to_quantize_dequantize_per_channel():
         sym_quantizer.run_export_quantization(x)
     except RuntimeError as e:
         assert str(
-            e) == """PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear
-                     doesn't support per channel quantization"""
+            e) == "PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear " \
+                  "doesn't support per channel quantization"
     # ASYMMETRIC
     q_config = QuantizerConfig(
         input_shape=(2, 64, 15, 10),
@@ -167,45 +167,5 @@ def test_onnx_export_to_quantize_dequantize_per_channel():
         assym_quantizer.run_export_quantization(x)
     except RuntimeError as e:
         assert str(
-            e) == """PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear
-                 doesn't support per channel quantization"""
-        # ASYMMETRIC
-        q_config = QuantizerConfig(
-            input_shape=(2, 64, 15, 10),
-            bits=8,
-            mode=QuantizationMode.ASYMMETRIC,
-            signedness_to_force=None,
-            per_channel=True)
-        assym_quantizer = AsymmetricQuantizer(q_config)
-        assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
-
-        x = torch.rand((2, 64, 15, 10))
-        assym_quantizer.run_export_quantization(x)
-
-        q_config = QuantizerConfig(
-            bits=8,
-            mode=QuantizationMode.ASYMMETRIC,
-            signedness_to_force=None,
-            per_channel=False)
-        assym_quantizer = AsymmetricQuantizer(q_config)
-        assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
-
-        x = torch.rand((2, 64, 15, 10))
-        assym_quantizer.run_export_quantization(x)
-
-        q_config = QuantizerConfig(
-            input_shape=(2, 64, 15, 10),
-            bits=8,
-            mode=QuantizationMode.ASYMMETRIC,
-            signedness_to_force=None,
-            per_channel=True)
-        assym_quantizer = AsymmetricQuantizer(q_config)
-        assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
-        sym_quantizer.scale = torch.nn.Parameter(torch.rand(1, 64, 1, 1))
-
-        x = torch.rand((2, 64, 15, 10))
-        try:
-            assym_quantizer.run_export_quantization(x)
-        except RuntimeError as e:
-            assert str(
-                e) == "PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization"
+            e) == "PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear" \
+                  " doesn't support per channel quantization"

--- a/tests/quantization/test_onnx_export.py
+++ b/tests/quantization/test_onnx_export.py
@@ -169,3 +169,43 @@ def test_onnx_export_to_quantize_dequantize_per_channel():
         assert str(
             e) == """PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear
                  doesn't support per channel quantization"""
+        # ASYMMETRIC
+        q_config = QuantizerConfig(
+            input_shape=(2, 64, 15, 10),
+            bits=8,
+            mode=QuantizationMode.ASYMMETRIC,
+            signedness_to_force=None,
+            per_channel=True)
+        assym_quantizer = AsymmetricQuantizer(q_config)
+        assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
+
+        x = torch.rand((2, 64, 15, 10))
+        assym_quantizer.run_export_quantization(x)
+
+        q_config = QuantizerConfig(
+            bits=8,
+            mode=QuantizationMode.ASYMMETRIC,
+            signedness_to_force=None,
+            per_channel=False)
+        assym_quantizer = AsymmetricQuantizer(q_config)
+        assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
+
+        x = torch.rand((2, 64, 15, 10))
+        assym_quantizer.run_export_quantization(x)
+
+        q_config = QuantizerConfig(
+            input_shape=(2, 64, 15, 10),
+            bits=8,
+            mode=QuantizationMode.ASYMMETRIC,
+            signedness_to_force=None,
+            per_channel=True)
+        assym_quantizer = AsymmetricQuantizer(q_config)
+        assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
+        sym_quantizer.scale = torch.nn.Parameter(torch.rand(1, 64, 1, 1))
+
+        x = torch.rand((2, 64, 15, 10))
+        try:
+            assym_quantizer.run_export_quantization(x)
+        except RuntimeError as e:
+            assert str(
+                e) == "PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization"

--- a/tests/quantization/test_onnx_export.py
+++ b/tests/quantization/test_onnx_export.py
@@ -89,6 +89,7 @@ def test_onnx_export_to_quantize_dequantize_per_channel():
         signedness_to_force=None,
         per_channel=True)
     sym_quantizer = SymmetricQuantizer(q_config)
+    # pylint: disable=protected-access
     sym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
 
     x = torch.rand((2, 64, 15, 10))
@@ -100,6 +101,7 @@ def test_onnx_export_to_quantize_dequantize_per_channel():
         signedness_to_force=None,
         per_channel=False)
     sym_quantizer = SymmetricQuantizer(q_config)
+    # pylint: disable=protected-access
     sym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
 
     x = torch.rand((2, 64, 15, 10))
@@ -112,6 +114,7 @@ def test_onnx_export_to_quantize_dequantize_per_channel():
         signedness_to_force=None,
         per_channel=True)
     sym_quantizer = SymmetricQuantizer(q_config)
+    # pylint: disable=protected-access
     sym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
     sym_quantizer.scale = torch.nn.Parameter(torch.rand(1, 64, 1, 1))
 
@@ -120,44 +123,49 @@ def test_onnx_export_to_quantize_dequantize_per_channel():
         sym_quantizer.run_export_quantization(x)
     except RuntimeError as e:
         assert str(
-            e) == "PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization"
-        # ASYMMETRIC
-        q_config = QuantizerConfig(
-            input_shape=(2, 64, 15, 10),
-            bits=8,
-            mode=QuantizationMode.ASYMMETRIC,
-            signedness_to_force=None,
-            per_channel=True)
-        assym_quantizer = AsymmetricQuantizer(q_config)
-        assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
+            e) == """PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear
+                     doesn't support per channel quantization"""
+    # ASYMMETRIC
+    q_config = QuantizerConfig(
+        input_shape=(2, 64, 15, 10),
+        bits=8,
+        mode=QuantizationMode.ASYMMETRIC,
+        signedness_to_force=None,
+        per_channel=True)
+    assym_quantizer = AsymmetricQuantizer(q_config)
+    # pylint: disable=protected-access
+    assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
 
-        x = torch.rand((2, 64, 15, 10))
+    x = torch.rand((2, 64, 15, 10))
+    assym_quantizer.run_export_quantization(x)
+
+    q_config = QuantizerConfig(
+        bits=8,
+        mode=QuantizationMode.ASYMMETRIC,
+        signedness_to_force=None,
+        per_channel=False)
+    assym_quantizer = AsymmetricQuantizer(q_config)
+    # pylint: disable=protected-access
+    assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
+
+    x = torch.rand((2, 64, 15, 10))
+    assym_quantizer.run_export_quantization(x)
+
+    q_config = QuantizerConfig(
+        input_shape=(2, 64, 15, 10),
+        bits=8,
+        mode=QuantizationMode.ASYMMETRIC,
+        signedness_to_force=None,
+        per_channel=True)
+    assym_quantizer = AsymmetricQuantizer(q_config)
+    # pylint: disable=protected-access
+    assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
+    sym_quantizer.scale = torch.nn.Parameter(torch.rand(1, 64, 1, 1))
+
+    x = torch.rand((2, 64, 15, 10))
+    try:
         assym_quantizer.run_export_quantization(x)
-
-        q_config = QuantizerConfig(
-            bits=8,
-            mode=QuantizationMode.ASYMMETRIC,
-            signedness_to_force=None,
-            per_channel=False)
-        assym_quantizer = AsymmetricQuantizer(q_config)
-        assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
-
-        x = torch.rand((2, 64, 15, 10))
-        assym_quantizer.run_export_quantization(x)
-
-        q_config = QuantizerConfig(
-            input_shape=(2, 64, 15, 10),
-            bits=8,
-            mode=QuantizationMode.ASYMMETRIC,
-            signedness_to_force=None,
-            per_channel=True)
-        assym_quantizer = AsymmetricQuantizer(q_config)
-        assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
-        sym_quantizer.scale = torch.nn.Parameter(torch.rand(1, 64, 1, 1))
-
-        x = torch.rand((2, 64, 15, 10))
-        try:
-            assym_quantizer.run_export_quantization(x)
-        except RuntimeError as e:
-            assert str(
-                e) == "PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization"
+    except RuntimeError as e:
+        assert str(
+            e) == """PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear
+                 doesn't support per channel quantization"""

--- a/tests/quantization/test_onnx_export.py
+++ b/tests/quantization/test_onnx_export.py
@@ -10,8 +10,11 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+import torch
 from nncf import NNCFConfig
 from tests.test_helpers import TwoConvTestModel, load_exported_onnx_version
+from nncf.quantization.layers import QuantizerConfig, QuantizationMode, SymmetricQuantizer, AsymmetricQuantizer, \
+    QuantizerExportMode
 
 
 def get_config_for_export_mode(should_be_onnx_standard: bool) -> NNCFConfig:
@@ -36,7 +39,7 @@ def test_onnx_export_to_fake_quantize(tmp_path):
     num_fq = 0
     num_model_nodes = 0
     num_other_nodes = 0
-    #pylint:disable=no-member
+    # pylint:disable=no-member
     for node in onnx_model_proto.graph.node:
         op_type = node.op_type
         if op_type == 'FakeQuantize':
@@ -61,7 +64,7 @@ def test_onnx_export_to_quantize_dequantize(tmp_path):
     num_dq = 0
     num_model_nodes = 0
     num_other_nodes = 0
-    #pylint:disable=no-member
+    # pylint:disable=no-member
     for node in onnx_model_proto.graph.node:
         op_type = node.op_type
         if op_type == 'QuantizeLinear':
@@ -75,3 +78,86 @@ def test_onnx_export_to_quantize_dequantize(tmp_path):
     assert num_q > 0
     assert num_q == num_dq
     assert num_other_nodes == 0
+
+
+def test_onnx_export_to_quantize_dequantize_per_channel():
+    # SYMMETRIC
+    q_config = QuantizerConfig(
+        input_shape=(2, 64, 15, 10),
+        bits=8,
+        mode=QuantizationMode.SYMMETRIC,
+        signedness_to_force=None,
+        per_channel=True)
+    sym_quantizer = SymmetricQuantizer(q_config)
+    sym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
+
+    x = torch.rand((2, 64, 15, 10))
+    sym_quantizer.run_export_quantization(x)
+
+    q_config = QuantizerConfig(
+        bits=8,
+        mode=QuantizationMode.SYMMETRIC,
+        signedness_to_force=None,
+        per_channel=False)
+    sym_quantizer = SymmetricQuantizer(q_config)
+    sym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
+
+    x = torch.rand((2, 64, 15, 10))
+    sym_quantizer.run_export_quantization(x)
+
+    q_config = QuantizerConfig(
+        input_shape=(2, 64, 15, 10),
+        bits=8,
+        mode=QuantizationMode.SYMMETRIC,
+        signedness_to_force=None,
+        per_channel=True)
+    sym_quantizer = SymmetricQuantizer(q_config)
+    sym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
+    sym_quantizer.scale = torch.nn.Parameter(torch.rand(1, 64, 1, 1))
+
+    x = torch.rand((2, 64, 15, 10))
+    try:
+        sym_quantizer.run_export_quantization(x)
+    except RuntimeError as e:
+        assert str(
+            e) == "PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization"
+        # ASYMMETRIC
+        q_config = QuantizerConfig(
+            input_shape=(2, 64, 15, 10),
+            bits=8,
+            mode=QuantizationMode.ASYMMETRIC,
+            signedness_to_force=None,
+            per_channel=True)
+        assym_quantizer = AsymmetricQuantizer(q_config)
+        assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
+
+        x = torch.rand((2, 64, 15, 10))
+        assym_quantizer.run_export_quantization(x)
+
+        q_config = QuantizerConfig(
+            bits=8,
+            mode=QuantizationMode.ASYMMETRIC,
+            signedness_to_force=None,
+            per_channel=False)
+        assym_quantizer = AsymmetricQuantizer(q_config)
+        assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
+
+        x = torch.rand((2, 64, 15, 10))
+        assym_quantizer.run_export_quantization(x)
+
+        q_config = QuantizerConfig(
+            input_shape=(2, 64, 15, 10),
+            bits=8,
+            mode=QuantizationMode.ASYMMETRIC,
+            signedness_to_force=None,
+            per_channel=True)
+        assym_quantizer = AsymmetricQuantizer(q_config)
+        assym_quantizer._export_mode = QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
+        sym_quantizer.scale = torch.nn.Parameter(torch.rand(1, 64, 1, 1))
+
+        x = torch.rand((2, 64, 15, 10))
+        try:
+            assym_quantizer.run_export_quantization(x)
+        except RuntimeError as e:
+            assert str(
+                e) == "PyTorch v1.5.0 export to ONNX using QuantizeLinear-DequantizeLinear doesn't support per channel quantization"


### PR DESCRIPTION
Add hack of export processing for our old checkpoints
Add Exception raising for exporting per-channel Q/DQ layers, as PyTorch ONNX exporting supports only per-tensor.