### PR TITLE
Add target compression idx to layer attributes

### DIFF
--- a/examples/torch/semantic_segmentation/configs/unet_camvid_int8.json
+++ b/examples/torch/semantic_segmentation/configs/unet_camvid_int8.json
@@ -1,7 +1,7 @@
 {
     "model": "unet",
     "dataset" : "camvid",
-
+    "epochs": 10,
     "preprocessing": {
         "resize": {
             "height": 368,

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -38,6 +38,7 @@ from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode
 from nncf.common.graph import NNCFNodeName
 from nncf.common.graph.layer_attributes import ConvolutionLayerAttributes
+from nncf.common.graph.layer_attributes import WeightedLayerAttributes
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.hardware.config import HWConfig
 from nncf.common.hardware.config import HWConfigType
@@ -904,8 +905,11 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
             if is_weights(ip):
                 target_node = target_model_graph.get_node_by_name(ip.target_node_name)
                 layer_attributes = target_node.layer_attributes
-                scale_shape = get_scale_shape(layer_attributes.get_weight_shape(), is_weights=True,
-                                              per_channel=qconfig.per_channel)
+                assert isinstance(layer_attributes, WeightedLayerAttributes)
+                scale_shape = get_scale_shape(layer_attributes.get_weight_shape(),
+                                              is_weights=True,
+                                              per_channel=qconfig.per_channel,
+                                              channel_idx=layer_attributes.get_target_dim_for_compression())
                 scale_shapes.append(scale_shape)
             else:
                 input_shape = target_model_graph.get_input_shape_for_insertion_point(ip)

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -465,11 +465,7 @@ class SymmetricQuantizer(BaseQuantizer):
             level_low = self.level_low
             level_high = self.level_high
             if self._half_range:
-                if self.scale_shape[0] > 1:
-                    for i in range(self.scale_shape[0]):
-                        x[i] = torch.clamp(x[i], min=input_low[i].item(), max=input_high[i].item())
-                else:
-                    x.data = torch.clamp(x, min=input_low.item(), max=input_high.item())
+                x = torch.min(torch.max(x, input_low), input_high)
                 level_low = 2 * self.level_low
                 level_high = 2 * self.level_high + 1
                 input_low, input_high = self._get_input_low_input_high(level_high / self.level_high * self.scale,
@@ -605,11 +601,7 @@ class AsymmetricQuantizer(BaseQuantizer):
             level_low = self.level_low
             level_high = self.level_high
             if self._half_range:
-                if self.scale_shape[0] > 1:
-                    for i in range(self.scale_shape[0]):
-                        x[i] = torch.clamp(x[i], min=input_low[i].item(), max=input_high[i].item())
-                else:
-                    x.data = torch.clamp(x, min=input_low.item(), max=input_high.item())
+                x = torch.min(torch.max(x, input_low), input_high)
                 level_low = 2 * level_low
                 level_high = 2 * level_high + 1
                 input_low, input_high = self._get_input_low_input_high(level_high / self.level_high * self.input_range,

--- a/nncf/torch/quantization/quantizer_propagation.py
+++ b/nncf/torch/quantization/quantizer_propagation.py
@@ -1230,7 +1230,7 @@ class QuantizerPropagationStateGraph(nx.DiGraph):
 
     def create_quantizer_setup(self, quantizable_module_node_names_vs_qconfigs: Dict[NNCFNodeName,
                                                                                      List[QuantizerConfig]]) \
-            -> 'MultiConfigQuantizerSetup':
+            -> MultiConfigQuantizerSetup:
         same_op_groups = self._get_all_quantizers_grouped_by_affecting_op_set()
         setup = MultiConfigQuantizerSetup()
 

--- a/nncf/torch/quantization/quantizer_setup.py
+++ b/nncf/torch/quantization/quantizer_setup.py
@@ -4,10 +4,10 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Set
-from typing import Tuple
 
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNodeName
+from nncf.common.graph.layer_attributes import WeightedLayerAttributes
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.utils.logger import logger as nncf_logger
 from nncf.torch.graph.transformations.commands import PTTargetPoint
@@ -34,7 +34,7 @@ class QuantizationPointBase:
     def is_weight_quantization_point(self) -> bool:
         return self.insertion_point.target_type == TargetType.OPERATION_WITH_WEIGHTS
 
-    def get_all_scale_shapes(self, input_shape: Tuple[int]) -> List[Tuple[int]]:
+    def get_all_configs_list(self) -> List[QuantizerConfig]:
         raise NotImplementedError
 
     def __eq__(self, other):
@@ -50,10 +50,8 @@ class SingleConfigQuantizationPoint(QuantizationPointBase):
     def __str__(self):
         return str(self.insertion_point) + ' ' + str(self.qconfig)
 
-    def get_all_scale_shapes(self, input_shape: Tuple[int]) -> List[Tuple[int]]:
-        return [tuple(get_scale_shape(
-            input_shape,
-            is_weights=self.is_weight_quantization_point(), per_channel=self.qconfig.per_channel))]
+    def get_all_configs_list(self) -> List[QuantizerConfig]:
+        return [self.qconfig]
 
 
 class MultiConfigQuantizationPoint(QuantizationPointBase):
@@ -86,13 +84,8 @@ class MultiConfigQuantizationPoint(QuantizationPointBase):
     def __str__(self):
         return str(self.insertion_point) + ' ' + ';'.join([str(qc) for qc in self.possible_qconfigs])
 
-    def get_all_scale_shapes(self, input_shape: Tuple[int]) -> List[Tuple[int]]:
-        scale_shapes_across_configs = set()  # type: Set[Tuple[int]]
-        for qc in self.possible_qconfigs:
-            scale_shapes_across_configs.add(tuple(get_scale_shape(
-                list(input_shape),
-                is_weights=self.is_weight_quantization_point(), per_channel=qc.per_channel)))
-        return list(scale_shapes_across_configs)
+    def get_all_configs_list(self) -> List[QuantizerConfig]:
+        return self.possible_qconfigs
 
 
 class QuantizerSetupBase:
@@ -257,17 +250,23 @@ class SingleConfigQuantizerSetup(QuantizerSetupBase):
             else:
                 target_node = target_model_graph.get_node_by_name(qp.insertion_point.target_node_name)
                 if qp.is_weight_quantization_point():
-                    input_shape = target_node.layer_attributes.get_weight_shape()
+                    layer_attrs = target_node.layer_attributes
+                    assert isinstance(layer_attrs, WeightedLayerAttributes)
+                    input_shape = layer_attrs.get_weight_shape()
+                    channel_idx = layer_attrs.get_target_dim_for_compression()
                 else:
                     input_shape = target_model_graph.get_input_shape_for_insertion_point(qp.insertion_point)
+                    channel_idx = 1  # channel dim for activations
                 scale_shape = tuple(get_scale_shape(input_shape,
                                                     qp.is_weight_quantization_point(),
-                                                    qp.qconfig.per_channel))
+                                                    qp.qconfig.per_channel,
+                                                    channel_idx))
                 if scale_shape not in tensor_statistics[ip]:
                     nncf_logger.debug("Did not collect tensor statistics at {} for shape {}".format(ip, scale_shape))
                     retval[qp_id] = None
-                minmax_stat = MinMaxTensorStatistic.from_stat(tensor_statistics[ip][scale_shape])
-                retval[qp_id] = minmax_stat
+                else:
+                    minmax_stat = MinMaxTensorStatistic.from_stat(tensor_statistics[ip][scale_shape])
+                    retval[qp_id] = minmax_stat
         return retval
 
 

--- a/nncf/torch/utils.py
+++ b/nncf/torch/utils.py
@@ -164,20 +164,22 @@ def sum_like(tensor_to_sum, ref_tensor):
     return tensor_to_sum
 
 
-def get_per_channel_scale_shape(input_shape, is_weights):
+def get_per_channel_scale_shape(input_shape, is_weights, channel_idx: int = None):
     scale_shape = [1 for _ in input_shape]
-    if is_weights:
-        scale_shape[0] = input_shape[0]  # Per weight channel scales
-    else:
-        scale_shape[1] = input_shape[1]  # Per activation channel scales
-
+    if channel_idx is None:
+        if is_weights:
+            channel_idx = 0  # Per weight channel scales
+        else:
+            channel_idx = 1  # Per activation channel scales
+    scale_shape[channel_idx] = input_shape[channel_idx]
     return scale_shape
 
 
-def get_scale_shape(input_shape: List[int], is_weights: bool, per_channel: bool) -> List[int]:
+def get_scale_shape(input_shape: List[int], is_weights: bool, per_channel: bool,
+                    channel_idx: int = None) -> List[int]:
     if not per_channel:
         return [1]
-    return get_per_channel_scale_shape(input_shape, is_weights)
+    return get_per_channel_scale_shape(input_shape, is_weights, channel_idx)
 
 
 def get_flat_tensor_contents_string(input_tensor):

--- a/tests/torch/helpers.py
+++ b/tests/torch/helpers.py
@@ -395,6 +395,18 @@ def get_all_inputs_for_graph_node(node: onnx.NodeProto, graph: onnx.GraphProto) 
     return retval
 
 
+def resolve_constant_node_inputs_to_values(node: onnx.NodeProto, graph: onnx.GraphProto) -> \
+        Dict[str, onnx.AttributeProto]:
+    retval = {}
+    for input_ in node.input:
+        constant_input_nodes = [x for x in graph.node if input_ in x.output and x.op_type == "Constant"]
+        for constant_input_node in constant_input_nodes:
+            assert len(constant_input_node.attribute) == 1
+            val = constant_input_node.attribute[0]
+            retval[input_] = numpy_helper.to_array(val.t)
+    return retval
+
+
 class Command(BaseCommand):
     def run(self, timeout=3600, assert_returncode_zero=True):
         if torch.cuda.is_available():

--- a/tests/torch/quantization/test_unified_scales.py
+++ b/tests/torch/quantization/test_unified_scales.py
@@ -19,7 +19,6 @@ import onnx
 import pytest
 import torch
 import torch.nn
-from onnx import numpy_helper
 
 from nncf.common.graph import NNCFNodeName
 from nncf.common.graph.transformations.commands import TargetType
@@ -32,6 +31,7 @@ from nncf.torch.quantization.quantizer_propagation import QuantizerPropagationSo
 from tests.torch.helpers import create_compressed_model_and_algo_for_test
 from tests.torch.helpers import get_nodes_by_type
 from tests.torch.helpers import register_bn_adaptation_init_args
+from tests.torch.helpers import resolve_constant_node_inputs_to_values
 from tests.torch.quantization.test_quantization_helpers import get_quantization_config_without_range_init
 
 
@@ -684,17 +684,6 @@ class TestsWithONNXInspection:
             output_nodes[target_node_name].append(node)
         return list(output_nodes.values())
 
-    @staticmethod
-    def resolve_constant_node_inputs_to_values(node: onnx.NodeProto, graph: onnx.GraphProto) -> \
-            Dict[str, onnx.AttributeProto]:
-        retval = {}
-        for input_ in node.input:
-            constant_input_nodes = [x for x in graph.node if input_ in x.output and x.op_type == "Constant"]
-            for constant_input_node in constant_input_nodes:
-                assert len(constant_input_node.attribute) == 1
-                val = constant_input_node.attribute[0]
-                retval[input_] = numpy_helper.to_array(val.t)
-        return retval
 
     def test_unified_scales_are_identical_in_onnx(self, tmp_path):
         # pylint:disable=no-member
@@ -743,8 +732,7 @@ class TestsWithONNXInspection:
             onnx_model.graph)
 
         for unified_scale_group in fq_nodes_grouped_by_output:
-            inputs = [TestsWithONNXInspection.resolve_constant_node_inputs_to_values(fq_node,
-                                                                                     onnx_model.graph)
+            inputs = [resolve_constant_node_inputs_to_values(fq_node, onnx_model.graph)
                       for fq_node in unified_scale_group]
             for inputs_dict in inputs[1:]:
                 curr_values = list(inputs_dict.values())
@@ -795,8 +783,7 @@ class TestsWithONNXInspection:
 
         fq_nodes_with_expected_unified_scales = embedding_weight_fq_nodes + eltwise_fq_nodes
 
-        unified_fq_node_inputs = [TestsWithONNXInspection.resolve_constant_node_inputs_to_values(fq_node,
-                                                                                                 onnx_model.graph)
+        unified_fq_node_inputs = [resolve_constant_node_inputs_to_values(fq_node, onnx_model.graph)
                                   for fq_node in fq_nodes_with_expected_unified_scales]
         for inputs_dict in unified_fq_node_inputs[1:]:
             curr_values = list(inputs_dict.values())


### PR DESCRIPTION
In particular, this fixes the issue with ConvTranspose2d's being
per-channel quantized on a wrong dimension.