### PR TITLE
Add pass_meta_from_tensor to trace torch non in-place operations

### DIFF
--- a/nncf/dynamic_graph/trace_tensor.py
+++ b/nncf/dynamic_graph/trace_tensor.py
@@ -51,6 +51,9 @@ class TracedTensor(torch.Tensor):
         tensor.__class__ = TracedTensor
         return tensor
 
+    def view(self, size):
+        tensor = super().view(size)
+        return pass_meta_from_tensor(tensor, self)
 
 def is_iterable(item):
     non_iterable_types = (str, bytes, bytearray, torch.Tensor, np.ndarray)
@@ -95,3 +98,9 @@ def make_input_infos(inputs):
         else:
             input_infos.append(None)
     return input_infos
+
+
+def pass_meta_from_tensor(to_tensor, from_tensor):
+    if not isinstance(from_tensor, TracedTensor):
+        return to_tensor
+    return TracedTensor.from_torch_tensor(to_tensor, from_tensor.tensor_meta)

--- a/tests/test_trace_tensor.py
+++ b/tests/test_trace_tensor.py
@@ -1,0 +1,17 @@
+import torch
+from nncf.dynamic_graph.trace_tensor import TracedTensor, TensorMeta, pass_meta_from_tensor
+
+
+def test_trace_non_in_place_ops():
+    tensor_ = torch.tensor([[1, 2], [3, 4]], dtype=torch.float32)
+    meta = TensorMeta(None, 0, tensor_.shape)
+    traced_tensor = TracedTensor.from_torch_tensor(tensor_, meta)
+
+    traced_tensor = traced_tensor.view((1, 4))
+    assert isinstance(traced_tensor, TracedTensor)
+
+    non_traced_tensor = traced_tensor.exp()
+    assert torch.is_tensor(non_traced_tensor)
+
+    traced_tensor = pass_meta_from_tensor(non_traced_tensor, traced_tensor)
+    assert isinstance(traced_tensor, TracedTensor)


### PR DESCRIPTION
Currently there is no option to trace tensors if the operations on them return a new tensor, non in-place.
Examples of such operations:` torch.tensor.exp(), torch.tensor.view()`

I add a new method and give an example of how to overload a `torch.tensor.view()` method to be able to still trace such operations