### PR TITLE
Fix quantization init

### DIFF
--- a/examples/tensorflow/segmentation/evaluation.py
+++ b/examples/tensorflow/segmentation/evaluation.py
@@ -184,7 +184,9 @@ def run_evaluation(config, eval_timeout=None):
                                 weights=config.get('weights', None),
                                 is_training=False) as model:
         with strategy.scope():
-            compression_ctrl, compress_model = create_compressed_model(model, config.nncf_config)
+            compression_ctrl, compress_model = create_compressed_model(model,
+                                                                       config.nncf_config,
+                                                                       should_init=False)
             variables = get_variables(compress_model)
             checkpoint = tf.train.Checkpoint(variables=variables,
                                              compression_ctrl=compression_ctrl,

--- a/nncf/config/extractors.py
+++ b/nncf/config/extractors.py
@@ -84,7 +84,7 @@ def extract_range_init_params(config: NNCFConfig) -> Optional[Dict[str, object]]
     range_init_args = None
     try:
         range_init_args = config.get_extra_struct(QuantizationRangeInitArgs)
-    except KeyError as e:
+    except KeyError:
         if not init_range_config_dict_or_list:
             logger.warning('Initializer section not specified for quantization algorithm in NNCF config and '
                            'quantization init args not supplied - the necessary parameters are not specified '
@@ -113,7 +113,7 @@ def extract_range_init_params(config: NNCFConfig) -> Optional[Dict[str, object]]
         raise ValueError(
             'Should run range initialization as specified via config,'
             'but the initializing data loader is not provided as an extra struct. '
-            'Refer to `NNCFConfig.register_extra_structs` and the `QuantizationRangeInitArgs` class') from e
+            'Refer to `NNCFConfig.register_extra_structs` and the `QuantizationRangeInitArgs` class')
 
     params = {
         'init_range_data_loader': range_init_args.data_loader,

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -84,7 +84,9 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
         for quantizer_group in QuantizerGroup:
             self._parse_group_params(self.config, quantizer_group)
 
-        self._parse_init_params()
+        if self.should_init:
+            self._parse_init_params()
+
         self._range_initializer = None
         self._bn_adaptation = None
 

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -193,7 +193,8 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
         return QuantizationController(model, self.config, self._op_names)
 
     def initialize(self, model: tf.keras.Model) -> None:
-        self._run_range_initialization(model)
+        if self._range_init_params is not None:
+            self._run_range_initialization(model)
 
         if self._batchnorm_adaptation:
             self._run_batchnorm_adaptation(model)

--- a/tests/tensorflow/data/configs/mask_rcnn_coco2017_magnitude_sparsity_int8.json
+++ b/tests/tensorflow/data/configs/mask_rcnn_coco2017_magnitude_sparsity_int8.json
@@ -1,7 +1,7 @@
 {
     "model": "MaskRCNN",
     "input_info": {
-        "sample_size": [1, 1024, 1024, 3]
+        "sample_size": [1, 64, 64, 3]
     },
 
     "epochs": 1,
@@ -21,14 +21,36 @@
         }
     },
 
-    "compression": {
-        "algorithm": "magnitude_sparsity",
-        "params": {
-            "schedule": "multistep",
-            "multistep_steps": [1],
-            "multistep_sparsity_levels": [0.5, 0.5]
+    "compression": [
+        {
+            "algorithm": "magnitude_sparsity",
+            "params": {
+                "schedule": "multistep",
+                "multistep_steps": [1],
+                "multistep_sparsity_levels": [0.5, 0.5]
+            }
+        },
+        {
+            "algorithm": "quantization",
+            "initializer": {
+                "range": {
+                    "num_init_samples": 1
+                }
+            },
+            "ignored_scopes": [
+                "{re}.*multilevel_propose_rois.*",
+                "{re}.*sample_proposals.*",
+                "{re}.*multilevel_crop_and_resize.*",
+                "{re}.*generate_detections.*",
+                "{re}.*sample_and_crop_foreground_masks.*",
+                "{re}.*decode_boxes.*",
+                "{re}.*encode_boxes.*",
+                "gt_boxes",
+                "gt_masks",
+                "image_info"
+        ]
         }
-    },
+    ],
 
     "include_mask": true,
     "model_params": {

--- a/tests/tensorflow/test_sanity_sample.py
+++ b/tests/tensorflow/test_sanity_sample.py
@@ -172,6 +172,7 @@ def generate_id(value):
 
 CONFIG_PARAMS = generate_config_params()
 
+
 @pytest.fixture(params=CONFIG_PARAMS, ids=generate_id)
 def _config(request, dataset_dir):
     sample_type, config_path, dataset_name, dataset_type, batch_size, tid = request.param
@@ -212,7 +213,6 @@ def test_model_eval(_config, tmp_path):
         '--log-dir': tmp_path,
         '--batch-size': _config['batch_size']
     }
-
     main = get_sample_fn(_config['sample_type'], modes=['test'])
     main(convert_to_argv(args))
 


### PR DESCRIPTION
When I tried to evaluate Maskrcnn I found
1) evaluation.py initialize model even if checkpoint is present
2) QuantizationBuilder._range_init_params attribute passed to MinMaxInitializer init even if this attribute is None, which isn't handled properly 