### PR TITLE
Support pruning models with FCOS detection head

### DIFF
--- a/nncf/dynamic_graph/graph.py
+++ b/nncf/dynamic_graph/graph.py
@@ -807,7 +807,9 @@ class NNCFGraph:
                 return nodes[node_key]
         return None
 
-    def find_node_in_nx_graph_by_input_agnostic(self, input_agnostic: 'InputAgnosticOperationExecutionContext') -> Optional[dict]:
+    def find_node_in_nx_graph_by_input_agnostic(
+        self, input_agnostic: InputAgnosticOperationExecutionContext
+    ) -> Optional[dict]:
         """
         Looking for node with input_agnostic == input_agnostic in networkx graph.
         :param self: graphs to work on

--- a/nncf/dynamic_graph/graph.py
+++ b/nncf/dynamic_graph/graph.py
@@ -807,6 +807,19 @@ class NNCFGraph:
                 return nodes[node_key]
         return None
 
+    def find_node_in_nx_graph_by_input_agnostic(self, input_agnostic: 'InputAgnosticOperationExecutionContext') -> Optional[dict]:
+        """
+        Looking for node with input_agnostic == input_agnostic in networkx graph.
+        :param self: graphs to work on
+        :param input_agnostic: Input agnostic to find in graph
+        :return: node from networkx graph for graph (or None if such scope is not found)
+        """
+        nodes = self._nx_graph.nodes
+        for node_key in nodes:
+            if nodes[node_key][NNCFGraph.OP_EXEC_CONTEXT_NODE_ATTR].input_agnostic == input_agnostic:
+                return nodes[node_key]
+        return None
+
     def get_op_nodes_in_scope(self, scope: 'Scope') -> List:
         matching_graph_op_nodes = []
         for _, node in self._nx_graph.nodes.items():

--- a/nncf/dynamic_graph/operator_metatypes.py
+++ b/nncf/dynamic_graph/operator_metatypes.py
@@ -280,6 +280,11 @@ class LayerNormMetatype(OperatorMetatype):
     torch_nn_functional_patch_spec = PatchSpec([name])
     hw_config_names = [HWConfigOpName.MVN]
 
+@OPERATOR_METATYPES.register()
+class GroupNormMetatype(OperatorMetatype):
+    name = "group_norm"
+    torch_nn_functional_patch_spec = PatchSpec([name])
+
 
 @OPERATOR_METATYPES.register()
 class GELUMetatype(OperatorMetatype):

--- a/nncf/nncf_network.py
+++ b/nncf/nncf_network.py
@@ -866,8 +866,9 @@ class NNCFNetwork(nn.Module, PostGraphBuildActing):
         general_conv_types = [v.op_func_name for v in NNCF_GENERAL_CONV_MODULES_DICT]
         for node in self._original_graph.get_nodes_by_types(general_conv_types):
             scope = node.op_exec_context.scope_in_model
+            input_agnostic = node.op_exec_context.input_agnostic
             module = self.get_module_by_scope(scope)
-            nx_node = self._original_graph.find_node_in_nx_graph_by_scope(scope)
+            nx_node = self._original_graph.find_node_in_nx_graph_by_input_agnostic(input_agnostic)
             nx_node[NNCFGraph.MODULE_ATTRIBUTES] = ConvolutionModuleAttributes(module.weight.requires_grad,
                                                                                module.in_channels,
                                                                                module.out_channels,

--- a/nncf/pruning/model_analysis.py
+++ b/nncf/pruning/model_analysis.py
@@ -70,7 +70,9 @@ class Clusterization:
 
         for node in self.clusters[cluster_id].nodes:
             node_id = getattr(node, self._id_attr)
-            self._node_to_cluster.pop(node_id)
+            if node_id in self._node_to_cluster:
+                #TODO:
+                self._node_to_cluster.pop(node_id)
         self.clusters.pop(cluster_id)
 
     def get_all_clusters(self) -> List[NodesCluster]:

--- a/nncf/pruning/model_analysis.py
+++ b/nncf/pruning/model_analysis.py
@@ -67,12 +67,9 @@ class Clusterization:
     def delete_cluster(self, cluster_id: int):
         if cluster_id not in self.clusters:
             raise IndexError('No cluster with index = {} to delete'.format(cluster_id))
-
         for node in self.clusters[cluster_id].nodes:
             node_id = getattr(node, self._id_attr)
-            if node_id in self._node_to_cluster:
-                #TODO:
-                self._node_to_cluster.pop(node_id)
+            self._node_to_cluster.pop(node_id)
         self.clusters.pop(cluster_id)
 
     def get_all_clusters(self) -> List[NodesCluster]:
@@ -97,6 +94,10 @@ class Clusterization:
             for node in cluster_1.nodes:
                 self._node_to_cluster[getattr(node, self._id_attr)] = second_id
             self.clusters.pop(first_id)
+
+    def merge_list_of_cluster(self, clusters: List[int]):
+        for cluster_id in clusters[:-1]:
+            self.merge_clusters(clusters[-1], cluster_id)
 
 
 def get_position(nx_nodes_list, idx):

--- a/tests/pruning/helpers.py
+++ b/tests/pruning/helpers.py
@@ -260,6 +260,33 @@ class TestModelShuffleNetUnitDW(nn.Module):
         x = self.unit1(x)
         return x
 
+
+class TestModelMultipleForward(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = create_conv(2, 16, 1, 1, -2)
+        for i in range(16):
+            self.conv1.weight.data[i] += i
+        self.conv2 = create_conv(2, 16, 1, 1, -2)
+        for i in range(16):
+            self.conv2.weight.data[i] += i
+        self.conv3 = create_conv(2, 16, 1, 1, -2)
+        # Wights of conv3 is initialized to check difference masks
+        self.conv4 = create_conv(16, 16, 1, 1, -2)
+        for i in range(16):
+            self.conv4.weight.data[i] += i
+
+    def forward(self, x):
+        x1 = self.conv1(x)
+        x2 = self.conv2(x)
+        x3 = self.conv3(x)
+        x1 = self.conv4(x1)
+        x2 = self.conv4(x2)
+        x3 = self.conv4(x3)
+
+        return x1, x2, x3
+
+
 def get_basic_pruning_config(input_sample_size=None) -> NNCFConfig:
     if input_sample_size is None:
         input_sample_size = [1, 1, 4, 4]


### PR DESCRIPTION
Nncf_network:
-  use `find_node_in_nx_graph_by_input_agnostic` instead of `find_node_in_nx_graph_by_scope` to set `ConvolutionModuleAttributes` for nodes
- Add `GroupNormMetatype`

Pruning:
 - Merge nodes that forwards several times into cluster 
 - Check nodes that already added to one of clusters