### PR TITLE
Pruning fixes

### DIFF
--- a/nncf/pruning/base_algo.py
+++ b/nncf/pruning/base_algo.py
@@ -176,7 +176,7 @@ class BasePruningAlgoController(CompressionAlgorithmController):
         self.pruned_module_info = pruned_module_info
         self.prune_first = params.get('prune_first_conv', False)
         self.prune_last = params.get('prune_last_conv', False)
-        self.prune_batch_norms = params.get('prune_batch_norms', False)
+        self.prune_batch_norms = params.get('prune_batch_norms', True)
         self.zero_grad = params.get('zero_grad', True)
         self._hooks = []
 
@@ -197,7 +197,7 @@ class BasePruningAlgoController(CompressionAlgorithmController):
             mask = mask.to(grad.device)
             return apply_filter_binary_mask(mask, grad)
 
-        for minfo in self.pruned_module_info[:1]:
+        for minfo in self.pruned_module_info:
             mask = minfo.operand.binary_filter_pruning_mask
             weight = minfo.module.weight
             partial_hook = update_wrapper(partial(hook, mask=mask), hook)

--- a/nncf/pruning/base_algo.py
+++ b/nncf/pruning/base_algo.py
@@ -48,7 +48,7 @@ class BasePruningAlgoBuilder(CompressionAlgorithmBuilder):
         self.ignore_frozen_layers = True
         self.prune_first = params.get('prune_first_conv', False)
         self.prune_last = params.get('prune_last_conv', False)
-        self.prune_batch_norms = params.get('prune_batch_norms', False)
+        self.prune_batch_norms = params.get('prune_batch_norms', True)
         self.prune_downsample_convs = params.get('prune_downsample_convs', False)
 
         self._pruned_module_info = []

--- a/tests/pruning/filter_pruning/test_algo.py
+++ b/tests/pruning/filter_pruning/test_algo.py
@@ -56,7 +56,7 @@ def test_check_default_algo_params():
     # Check default algo params
     assert compression_ctrl.prune_first is False
     assert compression_ctrl.prune_last is False
-    assert compression_ctrl.prune_batch_norms is False
+    assert compression_ctrl.prune_batch_norms is True
     assert compression_ctrl.filter_importance is l2_filter_norm
 
     assert compression_ctrl.all_weights is False
@@ -232,7 +232,6 @@ def test_zeroing_gradients(zero_grad):
         output = pruned_model(input_)
 
         loss = torch.sum(target.to(torch.float32) - output)
-
         optimizer.zero_grad()
         loss.backward()
 


### PR DESCRIPTION
Fixes for gradients and BatchNorms zeroing (now all batch norms are masked with the previous convolution by default).

cc @AlexKoff88  @vanyalzr @AlexanderDokuchaev  