### PR TITLE
Propagate masks before apply masks

### DIFF
--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -2,7 +2,7 @@
 
 #### Filter pruning    
 
- Filter pruning algorithm zeros output filters in Convolutional layers based on some filter importance criterion  (filters with smaller importance are pruned).     
+Filter pruning algorithm zeros output filters in Convolutional layers based on some filter importance criterion  (filters with smaller importance are pruned).     
 The framework contains three such criteria: `L1`, `L2` norm, and `Geometric Median`. Also, different schemes of pruning application are presented by different schedulers.    
 
 #### Filter importance criterions **L1, L2**
@@ -90,7 +90,7 @@ sparsity and filter pruning algorithms. It can be enabled by setting a non-zero 
         "prune_first_conv": false, // Whether to prune first Convolutional layers or not. First means that it is a convolutional layer such that there is a path from model input to this layer such that there are no other convolution operations on it. `False` by default. 
         "prune_last_conv": false, // Whether to prune last Convolutional layers or not.  Last means that it is a Convolutional layer such that there is a path from this layer to the model output such that there are no other convolution operations on it. `False` by default. 
         "prune_downsample_convs": false, // Whether to prune downsample Convolutional layers (with stride > 1) or not. `False` by default.
-        "prune_batch_norms": false, // Whether to nullifies parameters of Batch Norm layer corresponds to zeroed filters of convolution corresponding to this Batch Norm. `False` by default.
+        "prune_batch_norms": true, // Whether to nullifies parameters of Batch Norm layer corresponds to zeroed filters of convolution corresponding to this Batch Norm. `True` by default.
         "zero_grad": true // Whether to setting gradients corresponding to zeroed filters to zero during training, `True` by default.    
     },
 
@@ -123,4 +123,3 @@ To do this, the special `can_prune` attribute is propagated through the network.
 The result is a valid graph for the pruned and non-pruned parts: that is, there is no operation that does not accept a pruned input.
 
 3. On the final stage, there is a direct pruning of operations according to the obtained `can_prune` attribute values.
-

--- a/nncf/pruning/base_algo.py
+++ b/nncf/pruning/base_algo.py
@@ -10,9 +10,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from typing import Dict
 
-from functools import partial, update_wrapper
+from functools import partial
+from functools import update_wrapper
 from texttable import Texttable
 from torch import nn
 
@@ -30,7 +30,6 @@ from nncf.dynamic_graph.transformations.commands import PTInsertionCommand
 from nncf.pruning.filter_pruning.layers import apply_filter_binary_mask
 from nncf.common.pruning.pruning_node_selector import PruningNodeSelector
 from nncf.common.pruning.model_analysis import NodesCluster, Clusterization
-from nncf.pruning.utils import get_bn_for_module_scope
 from nncf.pruning.export_helpers import PT_PRUNING_OPERATOR_METATYPES
 
 
@@ -42,13 +41,10 @@ class BatchNormInfo:
 
 
 class PrunedModuleInfo:
-    BN_MODULE_NAME = 'bn_module'
-
-    def __init__(self, module_scope: Scope, module: nn.Module, operand, related_modules: Dict, node_id: int):
+    def __init__(self, module_scope: Scope, module: nn.Module, operand, node_id: int):
         self.module_scope = module_scope
         self.module = module
         self.operand = operand
-        self.related_modules = related_modules
         self.nncf_node_id = node_id
 
 
@@ -119,13 +115,7 @@ class BasePruningAlgoBuilder(PTCompressionAlgorithmBuilder):
                     )
                 )
 
-                related_modules = {}
-                if self.prune_batch_norms:
-                    bn_module, bn_scope = get_bn_for_module_scope(target_model, module_scope)
-                    related_modules[PrunedModuleInfo.BN_MODULE_NAME] = BatchNormInfo(module_scope,
-                                                                                     bn_module, bn_scope)
-
-                minfo = PrunedModuleInfo(module_scope, module, hook, related_modules, node.node_id)
+                minfo = PrunedModuleInfo(module_scope, module, hook, node.node_id)
                 group_minfos.append(minfo)
             cluster = NodesCluster(i, group_minfos, [n.node_id for n in group.nodes])
             self.pruned_module_groups_info.add_cluster(cluster)
