### PR TITLE
Common collectors of quantization statistics

### DIFF
--- a/nncf/common/quantization/collectors.py
+++ b/nncf/common/quantization/collectors.py
@@ -1,0 +1,151 @@
+"""
+ Copyright (c) 2021 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from typing import List, Tuple
+from collections import Counter
+from abc import abstractmethod
+
+from nncf.common.collector import StatisticsCollector
+from nncf.common.quantization.statistics import QuantizersCounter
+from nncf.common.quantization.statistics import QuantizationStatistics
+
+
+class QuantizerDescription:
+    """
+    Contains information about the quantizer.
+    """
+
+    def __init__(self,
+                 num_bits: int,
+                 is_per_channel: bool,
+                 is_signed: bool,
+                 is_symmetric: bool,
+                 is_weight_quantizer: bool,
+                 is_enabled: bool):
+        """
+        Initializes the description of the quantizer.
+
+        :param num_bits: Bitwidth of the quantization.
+        :param is_per_channel: `True` for per-channel quantization, `False` for per-tensor.
+        :param is_signed: `True` for signed quantization, `False` for unsigned.
+        :param is_symmetric: `True` for symmetric quantizer, `False` for asymmetric.
+        :param is_weight_quantizer: `True` for weight quantizer, `False` for non-weight.
+        :param is_enabled: `True` for enabled quantizer, `False` for disabled.
+        """
+        self._num_bits = num_bits
+        self._is_per_channel = is_per_channel
+        self._is_signed = is_signed
+        self._is_symmetric = is_symmetric
+        self._is_weight_quantizer = is_weight_quantizer
+        self._is_enabled = is_enabled
+
+    @property
+    def num_bits(self) -> int:
+        return self._num_bits
+
+    @property
+    def is_per_channel(self) -> bool:
+        return self._is_per_channel
+
+    @property
+    def is_signed(self) -> bool:
+        return self._is_signed
+
+    @property
+    def is_symmetric(self) -> bool:
+        return self._is_symmetric
+
+    @property
+    def is_weight_quantizer(self) -> bool:
+        return self._is_weight_quantizer
+
+    @property
+    def is_enabled(self) -> bool:
+        return self._is_enabled
+
+
+class QuantizationStatisticsCollector(StatisticsCollector):
+    """
+    Base class for the quantization statistics collector.
+    """
+
+    @abstractmethod
+    def _collect_quantizers_descriptions(self) -> List[QuantizerDescription]:
+        """
+        Collects descriptions of the quantizers.
+
+        :return: Descriptions of the quantizers.
+        """
+
+    @abstractmethod
+    def _get_potential_quantizers_num(self) -> Tuple[int, int]:
+        """
+        Returns a potential number of quantizers for weights and activations.
+
+        :return: A tuple (wq_potential_num, aq_potential_num) where
+            - `wq_potential_num` is a potential number of quantizers for weights.
+            - `aq_potential_num` is a potential number of quantizers for activations.
+        """
+
+    def collect(self) -> QuantizationStatistics:
+        """
+        Collects statistics of the quantization algorithm.
+
+        :return: A statistics of the quantization algorithm.
+        """
+        quantizers_descriptions = self._collect_quantizers_descriptions()
+
+        wq_counter = QuantizersCounter()
+        aq_counter = QuantizersCounter()
+        wq_bitwidths = []
+        aq_bitwidths = []
+        num_enabled_quantizers = 0
+
+        wq_counter.potential_count, aq_counter.potential_count = self._get_potential_quantizers_num()
+
+        for q in quantizers_descriptions:
+            if q.is_weight_quantizer:
+                counter = wq_counter
+                wq_bitwidths.append(q.num_bits)
+            else:
+                counter = aq_counter
+                aq_bitwidths.append(q.num_bits)
+
+            if q.is_per_channel:
+                counter.num_per_channel += 1
+            else:
+                counter.num_per_tensor += 1
+
+            if q.is_signed:
+                counter.num_signed += 1
+            else:
+                counter.num_unsigned += 1
+
+            if q.is_symmetric:
+                counter.num_symmetric += 1
+            else:
+                counter.num_asymmetric += 1
+
+            if q.is_enabled:
+                num_enabled_quantizers += 1
+
+            counter.total_count += 1
+
+        num_wq_per_bitwidth = dict(Counter(wq_bitwidths))
+        num_aq_per_bitwidth = dict(Counter(aq_bitwidths))
+
+        total_count = wq_counter.total_count + aq_counter.total_count
+        ratio_of_enabled_quantizations = 100 * (num_enabled_quantizers / total_count)
+
+        return QuantizationStatistics(wq_counter, aq_counter, num_wq_per_bitwidth,
+                                      num_aq_per_bitwidth, ratio_of_enabled_quantizations)

--- a/nncf/common/quantization/statistics.py
+++ b/nncf/common/quantization/statistics.py
@@ -11,7 +11,7 @@
  limitations under the License.
 """
 
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from nncf.api.statistics import Statistics
 from nncf.common.utils.helpers import create_table
@@ -22,56 +22,6 @@ def _proportion_str(num: int, total_count: int):
     return f'{percentage:.2f} % ({num} / {total_count})'
 
 
