### PR TITLE
Test sota checkpoint, batch size fix

### DIFF
--- a/beta/tests/sota_checkpoints_eval.json
+++ b/beta/tests/sota_checkpoints_eval.json
@@ -161,7 +161,7 @@
                     "weights": "retinanet/retinanet.h5",
                     "metric_type": "mAP",
                     "model_description": "retinanet",
-                    "batch": 40
+                    "batch_per_gpu": 1
                 },
                 "retinanet_int8_w_sym_t_a_sym_t": {
                     "config": "examples/tensorflow/object_detection/configs/quantization/retinanet_coco_int8.json",
@@ -171,7 +171,7 @@
                     "metric_type": "mAP",
                     "model_description": "retinanet_int8_w_sym_t_a_sym_t",
                     "compression_description": "INT8",
-                    "batch": 40
+                    "batch_per_gpu": 1
                 },
                 "retinanet_sparsity_50": {
                     "config": "examples/tensorflow/object_detection/configs/sparsity/retinanet_coco_magnitude_sparsity.json",
@@ -181,7 +181,7 @@
                     "metric_type": "mAP",
                     "model_description": "retinanet_sparsity_50",
                     "compression_description": "Sparsity 50",
-                    "batch": 40
+                    "batch_per_gpu": 1
                 },
                 "retinanet_pruning_40": {
                     "config": "examples/tensorflow/object_detection/configs/pruning/retinanet_coco_pruning.json",
@@ -191,7 +191,7 @@
                     "metric_type": "mAP",
                     "model_description": "retinanet_pruning_40",
                     "compression_description": "Filter pruning 40%",
-                    "batch": 40,
+                    "batch_per_gpu": 1,
                     "diff_fp32_min": -1,
                     "diff_fp32_max": 0.4
                 }
@@ -208,7 +208,7 @@
                     "weights": "mask_rcnn_baseline",
                     "metric_type": "mAP",
                     "model_description": "mask_rcnn_baseline",
-                    "batch": 16
+                    "batch_per_gpu": 1
                 },
                 "mask_rcnn_int8_w_sym_t_a_sym_t": {
                     "config": "examples/tensorflow/segmentation/configs/quantization/mask_rcnn_coco_int8.json",

--- a/beta/tests/sota_checkpoints_eval.json
+++ b/beta/tests/sota_checkpoints_eval.json
@@ -161,7 +161,7 @@
                     "weights": "retinanet/retinanet.h5",
                     "metric_type": "mAP",
                     "model_description": "retinanet",
-                    "batch_per_gpu": 1
+                    "batch_per_gpu": 15
                 },
                 "retinanet_int8_w_sym_t_a_sym_t": {
                     "config": "examples/tensorflow/object_detection/configs/quantization/retinanet_coco_int8.json",
@@ -171,7 +171,7 @@
                     "metric_type": "mAP",
                     "model_description": "retinanet_int8_w_sym_t_a_sym_t",
                     "compression_description": "INT8",
-                    "batch_per_gpu": 1
+                    "batch_per_gpu": 15
                 },
                 "retinanet_sparsity_50": {
                     "config": "examples/tensorflow/object_detection/configs/sparsity/retinanet_coco_magnitude_sparsity.json",
@@ -181,7 +181,7 @@
                     "metric_type": "mAP",
                     "model_description": "retinanet_sparsity_50",
                     "compression_description": "Sparsity 50",
-                    "batch_per_gpu": 1
+                    "batch_per_gpu": 15
                 },
                 "retinanet_pruning_40": {
                     "config": "examples/tensorflow/object_detection/configs/pruning/retinanet_coco_pruning.json",
@@ -191,7 +191,7 @@
                     "metric_type": "mAP",
                     "model_description": "retinanet_pruning_40",
                     "compression_description": "Filter pruning 40%",
-                    "batch_per_gpu": 1,
+                    "batch_per_gpu": 15,
                     "diff_fp32_min": -1,
                     "diff_fp32_max": 0.4
                 }
@@ -208,7 +208,7 @@
                     "weights": "mask_rcnn_baseline",
                     "metric_type": "mAP",
                     "model_description": "mask_rcnn_baseline",
-                    "batch_per_gpu": 1
+                    "batch_per_gpu": 9
                 },
                 "mask_rcnn_int8_w_sym_t_a_sym_t": {
                     "config": "examples/tensorflow/segmentation/configs/quantization/mask_rcnn_coco_int8.json",
@@ -217,7 +217,8 @@
                     "resume": "mask_rcnn_int8_w_sym_t_a_sym_t",
                     "metric_type": "mAP",
                     "model_description": "mask_rcnn_int8_w_sym_t_a_sym_t",
-                    "compression_description": "INT8"
+                    "compression_description": "INT8",
+		    "batch_per_gpu": 9
                 },
                 "mask_rcnn_sparsity_50": {
                     "config": "examples/tensorflow/segmentation/configs/sparsity/mask_rcnn_coco_magnitude_sparsity.json",
@@ -226,7 +227,8 @@
                     "resume": "mask_rcnn_sparsity_50",
                     "metric_type": "mAP",
                     "model_description": "mask_rcnn_sparsity_50",
-                    "compression_description": "Sparsity 50"
+                    "compression_description": "Sparsity 50",
+		    "batch_per_gpu": 9
                 }
             }
         }

--- a/beta/tests/test_sota_checkpoints.py
+++ b/beta/tests/test_sota_checkpoints.py
@@ -18,6 +18,7 @@ import csv
 import datetime
 from typing import Tuple, List, Optional
 
+import tensorflow as tf
 import pytest
 import subprocess
 import re
@@ -57,6 +58,8 @@ DATASET_TYPE_AVAILABILITY = {
     "segmentation": False,
 }
 
+num_gpus = len(tf.config.list_physical_devices('GPU'))
+BATCH_COEFF = num_gpus if num_gpus else 1
 
 class EvalRunParamsStruct:
     def __init__(self,
@@ -312,10 +315,10 @@ class TestSotaCheckpoints:
                     resume_file = model_dict[model_name].get('resume', {})
                 else:
                     resume_file = None
-                if model_dict[model_name].get('batch', {}):
-                    batch = model_dict[model_name].get('batch', {})
+                if model_dict[model_name].get('batch_per_gpu', {}):
+                    global_batch = model_dict[model_name]['batch_per_gpu'] * BATCH_COEFF
                 else:
-                    batch = None
+                    global_batch = None
                 if model_dict[model_name].get('mean_value', {}):
                     mean_val = model_dict[model_name].get('mean_value', {})
                 else:
@@ -340,7 +343,7 @@ class TestSotaCheckpoints:
                                                           sample_type_=sample_type_,
                                                           resume_file_=resume_file,
                                                           weights_=weights,
-                                                          batch_=batch,
+                                                          batch_=global_batch,
                                                           mean_val_=mean_val,
                                                           scale_val_=scale_val,
                                                           diff_fp32_min_=diff_fp32_min,


### PR DESCRIPTION
What's new:

`batch` key in `beta/tests/sota_checkpoints_eval.json`  renamed to `batch_per_gpu`. 

If `batch_per_gpu` is provided - `global_batch` is getting calculated at `beta/tests/test_sota_checkpoints.py` using the `BATCH_COEFF`.

If `batch_per_gpu` is NOT provided in `beta/tests/sota_checkpoints_eval.json` - the `global_batch` is getting from main model config.