### PR TITLE
Remove redundant pruning statistics. Align statistics report

### DIFF
--- a/examples/tensorflow/classification/main.py
+++ b/examples/tensorflow/classification/main.py
@@ -229,9 +229,6 @@ def run(config):
     }
 
     if 'train' in config.mode:
-        statistics = compression_ctrl.statistics()
-        logger.info(statistics.to_str())
-
         if is_accuracy_aware_training(config):
             logger.info('starting an accuracy-aware training loop...')
             result_dict_to_val_metric_fn = lambda results: 100 * results['acc@1']

--- a/examples/tensorflow/classification/main.py
+++ b/examples/tensorflow/classification/main.py
@@ -228,6 +228,9 @@ def run(config):
         'validation_freq': 1,
     }
 
+    statistics = compression_ctrl.statistics()
+    logger.info(statistics.to_str())
+
     if 'train' in config.mode:
         if is_accuracy_aware_training(config):
             logger.info('starting an accuracy-aware training loop...')

--- a/examples/tensorflow/classification/main.py
+++ b/examples/tensorflow/classification/main.py
@@ -228,10 +228,10 @@ def run(config):
         'validation_freq': 1,
     }
 
-    statistics = compression_ctrl.statistics()
-    logger.info(statistics.to_str())
-
     if 'train' in config.mode:
+        statistics = compression_ctrl.statistics()
+        logger.info(statistics.to_str())
+
         if is_accuracy_aware_training(config):
             logger.info('starting an accuracy-aware training loop...')
             result_dict_to_val_metric_fn = lambda results: 100 * results['acc@1']

--- a/examples/tensorflow/object_detection/main.py
+++ b/examples/tensorflow/object_detection/main.py
@@ -210,6 +210,9 @@ def train(train_step, test_step, eval_metric, train_dist_dataset, test_dist_data
     timer = Timer()
     timer.tic()
 
+    statistics = compression_ctrl.statistics()
+    logger.info(statistics.to_str())
+
     logger.info('Training...')
     for epoch in range(initial_epoch, epochs):
         logger.info('Epoch: {}/{}'.format(epoch, epochs))

--- a/examples/tensorflow/segmentation/train.py
+++ b/examples/tensorflow/segmentation/train.py
@@ -269,6 +269,9 @@ def run_train(config):
                                                                      config.ckpt_path,
                                                                      steps_per_epoch)
 
+    statistics = compression_ctrl.statistics()
+    logger.info(statistics.to_str())
+
     train_step = create_train_step_fn(strategy, compress_model, loss_fn, optimizer)
 
     train(train_step, train_dist_dataset, initial_epoch, initial_step,

--- a/nncf/common/pruning/statistics.py
+++ b/nncf/common/pruning/statistics.py
@@ -26,8 +26,6 @@ class PrunedLayerSummary:
                  name: str,
                  weight_shape: List[int],
                  mask_shape: List[int],
-                 weight_pruning_level: float,
-                 mask_pruning_level: float,
                  filter_pruning_level: float):
         """
         Initializes a summary about the pruned layer.
@@ -35,15 +33,11 @@ class PrunedLayerSummary:
         :param name: Layer's name.
         :param weight_shape: Weight's shape.
         :param mask_shape: Mask's shape.
-        :param weight_pruning_level: Weight's pruning level.
-        :param mask_pruning_level: Mask's pruning level.
         :param filter_pruning_level: Filter's pruning level.
         """
         self.name = name
         self.weight_shape = weight_shape
         self.mask_shape = mask_shape
-        self.weight_pruning_level = weight_pruning_level
-        self.mask_pruning_level = mask_pruning_level
         self.filter_pruning_level = filter_pruning_level
 
 
@@ -73,14 +67,10 @@ class PrunedModelStatistics(Statistics):
             ]
         )
 
-        header = ['Layer\'s name', 'Weight\'s shape', 'Mask\'s shape',
-                  'Zeros in mask, %', 'Pruning level', 'Filter pruning level']
+        header = ['Layer\'s name', 'Weight\'s shape', 'Mask\'s shape', 'Filter pruning level']
         rows = []
         for s in self.pruned_layers_summary:
-            rows.append([
-                s.name, s.weight_shape, s.mask_shape, 100 * s.mask_pruning_level,
-                s.weight_pruning_level, s.filter_pruning_level
-            ])
+            rows.append([s.name, s.weight_shape, s.mask_shape, s.filter_pruning_level])
 
         layers_string = create_table(header, rows)
 

--- a/nncf/tensorflow/callbacks/statistics_callback.py
+++ b/nncf/tensorflow/callbacks/statistics_callback.py
@@ -61,6 +61,14 @@ class StatisticsCallback(tf.keras.callbacks.Callback):
         if self._log_text:
             nncf_logger.info(nncf_stats.to_str())
 
+    def on_train_begin(self, logs: dict = None):
+        nncf_stats = self._statistics_fn()
+        if self._log_tensorboard:
+            self._dump_to_tensorboard(self._prepare_for_tensorboard(nncf_stats),
+                                      self.model.optimizer.iterations.numpy())
+        if self._log_text:
+            nncf_logger.info(nncf_stats.to_str())
+
     def on_train_end(self, logs: dict = None):
         if self._file_writer:
             self._file_writer.close()

--- a/nncf/tensorflow/pruning/base_algorithm.py
+++ b/nncf/tensorflow/pruning/base_algorithm.py
@@ -313,11 +313,8 @@ class BasePruningAlgoController(TFCompressionAlgorithmController):
 
         pruned_layers_summary = []
         for mask_name, weights_shape, mask_shape, pruning_rate in mask_pruning:
-            # TODO(andrey-churkin): Should be calculated
-            weight_pruning_level = -1
-            mask_pruning_level = -1
-            pruned_layers_summary.append(PrunedLayerSummary(mask_name, weights_shape, mask_shape,
-                                                            weight_pruning_level, mask_pruning_level, pruning_rate))
+            pruned_layers_summary.append(PrunedLayerSummary(mask_name, weights_shape,
+                                                            mask_shape, pruning_rate))
 
         return PrunedModelStatistics(self.pruning_rate, pruned_layers_summary)
 

--- a/nncf/tensorflow/pruning/callbacks.py
+++ b/nncf/tensorflow/pruning/callbacks.py
@@ -27,6 +27,7 @@ class PruningStatisticsCallback(StatisticsCallback):
         ms = nncf_stats.filter_pruning.model_statistics
         tensorboard_stats = {
             f'{base_prefix}/pruning_level_for_model': ms.pruning_level,
+            f'{base_prefix}/flops_pruning_level': nncf_stats.filter_pruning.flops_pruning_level,
             f'{base_prefix}/target_pruning_level': nncf_stats.filter_pruning.target_pruning_level,
         }
 

--- a/nncf/torch/pruning/filter_pruning/algo.py
+++ b/nncf/torch/pruning/filter_pruning/algo.py
@@ -165,9 +165,7 @@ class FilterPruningController(BasePruningAlgoController):
                     PrunedLayerSummary(layer_name,
                                        list(minfo.module.weight.size()),
                                        list(self.mask_shape(minfo)),
-                                       self.pruning_rate_for_weight(minfo),
-                                       self.pruning_rate_for_mask(minfo),
-                                       self.pruning_rate_for_filters(minfo))
+                                       self.pruning_rate_for_mask(minfo))
 
         model_statistics = PrunedModelStatistics(self._pruning_rate, list(pruned_layers_summary.values()))
         self._update_benchmark_statistics()
@@ -175,7 +173,6 @@ class FilterPruningController(BasePruningAlgoController):
 
         stats = FilterPruningStatistics(model_statistics, self.full_flops, self.current_flops,
                                         self.full_params_num, self.current_params_num, target_pruning_level)
-
 
         nncf_stats = NNCFStatistics()
         nncf_stats.register('filter_pruning', stats)


### PR DESCRIPTION
Two main changes:
1. Some statistics are removed from printing to console. 
from 
<img width="405" alt="pruning_stats" src="https://user-images.githubusercontent.com/37940171/123635304-33897200-d824-11eb-9dbd-68c4fa318c5e.PNG">
to 
<img width="442" alt="statistics new" src="https://user-images.githubusercontent.com/37940171/123635532-721f2c80-d824-11eb-8fa3-ecb1c044a18f.PNG">

2. Filter pruning level in PyTorch is now calculated using a layer mask.

\+ added to TF statistics printing after initialization