-class MemoryConsumptionStatistics(Statistics):
-    """
-    Contains statistics of the memory consumption.
-    """
-
-    def __init__(self,
-                 fp32_weight_size: int = 0,
-                 quantized_weight_size: int = 0,
-                 max_fp32_activation_size: int = 0,
-                 max_compressed_activation_size: int = 0,
-                 weight_memory_consumption_decrease: float = 0.0):
-        """
-        Initializes statistics of the memory consumption.
-
-        :param fp32_weight_size: Memory consumption for full-precision weights (Mbyte).
-        :param quantized_weight_size: Memory consumption for quantized weights (Mbyte).
-        :param max_fp32_activation_size: Max memory consumption for an activation
-            tensor in FP32 model (Mbyte).
-        :param max_compressed_activation_size: Max memory consumption for an activation
-            tensor in compressed model (Mbyte).
-        :param weight_memory_consumption_decrease: Memory consumption decrease for weights.
-        """
-        self.fp32_weight_size = fp32_weight_size
-        self.quantized_weight_size = quantized_weight_size
-        self.max_fp32_activation_size = max_fp32_activation_size
-        self.max_compressed_activation_size = max_compressed_activation_size
-        self.weight_memory_consumption_decrease = weight_memory_consumption_decrease
-
-    def to_str(self) -> str:
-        memory_consumption_string = create_table(
-            header=['Statistic\'s name', 'Value'],
-            rows=[
-                ['Memory consumption for full-precision weights (Mbyte)', self.fp32_weight_size],
-                ['Memory consumption for quantized weights (Mbyte)', self.quantized_weight_size],
-                [
-                    'Max memory consumption for an activation tensor in FP32 model (Mbyte)',
-                    self.max_fp32_activation_size
-                ],
-                [
-                    'Max memory consumption for an activation tensor in compressed model (Mbyte)',
-                    self.max_compressed_activation_size
-                ],
-                ['Memory consumption decrease for weights', self.weight_memory_consumption_decrease],
-            ]
-        )
-
-        pretty_string = f'Statistics of the memory consumption:\n{memory_consumption_string}'
-        return pretty_string
-
-
 class QuantizersCounter:
     def __init__(self,
                  num_symmetric: int = 0,
@@ -79,7 +29,9 @@ class QuantizersCounter:
                  num_signed: int = 0,
                  num_unsigned: int = 0,
                  num_per_tensor: int = 0,
-                 num_per_channel: int = 0):
+                 num_per_channel: int = 0,
+                 total_count: int = 0,
+                 potential_count: Optional[int] = None):
         """
         Initializes quantizers counter.
 
@@ -89,6 +41,8 @@ class QuantizersCounter:
         :param num_unsigned: Number of unsigned quantizers.
         :param num_per_tensor: Number of per-tensor quantizers.
         :param num_per_channel: Number of per-channel quantizers.
+        :param total_count: Total count of quantizers.
+        :param potential_count: Count of potential quantizers.
         """
         self.num_symmetric = num_symmetric
         self.num_asymmetric = num_asymmetric
@@ -96,86 +50,125 @@ class QuantizersCounter:
         self.num_unsigned = num_unsigned
         self.num_per_tensor = num_per_tensor
         self.num_per_channel = num_per_channel
+        self.total_count = total_count
+        self.potential_count = potential_count
 
 
-class QuantizationShareStatistics(Statistics):
+def _quantizers_counter_to_rows(counter: QuantizersCounter, qt: str) -> List[List[str]]:
     """
-    Contains statistics of the quantization share.
+    Converts the counter of quantizers to rows.
+
+    :param counter: Counter of quantizers.
+    :param qt: Type of the counter. Takes one of the following values:
+        - `WQ` - for the counter of the quantizers for weight.
+        - `AQ` - for the counter of the quantizers for activation.
+    :return: List of rows.
+    """
+    rows = [
+        [
+            f'Symmetric {qt}s / All placed {qt}s',
+            _proportion_str(counter.num_symmetric, counter.total_count),
+        ],
+        [
+            f'Asymmetric {qt}s / All placed {qt}s',
+            _proportion_str(counter.num_asymmetric, counter.total_count),
+        ],
+        [
+            f'Signed {qt}s / All placed {qt}s',
+            _proportion_str(counter.num_signed, counter.total_count),
+        ],
+        [
+            f'Unsigned {qt}s / All placed {qt}s',
+            _proportion_str(counter.num_unsigned, counter.total_count),
+        ],
+        [
+            f'Per-tensor {qt}s / All placed {qt}s',
+            _proportion_str(counter.num_per_tensor, counter.total_count),
+        ],
+        [
+            f'Per-channel {qt}s / All placed {qt}s',
+            _proportion_str(counter.num_per_channel, counter.total_count),
+        ],
+    ]
+
+    if counter.potential_count:
+        rows.append(
+            [
+                f'Placed {qt}s / Potential {qt}s',
+                _proportion_str(counter.total_count, counter.potential_count)
+            ]
+        )
+
+    return rows
+
+
+class QuantizationStatistics(Statistics):
+    """
+    Contains statistics of the quantization algorithm.
+
+    These statistics include:
+        - Information about the share of the quantization. It includes following:
+            - Percentage of symmetric/asymmetric/per-channel/per-tensor weight
+            quantizers relative to the number of placed weight quantizers.
+            - Percentage of symmetric/asymmetric/per-channel/per-tensor non-weight
+            quantizers relative to the number of placed non weight quantizers.
+            - Percentage of weight quantizers and non-weight quantizers for each
+            precision relative to the number potential* quantizers/placed quantizers.
+
+            * The maximum possible number of potential quantizers depends on the presence
+            of ignored scopes and the mode of quantizer setup that is used at the time of
+            collecting the metric.
+        - Information about the distribution of the bitwidth of the quantizers.
+        - Ratio of enabled quantization.
     """
 
     def __init__(self,
-                 wq_total_num: int,
-                 aq_total_num: int,
-                 wq_potential_num: int,
-                 aq_potential_num: int,
                  wq_counter: QuantizersCounter,
-                 aq_counter: QuantizersCounter):
+                 aq_counter: QuantizersCounter,
+                 num_wq_per_bitwidth: Dict[int, int],
+                 num_aq_per_bitwidth: Dict[int, int],
+                 ratio_of_enabled_quantizations: float):
         """
-        Initializes statistics of the quantization share.
+        Initializes statistics of the quantization algorithm.
 
-        :param wq_total_num: Total number of weight quantizers.
-        :param aq_total_num: Total number of activation quantizers.
-        :param wq_potential_num: Potential number of weight quantizers.
-        :param aq_potential_num: Potential number of activation quantizers.
         :param wq_counter: Weight quantizers counter.
         :param aq_counter: Activation quantizers counter.
-        """
-        self.wq_total_num = wq_total_num
-        self.aq_total_num = aq_total_num
-        self.wq_potential_num = wq_potential_num
-        self.aq_potential_num = aq_potential_num
-        self.wq_counter = wq_counter
-        self.aq_counter = aq_counter
-
-    def to_str(self) -> str:
-        mapping = [
-            ('num_symmetric', 'Symmetric'),
-            ('num_asymmetric', 'Asymmetric'),
-            ('num_signed', 'Signed'),
-            ('num_unsigned', 'Unsigned'),
-            ('num_per_tensor', 'Per-tensor'),
-            ('num_per_channel', 'Per-channel'),
-        ]
-
-        groups = [
-            ('WQ', self.wq_counter, self.wq_total_num),
-            ('AQ', self.aq_counter, self.aq_total_num),
-        ]
-
-        # Table creation
-        header = ['Statistic\'s name', 'Value']
-        rows = []
-        for q_type, counter, total_num in groups:
-            for attr_name, pretty_name in mapping:
-                statistic_name = f'{pretty_name} {q_type}s / All placed {q_type}s'
-                num = getattr(counter, attr_name)
-                rows.append([statistic_name, _proportion_str(num, total_num)])
-        rows.append(['Placed WQs / Potential WQs', _proportion_str(self.wq_total_num, self.wq_potential_num)])
-        rows.append(['Placed AQs / Potential AQs', _proportion_str(self.aq_total_num, self.aq_potential_num)])
-
-        qshare_string = create_table(header, rows)
-        pretty_string = f'Statistics of the quantization share:\n{qshare_string}'
-        return pretty_string
-
-
-class BitwidthDistributionStatistics(Statistics):
-    """
-    Contains statistics of the bitwidth distribution.
-    """
-
-    def __init__(self,
-                 num_wq_per_bitwidth: Dict[int, int],
-                 num_aq_per_bitwidth: Dict[int, int]):
-        """
-        Initializes bitwidth distribution statistics.
-
         :param num_wq_per_bitwidth: Number of weight quantizers per bit width.
         :param num_aq_per_bitwidth: Number of activation quantizers per bit width.
+        :param ratio_of_enabled_quantizations: Ratio of enabled quantizations.
         """
