### PR TITLE
Changed model name in AC config

### DIFF
--- a/beta/tests/tensorflow/data/ac_configs/yolo_v4_int8_w_sym_ch_a_asym_t.yml
+++ b/beta/tests/tensorflow/data/ac_configs/yolo_v4_int8_w_sym_ch_a_asym_t.yml
@@ -1,5 +1,5 @@
 models:
-  - name: yolo_v4
+  - name: yolo_v4_int8_w_sym_ch_a_asym_t
     launchers:
       - framework: dlsdk
         device: CPU


### PR DESCRIPTION
E2E test takes model name from AC config, so name must be unique.