### PR TITLE
Introduce evaluation option of loss function to SSD application

### DIFF
--- a/examples/object_detection/configs/ssd300_vgg_voc_int8.json
+++ b/examples/object_detection/configs/ssd300_vgg_voc_int8.json
@@ -34,7 +34,8 @@
     "steps": [8, 16, 32, 64, 100, 300],
     "aspect_ratios": [[2], [2, 3], [2, 3], [2, 3], [2], [2]],
     "flip": true,
-    "top_k": 200
+    "top_k": 200,
+    "loss_inference": false
   },
   "compression": {
       "algorithm": "quantization",

--- a/examples/object_detection/eval.py
+++ b/examples/object_detection/eval.py
@@ -319,7 +319,7 @@ def eval_net_loss(data_loader, device, net, criterion):
 
     # all_detections = []
     timer = Timer()
-    for batch_ind, (ims, _gts, hs, ws) in enumerate(data_loader):
+    for batch_ind, (ims, _gts, _, _) in enumerate(data_loader):
         images = ims.to(device)
         targets = [anno.requires_grad_(False).to(device) for anno in _gts]
 
@@ -337,10 +337,11 @@ def eval_net_loss(data_loader, device, net, criterion):
 
         if batch_ind % print_freq == 0:
             logger.info('Loss_inference: [{}/{}] || Time: {elapsed.val:.4f}s ({elapsed.avg:.4f}s)'
-            ' || Conf Loss: {conf_loss.val:.3f} ({conf_loss.avg:.3f})'
-            ' || Loc Loss: {loc_loss.val:.3f} ({loc_loss.avg:.3f})'
-            ' || Model Loss: {model_loss.val:.3f} ({model_loss.avg:.3f})'.format(
-                batch_ind, num_batches, elapsed=t_elapsed, conf_loss=batch_loss_c, loc_loss=batch_loss_l, model_loss=batch_loss))
+                        ' || Conf Loss: {conf_loss.val:.3f} ({conf_loss.avg:.3f})'
+                        ' || Loc Loss: {loc_loss.val:.3f} ({loc_loss.avg:.3f})'
+                        ' || Model Loss: {model_loss.val:.3f} ({model_loss.avg:.3f})'.format(
+                            batch_ind, num_batches, elapsed=t_elapsed, conf_loss=batch_loss_c,
+                            loc_loss=batch_loss_l, model_loss=batch_loss))
 
     model_loss = batch_loss_l.avg + batch_loss_c.avg
     return model_loss
