### PR TITLE
Optional parameters support on loading PT checkpoint

### DIFF
--- a/nncf/checkpoint_loading.py
+++ b/nncf/checkpoint_loading.py
@@ -1,5 +1,5 @@
 """
- Copyright (c) 2019-2020 Intel Corporation
+ Copyright (c) 2019-2021 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -10,12 +10,15 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from enum import Enum
+from typing import Dict
+from typing import List
+from typing import Set
 
 import re
 import torch
 
 from nncf.common.utils.logger import logger as nncf_logger
-from nncf.nncf_network import MODEL_WRAPPED_BY_NNCF_ATTR_NAME
 
 
 def load_state(model: torch.nn.Module, state_dict_to_load: dict, is_resume: bool = False) -> int:
@@ -38,97 +41,184 @@ def load_state(model: torch.nn.Module, state_dict_to_load: dict, is_resume: bool
     :return: The number of state_dict_to_load entries successfully matched and loaded into model.
     """
 
-    def key_normalizer(key):
-        new_key = key
-        match = re.search('(pre_ops|post_ops)\\.(\\d+?)\\.op', key)
-        return new_key if not match else new_key.replace(match.group(), 'operation')
-
     if 'state_dict' in state_dict_to_load:
         state_dict_to_load = state_dict_to_load['state_dict']
     model_state_dict = model.state_dict()
 
-    new_dict, num_loaded_layers, problematic_keys = match_keys(is_resume, state_dict_to_load, model_state_dict,
-                                                               key_normalizer)
-    num_saved_layers = len(state_dict_to_load.items())
-    process_problematic_keys(is_resume, problematic_keys, num_loaded_layers == num_saved_layers)
-    nncf_logger.info("Loaded {}/{} layers".format(num_loaded_layers, len(model_state_dict.items())))
+    key_matcher = KeyMatcher(is_resume, state_dict_to_load, model_state_dict)
+    new_dict = key_matcher.run()
+    num_loaded_params = len(new_dict)
+    key_matcher.handle_problematic_keys()
+    nncf_logger.info("Loaded {}/{} parameters".format(num_loaded_params, len(model_state_dict.items())))
 
     model.load_state_dict(new_dict, strict=False)
-    return num_loaded_layers
+    return num_loaded_params
 
 
-def process_problematic_keys(is_resume, issues, is_all_saved_loaded):
-    error_msgs = []
+class OptionalParametersRegistry:
+    """
+    Provides an interface to register optional parameters and get access to all of them.
+    If there is no optional parameters in a checkpoint, it can be loaded without an error in a strict mode.
+    New parameters can be introduced for the model without breaking backward compatibility with old checkpoint.
+    """
 
-    def add_error_msg(name, keys):
-        error_msgs.insert(
-            0, '{} key(s):\n{}. '.format(name,
-                                         ',\n'.join('\t\t"{}"'.format(k) for k in keys)))
+    def __init__(self):
+        self._optional_parameters_names = set()
 
-    for name, keys in issues.items():
-        is_missing = name == 'Missing'
-        if keys and (not is_missing or is_missing and (is_resume or not is_all_saved_loaded)):
-            add_error_msg(name, keys)
-    if error_msgs:
-        error_msg = 'Error(s) when loading model parameters:\n\t{}'.format("\n\t".join(error_msgs))
-        if is_resume:
-            raise RuntimeError(error_msg)
-        nncf_logger.warning(error_msg)
+    def register(self, parameter_name: str):
+        self._optional_parameters_names.add(parameter_name)
+
+    def get_optional_parameters_names(self) -> Set[str]:
+        return self._optional_parameters_names
 
 
-def match_keys(is_resume, state_dict_to_load, model_state_dict, key_normalizer):
-    skipped_keys = []
-    num_loaded_layers = 0
-    new_dict = {}
+OPTIONAL_PARAMETERS_REGISTRY = OptionalParametersRegistry()
 
-    def check_parameter_size(key, value_to_load, num_loaded_layers):
-        size_of_value_to_load = value_to_load.size()
-        size = model_state_dict[key].size()
-        if size_of_value_to_load == size:
-            new_dict[key] = value_to_load
-            return num_loaded_layers + 1
-        nncf_logger.warning("Different size of value of '{}' in resuming dictionary ({}) and in model ({})"
-                            .format(key, size_of_value_to_load, size, ))
-        skipped_keys.append(key)
-        return num_loaded_layers
 