+        self.wq_counter = wq_counter
+        self.aq_counter = aq_counter
         self.num_wq_per_bitwidth = num_wq_per_bitwidth
         self.num_aq_per_bitwidth = num_aq_per_bitwidth
+        self.ratio_of_enabled_quantizations = ratio_of_enabled_quantizations
 
     def to_str(self) -> str:
+        pretty_strings = []
+
+        table = create_table(
+            header=['Statistic\'s name', 'Value'],
+            rows=[['Ratio of enabled quantizations', self.ratio_of_enabled_quantizations]]
+        )
+
+        pretty_strings.append(f'Statistics of the quantization algorithm:\n{table}')
+        pretty_strings.append(self._get_quantization_share_str())
+        pretty_strings.append(self._get_bitwidth_distribution_str())
+        pretty_string = '\n\n'.join(pretty_strings)
+        return pretty_string
+
+    def _get_quantization_share_str(self) -> str:
+        header = ['Statistic\'s name', 'Value']
+
+        rows = []
+        rows.extend(_quantizers_counter_to_rows(self.wq_counter, 'WQ'))
+        rows.extend(_quantizers_counter_to_rows(self.aq_counter, 'AQ'))
+
+        table = create_table(header, rows)
+        pretty_string = f'Statistics of the quantization share:\n{table}'
+        return pretty_string
+
+    def _get_bitwidth_distribution_str(self) -> str:
         wq_total_num = sum(self.num_wq_per_bitwidth.values())
         aq_total_num = sum(self.num_aq_per_bitwidth.values())
         q_total_num = wq_total_num + aq_total_num
@@ -198,84 +191,6 @@ class BitwidthDistributionStatistics(Statistics):
                 _proportion_str(q_num, q_total_num)
             ])
 