@@ -277,7 +267,6 @@ class BasePruningAlgoController(PTCompressionAlgorithmController):
         stats["pruning_statistic_by_module"] = table
         return self.add_algo_specific_stats(stats)
 
-
     def add_algo_specific_stats(self, stats):
         return stats
 
@@ -297,17 +286,6 @@ class BasePruningAlgoController(PTCompressionAlgorithmController):
             layer_info["params_count"] = sum(p.numel() for p in minfo.module.parameters() if p.requires_grad)
 
             layer_info["mask_pr"] = self.pruning_rate_for_mask(minfo)
-
-            if PrunedModuleInfo.BN_MODULE_NAME in minfo.related_modules and \
-                    minfo.related_modules[PrunedModuleInfo.BN_MODULE_NAME].module is not None:
-                bn_info = {}
-                bn_module = minfo.related_modules[PrunedModuleInfo.BN_MODULE_NAME].module
-                bn_info['w_shape'] = bn_module.weight.size()
-
-                bn_info["b_shape"] = bn_module.bias.size() if bn_module.bias is not None else []
-                bn_info['params_count'] = sum(p.numel() for p in bn_module.parameters() if p.requires_grad)
-                bn_info["mask_pr"] = self.pruning_rate_for_mask(minfo)
-                stats[str(minfo.module_scope) + '/BatchNorm'] = bn_info
 
             stats[str(minfo.module_scope)] = layer_info
 

--- a/nncf/pruning/base_algo.py
+++ b/nncf/pruning/base_algo.py
@@ -33,13 +33,6 @@ from nncf.common.pruning.model_analysis import NodesCluster, Clusterization
 from nncf.pruning.export_helpers import PT_PRUNING_OPERATOR_METATYPES
 
 
-class BatchNormInfo:
-    def __init__(self, module_scope: Scope, module: nn.Module, nncf_id: int):
-        self.module = module
-        self.module_scope = module_scope
-        self.nncf_node_id = nncf_id
-
-
 class PrunedModuleInfo:
     def __init__(self, module_scope: Scope, module: nn.Module, operand, node_id: int):
         self.module_scope = module_scope

--- a/nncf/pruning/export_helpers.py
+++ b/nncf/pruning/export_helpers.py
@@ -31,6 +31,7 @@ from nncf.pruning.export_utils import identity_mask_propagation, get_input_masks
     fill_input_masks
 from nncf.layers import NNCF_WRAPPED_USER_MODULES_DICT
 from nncf.pruning.utils import is_depthwise_conv
+from nncf.pruning.filter_pruning.layers import FilterPruningBlock
 
 PT_PRUNING_OPERATOR_METATYPES = PTPruningOperationsMetatypeRegistry("operator_metatypes")
 
@@ -114,8 +115,10 @@ class PTConvolution(PTDefaultMetaOp):
         nncf_node = graph._nx_node_to_nncf_node(nx_node)
         node_module = model.get_module_by_scope(nncf_node.op_exec_context.scope_in_model)
 
-        if node_module.pre_ops:
-            output_mask = node_module.pre_ops['0'].op.binary_filter_pruning_mask
+        for pre_op in node_module.pre_ops.values():
+            if isinstance(pre_op.op, FilterPruningBlock):
+                output_mask = pre_op.op.binary_filter_pruning_mask
+                break
 
         # In case of group convs we can't prune by output filters
         if is_grouped_conv(nncf_node):
@@ -199,8 +202,10 @@ class PTTransposeConvolution(PTDefaultMetaOp):
         nncf_node = graph._nx_node_to_nncf_node(nx_node)
         node_module = model.get_module_by_scope(nncf_node.op_exec_context.scope_in_model)
 