-    clip_patterns = [MODEL_WRAPPED_BY_NNCF_ATTR_NAME + '.',
-                     'module.']
+class ProcessedKeyStatus(Enum):
+    """ Status of matching checkpoint key with model keys """
+    MATCHED = 'Matched'
+    MISSING = 'Missing'
+    UNEXPECTED = 'Unexpected'
+    SIZE_MISMATCHED = 'Size mismatched'
+    SKIPPED = 'Skipped'
 
-    clipped_keys = list(model_state_dict.keys())
-    for pattern in clip_patterns:
-        for i, _ in enumerate(clipped_keys):
-            clipped_keys[i] = clipped_keys[i].replace(pattern, '')
 
-    clipped_key_to_model_key_dict = dict(zip(clipped_keys, model_state_dict.keys()))
+class ProcessedKeys:
+    """ Contains checkpoint keys with their status of matching with model keys """
+    def __init__(self):
+        self._keys = {}  # type: Dict[ProcessedKeyStatus, List[str]]
+        for key_status in ProcessedKeyStatus:
+            self._keys[key_status] = []
 
-    norm_clipped_keys = {}
-    collisions = []
-    for clipped_key, orig_key in clipped_key_to_model_key_dict.items():
-        normalized_key = key_normalizer(clipped_key)
-        if normalized_key in norm_clipped_keys:
-            collisions.append(clipped_key)
-        norm_clipped_keys[normalized_key] = orig_key
+    def add_key(self, key: str, status: ProcessedKeyStatus):
+        self._keys[status].append(key)
 
-    unexpected_keys = []
+    def extend_keys(self, keys: List[str], status: ProcessedKeyStatus):
+        self._keys[status].extend(keys)
 
-    for (saved_key, saved_value) in state_dict_to_load.items():
-        clipped_saved_key = saved_key
+    def add_skipped_and_missing_keys(self, model_state_dict: Dict[str, torch.Tensor]):
+        all_processed_keys = []
+        params_to_skip = tuple('.' + name for name in OPTIONAL_PARAMETERS_REGISTRY.get_optional_parameters_names())
+        for keys in self._keys.values():
+            all_processed_keys.extend(keys)
+
+        for key in model_state_dict.keys():
+            if key not in all_processed_keys:
+                if key.endswith(params_to_skip):
+                    self.add_key(key, ProcessedKeyStatus.SKIPPED)
+                    nncf_logger.warning("The optional parameter {} is missed in the loaded state".format(key))
+                else:
+                    self.add_key(key, ProcessedKeyStatus.MISSING)
+
+    def handle_problematic(self, is_resume: bool, are_all_loaded_params_matched: bool):
+        """
+        Reports about errors during the matching state_dict_to_load parameters to the model's state_dict ones.
+        It raises an error if is_resume is True or prints warning when it's False. The report happens if
+        state_dict_to_load has parameters that could not be matched to model parameters or if the shape of parameters is
+        not matching. If some parameters required by model are missing in state_dict_to_load reporting occurs for
+        non optional parameters only or when not all parameters from state_dict_to_load match.
+        :param is_resume: Determines the behavior when the function cannot do a successful parameter match when loading.
+        :param are_all_loaded_params_matched: whether all parameters to load match with model parameters
+        """
+        error_msgs = []
+
+        def add_error_msg(name, keys_):
+            error_msgs.insert(
+                0, '{} key(s):\n{}. '.format(name,
+                                             ',\n'.join('\t\t"{}"'.format(k) for k in keys_)))
+
+        for key_status, keys in self._keys.items():
+            is_missing = key_status == ProcessedKeyStatus.MISSING
+            erroneous = key_status in (ProcessedKeyStatus.SIZE_MISMATCHED, ProcessedKeyStatus.UNEXPECTED)
+            if keys and (erroneous or is_missing and (is_resume or not are_all_loaded_params_matched)):
+                add_error_msg(key_status.value, keys)
+        if error_msgs:
+            error_msg = 'Error(s) when loading model parameters:\n\t{}'.format("\n\t".join(error_msgs))
+            if is_resume:
+                raise RuntimeError(error_msg)
+            nncf_logger.warning(error_msg)
+
+
+class KeyMatcher:
+    """
+    Matches state_dict_to_load parameters to the model's state_dict parameters while discarding irrelevant prefixes
+    added during wrapping in NNCFNetwork or DataParallel/DistributedDataParallel objects, skipping registered optional
+    parameters, and forms the model state dict with matched parameters.
+    """
+
+    def __init__(self, is_resume: bool,
+                 state_dict_to_load: Dict[str, torch.Tensor], model_state_dict: Dict[str, torch.Tensor]):
+        self._is_resume = is_resume
+        self.state_dict_to_load = state_dict_to_load
+
+        self.model_state_dict = model_state_dict
+        self._processed_keys = ProcessedKeys()
+        self._new_dict = {}
+        self._num_params_to_load = len(state_dict_to_load.items())
+
+    def run(self) -> Dict[str, torch.Tensor]:
+        """
+        :return: the model state dict with matched parameters
+        """
+        from nncf.nncf_network import MODEL_WRAPPED_BY_NNCF_ATTR_NAME
+        clip_patterns = [MODEL_WRAPPED_BY_NNCF_ATTR_NAME + '.', 'module.']
+
+        clipped_keys = list(self.model_state_dict.keys())
         for pattern in clip_patterns:
