### PR TITLE
Fixed pylint issue in DDPG

### DIFF
--- a/nncf/automl/agent/ddpg/ddpg.py
+++ b/nncf/automl/agent/ddpg/ddpg.py
@@ -223,7 +223,7 @@ class DDPG:
         # Actor update
         self.actor.zero_grad()
 
-        policy_loss = -self.critic([
+        policy_loss = (-1) * self.critic([
             to_tensor(state_batch),
             self.actor(to_tensor(state_batch))
         ])


### PR DESCRIPTION
Issue message: [E1130(invalid-unary-operand-type), DDPG.update_policy] bad operand type for unary -: tuple

@vuiseng9 @alexsu52 @aleksei-kashapov @andrey-churkin 