### PR TITLE
Switch gnc_graph calls in test to using positional args

### DIFF
--- a/tests/quantization/test_quantizer_propagation_solver.py
+++ b/tests/quantization/test_quantizer_propagation_solver.py
@@ -59,7 +59,7 @@ def get_mock_model_node_attrs_for_op_name(op_name: str, call_order=0) -> Operati
 
 def get_randomly_connected_model_graph(op_name_keys: List[str]) -> nx.DiGraph:
     graph_len = len(op_name_keys)
-    mock_graph = nx.generators.gnc_graph(graph_len, seed=0)
+    mock_graph = nx.generators.gnc_graph(graph_len, None, 0)
     shuffled_op_names = random.sample(op_name_keys, len(op_name_keys))
     for idx, (_, node) in enumerate(mock_graph.nodes.items()):
         op_name = shuffled_op_names[idx]


### PR DESCRIPTION
The random_index mechanism in networkx looks sketchy as it only
inspects args for a seed value (aka "random_state"), and not kwargs.
This is a workaround for "random_state_index is incorrect" errors.