### PR TITLE
Fixed backward compatibility issues

### DIFF
--- a/tests/data/configs/squeezenet1_1_cifar10_rb_sparsity_int8.json
+++ b/tests/data/configs/squeezenet1_1_cifar10_rb_sparsity_int8.json
@@ -4,6 +4,9 @@
     "input_info": {
       "sample_size":  [1, 3, 32, 32]
     },
+    "batch_size": 512,
+    "dataset": "CIFAR10",
+    "epochs": 5,
     "num_classes": 10,
     "optimizer": {
         "type": "sgd",

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -20,12 +20,14 @@ from examples.common.distributed import configure_distributed
 from examples.common.execution import ExecutionMode, prepare_model_for_execution, get_device
 from examples.common.model_loader import load_model
 from examples.common.sample_config import SampleConfig
+from nncf import register_default_init_args
 from nncf.checkpoint_loading import load_state
 from nncf.common.graph.graph import MODEL_INPUT_OP_NAME
 from nncf.config import NNCFConfig
 from nncf.nncf_network import LEGACY_ACT_STORAGE_NAME
 from nncf.nncf_network import MODEL_WRAPPED_BY_NNCF_ATTR_NAME
 from tests.conftest import TEST_ROOT
+from tests.helpers import create_ones_mock_dataloader
 from tests.quantization.test_range_init import SingleConv2dIdentityModel
 from tests.test_compressed_graph import get_basic_quantization_config
 from tests.test_compression_training import get_cli_dict_args
@@ -94,6 +96,7 @@ def test_model_can_be_loaded_with_resume(_params):
                        pretrained=False,
                        num_classes=config.get('num_classes', 1000),
                        model_params=config.get('model_params'))
+    nncf_config = register_default_init_args(nncf_config, train_loader=create_ones_mock_dataloader(nncf_config))
 
     model.to(config.device)
     model, compression_ctrl = create_compressed_model_and_algo_for_test(model, nncf_config)
@@ -136,7 +139,8 @@ def test_loaded_model_evals_according_to_saved_acc(_params, tmp_path, dataset_di
 
     with open(metrics_path) as metric_file:
         metrics = json.load(metric_file)
-        assert torch.load(checkpoint_path)['best_acc1'] == pytest.approx(metrics['Accuracy'])
+        # accuracy is rounded to hundredths
+        assert torch.load(checkpoint_path)['best_acc1'] == pytest.approx(metrics['Accuracy'], abs=1e-2)
 
 
 def test_renamed_activation_quantizer_storage_in_state_dict():

--- a/tests/test_load_model.py
+++ b/tests/test_load_model.py
@@ -222,9 +222,47 @@ MATCH_KEY_DESC_LIST = [
     MatchKeyDesc(num_loaded=0, expects_error=True)
         .keys_to_load(['module.nncf_module.1.1', 'module.2']).model_keys(['1', '2.2'])
         .all_not_matched(),
+
+    # collisions after normalization of keys
+
+    # different order of pre_ops
     MatchKeyDesc(num_loaded=2)
-        .keys_to_load(['pre_ops.0.op.1', 'pre_ops.1.op.2']).model_keys(['pre_ops.1.op.1', 'pre_ops.0.op.2'])
+        .keys_to_load(['pre_ops.0.op.1', 'pre_ops.1.op.2'])
+        .model_keys(['pre_ops.1.op.1', 'pre_ops.0.op.2'])
         .all_matched(),
+    # binarization of activation and weight may have the identical parameter (e.g. enabled)
+    MatchKeyDesc(num_loaded=2)
+        .keys_to_load(['pre_ops.0.op.1', 'pre_ops.1.op.1'])
+        .model_keys(['pre_ops.0.op.1', 'pre_ops.1.op.1'])
+        .all_matched(),
+    MatchKeyDesc(num_loaded=2)
+        .keys_to_load(['nncf_module.pre_ops.1.op.1', 'nncf_module.pre_ops.0.op.1'])
+        .model_keys(['module.nncf_module.pre_ops.1.op.1', 'module.nncf_module.pre_ops.0.op.1'])
+        .all_matched(),
+    # quantization -> quantization + sparsity: op.1 was first, than
+    MatchKeyDesc(num_loaded=2)
+        .keys_to_load(['pre_ops.0.op.1', 'pre_ops.1.op.2'])
+        .model_keys(['pre_ops.1.op.1', 'pre_ops.1.op.2'])
+        .all_matched(),
+    MatchKeyDesc(num_loaded=2)
+        .keys_to_load(['module.1', '1']).model_keys(['module.1', '1'])
+        .all_matched(),
+    MatchKeyDesc(num_loaded=1, expects_error=True)
+        .keys_to_load(['module.1', '1']).model_keys(['module.1'])
+        .matched(['module.1']).unexpected(['module.1']),
+    MatchKeyDesc(num_loaded=2)
+        .keys_to_load(['pre_ops.0.op.1', 'module.pre_ops.1.op.2'])
+        .model_keys(['module.pre_ops.0.op.1|OUTPUT', 'pre_ops.6.op.2'])
+        .all_matched(),
+    MatchKeyDesc(num_loaded=1, expects_error=True)
+        .keys_to_load(['module.1']).model_keys(['module.1', '1'])
+        .matched(['1']).missing(['module.1']),
+    MatchKeyDesc(num_loaded=1, expects_error=True)
+        .keys_to_load(['1']).model_keys(['module.1', '1'])
+        .matched(['1']).missing(['module.1']),
+    MatchKeyDesc(num_loaded=1, expects_error=True)
+        .keys_to_load(['1', 'module.1']).model_keys(['1'])
+        .matched(['1']).unexpected(['module.1']),
 
     # can match legacy activation quantizer storage name
     MatchKeyDesc(num_loaded=2)


### PR DESCRIPTION
- Checkpoint without |OUTPUT and |INPUT suffixes wasn't loadable
- No way to load separate compression parameters to the model with unified ones.
- Updated squeezenet1_1_custom_cifar10_rb_sparsity_int8_ddp.pth to avoid issue with duplicated FQ and with per-tensor input quantization instead of per-channel.
- fixed backward-compatibility test:
registered data_loader for range init and set proper tolerance for accuracy comparison
- refactored KeyMatcher class

resolves 53579