### PR TITLE
Minor fixes for HAWQ

### DIFF
--- a/nncf/model_creation.py
+++ b/nncf/model_creation.py
@@ -20,7 +20,7 @@ from torch.nn import Module
 
 from nncf.compression_method_api import CompressionAlgorithmController, CompressionAlgorithmBuilder
 from nncf.config import NNCFConfig
-from nncf.debug import is_debug, set_debug_log_dir
+from nncf.debug import set_debug_log_dir
 from nncf.dynamic_graph.graph_builder import GraphBuilder, create_input_infos, create_dummy_forward_fn
 from nncf.nncf_network import NNCFNetwork
 from nncf.utils import is_main_process
@@ -121,8 +121,7 @@ def create_compressed_model(model: Module, config: NNCFConfig,
             graph = graph_builder.build_graph(model)
             graph.visualize_graph(osp.join(config.get("log_dir", "."), "original_graph.dot"))
 
-    if is_debug():
-        set_debug_log_dir(config.get("log_dir", "."))
+    set_debug_log_dir(config.get("log_dir", "."))
 
     input_info_list = create_input_infos(config)
     scopes_without_shape_matching = config.get('scopes_without_shape_matching', [])

--- a/nncf/quantization/precision_init/hawq_init.py
+++ b/nncf/quantization/precision_init/hawq_init.py
@@ -83,13 +83,13 @@ class HAWQPrecisionInitParams(BasePrecisionInitParams):
                     user_init_args: QuantizationPrecisionInitArgs) -> 'HAWQPrecisionInitParams':
         return cls(
             user_init_args=user_init_args,
-            bits=hawq_init_config_dict.get('bits', [4, 8]),
+            bits=hawq_init_config_dict.get('bits', [2, 4, 8]),
             traces_per_layer_path=hawq_init_config_dict.get('traces_per_layer_path', None),
             num_data_points=hawq_init_config_dict.get('num_data_points', 100),
             iter_number=hawq_init_config_dict.get('iter_number', 200),
             tolerance=hawq_init_config_dict.get('tolerance', 1e-4),
             compression_ratio=hawq_init_config_dict.get('compression_ratio', 1.5),
-            dump_hawq_data=hawq_init_config_dict.get('dump_hawq_data', False),
+            dump_hawq_data=hawq_init_config_dict.get('dump_init_precision_data', False),
             bitwidth_assignment_mode=BitwidthAssignmentMode.from_str(
                 hawq_init_config_dict.get('bitwidth_assignment_mode', BitwidthAssignmentMode.LIBERAL.value)
             )
@@ -277,8 +277,9 @@ class HAWQPrecisionInitializer(BasePrecisionInitializer):
         config_index = self.choose_configuration(configuration_metric, flops_bits_per_config)
         chosen_config_in_traces_order = weight_qconfigs_in_trace_order[config_index]
         chosen_config_in_execution_order = traces_order.get_execution_order_config(chosen_config_in_traces_order)
+        biwidth_per_weightable_layer = [qconfig.bits for qconfig in chosen_config_in_execution_order]
         nncf_logger.info('Chosen HAWQ configuration with ratio={:.2f}, config per weightable layer={}'.format(
-            flops_bits_per_config[config_index], chosen_config_in_execution_order))
+            flops_bits_per_config[config_index], biwidth_per_weightable_layer))
         nncf_logger.debug('Order of the weightable layers in the HAWQ configuration (in descending order of average '
                           'Hessian traces) ={}'.format(traces_order))
 


### PR DESCRIPTION
- Set debug log directory for collecting hawq-related data not only in debug mode, but via option `dump_precision_init_data`
- Corrected printing of chosen bitwidth configuration