-        if node_module.pre_ops:
-            output_mask = node_module.pre_ops['0'].op.binary_filter_pruning_mask
+        for pre_op in node_module.pre_ops.values():
+            if isinstance(pre_op.op, FilterPruningBlock):
+                output_mask = pre_op.op.binary_filter_pruning_mask
+                break
 
         nx_node['input_masks'] = input_masks
         nx_node['output_mask'] = output_mask
@@ -367,7 +372,8 @@ class PTConcat(PTDefaultMetaOp):
         result_mask = None
 
         if cls.check_concat(nx_node, nx_graph, graph):
-            input_masks, filled_input_masks = fill_input_masks(nx_node, nx_graph)
+            device = next(model.parameters()).device
+            input_masks, filled_input_masks = fill_input_masks(nx_node, nx_graph, device)
 
             if all(mask is None for mask in input_masks):
                 result_mask = None

--- a/nncf/pruning/export_helpers.py
+++ b/nncf/pruning/export_helpers.py
@@ -451,8 +451,6 @@ class ModelPruner:
         """
         cls = PT_PRUNING_OPERATOR_METATYPES.get_operator_metatype_by_op_name(type_name)
         if cls is None:
-            nncf_logger.warning(
-                "Layer {} is not pruneable - will not propagate pruned filters through it".format(type_name))
             cls = PTStopMaskForwardOps
         return cls
 

--- a/nncf/pruning/export_helpers.py
+++ b/nncf/pruning/export_helpers.py
@@ -466,7 +466,6 @@ class ModelPruner:
             node_type = self.graph.node_type_fn(node)
             cls = self.get_class_by_type_name(node_type)
             cls.mask_propagation(self.model, node, self.graph, self.nx_graph)
-        nncf_logger.info('Finished mask propagation in graph')
 
     def apply_mask(self):
         """

--- a/nncf/pruning/export_utils.py
+++ b/nncf/pruning/export_utils.py
@@ -35,7 +35,7 @@ def identity_mask_propagation(nx_node, nx_graph):
     nx_node['output_mask'] = input_masks[0]
 
 
-def fill_input_masks(nx_node, nx_graph):
+def fill_input_masks(nx_node, nx_graph, device='cpu'):
     """
     Return all input masks and all input masks with all None replaced by identity masks.
     """
@@ -45,7 +45,7 @@ def fill_input_masks(nx_node, nx_graph):
     filled_input_masks = []
     for i, mask in enumerate(input_masks):
         if mask is None:
-            mask = torch.ones(nx_graph.edges[input_edges[i]]['activation_shape'][1])
+            mask = torch.ones(nx_graph.edges[input_edges[i]]['activation_shape'][1], device=device)
         filled_input_masks.append(mask)
     return input_masks, filled_input_masks
 

--- a/nncf/pruning/filter_pruning/algo.py
+++ b/nncf/pruning/filter_pruning/algo.py
@@ -467,10 +467,9 @@ class FilterPruningController(BasePruningAlgoController):
         types_to_apply_mask = [v.op_func_name for v in NNCF_GENERAL_CONV_MODULES_DICT] + ['group_norm']
         if self.prune_batch_norms:
             types_to_apply_mask.append('batch_norm')
-        nncf_nodes = graph.get_all_nodes()
+        nx_nodes = [nx_graph.nodes[name] for name in nx_graph]
         pruned_node_modules = list()
-
-        for node in nncf_nodes:
+        for node in nx_nodes:
             node_type = graph.node_type_fn(node)
             if node_type not in types_to_apply_mask:
                 continue

--- a/nncf/pruning/filter_pruning/algo.py
+++ b/nncf/pruning/filter_pruning/algo.py
@@ -25,19 +25,25 @@ from nncf.algo_selector import COMPRESSION_ALGORITHMS
 from nncf.api.compression import CompressionLevel
 from nncf.compression_method_api import PTCompressionAlgorithmController
 from nncf.layers import NNCF_PRUNING_MODULES_DICT
