### PR TITLE
The "concave" parameter is misleading

### DIFF
--- a/nncf/sparsity/schedulers.py
+++ b/nncf/sparsity/schedulers.py
@@ -72,7 +72,7 @@ class PolynomialSparseScheduler(SparsityScheduler):
     def __init__(self, sparsity_algo, params=None):
         super().__init__(sparsity_algo, params)
         self.power = self._params.get('power', 0.9)
-        self.concave = self._params.get('concave', False)
+        self.concave = self._params.get('concave', True)
         self._update_per_optimizer_step = self._params.get('update_per_optimizer_step', False)
         if self._update_per_optimizer_step:
             self._steps_per_epoch = self._params.get('steps_per_epoch')
@@ -126,7 +126,7 @@ class PolynomialSparseScheduler(SparsityScheduler):
         else:
             progress = (min(self.sparsity_target_epoch, self.current_epoch) / self.sparsity_target_epoch)
 
-        if self.concave:
+        if not self.concave:
             current_sparsity = self.initial_sparsity + (self.sparsity_target - self.initial_sparsity) * (
                 progress ** self.power)
         else:

--- a/tests/sparsity/test_common.py
+++ b/tests/sparsity/test_common.py
@@ -148,8 +148,8 @@ class TestPolynomialSparsityScheduler:
             set_sparsity_mock.reset_mock()
 
     @pytest.mark.parametrize("concavity_and_ref_sparsity_levels", [
-        (True, [0.1, pytest.approx(13 / 90), pytest.approx(25 / 90), 0.5, 0.5]),
-        (False, [pytest.approx(0.1), pytest.approx(29 / 90), pytest.approx(41 / 90), 0.5, 0.5])],
+        (False, [0.1, pytest.approx(13 / 90), pytest.approx(25 / 90), 0.5, 0.5]),
+        (True, [pytest.approx(0.1), pytest.approx(29 / 90), pytest.approx(41 / 90), 0.5, 0.5])],
                              ids=["concave", "convex"])
     def test_polynomial_schedule_per_epoch_step(self, magnitude_algo_mock, concavity_and_ref_sparsity_levels):
         concave = concavity_and_ref_sparsity_levels[0]
@@ -206,7 +206,7 @@ class TestPolynomialSparsityScheduler:
             "sparsity_target_epoch": 3,
             "sparsity_freeze_epoch": 4,
             "update_per_optimizer_step": True,
-            "concave": True
+            "concave": False
         }
 
         if specify_steps_per_epoch_in_config:


### PR DESCRIPTION
Let's consider test cases from NNCF tests

https://github.com/openvinotoolkit/nncf/blob/452ff2d7714a4e3da4b5da6484a8a13e27cbb2cc/tests/sparsity/test_common.py#L150-L156

and draw these dependencies, namely

```python
epochs = [0, 1, 2, 3, 4]
concave = [0.1, 13 / 90, 25 / 90, 0.5, 0.5]  # "concave": true
convex = [0.1, 29 / 90, 41 / 90, 0.5, 0.5]  # "concave": false

# plt.plot(epochs, convex, '-ro', label='Convex')
plt.plot(epochs, concave, '-bo', label='Concave')
plt.legend()
plt.ylabel('Sparsity level')
plt.grid(True)
plt.xlabel('Epochs')
plt.savefig('concave.png')
```

I got the following charts:

**"concave": true**
![concave](https://user-images.githubusercontent.com/77268007/107255637-93d07080-6a49-11eb-8501-90bb1fe10508.png)

**"concave": false"**
![convex](https://user-images.githubusercontent.com/77268007/107255299-33d9ca00-6a49-11eb-87e8-b675a7f1d0a6.png)

From these charts, we can see when we set the `"concave"` parameter to `true` we get the [convex function](https://en.wikipedia.org/wiki/Convex_function) and the [concave function](https://en.wikipedia.org/wiki/Concave_function) otherwise.
