### PR TITLE
[TF] Reduction of the sanity test time for object detection sample

### DIFF
--- a/beta/tests/tensorflow/data/configs/retinanet_coco2017_magnitude_sparsity_int8.json
+++ b/beta/tests/tensorflow/data/configs/retinanet_coco2017_magnitude_sparsity_int8.json
@@ -59,7 +59,7 @@
                 }
             },
             "min_level": 3,
-            "max_level": 7,
+            "max_level": 3,
             "multilevel_features": "fpn",
             "fpn_params": {
                 "fpn_feat_dims": 256,
@@ -68,7 +68,7 @@
             },
             "num_classes": 91,
             "head_params": {
-                "num_convs": 4,
+                "num_convs": 1,
                 "num_filters": 256,
                 "use_separable_conv": false
             }
@@ -95,7 +95,7 @@
             "box_loss_weight": 50
         },
         "postprocessing": {
-            "use_batched_nms": false,
+            "use_batched_nms": true,
             "max_total_size": 100,
             "nms_iou_threshold": 0.5,
             "score_threshold": 0.05,


### PR DESCRIPTION
The sanity test duration for the object detection sample is ~**19:30** minutes at the moment.
After these changes, the duration was reduced to ~**02:45** minutes.

Changes: `"use_batched_nms": false` ---> `"use_batched_nms": true`
Time reduction: 19:30 min ---> 09:27 min

Changes: `"num_convs": 4` ---> `"num_convs": 1`
Time reduction: 09:27 min ---> 06:51 min

Changes: `"max_level": 7` ---> `"max_level": 3`
Time reduction: 06:51 min ---> 02:45 min