### PR TITLE
Schedulers refactoring

### DIFF
--- a/beta/nncf/tensorflow/sparsity/schedulers.py
+++ b/beta/nncf/tensorflow/sparsity/schedulers.py
@@ -164,14 +164,11 @@ class MultiStepSparsityScheduler(SparsityScheduler):
     def __init__(self, sparsity_algo, params):
         super().__init__(sparsity_algo, params)
         self.sparsity_levels = self._params.get('multistep_sparsity_levels', [0.1, 0.5])
-        self.steps = self._params.get('multistep_steps', [90])
+        self.steps = sorted(self._params.get('multistep_steps', [90]))
         if len(self.steps) + 1 != len(self.sparsity_levels):
             raise AttributeError('number of sparsity levels must equal to number of steps + 1')
 
         self.initial_sparsity = self.sparsity_level = self.sparsity_levels[0]
-        self.max_sparsity = max(self.sparsity_levels)
-        self.steps = sorted(self.steps)
-        self.max_step = self.steps[-1]
         self.prev_ind = 0
         self.algo.set_sparsity_level(self.current_sparsity_level)
 

--- a/nncf/compression_method_api.py
+++ b/nncf/compression_method_api.py
@@ -106,9 +106,6 @@ class CompressionScheduler:
         default_keys = {'current_step', '_current_epoch'}
         return {key: val for key, val in self.__dict__.items() if key in default_keys}
 
-    def initialize(self):
-        pass
-
     @property
     def current_epoch(self):
         return 0 if self._current_epoch == -1 else self._current_epoch

--- a/nncf/sparsity/schedulers.py
+++ b/nncf/sparsity/schedulers.py
@@ -209,15 +209,11 @@ class MultiStepSparsityScheduler(SparsityScheduler):
     def __init__(self, sparsity_algo, params):
         super().__init__(sparsity_algo, params)
         self.sparsity_levels = self._params.get('multistep_sparsity_levels', [0.1, 0.5])
-        self.steps = self._params.get('multistep_steps', [90])
+        self.steps = sorted(self._params.get('multistep_steps', [90]))
         if len(self.steps) + 1 != len(self.sparsity_levels):
             raise AttributeError('number of sparsity levels must equal to number of steps + 1')
 
         self.initial_sparsity = self.sparsity_level = self.sparsity_levels[0]
-        self.max_sparsity = max(self.sparsity_levels)
-        self.sparsity_algo = sparsity_algo
-        self.steps = sorted(self.steps)
-        self.max_step = self.steps[-1]
         self.prev_ind = 0
 
     def epoch_step(self, next_epoch=None):

--- a/nncf/sparsity/schedulers.py
+++ b/nncf/sparsity/schedulers.py
@@ -108,10 +108,6 @@ class PolynomialSparseScheduler(SparsityScheduler):
         self._steps_in_current_epoch = 0
         super().epoch_step(next_epoch)
 
-    def load_state_dict(self, state_dict):
-        super().load_state_dict(state_dict)
-        self._set_sparsity_level()
-
     def state_dict(self):
         sd = super().state_dict()
         if self._update_per_optimizer_step:

--- a/nncf/sparsity/schedulers.py
+++ b/nncf/sparsity/schedulers.py
@@ -35,9 +35,6 @@ class SparsityScheduler(CompressionScheduler):
         self.sparsity_target_epoch = self._params.get('sparsity_target_epoch', 90)
         self.sparsity_freeze_epoch = self._params.get('sparsity_freeze_epoch', 100)
 
-    def initialize(self):
-        self._set_sparsity_level()
-
     def epoch_step(self, next_epoch=None):
         super().epoch_step(next_epoch)
         self._set_sparsity_level()


### PR DESCRIPTION
* Unused attributes were removed from `MultiStepSparsityScheduler` class.
* Method `load_state_dict()` was removed from `PolynomialSparseScheduler` because it is already defined in the super class.
* Method `initialize()` was removed from `CompressionScheduler` and `SparsityScheduler` because it is unused now.