### PR TITLE
Remove BN statistics forgetting step in BN adaptation

### DIFF
--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -1,64 +1,64 @@
 ### Pruning
 
-#### Filter pruning    
+#### Filter pruning
 
-Filter pruning algorithm zeros output filters in Convolutional layers based on some filter importance criterion (filters with smaller importance are pruned).  
-Not all Convolution layers in the model can be pruned. Such layers are determined by the model architecture automatically as well as cross-layer dependencies that impose constraints on pruning filters.   
-The framework contains three filter importance criteria: `L1`, `L2` norm, and `Geometric Median`. Also, different schemes of pruning application are presented by different schedulers.    
+Filter pruning algorithm zeros output filters in Convolutional layers based on some filter importance criterion  (filters with smaller importance are pruned).
+The framework contains three filter importance criteria: `L1`, `L2` norm, and `Geometric Median`. Also, different schemes of pruning application are presented by different schedulers.
+Not all Convolution layers in the model can be pruned. Such layers are determined by the model architecture automatically as well as cross-layer dependencies that impose constraints on pruning filters.
 
 #### Filter importance criteria **L1, L2**
 
- `L1`, `L2` filter importance criteria are based on the following assumption:    
-> Convolutional filters with small ![l_p](https://latex.codecogs.com/png.latex?l_p) norms do not significantly contribute to output activation values, and thus have a small impact on the final predictions of CNN models.   
-In the above, the ![l_p](https://latex.codecogs.com/png.latex?l_p) norm for filter F is:    
+ `L1`, `L2` filter importance criteria are based on the following assumption:
+> Convolutional filters with small ![l_p](https://latex.codecogs.com/png.latex?l_p) norms do not significantly contribute to output activation values, and thus have a small impact on the final predictions of CNN models.
+In the above, the ![l_p](https://latex.codecogs.com/png.latex?l_p) norm for filter F is:
 
-![||F||_p = \sqrt[p]{\sum_{c, k_1, k_2 = 1}^{C, K, K}|F(c, k_1, k_2)|^p}](https://latex.codecogs.com/png.latex?%7C%7CF%7C%7C_p%20%3D%20%5Csqrt%5Bp%5D%7B%5Csum_%7Bc%2C%20k_1%2C%20k_2%20%3D%201%7D%5E%7BC%2C%20K%2C%20K%7D%7CF%28c%2C%20k_1%2C%20k_2%29%7C%5Ep%7D)  
+![||F||_p = \sqrt[p]{\sum_{c, k_1, k_2 = 1}^{C, K, K}|F(c, k_1, k_2)|^p}](https://latex.codecogs.com/png.latex?%7C%7CF%7C%7C_p%20%3D%20%5Csqrt%5Bp%5D%7B%5Csum_%7Bc%2C%20k_1%2C%20k_2%20%3D%201%7D%5E%7BC%2C%20K%2C%20K%7D%7CF%28c%2C%20k_1%2C%20k_2%29%7C%5Ep%7D)
 
-During the pruning procedure filters with smaller  `L1` or `L2` norm will be pruned first.    
+During the pruning procedure filters with smaller  `L1` or `L2` norm will be pruned first.
 
 **Geometric Median**
 
-Usage of the geometric median filter importance criterion is based on the following assumptions:  
-> Let ![\{F_i, \dots , F_j\}](https://latex.codecogs.com/png.latex?%5C%7BF_i%2C%20..%20%2C%20F_j%5C%7D) be the set of N filters in a convolutional layer that are closest to the geometric median of all the filters in that layer.   As it was shown, each of those filters can be decomposed into a linear combination of the rest of the filters further from the geometric median with a small error. Hence, these filters can be pruned without much impact on network accuracy.  Since we have only fixed number of filters in each layer and the task of calculation of geometric median is a non-trivial problem in computational geometry, we can instead find which filters minimize the summation of the distance with other filters.  
+Usage of the geometric median filter importance criterion is based on the following assumptions:
+> Let ![\{F_i, \dots , F_j\}](https://latex.codecogs.com/png.latex?%5C%7BF_i%2C%20..%20%2C%20F_j%5C%7D) be the set of N filters in a convolutional layer that are closest to the geometric median of all the filters in that layer.   As it was shown, each of those filters can be decomposed into a linear combination of the rest of the filters further from the geometric median with a small error. Hence, these filters can be pruned without much impact on network accuracy.  Since we have only fixed number of filters in each layer and the task of calculation of geometric median is a non-trivial problem in computational geometry, we can instead find which filters minimize the summation of the distance with other filters.
 
-Then Geometric Median importance of ![F_i](https://latex.codecogs.com/png.latex?F_i) filter from ![L_j](https://latex.codecogs.com/png.latex?L_j) layer is:  
-![G(F_i) = \sum_{F_j \in \{F_1, \dots F_m\}, j\neq i} ||F_i - F_j||_2](https://latex.codecogs.com/png.latex?G%28F_i%29%20%3D%20%5Csum_%7BF_j%20%5Cin%20%5C%7BF_1%2C%20%5Cdots%20F_m%5C%7D%2C%20j%5Cneq%20i%7D%20%7C%7CF_i%20-%20F_j%7C%7C_2)  
-Where ![L_j](https://latex.codecogs.com/png.latex?L_j) is j-th convolutional layer in model. ![\{F_1, \dots F_m\} \in L_j](https://latex.codecogs.com/png.latex?%5C%7BF_1%2C%20%5Cdots%20F_m%5C%7D%20%5Cin%20L_j) - set of all  output filters in ![L_j](https://latex.codecogs.com/png.latex?L_j) layer.  
+Then Geometric Median importance of ![F_i](https://latex.codecogs.com/png.latex?F_i) filter from ![L_j](https://latex.codecogs.com/png.latex?L_j) layer is:
+![G(F_i) = \sum_{F_j \in \{F_1, \dots F_m\}, j\neq i} ||F_i - F_j||_2](https://latex.codecogs.com/png.latex?G%28F_i%29%20%3D%20%5Csum_%7BF_j%20%5Cin%20%5C%7BF_1%2C%20%5Cdots%20F_m%5C%7D%2C%20j%5Cneq%20i%7D%20%7C%7CF_i%20-%20F_j%7C%7C_2)
+Where ![L_j](https://latex.codecogs.com/png.latex?L_j) is j-th convolutional layer in model. ![\{F_1, \dots F_m\} \in L_j](https://latex.codecogs.com/png.latex?%5C%7BF_1%2C%20%5Cdots%20F_m%5C%7D%20%5Cin%20L_j) - set of all  output filters in ![L_j](https://latex.codecogs.com/png.latex?L_j) layer.
 
-Then during pruning filters with smaller ![G(F_i)](https://latex.codecogs.com/png.latex?G%28F_i%29) importance function will be pruned first.  
+Then during pruning filters with smaller ![G(F_i)](https://latex.codecogs.com/png.latex?G%28F_i%29) importance function will be pruned first.
 
 #### Schedulers
 
-**Baseline Scheduler**    
- Firstly, during `num_init_steps` epochs the model is trained without pruning. Secondly, the pruning algorithm calculates filter importances and prunes a `pruning_target` part of the filters with the smallest importance in each prunable convolution.   
-The zeroed filters are frozen afterwards and the remaining model parameters are fine-tuned.   
+**Baseline Scheduler**
+ Firstly, during `num_init_steps` epochs the model is trained without pruning. Secondly, the pruning algorithm calculates filter importances and prunes a `pruning_target` part of the filters with the smallest importance in each prunable convolution.
+The zeroed filters are frozen afterwards and the remaining model parameters are fine-tuned.
 
-**Parameters of the scheduler:**  
+**Parameters of the scheduler:**
 - `num_init_steps` - number of epochs for model pretraining **before** pruning.
 - `pruning_target` - pruning rate target. For example, the value `0.5` means that right after pretraining, convolutions that can be pruned will have 50% of their filters set to zero.
 
 
-**Exponential scheduler**   
+**Exponential scheduler**
 
-Similar to the Baseline scheduler, during `num_init_steps` epochs model is pretrained without pruning.  
-During the next `pruning steps` epochs `Exponential scheduler` gradually increasing pruning rate from `pruning_init` to `pruning_target`. After each pruning training epoch pruning algorithm calculates filter importances for all convolutional filters and prune (setting to zero) `current_pruning_rate` part of filters with the smallest importance in each Convolution.  After `num_init_steps` + `pruning_steps` epochs algorithm with zeroed filters is frozen and remaining model parameters only fine-tunes.    
+Similar to the Baseline scheduler, during `num_init_steps` epochs model is pretrained without pruning.
+During the next `pruning steps` epochs `Exponential scheduler` gradually increasing pruning rate from `pruning_init` to `pruning_target`. After each pruning training epoch pruning algorithm calculates filter importances for all convolutional filters and prune (setting to zero) `current_pruning_rate` part of filters with the smallest importance in each Convolution.  After `num_init_steps` + `pruning_steps` epochs algorithm with zeroed filters is frozen and remaining model parameters only fine-tunes.
 
-Current pruning rate ![P_{i}](https://latex.codecogs.com/svg.latex?P_{i}) (on i-th epoch) during training calculates by equation:  
-![P_i = a * e^{- k * i}](https://latex.codecogs.com/png.latex?P_i%20%3D%20a%20*%20e%5E%7B-%20k%20*%20i%7D)  
-Where ![a, k](https://latex.codecogs.com/svg.latex?a,%20k) - parameters.  
+Current pruning rate ![P_{i}](https://latex.codecogs.com/svg.latex?P_{i}) (on i-th epoch) during training calculates by equation:
+![P_i = a * e^{- k * i}](https://latex.codecogs.com/png.latex?P_i%20%3D%20a%20*%20e%5E%7B-%20k%20*%20i%7D)
+Where ![a, k](https://latex.codecogs.com/svg.latex?a,%20k) - parameters.
 
-**Parameters of scheduler:**  
+**Parameters of scheduler:**
 - `num_init_steps` - number of epochs for model pretraining before pruning.
 - `pruning_steps` - the number of epochs during which the pruning rate target is increased from `pruning_init` to `pruning_target` value.
 - `pruning_init` - initial pruning rate target. For example, value `0.1` means that at the begging of training, convolutions that can be pruned will have 10% of their filters set to zero.
 - `pruning_target` - pruning rate target at the end of the schedule. For example, the value `0.5` means that at the epoch with the number of `num_init_steps + pruning_steps`, convolutions that can be pruned will have 50% of their filters set to zero.
 
-**Exponential with bias scheduler**   
-Similar to the `Exponential scheduler`, but current pruning rate ![P_{i}](https://latex.codecogs.com/svg.latex?P_{i}) (on i-th epoch) during training calculates by equation:  
-![P_i = a * e^{- k * i} + b](https://latex.codecogs.com/png.latex?P_i%20%3D%20a%20*%20e%5E%7B-%20k%20*%20i%7D%20&plus;%20b)  
-Where ![a, k, b](https://latex.codecogs.com/png.latex?a%2C%20k%2C%20b) - parameters.  
+**Exponential with bias scheduler**
+Similar to the `Exponential scheduler`, but current pruning rate ![P_{i}](https://latex.codecogs.com/svg.latex?P_{i}) (on i-th epoch) during training calculates by equation:
+![P_i = a * e^{- k * i} + b](https://latex.codecogs.com/png.latex?P_i%20%3D%20a%20*%20e%5E%7B-%20k%20*%20i%7D%20&plus;%20b)
+Where ![a, k, b](https://latex.codecogs.com/png.latex?a%2C%20k%2C%20b) - parameters.
 
-> **NOTE**:  Baseline scheduler prunes filters only ONCE and after it just fine-tunes remaining parameters while exponential (and exponential with bias) schedulers choose and prune different filters subsets at each pruning epoch.  
+> **NOTE**:  Baseline scheduler prunes filters only ONCE and after it just fine-tunes remaining parameters while exponential (and exponential with bias) schedulers choose and prune different filters subsets at each pruning epoch.
 
 #### Batch-norm statistics adaptation
 
@@ -69,14 +69,13 @@ and reduce the corresponding accuracy drop even before model training. This opti
 sparsity and filter pruning algorithms. It can be enabled by setting a non-zero value of `num_bn_adaptation_samples` in the
 `batchnorm_adaptation` section of the `initializer` configuration (see example below).
 
-**Filter pruning configuration file parameters**:    
+**Filter pruning configuration file parameters**:
 ```
 {
     "algorithm": "filter_pruning",
     "initializer": {
         "batchnorm_adaptation": {
             "num_bn_adaptation_samples": 2048, // Number of samples from the training dataset to pass through the model at initialization in order to update batchnorm statistics of the original model. The actual number of samples will be a closest multiple of the batch size.
-            "num_bn_forget_samples": 1024, // Number of samples from the training dataset to pass through the model at initialization in order to erase batchnorm statistics of the original model (using large momentum value for rolling mean updates). The actual number of samples will be a closest multiple of the batch size.
         }
     }
     "pruning_init": 0.1, // Initial value of the pruning level applied to the convolutions that can be pruned in 'create_compressed_model' function. 0.0 by default.
@@ -87,11 +86,11 @@ sparsity and filter pruning algorithms. It can be enabled by setting a non-zero 
         "pruning_steps": 10, // Number of epochs during which the pruning rate is increased from `pruning_init` to `pruning_target` value.
         "weight_importance": "L2", // The type of filter importance metric. Can be one of `L1`, `L2`, `geometric_median`. `L2` by default.
         "all_weights": false, // Whether to prune layers independently (choose filters with the smallest importance in each layer separately) or not. `False` by default.
-        "prune_first_conv": false, // Whether to prune first Convolutional layers or not. First means that it is a convolutional layer such that there is a path from model input to this layer such that there are no other convolution operations on it. `False` by default. 
-        "prune_last_conv": false, // Whether to prune last Convolutional layers or not.  Last means that it is a Convolutional layer such that there is a path from this layer to the model output such that there are no other convolution operations on it. `False` by default. 
+        "prune_first_conv": false, // Whether to prune first Convolutional layers or not. First means that it is a convolutional layer such that there is a path from model input to this layer such that there are no other convolution operations on it. `False` by default.
+        "prune_last_conv": false, // Whether to prune last Convolutional layers or not.  Last means that it is a Convolutional layer such that there is a path from this layer to the model output such that there are no other convolution operations on it. `False` by default.
         "prune_downsample_convs": false, // Whether to prune downsample Convolutional layers (with stride > 1) or not. `False` by default.
         "prune_batch_norms": true, // Whether to nullifies parameters of Batch Norm layer corresponds to zeroed filters of convolution corresponding to this Batch Norm. `True` by default.
-        "zero_grad": true // Whether to setting gradients corresponding to zeroed filters to zero during training, `True` by default.    
+        "zero_grad": true // Whether to setting gradients corresponding to zeroed filters to zero during training, `True` by default.
     },
 
     // A list of model control flow graph node scopes to be ignored for this operation - functions as a 'denylist'. Optional.

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -84,21 +84,21 @@ For better accuracy, floating-point zero should be within quantization range and
 You can use the `num_init_samples` parameter from the `initializer` group to initialize the values of `input_low` and `input_range` from the collected statistics using given number of samples.
 
 #### Quantizer setup and hardware config files
-NNCF allows to quantize models for best results on a given Intel hardware type when executed using OpenVINO runtime. 
+NNCF allows to quantize models for best results on a given Intel hardware type when executed using OpenVINO runtime.
 To achieve this, the quantizer setup should be performed with following considerations in mind:
 1) every operation that can accept quantized inputs on a given HW (i.e. can be executed using quantized input values) should have its inputs quantized in NNCF
 2) the quantized inputs should be quantized with a configuration that is supported on a given HW for a given operation (e.g. per-tensor vs per-channel quantization, or 8 bits vs. 4 bits)
 3) for operations that are agnostic to quantization, the execution should handle quantized tensors rather than full-precision tensors.
 4) certain operation sequences will be runtime-optimized to execute in a single kernel call ("fused"), and additional quantizer insertion/quantization simulation within such operation sequences will be detrimental to overall performance
 
-These requirements are fulfilled by the quantizer propagation algorithm. 
+These requirements are fulfilled by the quantizer propagation algorithm.
 The algorithm first searches the internal NNCF representation of the model's control flow graph for predefined patterns that are "fusable", and apply the fusing to the internal graph representation as well.
 Next, the operations in the graph that can be associated to input-quantizable operations on a given target hardware are assigned a single quantizer for each its quantizable activation input, with a number of possible quantizer configurations attached to it (that are feasible on target HW).
 The quantizers are then "propagated" against the data flow in the model's control flow graph as far as possible, potentially merging with other quantizers.
 Once all quantizers have reached a standstill in their propagation process, each will have a final (possibly reduced) set of possible quantizer configurations, from which a single one is either chosen manually, or using a precision initialization algorithm (which accepts the potential quantizer locations and associated potential quantizer configuration sets).
-The resulting configuration is then applied as a final quantizer setup configuration. 
+The resulting configuration is then applied as a final quantizer setup configuration.
 
-Note that this algorithm applies to activation quantization only - the weight quantizers do not require propagation. 
+Note that this algorithm applies to activation quantization only - the weight quantizers do not require propagation.
 However, the possible configurations of weight quantizers themselves are also sourced from the HW config file definitions.
 
 The HW to target for a given quantization algorithm run can be specified in NNCF config using the global `"target_device"` option.
@@ -131,15 +131,15 @@ There is a known issue with AVX2 and AVX512 CPU devices. The issue appears with 
 AVX2 and AVX512 utilize a 16-bit register to store the result of operations on tensors. In case when tensors are saturated the buffer overflow happens.
 This leads to accuracy degradation.
 
-To fix this issue inside NNCF, weight tensors are quantized in 8 bits but only 7 bits are effectively used. 
+To fix this issue inside NNCF, weight tensors are quantized in 8 bits but only 7 bits are effectively used.
 This regime is used when `"target_device": "CPU"` or `"target_device": "ANY"` set.
 
 ---
 
 #### Mixed-Precision Quantization
 
-Quantization to lower precisions (e.g. 6, 4, 2 bits) is an efficient way to accelerate inference of neural networks. 
-Although NNCF supports quantization with an arbitrary number of bits to represent weights and activations values, 
+Quantization to lower precisions (e.g. 6, 4, 2 bits) is an efficient way to accelerate inference of neural networks.
+Although NNCF supports quantization with an arbitrary number of bits to represent weights and activations values,
 choosing ultra-low bitwidth could noticeably affect the model's accuracy. A good trade-off between accuracy and performance is achieved by assigning different precisions to different layers. NNCF provides two automatic precision assignment algorithms, namely **HAWQ** and **AutoQ**.
 
 #### HAWQ
@@ -150,23 +150,23 @@ calculated by multiplying the average Hessian trace with the L2 norm of quantiza
 
 ![\overline{Tr}(H_{i}) * \left \| Q(W_{i}) - W_{i} \right \|^2_2](https://latex.codecogs.com/png.latex?%5Coverline%7BTr%7D%28H_%7Bi%7D%29%20*%20%5Cleft%20%5C%7C%20Q%28W_%7Bi%7D%29%20-%20W_%7Bi%7D%20%5Cright%20%5C%7C%5E2_2)
 
-The sum of the sensitivities for each layer forms a metric which serves as a proxy to the accuracy of the compressed 
-model: the lower the metric, the more accurate should be the corresponding mixed precision model on the validation 
-dataset. 
+The sum of the sensitivities for each layer forms a metric which serves as a proxy to the accuracy of the compressed
+model: the lower the metric, the more accurate should be the corresponding mixed precision model on the validation
+dataset.
 
-To find the optimal trade-off between accuracy and performance of the mixed precision model we also compute a 
-compression ratio - the ratio between **bit complexity** of a fully INT8 model and mixed-precision lower bitwidth one. 
-The bit complexity of the model is a sum of bit complexities for each quantized layer, which are defined as a product 
-of the layer FLOPS and the quantization bitwidth. The optimal configuration is found by calculating the sensitivity 
-metric and the compression ratio for all possible bitwidth settings and selecting the one with the minimal metric value 
+To find the optimal trade-off between accuracy and performance of the mixed precision model we also compute a
+compression ratio - the ratio between **bit complexity** of a fully INT8 model and mixed-precision lower bitwidth one.
+The bit complexity of the model is a sum of bit complexities for each quantized layer, which are defined as a product
+of the layer FLOPS and the quantization bitwidth. The optimal configuration is found by calculating the sensitivity
+metric and the compression ratio for all possible bitwidth settings and selecting the one with the minimal metric value
 among all configurations with a compression ratio below the specified threshold.
 
-By default, the compression ratio is 1.5. It should be enough to compress the model with no more than 1% accuracy drop. 
-But if it doesn't happen, the lower ratio can be set by `compression_ratio` parameter in the `precision` section of 
+By default, the compression ratio is 1.5. It should be enough to compress the model with no more than 1% accuracy drop.
+But if it doesn't happen, the lower ratio can be set by `compression_ratio` parameter in the `precision` section of
 configuration file.
 
-To avoid the exponential search procedure, we apply the following restriction: layers with a small average Hessian 
-trace value are quantized to lower bitwidth and vice versa. 
+To avoid the exponential search procedure, we apply the following restriction: layers with a small average Hessian
+trace value are quantized to lower bitwidth and vice versa.
 
 The Hessian trace is estimated with the randomized [Hutchinson algorithm](https://www.researchgate.net/publication/220432178_Randomized_Algorithms_for_Estimating_the_Trace_of_an_Implicit_Symmetric_Positive_Semi-Definite_Matrix).
 Given Rademacher distributed random vector v, the trace of symmetric matrix H is equal to the estimation of a quadratic form:
@@ -188,14 +188,14 @@ a random vector v, which is independent of ![W_i](https://latex.codecogs.com/png
 where ![H_i](https://latex.codecogs.com/png.latex?H_i) is the Hessian matrix of loss with respect to
 ![W_i](https://latex.codecogs.com/png.latex?W_i). Hence ![Hv](https://latex.codecogs.com/png.latex?Hv) can be
 computed by 2 backpropagation passes: first  - with respect to the loss and second - with respect to the product of the
-gradients and a random vector.   
+gradients and a random vector.
 
-The aforementioned procedure sets bitwidth for weight quantizers only. Bitwidth for activation quantizers is assigned 
-on the next step in two ways: strict or liberal. All quantizers between modules with quantizable inputs have the same 
-bitwidth in the strict mode. Liberal mode allows different precisions within the group. For both cases, bitwidth is 
-assigned based on the rules of the hardware config. If multiple variants are possible the minimal compatible bitwidth 
-is chosen. By default, liberal mode is used as it does not reject a large number of possible bitwidth settings.   
-The `bitwidth_assignment_mode` parameter can override it to the strict one. 
+The aforementioned procedure sets bitwidth for weight quantizers only. Bitwidth for activation quantizers is assigned
+on the next step in two ways: strict or liberal. All quantizers between modules with quantizable inputs have the same
+bitwidth in the strict mode. Liberal mode allows different precisions within the group. For both cases, bitwidth is
+assigned based on the rules of the hardware config. If multiple variants are possible the minimal compatible bitwidth
+is chosen. By default, liberal mode is used as it does not reject a large number of possible bitwidth settings.
+The `bitwidth_assignment_mode` parameter can override it to the strict one.
 
 For automatic mixed-precision selection it's recommended to use the following template of configuration file:
 ```
@@ -226,10 +226,10 @@ Note, optimizer parameters are model specific, this template contains optimal on
 Here's an [example](../../examples/torch/classification/configs/mixed_precision/squeezenet1_1_imagenet_mixed_int_hawq.json) of
 using the template in the full configuration file.
 
-This template uses `plateau` scheduler. Though it usually leads to a lot of epochs of tuning for achieving a good 
-model's accuracy, this is the most reliable way. Staged quantization is an alternative approach and can be more than 
-two times faster, but it may require tweaking of hyper-parameters for each model. Please refer to configuration files 
-ending by `*_staged` for an example of this method.     
+This template uses `plateau` scheduler. Though it usually leads to a lot of epochs of tuning for achieving a good
+model's accuracy, this is the most reliable way. Staged quantization is an alternative approach and can be more than
+two times faster, but it may require tweaking of hyper-parameters for each model. Please refer to configuration files
+ending by `*_staged` for an example of this method.
 
 The manual mode of mixed-precision quantization is also available by explicitly setting the bitwidth per layer
  through `bitwidth_per_scope` parameter.
@@ -237,13 +237,13 @@ The manual mode of mixed-precision quantization is also available by explicitly 
 ---
 **NOTE**
 
-Precision initialization overrides bits settings specified in `weights` and `activations` sections of configuration 
-file. 
+Precision initialization overrides bits settings specified in `weights` and `activations` sections of configuration
+file.
 
 ---
 
 #### AutoQ
-NNCF provides an alternate mode, namely AutoQ, for mixed-precision automation. It is an AutoML-based technique that automatically learns the layer-wise bitwidth with explored experiences. Based on [HAQ](https://openaccess.thecvf.com/content_CVPR_2019/papers/Wang_HAQ_Hardware-Aware_Automated_Quantization_With_Mixed_Precision_CVPR_2019_paper.pdf), AutoQ utilizes an actor-critic algorithm, Deep Deterministic Policy Gradient (DDPG) for efficient search over the bitwidth space. DDPG is trained in an episodic fashion, converging to a deterministic mixed-precision policy after a number of episodes. An episode is constituted by stepping, the DDPG transitions from quantizer to quantizer sequentially to predict a precision of a layer. Each quantizer essentially denotes a state in RL framework and it is represented by attributes of the associated layers. For example, a quantizer for 2D Convolution is represented by its quantizer Id (integer), input and output channel size, feature map dimension, stride size, if it is depthwise, number of parameters etc. It is recommended to check out ```_get_layer_attr``` in [```quantization_env.py```](https://github.com/openvinotoolkit/nncf/blob/develop/nncf/automl/environment/quantization_env.py#L333) for the featurization of different network layer types. 
+NNCF provides an alternate mode, namely AutoQ, for mixed-precision automation. It is an AutoML-based technique that automatically learns the layer-wise bitwidth with explored experiences. Based on [HAQ](https://openaccess.thecvf.com/content_CVPR_2019/papers/Wang_HAQ_Hardware-Aware_Automated_Quantization_With_Mixed_Precision_CVPR_2019_paper.pdf), AutoQ utilizes an actor-critic algorithm, Deep Deterministic Policy Gradient (DDPG) for efficient search over the bitwidth space. DDPG is trained in an episodic fashion, converging to a deterministic mixed-precision policy after a number of episodes. An episode is constituted by stepping, the DDPG transitions from quantizer to quantizer sequentially to predict a precision of a layer. Each quantizer essentially denotes a state in RL framework and it is represented by attributes of the associated layers. For example, a quantizer for 2D Convolution is represented by its quantizer Id (integer), input and output channel size, feature map dimension, stride size, if it is depthwise, number of parameters etc. It is recommended to check out ```_get_layer_attr``` in [```quantization_env.py```](https://github.com/openvinotoolkit/nncf/blob/develop/nncf/automl/environment/quantization_env.py#L333) for the featurization of different network layer types.
 
 When the agent enters a state/quantizer, it receives the state features and forward passes them through its network. The output of the forward pass is a scalar continuous action output which is subsequently mapped to the bitwidth options of the particular quantizer. The episode terminates after the prediction of the last quantizer and a complete layer-wise mixed-precision policy is obtained. To ensure a policy fits in the user-specified compression ratio, the policy is post processed by reducing the precision sequentially from the last quantizer until the compression ratio is met.
 
@@ -266,7 +266,7 @@ To evaluate the goodness of a policy, NNCF backend quantizes the workload accord
     }
 ```
 
-The snippet above demonstrates the specification of AutoQ in NNCF config. ```target_device``` determines the bitwidth choices available for a particular layer. ```bits``` also defines the precision space of quantizer but it is only active in the absence of target device. 
+The snippet above demonstrates the specification of AutoQ in NNCF config. ```target_device``` determines the bitwidth choices available for a particular layer. ```bits``` also defines the precision space of quantizer but it is only active in the absence of target device.
 
 ```iter_number``` is synonymous to the number of episodes. A good choice depends on the number of quantizers in a workload and also the number of bitwidth choice. The larger the number, more episodes are required.
 
@@ -329,7 +329,6 @@ sparsity and filter pruning algorithms. It can be enabled by setting a non-zero 
         }
         "batchnorm_adaptation": {
             "num_bn_adaptation_samples": 2048, // Number of samples from the training dataset to pass through the model at initialization in order to update batchnorm statistics of the original model. The actual number of samples will be a closest multiple of the batch size.
-            "num_bn_forget_samples": 1024, // Number of samples from the training dataset to pass through the model at initialization in order to erase batchnorm statistics of the original model (using large momentum value for rolling mean updates). The actual number of samples will be a closest multiple of the batch size.
         }
     }
     "weights": { // Constraints to be applied to model weights quantization only.

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -78,7 +78,6 @@ The magnitude sparsity method implements a naive approach that is based on the a
     "initializer": {
         "batchnorm_adaptation": {
             "num_bn_adaptation_samples": 2048, // Number of samples from the training dataset to pass through the model at initialization in order to update batchnorm statistics of the original model. The actual number of samples will be a closest multiple of the batch size.
-            "num_bn_forget_samples": 1024, // Number of samples from the training dataset to pass through the model at initialization in order to erase batchnorm statistics of the original model (using large momentum value for rolling mean updates). The actual number of samples will be a closest multiple of the batch size.
         }
     }
     "sparsity_init": 0.05,// "Initial value of the sparsity level applied to the model in 'create_compressed_model' function

--- a/examples/tensorflow/classification/configs/quantization/inception_v3_imagenet_int8.json
+++ b/examples/tensorflow/classification/configs/quantization/inception_v3_imagenet_int8.json
@@ -25,7 +25,6 @@
         "initializer": {
             "batchnorm_adaptation": {
                 "num_bn_adaptation_samples": 2048,
-                "num_bn_forget_samples": 1024
             }
         }
     }

--- a/examples/tensorflow/classification/configs/quantization/mobilenet_v2_imagenet_int8.json
+++ b/examples/tensorflow/classification/configs/quantization/mobilenet_v2_imagenet_int8.json
@@ -19,13 +19,12 @@
 
     "dataset": "imagenet2012",
     "dataset_type": "tfds",
-    
+
     "compression": {
         "algorithm": "quantization",
         "initializer": {
             "batchnorm_adaptation": {
                 "num_bn_adaptation_samples": 2048,
-                "num_bn_forget_samples": 1024
             }
         }
     }

--- a/examples/tensorflow/classification/configs/quantization/mobilenet_v3_large_imagenet_int8.json
+++ b/examples/tensorflow/classification/configs/quantization/mobilenet_v3_large_imagenet_int8.json
@@ -25,7 +25,6 @@
         "initializer": {
             "batchnorm_adaptation": {
                 "num_bn_adaptation_samples": 2048,
-                "num_bn_forget_samples": 1024
             }
         },
         "weights": {

--- a/examples/tensorflow/classification/configs/quantization/mobilenet_v3_small_imagenet_int8.json
+++ b/examples/tensorflow/classification/configs/quantization/mobilenet_v3_small_imagenet_int8.json
@@ -25,7 +25,6 @@
         "initializer": {
             "batchnorm_adaptation": {
                 "num_bn_adaptation_samples": 2048,
-                "num_bn_forget_samples": 1024
             }
         },
         "weights": {

--- a/examples/tensorflow/classification/configs/quantization/resnet50_imagenet_int8.json
+++ b/examples/tensorflow/classification/configs/quantization/resnet50_imagenet_int8.json
@@ -22,7 +22,6 @@
         "initializer": {
             "batchnorm_adaptation": {
                 "num_bn_adaptation_samples": 2048,
-                "num_bn_forget_samples": 1024
             }
         }
     }

--- a/nncf/config/extractors.py
+++ b/nncf/config/extractors.py
@@ -135,7 +135,6 @@ def extract_bn_adaptation_init_params(config: NNCFConfig) -> Dict[str, object]:
     """
     params = config.get('initializer', {}).get('batchnorm_adaptation', {})
     num_bn_adaptation_samples = params.get('num_bn_adaptation_samples', 2000)
-    num_bn_forget_samples = params.get('num_bn_forget_samples', 1000)
 
     try:
         args = config.get_extra_struct(BNAdaptationInitArgs)
@@ -147,7 +146,6 @@ def extract_bn_adaptation_init_params(config: NNCFConfig) -> Dict[str, object]:
 
     params = {
         'num_bn_adaptation_samples': num_bn_adaptation_samples,
-        'num_bn_forget_samples': num_bn_forget_samples,
         'data_loader': args.data_loader,
         'device': args.device
     }

--- a/nncf/config/schema.py
+++ b/nncf/config/schema.py
@@ -177,14 +177,7 @@ GENERIC_INITIALIZER_SCHEMA = {
                                                                              "adaptation procedure for the compressed "
                                                                              "model. The actual number of samples will "
                                                                              "be a closest multiple of the batch "
-                                                                             "size."),
-                    "num_bn_forget_samples": with_attributes(_NUMBER,
-                                                             description="Number of samples from the training "
-                                                                         "dataset to use for model inference during "
-                                                                         "the BatchNorm statistics adaptation "
-                                                                         "in the initial statistics forgetting step. "
-                                                                         "The actual number of samples will be a "
-                                                                         "closest multiple of the batch size."),
+                                                                             "size.")
                 },
                 "additionalProperties": False,
             },
@@ -276,11 +269,6 @@ QUANTIZATION_INITIALIZER_SCHEMA = {
                                                                              "durung the BatchNorm statistics "
                                                                              "adaptation procedure for the compressed "
                                                                              "model"),
-                    "num_bn_forget_samples": with_attributes(_NUMBER,
-                                                             description="Number of samples from the training "
-                                                                         "dataset to use for model inference during "
-                                                                         "the BatchNorm statistics adaptation "
-                                                                         "in the initial statistics forgetting step"),
                 },
                 "additionalProperties": False,
             },

--- a/nncf/tensorflow/batchnorm_adaptation.py
+++ b/nncf/tensorflow/batchnorm_adaptation.py
@@ -44,29 +44,6 @@ class BNTrainingStateSwitcher:
                 layer.trainable = self._original_training_state[layer]
 
 
-class BNMomentumSwitcher:
-    """
-    Context manager for setting BatchNormalization layer momentum value.
-    At the enter, set BatchNormalization layer momentum to 0.1 to erase the history of statistics.
-    At the exit, restore original BatchNormalization layer momentum (used for further adaptation).
-    """
-
-    def __init__(self, model: tf.keras.Model):
-        self._model = model
-        self._original_momentum_values = {}
-
-    def __enter__(self):
-        for layer in self._model.layers:
-            if get_keras_layer_metatype(layer) == TFBatchNormalizationLayerMetatype:
-                self._original_momentum_values[layer] = layer.momentum
-                layer.momentum = 0.1
-
-    def __exit__(self, *exc):
-        for layer in self._model.layers:
-            if get_keras_layer_metatype(layer) == TFBatchNormalizationLayerMetatype:
-                layer.momentum = self._original_momentum_values[layer]
-
-
 class TFBatchnormAdaptationAlgorithmImpl(BatchnormAdaptationAlgorithmImpl):
     """
     Implementation of the batch-norm statistics adaptation algorithm for the TensorFlow backend.
@@ -83,13 +60,6 @@ class TFBatchnormAdaptationAlgorithmImpl(BatchnormAdaptationAlgorithmImpl):
                              'does not support switch of devices. Model initial device '
                              'is used by default for batchnorm adaptation.')
         with BNTrainingStateSwitcher(model):
-            with BNMomentumSwitcher(model):
-                for (x, _) in ProgressBar(
-                        islice(self._data_loader, self._num_bn_forget_steps),
-                        total=self._num_bn_forget_steps,
-                        desc='BatchNorm statistics forget'
-                ):
-                    model(x, training=True)
             for (x, _) in ProgressBar(
                     islice(self._data_loader, self._num_bn_adaptation_steps),
                     total=self._num_bn_adaptation_steps,

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -91,7 +91,6 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
         self._bn_adaptation = None
 
     def _parse_init_params(self):
-        self._batchnorm_adaptation = 'batchnorm_adaptation' in self.config.get('initializer', {})
         self._range_init_params = self._parse_range_init_params()
 
     def _parse_range_init_params(self) -> TFRangeInitParams:
@@ -197,9 +196,7 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
     def initialize(self, model: tf.keras.Model) -> None:
         if self._range_init_params is not None:
             self._run_range_initialization(model)
-
-        if self._batchnorm_adaptation:
-            self._run_batchnorm_adaptation(model)
+        self._run_batchnorm_adaptation(model)
 
     def _run_range_initialization(self, model: tf.keras.Model) -> None:
         if self._range_initializer is None:

--- a/nncf/torch/batchnorm_adaptation.py
+++ b/nncf/torch/batchnorm_adaptation.py
@@ -26,5 +26,5 @@ class PTBatchnormAdaptationAlgorithmImpl(BatchnormAdaptationAlgorithmImpl):
 
         :param model: A model for which the algorithm will be applied.
         """
-        bn_adaptation_runner = DataLoaderBNAdaptationRunner(model, self._device, self._num_bn_forget_steps)
+        bn_adaptation_runner = DataLoaderBNAdaptationRunner(model, self._device)
         bn_adaptation_runner.run(self._data_loader, self._num_bn_adaptation_steps)

--- a/tests/tensorflow/test_bn_adaptation.py
+++ b/tests/tensorflow/test_bn_adaptation.py
@@ -33,7 +33,7 @@ def get_dataset_for_test(batch_size=10):
     return dataset
 
 
-def get_config_for_test(batch_size=10, num_bn_adaptation_samples=100, num_bn_forget_samples=50):
+def get_config_for_test(batch_size=10, num_bn_adaptation_samples=100):
     config = NNCFConfig()
     config.update(Dict({
         "compression":
@@ -41,7 +41,6 @@ def get_config_for_test(batch_size=10, num_bn_adaptation_samples=100, num_bn_for
                 "initializer": {
                     "batchnorm_adaptation": {
                         "num_bn_adaptation_samples": num_bn_adaptation_samples,
-                        "num_bn_forget_samples": num_bn_forget_samples
                     }
                 }
             }
@@ -113,7 +112,7 @@ def test_all_parameter_keep():
     for layer in model.layers:
         original_all_param_values[layer] = deepcopy(layer.weights)
 
-    config = get_config_for_test(num_bn_adaptation_samples=0, num_bn_forget_samples=0)
+    config = get_config_for_test(num_bn_adaptation_samples=0)
 
     bn_adaptation = BatchnormAdaptationAlgorithm(**extract_bn_adaptation_init_params(config))
     bn_adaptation.run(model)

--- a/tests/torch/data/configs/hawq/icnet_camvid_mixed_int.json
+++ b/tests/torch/data/configs/hawq/icnet_camvid_mixed_int.json
@@ -49,8 +49,7 @@
                 "iter_number": 1
             },
             "batchnorm_adaptation": {
-                "num_bn_adaptation_samples": 2,
-                "num_bn_forget_samples": 1
+                "num_bn_adaptation_samples": 2
             },
             "range": {
                 "num_init_samples": 1

--- a/tests/torch/data/configs/hawq/inception_v3_cifar10_mixed_int.json
+++ b/tests/torch/data/configs/hawq/inception_v3_cifar10_mixed_int.json
@@ -21,8 +21,7 @@
                     "iter_number": 1
                 },
                 "batchnorm_adaptation": {
-                    "num_bn_adaptation_samples": 2,
-                    "num_bn_forget_samples": 1
+                    "num_bn_adaptation_samples": 2
                 },
                 "range": {
                     "num_init_samples": 1

--- a/tests/torch/data/configs/hawq/resnet18_cifar10_mixed_int.json
+++ b/tests/torch/data/configs/hawq/resnet18_cifar10_mixed_int.json
@@ -21,8 +21,7 @@
                     "iter_number": 1
                 },
                 "batchnorm_adaptation": {
-                    "num_bn_adaptation_samples": 2,
-                    "num_bn_forget_samples": 1
+                    "num_bn_adaptation_samples": 2
                 },
                 "range": {
                     "num_init_samples": 1

--- a/tests/torch/data/configs/hawq/resnet18_cifar10_mixed_int_manual.json
+++ b/tests/torch/data/configs/hawq/resnet18_cifar10_mixed_int_manual.json
@@ -72,8 +72,7 @@
                     ]
                 },
                 "batchnorm_adaptation": {
-                    "num_bn_adaptation_samples": 0,
-                    "num_bn_forget_samples": 0
+                    "num_bn_adaptation_samples": 0
                 },
                 "range": {
                     "num_init_samples": 0

--- a/tests/torch/data/configs/hawq/ssd300_vgg_voc_mixed_int.json
+++ b/tests/torch/data/configs/hawq/ssd300_vgg_voc_mixed_int.json
@@ -94,8 +94,7 @@
                 "iter_number": 1
             },
             "batchnorm_adaptation": {
-                "num_bn_adaptation_samples": 2,
-                "num_bn_forget_samples": 1
+                "num_bn_adaptation_samples": 2
             },
             "range": {
                 "num_init_samples": 1

--- a/tests/torch/data/configs/hawq/unet_camvid_mixed_int.json
+++ b/tests/torch/data/configs/hawq/unet_camvid_mixed_int.json
@@ -44,8 +44,7 @@
                 "iter_number": 1
             },
             "batchnorm_adaptation": {
-                "num_bn_adaptation_samples": 2,
-                "num_bn_forget_samples": 1
+                "num_bn_adaptation_samples": 2
             },
             "range": {
                 "num_init_samples": 1

--- a/tests/torch/quantization/test_autoq_precision_init.py
+++ b/tests/torch/quantization/test_autoq_precision_init.py
@@ -86,8 +86,7 @@ class AutoQConfigBuilder(BaseConfigBuilder):
                     'num_init_samples': num_init_samples
                 },
                 'batchnorm_adaptation': {
-                    'num_bn_adaptation_samples': 0,
-                    'num_bn_forget_samples': 0
+                    'num_bn_adaptation_samples': 0
                 }
             }})
         return config

--- a/tests/torch/quantization/test_hawq_precision_init.py
+++ b/tests/torch/quantization/test_hawq_precision_init.py
@@ -247,8 +247,7 @@ class HAWQConfigBuilder(BaseConfigBuilder):
                     'num_init_samples': 1
                 },
                 'batchnorm_adaptation': {
-                    'num_bn_adaptation_samples': 0,
-                    'num_bn_forget_samples': 0
+                    'num_bn_adaptation_samples': 0
                 }
             }})
         return config

--- a/tests/torch/quantization/test_manual_precision_init.py
+++ b/tests/torch/quantization/test_manual_precision_init.py
@@ -221,8 +221,7 @@ def test_can_resume_with_manual_init(mocker):
             'num_init_samples': 1
         },
         'batchnorm_adaptation': {
-            'num_bn_adaptation_samples': 1,
-            'num_bn_forget_samples': 1
+            'num_bn_adaptation_samples': 1
         },
     })
     config['target_device'] = 'TRIAL'

--- a/tests/torch/test_api_behavior.py
+++ b/tests/torch/test_api_behavior.py
@@ -50,8 +50,7 @@ CONFIG_WITH_ALL_INIT_TYPES = {
                     'num_init_samples': 1
                 },
                 'batchnorm_adaptation': {
-                    'num_bn_adaptation_samples': 5,
-                    'num_bn_forget_samples': 0
+                    'num_bn_adaptation_samples': 5
                 }
             }
         }

--- a/tests/torch/test_sanity_sample.py
+++ b/tests/torch/test_sanity_sample.py
@@ -122,11 +122,9 @@ def update_compression_algo_dict_with_reduced_bn_adapt_params(algo_dict):
     if algo_dict["algorithm"] == "rb_sparsity":
         return
     if 'initializer' not in algo_dict:
-        algo_dict['initializer'] = {'batchnorm_adaptation': {'num_bn_adaptation_samples': 5,
-                                                             'num_bn_forget_samples': 5}}
+        algo_dict['initializer'] = {'batchnorm_adaptation': {'num_bn_adaptation_samples': 5}}
     else:
-        algo_dict['initializer'].update({'batchnorm_adaptation': {'num_bn_adaptation_samples': 5,
-                                                                  'num_bn_forget_samples': 5}})
+        algo_dict['initializer'].update({'batchnorm_adaptation': {'num_bn_adaptation_samples': 5}})
 
 def _get_test_case_id(p) -> str:
     return "-".join([p[0], p[1].name, p[2], str(p[3])])
@@ -513,7 +511,6 @@ class TestCaseDescriptor:
                     },
                     "batchnorm_adaptation": {
                         "num_bn_adaptation_samples": 1,
-                        "num_bn_forget_samples": 1
                     }
                 },
                 'params': self.quantization_algo_params,

--- a/tests/torch/test_utils.py
+++ b/tests/torch/test_utils.py
@@ -64,7 +64,7 @@ def test_bn_training_state_switcher(_seed, model: nn.Module):
             else:
                 assert ch.training == saved_state.training_state[ch]
 
-    runner = DataLoaderBNAdaptationRunner(model, 'cuda', 0)
+    runner = DataLoaderBNAdaptationRunner(model, 'cuda')
 
     randomly_change_model_state(model)
     saved_state = save_module_state(model)


### PR DESCRIPTION
- Remove the BN statistics forgetting step from the BN adaptation algo
- Make BN adaptation default for quantization in TF


| model | orig. metric  | init. w/o BN adapt | init. w/ BN adapt (develop) | init. w/ BN adapt (this branch)
|:-------------:|:-------------:|:-----:|:-----:|:-----:|
| YOLOv4/COCO INT8 (TF, no 7bit fix) | 47.029 | 46.113 | 45.971 | 46.141 |
| RetinaNet-R50/COCO INT8 (TF, no 7 bit fix)      | 33.44 | 33.24 | 32.95 | 33.28 |
| MobileNetV2 INT8 (PT) | 71.8 | 69.351 | 70.946 | 70.459 (71.032 at 5k samples) |
| Squeezenet1.1 INT8 (PT), 5k samples | 58.178 | 57.929 | 57.963 | 58.005 |