### PR TITLE
Update threshold for yolov4 int8

### DIFF
--- a/beta/tests/sota_checkpoints_eval.json
+++ b/beta/tests/sota_checkpoints_eval.json
@@ -311,7 +311,8 @@
                     "compression_description":"INT8",
                     "batch_per_gpu": 15,
                     "reverse_input_channels": true,
-                    "scale_value": "Placeholder[255]"
+                    "scale_value": "Placeholder[255]",
+                    "diff_target_max": 0.15
                 },
                 "yolo_v4_sparsity_50": {
                     "config":"examples/tensorflow/object_detection/configs/sparsity/yolo_v4_coco_magnitude_sparsity.json",


### PR DESCRIPTION
Last validation disclosed fluctuation in the value of target value of  yolo_v4_int8_w_sym_ch_a_asym_t checkpoint. Mean growth is 0.1, thus I suggest to increase diff target to 0.15