### PR TITLE
Fixed re-write metrics in json

### DIFF
--- a/examples/common/utils.py
+++ b/examples/common/utils.py
@@ -77,12 +77,8 @@ def get_name(config):
 def write_metrics(acc, filename):
     avg = round(acc * 100, 2)
     metrics = {"Accuracy": avg}
-    if os.path.isfile(filename):
-        with open(filename, 'r+') as metric_file:
-            json.dump(metrics, metric_file)
-    else:
-        with open(filename, 'w') as outfile:
-            json.dump(metrics, outfile)
+    with open(filename, 'w') as outfile:
+        json.dump(metrics, outfile)
 
 
 def configure_paths(config):


### PR DESCRIPTION
Sometime when writing metrics in json file, there is a failure - extra bracket is appears in json file ( {"Accuracy": 78.2}} ), and when collecting common table, script return error, for example - 165 build. This PR trying to fix it. (See 166 build)