-        distribution_string = create_table(header, rows)
-        pretty_string = f'Statistics of the bitwidth distribution:\n{distribution_string}'
-        return pretty_string
-
-
-class QuantizationConfigurationStatistics(Statistics):
-    """
-    Contains statistics of the quantization configuration.
-    """
-
-    def __init__(self, quantized_edges_in_cfg: int, total_edges_in_cfg: int):
-        """
-        Initializes statistics of the quantization configuration.
-
-        :param quantized_edges_in_cfg: Number of quantized edges in quantization configuration.
-        :param total_edges_in_cfg: Total number of edges in quantization configuration.
-        """
-        self.quantized_edges_in_cfg = quantized_edges_in_cfg
-        self.total_edges_in_cfg = total_edges_in_cfg
-
-    def to_str(self) -> str:
-        header = ['Statistic\'s name', 'Value']
-        rows = [
-            [
-                'Share edges of the quantized data path',
-                _proportion_str(self.quantized_edges_in_cfg, self.total_edges_in_cfg)
-            ]
-        ]
-        qc_string = create_table(header, rows)
-        pretty_string = f'Statistics of the quantization configuration:\n{qc_string}'
-        return pretty_string
-
-
-class QuantizationStatistics(Statistics):
-    """
-    Contains statistics of the quantization algorithm.
-    """
-
-    def __init__(self,
-                 ratio_of_enabled_quantizations: float,
-                 quantization_share_statistics: Optional[QuantizationShareStatistics] = None,
-                 bitwidth_distribution_statistics: Optional[BitwidthDistributionStatistics] = None,
-                 memory_consumption_statistics: Optional[MemoryConsumptionStatistics] = None,
-                 quantization_configuration_statistics: Optional[QuantizationConfigurationStatistics] = None):
-        """
-        Initializes statistics of the quantization algorithm.
-
-        :param ratio_of_enabled_quantizations: Ratio of enabled quantizations.
-        :param quantization_share_statistics: Statistics of the quantization share.
-        :param bitwidth_distribution_statistics: Statistics of the bitwidth distribution.
-        :param memory_consumption_statistics: Statistics of the memory consumption.
-        :param quantization_configuration_statistics: Statistics of the quantization configuration.
-        """
-        self.ratio_of_enabled_quantizations = ratio_of_enabled_quantizations
-        self.quantization_share_statistics = quantization_share_statistics
-        self.bitwidth_distribution_statistics = bitwidth_distribution_statistics
-        self.memory_consumption_statistics = memory_consumption_statistics
-        self.quantization_configuration_statistics = quantization_configuration_statistics
-
-    def to_str(self) -> str:
-        pretty_strings = []
-
-        table_string = create_table(
-            header=['Statistic\'s name', 'Value'],
-            rows=[['Ratio of enabled quantizations', self.ratio_of_enabled_quantizations]]
-        )
-        pretty_strings.append(f'Statistics of the quantization algorithm:\n{table_string}')
-
-        statistics = [
-            self.quantization_share_statistics,
-            self.bitwidth_distribution_statistics,
-            self.memory_consumption_statistics,
-            self.quantization_configuration_statistics
-        ]
-
-        for stats in statistics:
-            if stats:
-                pretty_strings.append(stats.to_str())
-
-        pretty_string = '\n\n'.join(pretty_strings)
+        table = create_table(header, rows)
+        pretty_string = f'Statistics of the bitwidth distribution:\n{table}'
         return pretty_string

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -64,6 +64,7 @@ from nncf.tensorflow.quantization.layers import FakeQuantize
 from nncf.tensorflow.quantization.quantizers import Quantizer
 from nncf.tensorflow.quantization.quantizers import TFQuantizerSpec
 from nncf.tensorflow.quantization.utils import apply_saturation_fix
+from nncf.tensorflow.quantization.collectors import TFQuantizationStatisticsCollector
 
 QUANTIZATION_LAYER_METATYPES = GENERAL_CONV_LAYER_METATYPES + LINEAR_LAYER_METATYPES
 
@@ -483,4 +484,9 @@ class QuantizationController(BaseCompressionAlgorithmController):
         return model
 
     def statistics(self, quickly_collected_only: bool = False) -> NNCFStatistics:
-        return NNCFStatistics()
+        collector = TFQuantizationStatisticsCollector(self.model, self._op_names)
+        stats = collector.collect()
+
+        nncf_stats = NNCFStatistics()
+        nncf_stats.register('quantization', stats)
+        return nncf_stats

--- a/nncf/tensorflow/quantization/collectors.py
+++ b/nncf/tensorflow/quantization/collectors.py
@@ -1,0 +1,92 @@
+"""
+ Copyright (c) 2021 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from typing import List, Tuple
+
+import tensorflow as tf
+
+from nncf.common.quantization.structs import QuantizationMode
+from nncf.common.quantization.collectors import QuantizerDescription
+from nncf.common.quantization.collectors import QuantizationStatisticsCollector
+from nncf.tensorflow.quantization.utils import collect_fake_quantize_layers
+from nncf.tensorflow.graph.utils import get_nncf_operations
+
+
+class TFQuantizationStatisticsCollector(QuantizationStatisticsCollector):
+    """
+    Implementation of the quantization statistics collector for the TensorFlow backend.
+    """
+
+    def __init__(self, model: tf.keras.Model, operation_names: List[str]):
+        """
+        Initializes a collector of the quantization statistics.
+
+        :param model: An instance of the `tf.keras.Model` class.
+        :param operation_names: List of names of quantizer operations. It includes
+            names of weight and non-weight quantizers.
+        """
+        self._model = model
+        self._operation_names = operation_names
+
+    def _collect_quantizers_descriptions(self) -> List[QuantizerDescription]:
+        """
+        Collects descriptions of the quantizers.
+
+        :return: Descriptions of the quantizers.
+        """
+        quantizers_descriptions = []
+
+        for wrapped_layer, _, op in get_nncf_operations(self._model, self._operation_names):
+            is_symmetric = (op.mode == QuantizationMode.SYMMETRIC)
+
+            is_signed = True
+            if is_symmetric:
+                operation_weights = wrapped_layer.get_operation_weights(op.name)
+                is_signed = op.signed(operation_weights)
+
+            quantizers_descriptions.append(
+                QuantizerDescription(
+                    op.num_bits,
+                    op.per_channel,
+                    is_signed,
+                    is_symmetric,
+                    True,
+                    op.enabled
+                )
+            )
+
+        for fq_layer in collect_fake_quantize_layers(self._model):
+            is_symmetric = (fq_layer.mode == QuantizationMode.SYMMETRIC)
+
+            quantizers_descriptions.append(
+                QuantizerDescription(
+                    fq_layer.num_bits,
+                    fq_layer.per_channel,
+                    fq_layer.signed,
+                    is_symmetric,
+                    False,
+                    fq_layer.enabled
+                )
+            )
+
+        return quantizers_descriptions
+
+    def _get_potential_quantizers_num(self) -> Tuple[int, int]:
+        """
+        Returns a potential number of quantizers for weights and activations.
+
+        :return: A tuple (wq_potential_num, aq_potential_num) where
+            - `wq_potential_num` is a potential number of quantizers for weights.
+            - `aq_potential_num` is a potential number of quantizers for activations.
+        """
+        return None, None

--- a/nncf/tensorflow/quantization/quantizers.py
+++ b/nncf/tensorflow/quantization/quantizers.py
@@ -91,6 +91,15 @@ class Quantizer(NNCFOperation):
         self._pre_processing_fn = self._make_pre_processing_fn()
         self._post_processing_fn = self._make_post_processing_fn()
 
+    @property
+    def mode(self) -> str:
+        """
+        Returns mode of the quantization (symmetric or asymmetric).
+
+        :return: The mode of the quantization.
+        """
+        raise NotImplementedError
+
     def call(self, inputs, weights, training):
         """
         The method applies quantization to the input tensor if the quantizer is enabled,
