### PR TITLE
Dropped last data point in all DataLoaders to prevent issue with BN

### DIFF
--- a/examples/classification/main.py
+++ b/examples/classification/main.py
@@ -334,7 +334,7 @@ def create_data_loaders(config, train_dataset, val_dataset):
         val_dataset,
         batch_size=batch_size, shuffle=False,
         num_workers=workers, pin_memory=pin_memory,
-        sampler=val_sampler)
+        sampler=val_sampler, drop_last=True)
 
     train_sampler = None
     if config.distributed:
@@ -343,12 +343,12 @@ def create_data_loaders(config, train_dataset, val_dataset):
     def create_train_data_loader(batch_size_):
         return torch.utils.data.DataLoader(
             train_dataset, batch_size=batch_size_, shuffle=(train_sampler is None),
-            num_workers=workers, pin_memory=pin_memory, sampler=train_sampler)
+            num_workers=workers, pin_memory=pin_memory, sampler=train_sampler, drop_last=True)
 
     train_loader = create_train_data_loader(batch_size)
 
     init_loader = train_loader
-    if config.batch_size_init:
+    if config.batch_size_init and config.batch_size_init != config.batch_size:
         init_loader = create_train_data_loader(config.batch_size_init)
 
     return train_loader, train_sampler, val_loader, init_loader

--- a/examples/semantic_segmentation/main.py
+++ b/examples/semantic_segmentation/main.py
@@ -193,7 +193,7 @@ def load_dataset(dataset, config):
         batch_size=1, num_workers=num_workers,
         shuffle=False,
         sampler=val_sampler,
-        collate_fn=data_utils.collate_fn)
+        collate_fn=data_utils.collate_fn, drop_last=True)
 
     # Get encoding between pixel values in label images and RGB colors
     class_encoding = train_set.color_encoding

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -246,5 +246,5 @@ def create_mock_dataloader(config, num_samples=1):
     data_loader = torch.utils.data.DataLoader(OnesDatasetMock(input_sample_size[1:], num_samples),
                                               batch_size=1,
                                               num_workers=0,  # Workaround
-                                              shuffle=False)
+                                              shuffle=False, drop_last=True)
     return data_loader

--- a/tests/quantization/test_logarithm_scale.py
+++ b/tests/quantization/test_logarithm_scale.py
@@ -59,7 +59,7 @@ def get_config_for_logarithm_scale(logarithm_scale: bool, quantization_type: str
         def __len__(self):
             return 4
 
-    data_loader = torch.utils.data.DataLoader(RandDatasetMock(), batch_size=1, shuffle=False)
+    data_loader = torch.utils.data.DataLoader(RandDatasetMock(), batch_size=1, shuffle=False, drop_last=True)
 
     class SquadInitializingDataloader(nncf.initialization.InitializingDataLoader):
         def get_inputs(self, batch):

--- a/tests/quantization/test_precision_init.py
+++ b/tests/quantization/test_precision_init.py
@@ -82,7 +82,7 @@ def create_test_dataloaders(config, dataset_dir):
 
     # Do not set num_workers > 0 here - random hangs occur during pytest runs of this files
     train_loader = torch.utils.data.DataLoader(train_dataset, batch_size=batch_size, shuffle=False,
-                                               pin_memory=True)
+                                               pin_memory=True, drop_last=True)
     return train_loader, train_dataset
 
 

--- a/tests/quantization/test_quantization_helpers.py
+++ b/tests/quantization/test_quantization_helpers.py
@@ -93,7 +93,7 @@ def distributed_init_test_default(gpu, ngpus_per_node, config):
     data_loader = torch.utils.data.DataLoader(RankDatasetMock(input_sample_size[1:], config.rank),
                                               batch_size=3,
                                               num_workers=0, #  workaround
-                                              shuffle=False)
+                                              shuffle=False, drop_last=True)
     return data_loader
 
 

--- a/tests/quantization/test_range_init.py
+++ b/tests/quantization/test_range_init.py
@@ -476,7 +476,7 @@ def test_percentile_init(quantization_mode: str, per_channel: bool):
         def __len__(self):
             return self._length
 
-    data_loader = torch.utils.data.DataLoader(SyntheticDataset(), batch_size=1)
+    data_loader = torch.utils.data.DataLoader(SyntheticDataset(), batch_size=1, drop_last=True)
 
     config_with_init = NNCFConfig()
     config_with_init.update(


### PR DESCRIPTION
There is a little chance that last data point may have a batch size equal to 1, which leads to an error:
```
ValueError: Expected more than 1 value per channel when training
```
We caught this error in sanity tests with CIFAR10. The dataset has 1000 data points.
There're 333 data points with batch_size=3 and the last one with batch_size=1. Training may fail in the end of epoch, which is not accepted for bigger datasets.

@vuiseng9 