-            clipped_saved_key = clipped_saved_key.replace(pattern, '')
+            for i, _ in enumerate(clipped_keys):
+                clipped_keys[i] = clipped_keys[i].replace(pattern, '')
 
-        if clipped_saved_key in clipped_key_to_model_key_dict:
-            key = clipped_key_to_model_key_dict[clipped_saved_key]
-            num_loaded_layers = check_parameter_size(key, saved_value, num_loaded_layers)
-        else:
-            norm_clipped_saved_key = key_normalizer(clipped_saved_key)
-            if norm_clipped_saved_key in norm_clipped_keys and clipped_saved_key not in collisions and not is_resume:
-                key = norm_clipped_keys[norm_clipped_saved_key]
-                num_loaded_layers = check_parameter_size(key, saved_value, num_loaded_layers)
+        clipped_key_to_model_key_dict = dict(zip(clipped_keys, self.model_state_dict.keys()))
+
+        norm_clipped_keys = {}
+        collisions = []
+        for clipped_key, orig_key in clipped_key_to_model_key_dict.items():
+            normalized_key = self._key_normalizer(clipped_key)
+            if normalized_key in norm_clipped_keys:
+                collisions.append(clipped_key)
+            norm_clipped_keys[normalized_key] = orig_key
+
+        for (saved_key, saved_value) in self.state_dict_to_load.items():
+            clipped_saved_key = saved_key
+            for pattern in clip_patterns:
+                clipped_saved_key = clipped_saved_key.replace(pattern, '')
+
+            if clipped_saved_key in clipped_key_to_model_key_dict:
+                key = clipped_key_to_model_key_dict[clipped_saved_key]
+                self._check_parameter_size(key, saved_value)
             else:
-                unexpected_keys.append(saved_key)
-    missing_keys = [k for k in model_state_dict.keys() if k not in new_dict and k not in skipped_keys]
-    problematic_keys = {'Missing': missing_keys,
-                        'Unexpected': unexpected_keys,
-                        'Skipped': skipped_keys}
-    return new_dict, num_loaded_layers, problematic_keys
+                norm_clipped_saved_key = self._key_normalizer(clipped_saved_key)
+                in_norm_clipped = norm_clipped_saved_key in norm_clipped_keys
+                not_in_collisions = clipped_saved_key not in collisions
+                if in_norm_clipped and not_in_collisions and not self._is_resume:
+                    key = norm_clipped_keys[norm_clipped_saved_key]
+                    self._check_parameter_size(key, saved_value)
+                else:
+                    self._processed_keys.add_key(saved_key, ProcessedKeyStatus.UNEXPECTED)
+        self._processed_keys.add_skipped_and_missing_keys(self.model_state_dict)
+        return self._new_dict
+
+    def handle_problematic_keys(self):
+        """
+        Reports about errors during the matching state_dict_to_load parameters to the model's state_dict ones.
+        """
+        num_matched_params = len(self._new_dict)
+        self._processed_keys.handle_problematic(self._is_resume, num_matched_params == self._num_params_to_load)
+
+    @staticmethod
+    def _key_normalizer(key: str) -> str:
+        new_key = key
+        match = re.search('(pre_ops|post_ops)\\.(\\d+?)\\.op', key)
+        return new_key if not match else new_key.replace(match.group(), 'operation')
+
+    def _check_parameter_size(self, key: str, value_to_load: torch.Tensor):
+        size_of_value_to_load = value_to_load.size()
+        size = self.model_state_dict[key].size()
+        if size_of_value_to_load == size:
+            self._new_dict[key] = value_to_load
+            self._processed_keys.add_key(key, ProcessedKeyStatus.MATCHED)
+        else:
+            nncf_logger.warning("Different size of value of '{}' in resuming dictionary ({}) and in model ({})"
+                                .format(key, size_of_value_to_load, size, ))
+            self._processed_keys.add_key(key, ProcessedKeyStatus.SIZE_MISMATCHED)

