### PR TITLE
To add --all install option to setup.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,10 @@ if "--tf" in sys.argv:
     INSTALL_REQUIRES.extend(EXTRAS_REQUIRE["tf"])
     sys.argv.remove("--tf")
 
+if "--all" in sys.argv:
+    INSTALL_REQUIRES.extend(EXTRAS_REQUIRE["all"])
+    sys.argv.remove("--all")
+
 setup(
     name="nncf",
     version=find_version(os.path.join(here, "nncf/version.py")),


### PR DESCRIPTION
For now setup.py has two option --tf and --torch
Both intended to install tensorflow and pytorch parts of the product separately
But EXTRAS_REQUIRE also has 'all' label that suppose to install both tensorflow and torch at the same time.
The option '--all' covers using of this label.