### PR TITLE
Save compression controller state together with model

### DIFF
--- a/beta/examples/tensorflow/common/prepare_checkpoint.py
+++ b/beta/examples/tensorflow/common/prepare_checkpoint.py
@@ -62,9 +62,9 @@ def checkpoint_saver(config):
     model_builder = get_model_builder(config)
     model = model_builder.build_model()
 
-    _, compress_model = create_compressed_model(model, config.nncf_config)
+    compression_ctrl, compress_model = create_compressed_model(model, config.nncf_config)
 
-    checkpoint = tf.train.Checkpoint(model=compress_model)
+    checkpoint = tf.train.Checkpoint(model=compress_model, compression_ctrl=compression_ctrl)
     load_checkpoint(checkpoint, config.ckpt_path)
 
     checkpoint_manager = tf.train.CheckpointManager(checkpoint, config.checkpoint_save_dir, max_to_keep=None)

--- a/beta/nncf/tensorflow/callbacks/statistics_callback.py
+++ b/beta/nncf/tensorflow/callbacks/statistics_callback.py
@@ -38,7 +38,7 @@ class StatisticsCallback(tf.keras.callbacks.Callback):
         :param log_dir: The directory for tensorbard logging.
         """
         super().__init__()
-        self._statistics_fn =  statistics_fn
+        self._statistics_fn = statistics_fn
         self._log_tensorboard = log_tensorboard
         self._log_text = log_text
         self._file_writer = None


### PR DESCRIPTION
* keep compression controller state in clipped version of the checkpoint. This allow us to do model export properly in case of RB sparsity algo