### PR TITLE
[TF] update requirements

### DIFF
--- a/beta/requirements.txt
+++ b/beta/requirements.txt
@@ -1,4 +1,4 @@
-absl-py~=0.10
+absl-py==0.10
 addict
 networkx
 tensorflow==2.4.0


### PR DESCRIPTION
Fixed absl-py version to avoid the following error during installation:

`ERROR: tensorflow-metadata 0.28.0 has requirement absl-py<0.11,>=0.9, but you'll have absl-py 0.11.0 which is incompatible.`