### PR TITLE
make customer happy to see param name that is wrong

### DIFF
--- a/nncf/dynamic_graph/input_wrapping.py
+++ b/nncf/dynamic_graph/input_wrapping.py
@@ -74,7 +74,7 @@ class InputInfoWrapManager:
                 # Default was None - cannot wrap as-is. Will wrap a dummy tensor as specified in
                 # input infos - will conserve the call order of nncf_model_input nodes,
                 # and the post-hooks for the input node will execute. The result won't go anywhere, though.
-                nncf_logger.warning("Wrapping a dummy tensor for input {}".format('param_name'))
+                nncf_logger.warning("Wrapping a dummy tensor for input {}".format(param_name))
                 info_for_missing_input = self._fwd_params_to_input_infos_odict[param_name]
                 device = 'cuda'
                 if self._module_ref_for_device is not None:


### PR DESCRIPTION
Right now a lot of messaged outputs that something wrong with parameter 'param_name'. it is better to output real parameter name.