### PR TITLE
Accuracy validation doesn't depend on batch size and number of GPU

### DIFF
--- a/examples/torch/classification/main.py
+++ b/examples/torch/classification/main.py
@@ -411,7 +411,7 @@ def create_data_loaders(config, train_dataset, val_dataset):
         val_dataset,
         batch_size=batch_size, shuffle=False,
         num_workers=workers, pin_memory=pin_memory,
-        sampler=val_sampler, drop_last=True)
+        sampler=val_sampler, drop_last=False)
 
     train_sampler = None
     if config.distributed:

--- a/examples/torch/semantic_segmentation/main.py
+++ b/examples/torch/semantic_segmentation/main.py
@@ -209,7 +209,7 @@ def load_dataset(dataset, config):
         batch_size=1, num_workers=num_workers,
         shuffle=False,
         sampler=val_sampler,
-        collate_fn=data_utils.collate_fn, drop_last=True)
+        collate_fn=data_utils.collate_fn, drop_last=False)
 
     # Get encoding between pixel values in label images and RGB colors
     class_encoding = train_set.color_encoding


### PR DESCRIPTION
Previously, last data point in all DataLoaders were dropped to prevent issue with BN (#379)
But it's actual for training only, on eval it shouldn't happen.