### PR TITLE
[TF] Reduction of the sanity test time for segmentation sample

### DIFF
--- a/beta/tests/tensorflow/data/configs/mask_rcnn_coco2017_magnitude_sparsity_int8.json
+++ b/beta/tests/tensorflow/data/configs/mask_rcnn_coco2017_magnitude_sparsity_int8.json
@@ -40,7 +40,7 @@
                 }
             },
             "min_level": 2,
-            "max_level": 6,
+            "max_level": 2,
             "multilevel_features": "fpn",
             "fpn_params": {
                 "fpn_feat_dims": 256,


### PR DESCRIPTION
The sanity test duration for the segmentation sample is ~**05:10** minutes at the moment.
After these changes, the duration was reduced to ~**02:35** minutes.