@@ -281,6 +290,19 @@ class SymmetricQuantizer(Quantizer):
     def half_range(self):
         return self._half_range
 
+    @property
+    def mode(self) -> str:
+        return QuantizationMode.SYMMETRIC
+
+    def signed(self, op_weights) -> bool:
+        """
+        Returns `True` for signed quantization, `False` for unsigned.
+
+        :return: `True` for signed quantization, `False` for unsigned.
+        """
+        signed_var = op_weights['signed_var']
+        return signed_var.numpy() < 0.0
+
     def build(self, input_shape, input_type, name, layer):
         shape = None
         if self.per_channel:
@@ -401,6 +423,10 @@ class AsymmetricQuantizer(Quantizer):
     @property
     def half_range(self):
         return self._half_range
+
+    @property
+    def mode(self) -> str:
+        return QuantizationMode.ASYMMETRIC
 
     def build(self, input_shape, input_type, name, layer):
         shape = None

--- a/nncf/torch/quantization/metrics.py
+++ b/nncf/torch/quantization/metrics.py
@@ -10,34 +10,33 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from typing import Dict, Optional, Any
+
+from typing import Dict, List, Tuple, Optional, Any
+from itertools import chain
 
 import networkx as nx
 import torch
 import numpy as np
-from collections import Counter
 from collections import deque
 from copy import deepcopy
 
 from nncf.common.graph import NNCFGraph
 from nncf.torch.quantization.default_quantization import DEFAULT_PT_QUANT_TRAIT_TO_OP_DICT
 from nncf.torch.quantization.layers import BaseQuantizer
-from nncf.common.quantization.structs import QuantizerId
-
 from nncf.torch.quantization.layers import SymmetricQuantizer
 from nncf.torch.nncf_network import NNCFNetwork, PTNNCFGraph
 from nncf.torch.dynamic_graph.transform_graph import is_nncf_module
 from nncf.common.quantization.quantizer_propagation.structs import QuantizationTrait
+from nncf.torch.debug import is_debug
 from nncf.common.quantization.structs import WeightQuantizerId
 from nncf.common.quantization.structs import NonWeightQuantizerId
 from nncf.torch.quantization.structs import WeightQuantizerInfo
 from nncf.torch.quantization.structs import NonWeightQuantizerInfo
 from nncf.common.collector import StatisticsCollector
-from nncf.common.quantization.statistics import QuantizationShareStatistics
-from nncf.common.quantization.statistics import QuantizersCounter
-from nncf.common.quantization.statistics import BitwidthDistributionStatistics
-from nncf.common.quantization.statistics import MemoryConsumptionStatistics
-from nncf.common.quantization.statistics import QuantizationConfigurationStatistics
+from nncf.torch.quantization.statistics import MemoryConsumptionStatistics
+from nncf.torch.quantization.statistics import QuantizationConfigurationStatistics
+from nncf.common.quantization.collectors import QuantizerDescription
+from nncf.common.quantization.collectors import QuantizationStatisticsCollector
 from nncf.common.graph.graph_matching import find_subgraphs_matching_pattern
 from nncf.torch.graph.patterns import get_full_pattern_graph
 
@@ -69,96 +68,61 @@ class QuantizationShareBuildTimeInfo:
         return cls(**state)
 
 
-class QuantizationShareStatisticsCollector(StatisticsCollector):
+class PTQuantizationStatisticsCollector(QuantizationStatisticsCollector):
     """
-    This is a metric representing the share of the model that has been quantized.
-    It includes the calculation of the following numbers:
-    - Percentage of symmetric/asymmetric/per-channel/per-tensor weight quantizers relative
-      to the number of placed weight quantizers
-    - Percentage of symmetric/asymmetric/per-channel/per-tensor non weight quantizers relative
-      to the number of placed non weight quantizers
-    - Percentage of weight quantizers and non weight quantizers for each precision relative
-      to the number potential* quantizers / placed quantizers
-    Bitwidth distribution data is also collected.
-
-    * The maximum possible number of potential quantizers depends on the presence of ignored
-    scopes and the mode of quantizer setup that is used at the time of collecting the metric.
+    Implementation of the quantization statistics collector for the PyTorch backend.
     """
-
-    NAME_STR = 'quantization_share_statistics'
 
     def __init__(self,
                  weight_quantizers: Dict[WeightQuantizerId, WeightQuantizerInfo],
                  non_weight_quantizers: Dict[NonWeightQuantizerId, NonWeightQuantizerInfo],
                  build_time_info: QuantizationShareBuildTimeInfo):
