### PR TITLE
Add TF test install with examples and tests requirements

### DIFF
--- a/examples/tensorflow/requirements.txt
+++ b/examples/tensorflow/requirements.txt
@@ -3,4 +3,5 @@ tensorflow_datasets==4.2.0
 tensorflow_hub
 tensorflow_addons==0.12.1
 opencv-python
+protobuf==3.17.3
 git+https://github.com/alexsu52/cocoapi.git#egg=pycocotools&subdirectory=PythonAPI

--- a/tests/tensorflow/conftest.py
+++ b/tests/tensorflow/conftest.py
@@ -56,7 +56,7 @@ def pytest_addoption(parser):
         "--models-dir", type=str, default=None, help="Path to checkpoints directory for weekly tests"
     )
     parser.addoption(
-        "--run-install-tests", type=str, help="To run installation tests"
+        "--run-install-tests", action="store_true", default=False, help="To run installation tests"
     )
 
 
@@ -107,7 +107,7 @@ def install_tests(request):
 
 @pytest.fixture(scope="function")
 def tmp_venv_with_nncf(tmp_path, package_type, venv_type, install_tests):  # pylint:disable=redefined-outer-name
-    if install_tests is None:
+    if not install_tests:
         pytest.skip('To test the installation, use --run-install-tests option.')
     venv_path = create_venv_with_nncf(tmp_path, package_type, venv_type, extra_reqs='tf')
     return venv_path

--- a/tests/tensorflow/test_install.py
+++ b/tests/tensorflow/test_install.py
@@ -12,6 +12,9 @@
 """
 
 import pytest
+import subprocess
+
+from tests.common.helpers import PROJECT_ROOT
 from tests.common.helpers import run_install_checks
 
 
@@ -29,4 +32,15 @@ def package_type_(request):
 
 
 def test_install(tmp_venv_with_nncf, tmp_path, package_type):
+    run_install_checks(tmp_venv_with_nncf, tmp_path, package_type, test_dir='tensorflow')
+
+
+def test_install_with_examples_and_tests_requirements(tmp_venv_with_nncf, tmp_path, package_type):
+    pip_with_venv = '. {0}/bin/activate && {0}/bin/pip'.format(tmp_venv_with_nncf)
+    subprocess.call(
+        '{} install -r {}/examples/tensorflow/requirements.txt'.format(pip_with_venv, PROJECT_ROOT),
+        shell=True)
+    subprocess.call(
+        '{} install -r {}/tests/tensorflow/requirements.txt'.format(pip_with_venv, PROJECT_ROOT),
+        shell=True)
     run_install_checks(tmp_venv_with_nncf, tmp_path, package_type, test_dir='tensorflow')


### PR DESCRIPTION
Freeze `protobuf==3.17.3` to avoid problems with old pip versions