--- a/nncf/quantization/layers.py
+++ b/nncf/quantization/layers.py
@@ -19,6 +19,7 @@ import torch.nn as nn
 from functools import partial
 from torch import distributed
 
+from nncf.checkpoint_loading import OPTIONAL_PARAMETERS_REGISTRY
 from nncf.debug import is_debug
 from nncf.functions import clamp
 from nncf.common.utils.logger import logger as nncf_logger
@@ -72,12 +73,14 @@ class BaseQuantizer(nn.Module):
         self._signedness_to_force = qspec.signedness_to_force
         self._is_using_log_scale_storage = qspec.logarithm_scale
         self._num_bits = nn.Parameter(torch.IntTensor([qspec.num_bits]), requires_grad=False)
+        OPTIONAL_PARAMETERS_REGISTRY.register('_num_bits')
         self.level_high = None
         self.level_low = None
 
         self.levels = 0
-
-        self.register_buffer('enabled', torch.IntTensor([1]))
+        ENABLED_VAR_NAME = 'enabled'
+        self.register_buffer(ENABLED_VAR_NAME, torch.IntTensor([1]))
+        OPTIONAL_PARAMETERS_REGISTRY.register(ENABLED_VAR_NAME)
         self.initialized = False
         self.state_dict_name = None
         self.call_count = 0

--- a/tests/test_load_model.py
+++ b/tests/test_load_model.py
@@ -10,14 +10,22 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from typing import Dict
+from typing import List
+from typing import Set
 
 import os
+import pytest
 import torch
 
 from examples.common.model_loader import load_model
+from nncf.checkpoint_loading import KeyMatcher
+from nncf.checkpoint_loading import OPTIONAL_PARAMETERS_REGISTRY
+from nncf.checkpoint_loading import ProcessedKeyStatus
+from nncf.checkpoint_loading import ProcessedKeys
 from nncf.checkpoint_loading import load_state
-from tests.quantization.test_functions import check_equal
 from tests.helpers import BasicConvTestModel
+from tests.quantization.test_functions import check_equal
 
 
 def test_export_sq_11_is_ok(tmp_path):
@@ -57,3 +65,174 @@ def test_load_state_skips_not_matched_params__from_smaller_to_larger():
     act_weights = model_load.conv.weight.data
     check_equal(act_bias, ref_bias)
     check_equal(act_weights, ref_weights)
