### PR TITLE
Print flops pruning level in statistic

### DIFF
--- a/nncf/pruning/base_algo.py
+++ b/nncf/pruning/base_algo.py
@@ -416,8 +416,8 @@ class BasePruningAlgoController(CompressionAlgorithmController):
         stats["pruning_statistic_by_module"] = table
         return self.add_algo_specific_stats(stats)
 
-    @staticmethod
-    def add_algo_specific_stats(stats):
+
+    def add_algo_specific_stats(self, stats):
         return stats
 
     def get_stats_for_pruned_modules(self):

--- a/nncf/pruning/filter_pruning/algo.py
+++ b/nncf/pruning/filter_pruning/algo.py
@@ -23,7 +23,7 @@ from nncf.layer_utils import _NNCFModuleMixin
 from nncf.nncf_logger import logger as nncf_logger
 from nncf.nncf_network import NNCFNetwork
 from nncf.pruning.base_algo import BasePruningAlgoBuilder, PrunedModuleInfo, BasePruningAlgoController
-from nncf.pruning.export_helpers import ModelPruner, Elementwise, Convolution
+from nncf.pruning.export_helpers import ModelPruner, Elementwise, Convolution, TransposeConvolution
 from nncf.pruning.filter_pruning.functions import calculate_binary_mask, FILTER_IMPORTANCE_FUNCTIONS, \
     tensor_l2_normalizer
 from nncf.pruning.filter_pruning.layers import FilterPruningBlock, inplace_apply_filter_binary_mask
@@ -118,7 +118,7 @@ class FilterPruningController(BasePruningAlgoController):
             if out_channels:
                 self.modules_out_channels[nncf_node.node_id] = out_channels
 
-        prunable_types = Convolution.get_all_op_aliases()
+        prunable_types = Convolution.get_all_op_aliases() + TransposeConvolution.get_all_op_aliases()
         # 2. Init next_nodes for every pruning cluster
         for cluster in self.pruned_module_groups_info.get_all_clusters():
             next_nodes_cluster = set()
@@ -170,6 +170,7 @@ class FilterPruningController(BasePruningAlgoController):
     def _calculate_flops_pruned_model_by_masks(self):
         """
         Calculates number of flops for pruned model by using binary_filter_pruning_mask.
+        :return: number of flops in model
         """
         tmp_in_channels = self.modules_in_channels.copy()
         tmp_out_channels = self.modules_out_channels.copy()

--- a/nncf/utils.py
+++ b/nncf/utils.py
@@ -369,7 +369,10 @@ def compute_FLOPs_hook(module, input_, output, dict_to_save, name):
         ks = module.weight.data.shape
         mac_count = np.prod(ks) * np.prod(output.shape[2:])
     elif isinstance(module, nn.Linear):
-        mac_count = input_[0].shape[0] * output.shape[-1]
+        if len(input_[0].shape) == 1:
+            mac_count = input_[0].shape[0] * output.shape[-1]
+        else:
+            mac_count = np.prod(input_[0].shape[1:]) * output.shape[-1]
     else:
         return
     dict_to_save[name] = 2 * mac_count

--- a/nncf/utils.py
+++ b/nncf/utils.py
@@ -370,6 +370,7 @@ def compute_FLOPs_hook(module, input_, output, dict_to_save, name):
         mac_count = np.prod(ks) * np.prod(output.shape[2:])
     elif isinstance(module, nn.Linear):
         if len(input_[0].shape) == 1:
+            # In some test cases input tensor could have dimension [N]
             mac_count = input_[0].shape[0] * output.shape[-1]
         else:
             mac_count = np.prod(input_[0].shape[1:]) * output.shape[-1]

--- a/nncf/utils.py
+++ b/nncf/utils.py
@@ -369,7 +369,7 @@ def compute_FLOPs_hook(module, input_, output, dict_to_save, name):
         ks = module.weight.data.shape
         mac_count = np.prod(ks) * np.prod(output.shape[2:])
     elif isinstance(module, nn.Linear):
-        mac_count = input_[0].shape[1] * output.shape[-1]
+        mac_count = input_[0].shape[0] * output.shape[-1]
     else:
         return
     dict_to_save[name] = 2 * mac_count

--- a/tests/quantization/test_precision_init.py
+++ b/tests/quantization/test_precision_init.py
@@ -675,7 +675,7 @@ def get_quantization_config_with_ignored_scope():
 @pytest.mark.parametrize(('config_creator', 'ref_values'), (
     [
         get_quantization_config_without_range_init,
-        (1.75, pytest.approx(1.07, abs=1e-2), (1, 2), (1, 4), (1, 1.12))
+        (1.25, pytest.approx(1.42, abs=1e-2), (1, 2), (1, 4), (1, pytest.approx(1.8181, abs=1e-4)))
     ],
     [
         get_quantization_config_with_ignored_scope,


### PR DESCRIPTION
Example of output:
```
pruning_rate: 0.09999999999999998
FLOPS pruning level: 0.1128178144173182
FLOPS current / full: 533683152 / 601548544
```

Additions fixes:
- Missed transpose convolution for 'prunable_types'
- Fix incorrect computation FLOPS of linear module  