### PR TITLE
Remove __getattr__ from SampleConfig

### DIFF
--- a/examples/common/sample_config.py
+++ b/examples/common/sample_config.py
@@ -72,11 +72,6 @@ class CustomArgumentParser(CustomActionContainer, argparse.ArgumentParser):
 
 
 class SampleConfig(Dict):
-    def __getattr__(self, item):
-        if item not in self:
-            raise KeyError("Key {} not found in config".format(item))
-        return super().__getattr__(item)
-
     @classmethod
     def from_json(cls, path) -> 'SampleConfig':
         with open(path) as f:


### PR DESCRIPTION
Newer `addict` version uses custom private attributes for internal
working and __getattr__ disrupted it. It was quite useless anyway.