### PR TITLE
Proper usage of pytest-dependency plugin: name should hashable

### DIFF
--- a/tests/test_compression_training.py
+++ b/tests/test_compression_training.py
@@ -222,7 +222,7 @@ def _params(request, tmp_path_factory, dataset_dir, weekly_models_path, enable_i
     }
 
 
-@pytest.mark.dependency(name=["train"])
+@pytest.mark.dependency(name="train")
 def test_compression_train(_params, tmp_path):
     p = _params
     args = p['args']


### PR DESCRIPTION
Should fix internal error during nncf_cuda nightly run
CVS-49053
@pfinashx @aleksei-kashapov 