+        """
+        Initializes a collector of the quantization statistics.
+        """
         self._weight_quantizers = {k: v.quantizer_module_ref for k, v in weight_quantizers.items()}
         self._non_weight_quantizers = {k: v.quantizer_module_ref for k, v in non_weight_quantizers.items()}
         self._info = build_time_info
 
-    def collect(self) -> QuantizationShareStatistics:
+    def _collect_quantizers_descriptions(self) -> List[QuantizerDescription]:
         """
-        Collects quantization share statistics.
+        Collects descriptions of the quantizers.
+
+        :return: Descriptions of the quantizers.
         """
-        all_quantizers = {**self._weight_quantizers, **self._non_weight_quantizers}
+        # `True` for weight quantizer, `False` otherwise.
+        quantizers = chain(
+            map(lambda x: (True, x), self._weight_quantizers.values()),
+            map(lambda x: (False, x), self._non_weight_quantizers.values())
+        )
 
-        wq_counter = QuantizersCounter()
-        aq_counter = QuantizersCounter()
-        for qid, quantizer in all_quantizers.items():  # type: Tuple[QuantizerId, BaseQuantizer]
-            counter = wq_counter if qid in self._weight_quantizers else aq_counter
+        quantizers_descriptions = []
+        for is_weight_quantizer, q in quantizers:
+            is_symmetric = isinstance(q, SymmetricQuantizer)
 
-            if quantizer.per_channel:
-                counter.num_per_channel += 1
-            else:
-                counter.num_per_tensor += 1
+            quantizers_descriptions.append(
+                QuantizerDescription(
+                    q.num_bits,
+                    q.per_channel,
+                    q.signed,
+                    is_symmetric,
+                    is_weight_quantizer,
+                    q.is_enabled_quantization()
+                )
+            )
 
-            if quantizer.signed:
-                counter.num_signed += 1
-            else:
-                counter.num_unsigned += 1
+        return quantizers_descriptions
 
-            if isinstance(quantizer, SymmetricQuantizer):
-                counter.num_symmetric += 1
-            else:
-                counter.num_asymmetric += 1
-
-        wq_total_num = len(self._weight_quantizers)
-        aq_total_num = len(self._non_weight_quantizers)
-
-        return QuantizationShareStatistics(wq_total_num, aq_total_num, self._info.wq_potential_num,
-                                           self._info.aq_potential_num, wq_counter, aq_counter)
-
-
-class BitwidthDistributionStatisticsCollector(StatisticsCollector):
-    """
-    Collects bit width distribution statistics.
-    """
-
-    NAME_STR = 'bitwidth_distribution_statistics'
-
-    def __init__(self,
-                 weight_quantizers: Dict[WeightQuantizerId, WeightQuantizerInfo],
-                 non_weight_quantizers: Dict[NonWeightQuantizerId, NonWeightQuantizerInfo]):
+    def _get_potential_quantizers_num(self) -> Tuple[int, int]:
         """
-        Initializes collector of the bit width distribution statistics.
-        """
-        self._weight_quantizers = {k: v.quantizer_module_ref for k, v in weight_quantizers.items()}
-        self._non_weight_quantizers = {k: v.quantizer_module_ref for k, v in non_weight_quantizers.items()}
+        Returns a potential number of quantizers for weights and activations.
 
-    def collect(self) -> BitwidthDistributionStatistics:
+        :return: A tuple (wq_potential_num, aq_potential_num) where
+            - `wq_potential_num` is a potential number of quantizers for weights.
+            - `aq_potential_num` is a potential number of quantizers for activations.
         """
-        Collects bit width distribution statistics.
-        """
-        all_quantizers = {**self._weight_quantizers, **self._non_weight_quantizers}
-        wq_bitwidths = []
-        aq_bitwidths = []
-        for qid, quantizer in all_quantizers.items():
-            if qid in self._weight_quantizers:
-                wq_bitwidths.append(quantizer.num_bits)
-            else:
-                aq_bitwidths.append(quantizer.num_bits)
-
-        return BitwidthDistributionStatistics(dict(Counter(wq_bitwidths)),
-                                              dict(Counter(aq_bitwidths)))
+        aq_potential_num = self._info.aq_potential_num if is_debug() else None
+        return self._info.wq_potential_num, aq_potential_num
 
 
 class MemoryConsumptionStatisticsCollector(StatisticsCollector):
@@ -170,8 +134,6 @@ class MemoryConsumptionStatisticsCollector(StatisticsCollector):
     * Reflects host memory consumption, assuming only the final low-precision output activation tensors are stored
       in host memory (i.e. assuming intermediate accumulation results are only stored in device memory)
     """
-
-    NAME_STR = 'memory_consumption_statistics'
 
     def __init__(self,
                  compressed_model: NNCFNetwork,
@@ -266,7 +228,6 @@ class ShareEdgesQuantizedDataPathStatisticsCollector(StatisticsCollector):
     in the original network graph. "Quantized edge" is an edge representing a quantized activation tensor.
     """
 
-    NAME_STR = 'quantization_configuration_statistics'
     QUANTIZED_EDGES_ATTR = 'quantized'
     PASSED_EDGES_ATTR = 'passed'
     NODES_GRAPH_ATTR = 'nodes'

--- a/nncf/torch/quantization/precision_init/autoq_init.py
+++ b/nncf/torch/quantization/precision_init/autoq_init.py
@@ -288,8 +288,8 @@ class AutoQPrecisionInitializer(BasePrecisionInitializer):
 
                 nncf_stats = env.qctrl.statistics()
                 bit_stats_df = pd.DataFrame.from_dict(
-                    [nncf_stats.quantization.bitwidth_distribution_statistics.num_wq_per_bitwidth,
-                     nncf_stats.quantization.bitwidth_distribution_statistics.num_aq_per_bitwidth])\
+                    [nncf_stats.quantization.num_wq_per_bitwidth,
+                     nncf_stats.quantization.num_aq_per_bitwidth])\
                          .fillna(0).astype(int).rename(index={0:'WQ',1:'AQ'}).transpose().sort_index(ascending=False)
                 bit_stats_df.index.name = 'bitwidth'
                 bit_stats_df=bit_stats_df.reset_index()

