### PR TITLE
Refactor test_prepare_checkpoints

### DIFF
--- a/examples/tensorflow/common/argparser.py
+++ b/examples/tensorflow/common/argparser.py
@@ -34,29 +34,30 @@ def get_common_argument_parser(**flags):
             type=str,
             help='Name of metrics collecting .json file'))
 
-    model_init_mode = parser.add_mutually_exclusive_group()
+    if flags.get('resume_args', True):
+        model_init_mode = parser.add_mutually_exclusive_group()
 
-    add_argument(
-        parser=model_init_mode,
-        condition=flags.get('resume', True),
-        parameters=argument_parameters(
-            '--resume',
-            metavar='PATH',
-            type=str,
-            default=None,
-            dest='ckpt_path',
-            help='Specifies the path to the checkpoint to resume training, test or export model '
-                'from the defined checkpoint or folder with checkpoints to resume training, test '
-                'or export from the last checkpoint.'))
+        add_argument(
+            parser=model_init_mode,
+            condition=flags.get('resume', True),
+            parameters=argument_parameters(
+                '--resume',
+                metavar='PATH',
+                type=str,
+                default=None,
+                dest='ckpt_path',
+                help='Specifies the path to the checkpoint to resume training, test or export model '
+                    'from the defined checkpoint or folder with checkpoints to resume training, test '
+                    'or export from the last checkpoint.'))
 
-    add_argument(
-        parser=model_init_mode,
-        condition=flags.get('weights', True),
-        parameters=argument_parameters(
-            '--weights',
-            default=None,
-            type=str,
-            help='Path to pretrained weights in H5 format.'))
+        add_argument(
+            parser=model_init_mode,
+            condition=flags.get('weights', True),
+            parameters=argument_parameters(
+                '--weights',
+                default=None,
+                type=str,
+                help='Path to pretrained weights in H5 format.'))
 
     add_argument(
         parser=parser,

--- a/examples/tensorflow/common/prepare_checkpoint.py
+++ b/examples/tensorflow/common/prepare_checkpoint.py
@@ -49,9 +49,6 @@ def get_config_and_model_type_from_argv(argv, parser):
         raise RuntimeError('Wrong model type specified')
 
     predefined_config.update(config_from_json)
-    if not predefined_config.ckpt_path:
-        raise RuntimeError('Checkpoint path should be specified')
-
     return predefined_config, args.model_type
 
 
@@ -126,7 +123,7 @@ def load_and_save_checkpoint(checkpoint, config):
 
 def main(argv):
     parser = get_common_argument_parser(metrics_dump=False,
-                                        weights=False,
+                                        resume_args=False,
                                         execution_args=False,
                                         epochs=False,
                                         precision=False,
@@ -141,6 +138,15 @@ def main(argv):
         choices=[ModelType.object_detection,
                  ModelType.segmentation],
         help='Type of the model which checkpoint is being provided.',
+        required=True)
+
+    parser.add_argument(
+        '--resume',
+        metavar='PATH',
+        type=str,
+        default=None,
+        dest='ckpt_path',
+        help='Specifies the path to the checkpoint which should be optimized.',
         required=True)
 
     config, model_type = get_config_and_model_type_from_argv(argv, parser)

--- a/examples/tensorflow/common/prepare_checkpoint.py
+++ b/examples/tensorflow/common/prepare_checkpoint.py
@@ -49,6 +49,9 @@ def get_config_and_model_type_from_argv(argv, parser):
         raise RuntimeError('Wrong model type specified')
 
     predefined_config.update(config_from_json)
+    if not predefined_config.ckpt_path:
+        raise RuntimeError('Checkpoint path should be specified')
+
     return predefined_config, args.model_type
 
 

--- a/tests/tensorflow/data/configs/resnet50_cifar10_magnitude_sparsity_int8.json
+++ b/tests/tensorflow/data/configs/resnet50_cifar10_magnitude_sparsity_int8.json
@@ -38,7 +38,15 @@
             }
         },
         {
-            "algorithm": "quantization"
+            "algorithm": "quantization",
+            "initializer": {
+                "range": {
+                    "num_init_samples": 1
+                },
+                "batchnorm_adaptation": {
+                    "num_bn_adaptation_samples": 1
+                }
+            }
         }
     ]
 }

--- a/tests/tensorflow/data/configs/retinanet_coco2017_magnitude_sparsity_int8.json
+++ b/tests/tensorflow/data/configs/retinanet_coco2017_magnitude_sparsity_int8.json
@@ -36,7 +36,15 @@
             }
         },
         {
-            "algorithm": "quantization"
+            "algorithm": "quantization",
+            "initializer": {
+                "range": {
+                    "num_init_samples": 1
+                },
+                "batchnorm_adaptation": {
+                    "num_bn_adaptation_samples": 1
+                }
+            }
         }
     ],
 

--- a/tests/tensorflow/data/configs/sequential_model_cifar10_magnitude_sparsity_int8.json
+++ b/tests/tensorflow/data/configs/sequential_model_cifar10_magnitude_sparsity_int8.json
@@ -37,7 +37,15 @@
             }
         },
         {
-            "algorithm": "quantization"
+            "algorithm": "quantization",
+            "initializer": {
+                "range": {
+                    "num_init_samples": 1
+                },
+                "batchnorm_adaptation": {
+                    "num_bn_adaptation_samples": 1
+                }
+            }
         }
     ]
 }

--- a/tests/tensorflow/data/configs/sequential_model_no_input_cifar10_magnitude_sparsity_int8.json
+++ b/tests/tensorflow/data/configs/sequential_model_no_input_cifar10_magnitude_sparsity_int8.json
@@ -37,7 +37,15 @@
             }
         },
         {
-            "algorithm": "quantization"
+            "algorithm": "quantization",
+            "initializer": {
+                "range": {
+                    "num_init_samples": 1
+                },
+                "batchnorm_adaptation": {
+                    "num_bn_adaptation_samples": 1
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
* Required checkpoint path in `prepare_checkpoints.py`
* Refactored test to load real checkpoints from sanity test_model_train to properly test  `prepare_checkpoints.py`, which required checkpoint path. (It was impossible to make new small model to pass it into prepare checkpoint because prepare checkpoint can build only yolo, retinanet and maskrcnn models.) 

Local check shows new version of the test small time consuming (~30 sec ~= not refactored test running time).