+from nncf.layers import NNCF_GENERAL_CONV_MODULES_DICT
 from nncf.layer_utils import _NNCFModuleMixin
 from nncf.common.utils.logger import logger as nncf_logger
 from nncf.nncf_network import NNCFNetwork
-from nncf.pruning.base_algo import BasePruningAlgoBuilder, PrunedModuleInfo, BasePruningAlgoController
+from nncf.pruning.base_algo import BasePruningAlgoBuilder
+from nncf.pruning.base_algo import PrunedModuleInfo
+from nncf.pruning.base_algo import BasePruningAlgoController
 from nncf.pruning.export_helpers import ModelPruner
 from nncf.pruning.export_helpers import PTElementwise
 from nncf.pruning.export_helpers import PTConvolution
 from nncf.pruning.export_helpers import PTTransposeConvolution
-from nncf.pruning.filter_pruning.functions import calculate_binary_mask, FILTER_IMPORTANCE_FUNCTIONS, \
-    tensor_l2_normalizer
-from nncf.pruning.filter_pruning.layers import FilterPruningBlock, inplace_apply_filter_binary_mask
+from nncf.pruning.filter_pruning.functions import calculate_binary_mask
+from nncf.pruning.filter_pruning.functions import FILTER_IMPORTANCE_FUNCTIONS
+from nncf.pruning.filter_pruning.functions import tensor_l2_normalizer
+from nncf.pruning.filter_pruning.layers import FilterPruningBlock
+from nncf.pruning.filter_pruning.layers import inplace_apply_filter_binary_mask
 from nncf.common.pruning.model_analysis import Clusterization
-from nncf.common.pruning.utils import get_next_nodes_of_types, get_rounded_pruned_element_number
+from nncf.common.pruning.utils import get_next_nodes_of_types
+from nncf.common.pruning.utils import get_rounded_pruned_element_number
 from nncf.common.pruning.schedulers import PRUNING_SCHEDULERS
 from nncf.utils import get_filters_num, compute_FLOPs_hook
 
@@ -449,17 +455,28 @@ class FilterPruningController(BasePruningAlgoController):
                 if module.bias is not None:
                     inplace_apply_filter_binary_mask(mask, module.bias, module_scope)
 
-        for minfo in self.pruned_module_groups_info.get_all_nodes():
-            _apply_binary_mask_to_module_weight_and_bias(minfo.module, minfo.operand.binary_filter_pruning_mask,
-                                                         minfo.module_scope)
 
-            # Applying mask to the BatchNorm node
-            related_modules = minfo.related_modules
-            if minfo.related_modules is not None and PrunedModuleInfo.BN_MODULE_NAME in minfo.related_modules \
-                    and related_modules[PrunedModuleInfo.BN_MODULE_NAME].module is not None:
-                bn_module = related_modules[PrunedModuleInfo.BN_MODULE_NAME].module
-                _apply_binary_mask_to_module_weight_and_bias(bn_module, minfo.operand.binary_filter_pruning_mask,
-                                                             minfo.module_scope)
+        # 1. Propagate masks for all modules
+        graph = self.model.get_original_graph()
+        # pylint: disable=protected-access
+        nx_graph = graph._nx_graph
+        model_pruner = ModelPruner(self.model, graph, nx_graph)
+        model_pruner.mask_propagation()
+
+        # 2. Apply masks
+        node_types = [v.op_func_name for v in NNCF_GENERAL_CONV_MODULES_DICT] + ["batch_norm"]
+        nncf_nodes = [nx_graph.nodes[name] for name in nx_graph]
+        pruned_node_modules = list()
+        with torch.no_grad():
+            for node in nncf_nodes:
+                node_type = graph.node_type_fn(node)
+                if node_type not in node_types:
+                    continue
+                nncf_node = graph._nx_node_to_nncf_node(node)
+                scope = nncf_node.op_exec_context.scope_in_model
+                node_module = self.model.get_module_by_scope(scope)
+                if node['output_mask'] is not None and node_module not in pruned_node_modules:
+                    _apply_binary_mask_to_module_weight_and_bias(node_module, node['output_mask'], scope)
 
     @staticmethod
     def create_stats_table_for_pruning_export(old_modules_info, new_modules_info):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,7 +10,11 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from typing import Dict, Callable, Any, Union, List