+
+
+class MatchKeyDesc:
+    MOCKED_VALUE = torch.zeros([1])
+
+    def __init__(self, num_loaded=0, is_resume=True, expects_error=False,
+                 state_dict_to_load: Dict[str, torch.Tensor] = None,
+                 model_state_dict: Dict[str, torch.Tensor] = None):
+        self.state_dict_to_load = state_dict_to_load if state_dict_to_load else {}
+        self.model_state_dict = model_state_dict if model_state_dict else {}
+        self.new_dict: Dict[str, torch.Tensor] = {}
+        self.num_loaded = num_loaded
+        self.processed_keys = ProcessedKeys()
+        self.is_resume = is_resume
+        self.expects_error = expects_error
+
+    def __str__(self):
+        result = '-'.join(self.state_dict_to_load.keys()) + '__TO__' + '-'.join(self.model_state_dict.keys())
+        if self.is_resume:
+            result += '__resume'
+        return result
+
+    def setup_test(self, mocker):
+        pass
+
+    def keys_to_load(self, keys: List[str]):
+        for k in keys:
+            self.state_dict_to_load[k] = self.MOCKED_VALUE
+        return self
+
+    def model_keys(self, keys: List[str]):
+        for k in keys:
+            self.model_state_dict[k] = self.MOCKED_VALUE
+        return self
+
+    def missing(self, keys: List[str]):
+        self.processed_keys.extend_keys(keys, ProcessedKeyStatus.MISSING)
+        return self
+
+    def unexpected(self, keys: List[str]):
+        self.processed_keys.extend_keys(keys, ProcessedKeyStatus.UNEXPECTED)
+        return self
+
+    def size_mismatched(self, keys: List[str]):
+        self.processed_keys.extend_keys(keys, ProcessedKeyStatus.SIZE_MISMATCHED)
+        return self
+
+    def matched(self, keys: List[str]):
+        self.processed_keys.extend_keys(keys, ProcessedKeyStatus.MATCHED)
+        return self
+
+    def skipped(self, keys: List[str]):
+        self.processed_keys.extend_keys(keys, ProcessedKeyStatus.SKIPPED)
+        return self
+
+    def all_not_matched(self):
+        self.unexpected(list(self.state_dict_to_load))
+        self.missing(list(self.model_state_dict))
+        return self
+
+    def all_matched(self):
+        self.matched(list(self.model_state_dict))
+        return self
+
+
+OP1 = 'op1'
+OP2 = 'op2'
+PREFIX = 'prx'
+SUFFIX = 'sfx'
+OP1_NOT_PARAM = f'{PREFIX}_{OP1}'
+OP1_SUFFIX = f'{PREFIX}.{OP1}'
+OP1_PREFIX = f'{OP1}.{SUFFIX}'
+OP2_SUFFIX = f'{PREFIX}.{OP2}'
+OP2_NOT_PARAM = f'{PREFIX}_{OP2}'
+OP2_MIDDLE = f'{PREFIX}.{OP2}.{SUFFIX}'
+
+
+class OptionalMatchKeyDesc(MatchKeyDesc):
+    def setup_test(self, mocker):
+        def fn() -> Set['str']:
+            return {OP1, OP2}
+
+        mocked_registry_get = mocker.patch.object(OPTIONAL_PARAMETERS_REGISTRY, 'get_optional_parameters_names')
+        mocked_registry_get.side_effect = fn
+
+
+MATCH_KEY_DESC_LIST = [
+    MatchKeyDesc(num_loaded=0, expects_error=True,
+                 state_dict_to_load={'1': torch.zeros(1)},
+                 model_state_dict={'1': torch.zeros(2)})
+        .size_mismatched(['1']),
+    MatchKeyDesc(num_loaded=0, is_resume=False,
+                 state_dict_to_load={'1': torch.zeros(1)},
+                 model_state_dict={'1': torch.zeros(2)})
+        .size_mismatched(['1']),
+    MatchKeyDesc(num_loaded=1, is_resume=False,
+                 state_dict_to_load={'1': torch.zeros(1)},
+                 model_state_dict={'1': torch.zeros(2)}).keys_to_load(['2']).model_keys(['2', '3'])
+        .size_mismatched(['1']).missing(['3']).matched(['2']),
+    MatchKeyDesc(num_loaded=1, is_resume=False,
+                 state_dict_to_load={'1': torch.zeros(1)},
+                 model_state_dict={'1': torch.zeros(2)}).keys_to_load(['2', '4']).model_keys(['2', '3'])
+        .size_mismatched(['1']).missing(['3']).unexpected(['4']).matched(['2']),
+    MatchKeyDesc(num_loaded=2).keys_to_load(['1', '2']).model_keys(['1', '2'])
+        .all_matched(),
+    MatchKeyDesc(num_loaded=1, expects_error=True).keys_to_load(['1', '2']).model_keys(['1'])
+        .unexpected(['2']).matched(['1']),
+    MatchKeyDesc(num_loaded=1, expects_error=True).keys_to_load(['1']).model_keys(['1', '2'])
+        .missing(['2']).matched(['1']),
+    MatchKeyDesc(num_loaded=1, is_resume=False).keys_to_load(['1']).model_keys(['1', '2'])
+        .missing(['2']).matched(['1']),
+    MatchKeyDesc(num_loaded=2).keys_to_load(['module.1', 'nncf_module.2']).model_keys(['1', '2'])
+        .all_matched(),
+    MatchKeyDesc(num_loaded=2).keys_to_load(['1', '2']).model_keys(['module.1', 'nncf_module.2'])
+        .all_matched(),
+    MatchKeyDesc(num_loaded=2).keys_to_load(['module.nncf_module.1', 'module.2']).model_keys(['1', 'nncf_module.2'])
+        .all_matched(),
+    MatchKeyDesc(num_loaded=0, expects_error=True)
+        .keys_to_load(['module.nncf_module.1.1', 'module.2']).model_keys(['1', '2.2'])
+        .all_not_matched(),
+    MatchKeyDesc(num_loaded=0, expects_error=True)
+        .keys_to_load(['pre_ops.0.op.1', 'pre_ops.1.op.2']).model_keys(['pre_ops.1.op.1', 'pre_ops.0.op.2'])
+        .all_not_matched(),
+    MatchKeyDesc(num_loaded=2, is_resume=False)
+        .keys_to_load(['pre_ops.0.op.1', 'pre_ops.1.op.2']).model_keys(['pre_ops.1.op.1', 'pre_ops.0.op.2'])
+        .all_matched(),
+
+    OptionalMatchKeyDesc(num_loaded=1)
+        .keys_to_load([OP1_PREFIX])
+        .model_keys([OP1_PREFIX, OP1_SUFFIX, OP2_SUFFIX])
+        .matched([OP1_PREFIX]).skipped([OP1_SUFFIX, OP2_SUFFIX]),
+    OptionalMatchKeyDesc(num_loaded=1, expects_error=True)
+        .keys_to_load([OP1_PREFIX, OP2_MIDDLE])
+        .model_keys([OP1_PREFIX, OP1_SUFFIX, OP2_SUFFIX])
+        .unexpected([OP2_MIDDLE]).matched([OP1_PREFIX]).skipped([OP1_SUFFIX, OP2_SUFFIX]),
+    OptionalMatchKeyDesc(num_loaded=1, expects_error=True)
+        .keys_to_load([OP1_PREFIX])
+        .model_keys([OP1_PREFIX, OP1_SUFFIX, OP2_SUFFIX, OP2_MIDDLE])
+        .missing([OP2_MIDDLE]).matched([OP1_PREFIX]).skipped([OP1_SUFFIX, OP2_SUFFIX]),
+    OptionalMatchKeyDesc(num_loaded=2, expects_error=True)
+        .keys_to_load([OP1_PREFIX, OP1_SUFFIX, OP2_SUFFIX])
+        .model_keys([OP1_PREFIX, OP1_SUFFIX, OP2_MIDDLE])
+        .missing([OP2_MIDDLE]).unexpected([OP2_SUFFIX]).matched([OP1_PREFIX, OP1_SUFFIX]),
+
+    OptionalMatchKeyDesc(num_loaded=1, expects_error=True)
+        .keys_to_load([OP1_PREFIX])
+        .model_keys([OP1_PREFIX, OP1_NOT_PARAM, OP2_NOT_PARAM])
+        .matched([OP1_PREFIX]).missing([OP1_NOT_PARAM, OP2_NOT_PARAM]),
+    OptionalMatchKeyDesc(num_loaded=2, expects_error=True)
+        .keys_to_load([OP1_PREFIX, OP1_NOT_PARAM, OP2_NOT_PARAM])
+        .model_keys([OP1_PREFIX, OP1_NOT_PARAM, OP2_MIDDLE])
+        .missing([OP2_MIDDLE]).unexpected([OP2_NOT_PARAM]).matched([OP1_PREFIX, OP1_NOT_PARAM]),
+]
+
+
+@pytest.mark.parametrize('desc', MATCH_KEY_DESC_LIST, ids=[str(d) for d in MATCH_KEY_DESC_LIST])
+def test_match_key(desc: MatchKeyDesc, mocker):
+    desc.setup_test(mocker)
+
+    key_matcher = KeyMatcher(desc.is_resume, desc.state_dict_to_load, desc.model_state_dict)
+    new_dict = key_matcher.run()
+    num_loaded_layers = len(new_dict)
+
+    assert num_loaded_layers == desc.num_loaded
+    # pylint: disable=protected-access
+    assert key_matcher._processed_keys._keys == desc.processed_keys._keys
+    if desc.expects_error:
+        with pytest.raises(RuntimeError):
+            key_matcher.handle_problematic_keys()
+    else:
+        key_matcher.handle_problematic_keys()


### PR DESCRIPTION
Also refactored load_data functionality

This feature is needed for #518 to not update all checkpoints when new parameter is introduced.
Instead, if old checkpoint doesn't have this new optional attribute, it can be successfully loaded even in a resume mode. The new attribute will be initialized by default (e.g. padding_value=0)