--- a/nncf/torch/quantization/statistics.py
+++ b/nncf/torch/quantization/statistics.py
@@ -1,0 +1,98 @@
+"""
+ Copyright (c) 2021 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from nncf.api.statistics import Statistics
+from nncf.common.utils.helpers import create_table
+
+
+def _proportion_str(num: int, total_count: int):
+    percentage = 100 * (num / max(total_count, 1))
+    return f'{percentage:.2f} % ({num} / {total_count})'
+
+
+class MemoryConsumptionStatistics(Statistics):
+    """
+    Contains statistics of the memory consumption.
+    """
+
+    def __init__(self,
+                 fp32_weight_size: int = 0,
+                 quantized_weight_size: int = 0,
+                 max_fp32_activation_size: int = 0,
+                 max_compressed_activation_size: int = 0,
+                 weight_memory_consumption_decrease: float = 0.0):
+        """
+        Initializes statistics of the memory consumption.
+
+        :param fp32_weight_size: Memory consumption for full-precision weights (Mbyte).
+        :param quantized_weight_size: Memory consumption for quantized weights (Mbyte).
+        :param max_fp32_activation_size: Max memory consumption for an activation
+            tensor in FP32 model (Mbyte).
+        :param max_compressed_activation_size: Max memory consumption for an activation
+            tensor in compressed model (Mbyte).
+        :param weight_memory_consumption_decrease: Memory consumption decrease for weights.
+        """
+        self.fp32_weight_size = fp32_weight_size
+        self.quantized_weight_size = quantized_weight_size
+        self.max_fp32_activation_size = max_fp32_activation_size
+        self.max_compressed_activation_size = max_compressed_activation_size
+        self.weight_memory_consumption_decrease = weight_memory_consumption_decrease
+
+    def to_str(self) -> str:
+        memory_consumption_string = create_table(
+            header=['Statistic\'s name', 'Value'],
+            rows=[
+                ['Memory consumption for full-precision weights (Mbyte)', self.fp32_weight_size],
+                ['Memory consumption for quantized weights (Mbyte)', self.quantized_weight_size],
+                [
+                    'Max memory consumption for an activation tensor in FP32 model (Mbyte)',
+                    self.max_fp32_activation_size
+                ],
+                [
+                    'Max memory consumption for an activation tensor in compressed model (Mbyte)',
+                    self.max_compressed_activation_size
+                ],
+                ['Memory consumption decrease for weights', self.weight_memory_consumption_decrease],
+            ]
+        )
+
+        pretty_string = f'Statistics of the memory consumption:\n{memory_consumption_string}'
+        return pretty_string
+
+
+class QuantizationConfigurationStatistics(Statistics):
+    """
+    Contains statistics of the quantization configuration.
+    """
+
+    def __init__(self, quantized_edges_in_cfg: int, total_edges_in_cfg: int):
+        """
+        Initializes statistics of the quantization configuration.
+
+        :param quantized_edges_in_cfg: Number of quantized edges in quantization configuration.
+        :param total_edges_in_cfg: Total number of edges in quantization configuration.
+        """
+        self.quantized_edges_in_cfg = quantized_edges_in_cfg
+        self.total_edges_in_cfg = total_edges_in_cfg
+
+    def to_str(self) -> str:
+        header = ['Statistic\'s name', 'Value']
+        rows = [
+            [
+                'Share edges of the quantized data path',
+                _proportion_str(self.quantized_edges_in_cfg, self.total_edges_in_cfg)
+            ]
+        ]
+        qc_string = create_table(header, rows)
+        pretty_string = f'Statistics of the quantization configuration:\n{qc_string}'
+        return pretty_string

--- a/tests/tensorflow/quantization/test_statistics.py
+++ b/tests/tensorflow/quantization/test_statistics.py
@@ -1,0 +1,123 @@
+"""
+ Copyright (c) 2021 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from typing import Optional, List
+
+import pytest
+
+from nncf.common.quantization.statistics import QuantizersCounter
+from nncf.common.quantization.statistics import QuantizationStatistics
+from tests.tensorflow import test_models
+from tests.tensorflow.helpers import get_empty_config
+from tests.tensorflow.helpers import create_compressed_model_and_algo_for_test
+
+
+def _get_basic_quantization_config(mode: str,
+                                   granularity: str,
+                                   input_sample_sizes: Optional[List[int]] = None):
+    config = get_empty_config(input_sample_sizes)
+    per_channel = (granularity == 'per_channel')
+
+    compression_section = {
+        'algorithm': 'quantization',
+        'activations': {
+            'mode': mode,
+            'per_channel': per_channel,
+        },
+        'weights': {
+            'mode': mode,
+            'per_channel': per_channel,
+        }
+    }
+
+    config['compression'] = compression_section
+    return config
+
+
+class Case:
+    def __init__(self,
+                 model_name: str,
+                 model_builder,
+                 input_sample_sizes: List[int],
+                 mode: str,
+                 granularity: str,
+                 expected: QuantizationStatistics):
+        self._model_name = model_name
+        self._model_builder = model_builder
+        self._input_sample_sizes = input_sample_sizes
+        self._mode = mode
+        self._granularity = granularity
+        self._expected = expected
+
+    @property
+    def model(self):
+        return self._model_builder(input_shape=tuple(self._input_sample_sizes[1:]))
+
+    @property
+    def config(self):
+        return _get_basic_quantization_config(self._mode, self._granularity, self._input_sample_sizes)
+
+    @property
+    def expected(self):
+        return self._expected
+
+    def get_id(self) -> str:
+        return f'{self._model_name}-{self._mode}-{self._granularity}'
+
+
+TEST_CASES = [
+    Case(
+        model_name='mobilenet_v2',
+        model_builder=test_models.MobileNetV2,
+        input_sample_sizes=[1, 96, 96, 3],
+        mode='symmetric',
+        granularity='per_tensor',
+        expected=QuantizationStatistics(
+            wq_counter=QuantizersCounter(53, 0, 53, 0, 53, 0, 53),
+            aq_counter=QuantizersCounter(64, 0, 64, 0, 64, 0, 64),
+            num_wq_per_bitwidth={8: 53},
+            num_aq_per_bitwidth={8: 64},
+            ratio_of_enabled_quantizations=100.0
+        )
+    ),
+    Case(
+        model_name='mobilenet_v2',
+        model_builder=test_models.MobileNetV2,
+        input_sample_sizes=[1, 96, 96, 3],
+        mode='asymmetric',
+        granularity='per_channel',
+        expected=QuantizationStatistics(
+            wq_counter=QuantizersCounter(0, 53, 53, 0, 0, 53, 53),
+            aq_counter=QuantizersCounter(0, 64, 64, 0, 0, 64, 64),
+            num_wq_per_bitwidth={8: 53},
+            num_aq_per_bitwidth={8: 64},
+            ratio_of_enabled_quantizations=100.0
+        )
+    ),
+]
+TEST_CASES_IDS = [test_case.get_id() for test_case in TEST_CASES]
+
+
+@pytest.mark.parametrize('test_case', TEST_CASES, ids=TEST_CASES_IDS)
+def test_quantization_statistics(test_case):
+    _, compression_ctrl = create_compressed_model_and_algo_for_test(test_case.model,
+                                                                    test_case.config,
+                                                                    force_no_init=True)
+    actual = compression_ctrl.statistics().quantization
+    expected = test_case.expected
+
+    assert expected.wq_counter.__dict__ == actual.wq_counter.__dict__
+    assert expected.aq_counter.__dict__ == actual.aq_counter.__dict__
+    assert expected.num_wq_per_bitwidth == actual.num_wq_per_bitwidth
+    assert expected.num_aq_per_bitwidth == actual.num_aq_per_bitwidth
+    assert expected.ratio_of_enabled_quantizations == actual.ratio_of_enabled_quantizations