+from typing import Dict
+from typing import Callable
+from typing import Any
+from typing import Union
+from typing import List
 from typing import Tuple
 
 import numpy as np
@@ -165,7 +169,7 @@ def check_equal(test, reference, rtol=1e-4):
         np.testing.assert_allclose(x, y, rtol=rtol, err_msg="Index: {}".format(i))
 
 
-def create_compressed_model_and_algo_for_test(model: NNCFNetwork, config: NNCFConfig,
+def create_compressed_model_and_algo_for_test(model: Module, config: NNCFConfig,
                                               dummy_forward_fn: Callable[[Module], Any] = None,
                                               wrap_inputs_fn: Callable[[Tuple, Dict], Tuple[Tuple, Dict]] = None,
                                               resuming_state_dict: dict = None) \

--- a/tests/pruning/filter_pruning/test_algo.py
+++ b/tests/pruning/filter_pruning/test_algo.py
@@ -17,13 +17,18 @@ from examples.common.optimizer import make_optimizer, get_parameter_groups
 from nncf.module_operations import UpdateWeight
 from nncf.pruning.filter_pruning.algo import FilterPruningController
 from nncf.pruning.filter_pruning.functions import l2_filter_norm
-from nncf.pruning.filter_pruning.layers import FilterPruningBlock, apply_filter_binary_mask
+from nncf.pruning.filter_pruning.layers import FilterPruningBlock
+from nncf.pruning.filter_pruning.layers import apply_filter_binary_mask
 from nncf.common.pruning.schedulers import BaselinePruningScheduler
-from tests.helpers import create_compressed_model_and_algo_for_test, check_correct_nncf_modules_replacement, \
-    create_mock_dataloader
-from tests.pruning.helpers import gen_ref_masks, get_basic_pruning_config, PruningTestModel, BigPruningTestModel, \
-    TestModelMultipleForward
-
+from tests.helpers import create_compressed_model_and_algo_for_test
+from tests.helpers import check_correct_nncf_modules_replacement
+from tests.helpers import create_mock_dataloader
+from tests.pruning.helpers import gen_ref_masks
+from tests.pruning.helpers import get_basic_pruning_config
+from tests.pruning.helpers import PruningTestModel
+from tests.pruning.helpers import BigPruningTestModel
+from tests.pruning.helpers import TestModelMultipleForward
+from tests.pruning.helpers import PruningTestModelConcatBN
 
 def create_pruning_algo_with_config(config):
     """
@@ -194,6 +199,7 @@ def test_applying_masks(prune_bn):
     config['compression']['params']['prune_batch_norms'] = prune_bn
     config['compression']['params']['prune_first_conv'] = True
     config['compression']['params']['prune_last_conv'] = True
+    config['compression']['pruning_init'] = 0.5
 
     pruned_model, pruning_algo, nncf_modules = create_pruning_algo_with_config(config)
     pruned_module_info = pruning_algo.pruned_module_groups_info.get_all_nodes()
@@ -218,6 +224,34 @@ def test_applying_masks(prune_bn):
         masked_bn_bias = apply_filter_binary_mask(bn_mask, bn_module.bias)
         assert torch.allclose(bn_module.weight, masked_bn_weight)
         assert torch.allclose(bn_module.bias, masked_bn_bias)
+    else:
+        assert sum(bn_module.weight) == len(bn_module.weight)
+        # Can not check bias because bias initialized with zeros
+
+@pytest.mark.parametrize('prune_bn',
+                         [False,
+                          True]
+                         )
+def test_applying_masks_for_bn_after_concat(prune_bn):
+    config = get_basic_pruning_config(input_sample_size=[1, 1, 8, 8])
+    config['compression']['algorithm'] = 'filter_pruning'
+    config['compression']['params']['prune_batch_norms'] = prune_bn
+    config['compression']['params']['prune_first_conv'] = True
+    config['compression']['params']['prune_last_conv'] = True
+    config['compression']['pruning_init'] = 0.5
+    model = PruningTestModelConcatBN()
+    pruned_model, _ = create_compressed_model_and_algo_for_test(model, config)
+
+    bn_modules = [pruned_model.bn, pruned_model.bn1, pruned_model.bn2]
+    for bn_module in bn_modules:
+        if prune_bn:
+            # Check that mask was applied for batch_norm module
+            assert sum(bn_module.weight) == len(bn_module.weight) * 0.5
+            assert sum(bn_module.bias) == len(bn_module.bias) * 0.5
+        else:
+            # Check that mask was not applied for batch_norm module
+            assert sum(bn_module.weight) == len(bn_module.weight)
+            assert sum(bn_module.bias) == len(bn_module.bias)
 
 
 @pytest.mark.parametrize('zero_grad',
@@ -267,7 +301,6 @@ def test_zeroing_gradients(zero_grad):
                 assert torch.allclose(masked_grad, grad)
 
 
-
 @pytest.mark.parametrize(('all_weights', 'pruning_flops_target', 'ref_flops'),
                          [
                              (False, None, 1315008),
@@ -300,11 +333,11 @@ def test_calculation_of_flops(all_weights, pruning_flops_target, ref_flops):
 
 def test_clasters_for_multiple_forward():
     config = get_basic_pruning_config(input_sample_size=[1, 2, 8, 8])
+    config['compression']['algorithm'] = 'filter_pruning'
     config['compression']['params']['all_weights'] = False
     config['compression']['params']['prune_first_conv'] = True
     config['compression']['params']['prune_last_conv'] = True
     config['compression']['pruning_init'] = 0.5
-    config['compression']['algorithm'] = 'filter_pruning'
     model = TestModelMultipleForward()
     _, pruning_algo = create_compressed_model_and_algo_for_test(model, config)
 

--- a/tests/pruning/helpers.py
+++ b/tests/pruning/helpers.py
@@ -142,6 +142,45 @@ class PruningTestModelConcat(nn.Module):
         return x
 
 
+class PruningTestModelConcatBN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = create_conv(1, 16, 1, 1, -2)
+        for i in range(16):
+            self.conv1.weight.data[i] += i
+
+        self.conv2 = create_conv(16, 16, 1, 2, -2)
+        self.conv3 = create_conv(16, 16, 1, 2, -2)
+        for i in range(16):
+            self.conv2.weight.data[i] += i
+            self.conv3.weight.data[i] += i
+        self.relu = nn.ReLU()
+        self.conv4 = create_conv(32, 16, 1, 10, 0)
+        for i in range(16):
+            self.conv4.weight.data[i] += i
+        self.conv5 = create_conv(48, 16, 1, 10, 0)
+
+        self.bn = nn.BatchNorm2d(16)
+        self.bn.bias = torch.nn.Parameter(torch.ones(16))
+
+        self.bn1 = nn.BatchNorm2d(32)
+        self.bn1.bias = torch.nn.Parameter(torch.ones(32))
+
+        self.bn2 = nn.BatchNorm2d(48)
+        self.bn2.bias = torch.nn.Parameter(torch.ones(48))
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.bn(x)
+        x = torch.cat([self.conv2(x), self.conv3(x)], dim=1)
+        x1 = self.bn1(x)
+        x1 = self.conv4(x1)
+        x = torch.cat([x, x1], dim=1)
+        x = self.bn2(x)
+        x = self.conv5(x)
+        return x
+
+
 class PruningTestModelEltwise(nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
REF: 50604

In some case (like DenseNet) when batch_norm layer is after not convolution layer we should propagate masks to apply actual mask for this batch_norm layer

```
conv1 conv2 
  \    / 
  concat
    | 
batch_norm 
```