@@ -352,10 +353,10 @@ def test_net(net, device, data_loader, distributed=False, loss_inference=False, 
         logger.info("Testing... loss function will be evaluated instead of detection mAP")
         if distributed:
             raise NotImplementedError
-        if criterion is not None:
-            return eval_net_loss(data_loader, device, net, criterion)
-        else:
+        if criterion is None:
             raise ValueError("Missing loss inference function (criterion)")
+        else:
+            return eval_net_loss(data_loader, device, net, criterion)
     else:
         logger.info("Testing...")
         num_images = len(data_loader.dataset)

--- a/examples/object_detection/eval.py
+++ b/examples/object_detection/eval.py
@@ -355,16 +355,15 @@ def test_net(net, device, data_loader, distributed=False, loss_inference=False, 
             raise NotImplementedError
         if criterion is None:
             raise ValueError("Missing loss inference function (criterion)")
-        else:
-            return eval_net_loss(data_loader, device, net, criterion)
-    else:
-        logger.info("Testing...")
-        num_images = len(data_loader.dataset)
-        batch_detections = predict_detections(data_loader, device, net)
-        if distributed:
-            batch_detections = gather_detections(batch_detections, data_loader.sampler.samples_per_rank)
-        batch_detections = batch_detections[:num_images]
-        all_boxes = convert_detections(batch_detections)
+        return eval_net_loss(data_loader, device, net, criterion)
 
-        logger.info('Evaluating detections')
-        return evaluate_detections(all_boxes, data_loader.dataset)
+    logger.info("Testing...")
+    num_images = len(data_loader.dataset)
+    batch_detections = predict_detections(data_loader, device, net)
+    if distributed:
+        batch_detections = gather_detections(batch_detections, data_loader.sampler.samples_per_rank)
+    batch_detections = batch_detections[:num_images]
+    all_boxes = convert_detections(batch_detections)
+
+    logger.info('Evaluating detections')
+    return evaluate_detections(all_boxes, data_loader.dataset)

--- a/examples/object_detection/layers/modules/ssd_head.py
+++ b/examples/object_detection/layers/modules/ssd_head.py
@@ -25,7 +25,7 @@ class SSDDetectionOutput(nn.Module):
         self.config = config
         self.num_classes = num_classes
         self.loss_inference = config.get('loss_inference', False)
-       
+
         self.heads = nn.ModuleList()
         for i, num_features in enumerate(num_input_features):
             self.heads.append(SSDHead(

--- a/examples/object_detection/layers/modules/ssd_head.py
+++ b/examples/object_detection/layers/modules/ssd_head.py
@@ -25,7 +25,7 @@ class SSDDetectionOutput(nn.Module):
         self.config = config
         self.num_classes = num_classes
         self.loss_inference = config.get('loss_inference', False)
-        
+       
         self.heads = nn.ModuleList()
         for i, num_features in enumerate(num_input_features):
             self.heads.append(SSDHead(

--- a/examples/object_detection/layers/modules/ssd_head.py
+++ b/examples/object_detection/layers/modules/ssd_head.py
@@ -24,7 +24,8 @@ class SSDDetectionOutput(nn.Module):
         super().__init__()
         self.config = config
         self.num_classes = num_classes
-
+        self.loss_inference = config.get('loss_inference', False)
+        
         self.heads = nn.ModuleList()
         for i, num_features in enumerate(num_input_features):
             self.heads.append(SSDHead(
@@ -59,6 +60,8 @@ class SSDDetectionOutput(nn.Module):
             return loc.view(batch, -1, 4), conf.view(batch, -1, self.num_classes), priors.view(1, 2, -1, 4)
 
         with no_nncf_trace():
+            if self.loss_inference is True:
+                return loc.view(batch, -1, 4), conf.view(batch, -1, self.num_classes), priors.view(1, 2, -1, 4)
             return self.detection_output(loc, conf_softmax.view(batch, -1), priors)
 
 

--- a/examples/object_detection/main.py
+++ b/examples/object_detection/main.py
@@ -183,7 +183,7 @@ def main_worker(current_gpu, config):
             net.eval()
             if config['ssd_params'].get('loss_inference', False):
                 model_loss = test_net(net, config.device, test_data_loader, distributed=config.distributed,
-                                        loss_inference=True, criterion=criterion)
+                                      loss_inference=True, criterion=criterion)
                 logger.info("Final model loss: {:.3f}".format(model_loss))
             else:
                 mAp = test_net(net, config.device, test_data_loader, distributed=config.distributed)

--- a/examples/object_detection/main.py
+++ b/examples/object_detection/main.py
@@ -181,9 +181,14 @@ def main_worker(current_gpu, config):
         with torch.no_grad():
             print_statistics(compression_ctrl.statistics())
             net.eval()
-            mAp = test_net(net, config.device, test_data_loader, distributed=config.distributed)
-            if config.metrics_dump is not None:
-                write_metrics(mAp, config.metrics_dump)
+            if config['ssd_params'].get('loss_inference', False):
+                model_loss = test_net(net, config.device, test_data_loader, distributed=config.distributed,
+                                        loss_inference=True, criterion=criterion)
+                logger.info("Final model loss: {:.3f}".format(model_loss))
+            else:
+                mAp = test_net(net, config.device, test_data_loader, distributed=config.distributed)
+                if config.metrics_dump is not None:
+                    write_metrics(mAp, config.metrics_dump)
             return
 
     train(net, compression_ctrl, train_data_loader, test_data_loader, criterion, optimizer, config, lr_scheduler)


### PR DESCRIPTION
Backward compatible changes. Introduce a config key "loss_inference" to specify test with loss evaluation or the default mAP evaluation. It is disabled by default. This patch support issue #131 