--- a/tests/torch/quantization/test_manual_precision_init.py
+++ b/tests/torch/quantization/test_manual_precision_init.py
@@ -17,7 +17,6 @@ from typing import List
 import pytest
 from nncf.torch.quantization.algo import QuantizationController
 
-from nncf.common.quantization.statistics import BitwidthDistributionStatistics
 from examples.torch.common.model_loader import load_model
 from nncf import NNCFConfig
 from nncf.torch import register_default_init_args
@@ -59,6 +58,12 @@ class ManualSampleConfigTestParams(ManualConfigTestParamsBase):
 class ManualTestConfigTestParams(ManualConfigTestParamsBase):
     def _get_config_path(self):
         return TEST_ROOT.joinpath('torch', 'data', 'configs', 'hawq') / self.name
+
+
+class BitwidthDistributionStatistics:
+    def __init__(self, num_wq_per_bitwidth, num_aq_per_bitwidth):
+        self.num_wq_per_bitwidth = num_wq_per_bitwidth
+        self.num_aq_per_bitwidth = num_aq_per_bitwidth
 
 
 MANUAL_CONFIG_TEST_PARAMS = [
@@ -120,7 +125,7 @@ def test_hawq_manual_configs(manual_config_params):
     nncf_stats = compression_ctrl.statistics()
 
     expected = manual_config_params.bit_stats
-    actual = nncf_stats.quantization.bitwidth_distribution_statistics
+    actual = nncf_stats.quantization
 
     assert expected.num_wq_per_bitwidth == actual.num_wq_per_bitwidth
     assert expected.num_aq_per_bitwidth == actual.num_aq_per_bitwidth
@@ -238,7 +243,7 @@ class TestPrecisionInitDesc:
             assert quantizer.num_bits == expected_bit, 'Unexpected number of bits for {}'.format(str(qid))
 
         nncf_stats = compression_ctrl.statistics()
-        actual_stats = nncf_stats.quantization.bitwidth_distribution_statistics
+        actual_stats = nncf_stats.quantization
 
         assert self.expected_stats.num_wq_per_bitwidth == actual_stats.num_wq_per_bitwidth
         assert self.expected_stats.num_aq_per_bitwidth == actual_stats.num_aq_per_bitwidth


### PR DESCRIPTION
Prior to these changes, we were printing the following statistics:

- statistics of the memory consumption
- statistics of the quantization share
- statistics of the bitwidth distribution
- statistics of the quantization configuration
- ratio of enabled quantizations.

After this PR we print the following statistics:
- statistics of the quantization share
- statistics of the bitwidth distribution
- ratio of enabled quantizations

The statistics of the memory consumption and the statistics of the quantization configuration are printed only for NNCF PT in debug mode.

**Before my changes:**
![before](https://user-images.githubusercontent.com/77268007/124755142-aafd8680-df33-11eb-9a32-7a3cb58a801d.PNG)

**After my changes:**
![after](https://user-images.githubusercontent.com/77268007/124755213-c36da100-df33-11eb-8bd5-c23dccfa7767.PNG)
