### PR TITLE
Print command line arguments

### DIFF
--- a/examples/tensorflow/classification/main.py
+++ b/examples/tensorflow/classification/main.py
@@ -37,6 +37,7 @@ from examples.tensorflow.common.scheduler import build_scheduler
 from examples.tensorflow.common.utils import configure_paths
 from examples.tensorflow.common.utils import create_code_snapshot
 from examples.tensorflow.common.utils import get_saving_parameters
+from examples.tensorflow.common.utils import print_args
 from examples.tensorflow.common.utils import serialize_config
 from examples.tensorflow.common.utils import write_metrics
 
@@ -307,6 +308,7 @@ def export(config):
 def main(argv):
     parser = get_argument_parser()
     config = get_config_from_argv(argv, parser)
+    print_args(config)
 
     serialize_config(config, config.log_dir)
 

--- a/examples/tensorflow/common/utils.py
+++ b/examples/tensorflow/common/utils.py
@@ -109,8 +109,9 @@ def create_code_snapshot(root, dst_path, extensions=(".py", ".json", ".cpp", ".c
 
 
 def print_args(config, logger=default_logger):
-    for arg in sorted(config):
-        logger.info("{: <27s}: {}".format(arg, config.get(arg)))
+    args = 'Command line arguments\n'
+    args += '\n'.join(["{: <27s}: {}".format(arg, config.get(arg)) for arg in sorted(config)])
+    logger.info(args)
 
 
 def serialize_config(config, log_dir):

--- a/examples/tensorflow/object_detection/main.py
+++ b/examples/tensorflow/object_detection/main.py
@@ -35,6 +35,7 @@ from examples.tensorflow.common.sample_config import create_sample_config
 from examples.tensorflow.common.scheduler import build_scheduler
 from examples.tensorflow.common.utils import SummaryWriter
 from examples.tensorflow.common.utils import Timer
+from examples.tensorflow.common.utils import print_args
 from examples.tensorflow.common.utils import serialize_config
 from examples.tensorflow.common.utils import create_code_snapshot
 from examples.tensorflow.common.utils import configure_paths
@@ -398,6 +399,7 @@ def export(config):
 def main(argv):
     parser = get_argument_parser()
     config = get_config_from_argv(argv, parser)
+    print_args(config)
 
     serialize_config(config, config.log_dir)
 

--- a/examples/tensorflow/segmentation/evaluation.py
+++ b/examples/tensorflow/segmentation/evaluation.py
@@ -27,6 +27,7 @@ from examples.tensorflow.common.sample_config import create_sample_config
 from examples.tensorflow.common.sample_config import SampleConfig
 from examples.tensorflow.common.utils import configure_paths
 from examples.tensorflow.common.utils import get_saving_parameters
+from examples.tensorflow.common.utils import print_args
 from examples.tensorflow.common.utils import SummaryWriter
 from examples.tensorflow.common.utils import write_metrics
 from examples.tensorflow.common.utils import Timer
@@ -259,6 +260,7 @@ def main(argv):
     tf.get_logger().setLevel('INFO')
     parser = get_argument_parser()
     config = get_config_from_argv(argv, parser)
+    print_args(config)
 
     if config.dataset_type != 'tfrecords':
         raise RuntimeError('The train.py does not support TensorFlow Datasets (TFDS). '

--- a/examples/tensorflow/segmentation/train.py
+++ b/examples/tensorflow/segmentation/train.py
@@ -34,6 +34,7 @@ from examples.tensorflow.common.sample_config import SampleConfig
 from examples.tensorflow.common.scheduler import build_scheduler
 from examples.tensorflow.common.utils import configure_paths
 from examples.tensorflow.common.utils import create_code_snapshot
+from examples.tensorflow.common.utils import print_args
 from examples.tensorflow.common.utils import serialize_config
 from examples.tensorflow.common.utils import SummaryWriter
 from examples.tensorflow.common.utils import Timer
@@ -285,6 +286,7 @@ def run_train(config):
 def main(argv):
     parser = get_argument_parser()
     config = get_config_from_argv(argv, parser)
+    print_args(config)
 
     serialize_config(config, config.log_dir)
 


### PR DESCRIPTION
After these changes, the values of the command line arguments are printed in the TF samples, as in the PT samples.
Example of classification sample output 
```bash
INFO:example:Command line arguments
batch_size                 : 256
checkpoint_save_dir        : ../../results/quantization/tmp/MobileNetV2_imagenet2012_int8/2021-07-06__09-30-09
ckpt_path                  : None
compression                : {'algorithm': 'quantization', 'initializer': {'batchnorm_adaptation': {'num_bn_adaptation_samples': 2048}}, 'log_dir': '../../results/quantization/tmp/MobileNetV2_imagenet2012_int8/2021-07-06__09-30-09'}
config                     : configs/quantization/mobilenet_v2_imagenet_int8.json
cpu_only                   : False
dataset                    : imagenet2012
dataset_dir                : /hdd/datasets/imagenet_tfds/
dataset_type               : tfds
epochs                     : 15
gpu_id                     : None
input_info                 : {'sample_size': [1, 224, 224, 3]}
log_dir                    : ../../results/quantization/tmp/MobileNetV2_imagenet2012_int8/2021-07-06__09-30-09
metrics_dump               : None
mode                       : ['train']
model                      : MobileNetV2
name                       : MobileNetV2_imagenet2012_int8
nncf_config                : {'model': 'MobileNetV2', 'pretrained': True, 'input_info': {'sample_size': [1, 224, 224, 3]}, 'batch_size': 256, 'epochs': 15, 'optimizer': {'type': 'Adam', 'schedule_type': 'piecewise_constant', 'schedule_params': {'boundaries': [5, 10], 'values': [0.0001, 1e-05, 1e-06]}}, 'dataset': 'imagenet2012', 'dataset_type': 'tfds', 'compression': {'algorithm': 'quantization', 'initializer': {'batchnorm_adaptation': {'num_bn_adaptation_samples': 2048}}}}
optimizer                  : {'type': 'Adam', 'schedule_type': 'piecewise_constant', 'schedule_params': {'boundaries': [5, 10], 'values': [0.0001, 1e-05, 1e-06]}}
pretrained                 : True
test_every_n_epochs        : 1
to_frozen_graph            : None
to_h5                      : None
to_saved_model             : None
weights                    : None
```

