### PR TITLE
WIP Fk/cmake nncf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,26 @@
-
-set (CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
-set (CUDA_INCLUDE_DIRS /usr/local/cuda/include/ ${CUDA_INCLUDE_DIRS})
+cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 
 project (CMAKE_EXTENSIONS_BUILD)
 
+
 find_package (PythonInterp 3.7 REQUIRED)
+find_program (PYTEST pytest)
 
-
+if(NOT PYTEST)
+    message(FATAL_ERROR "No pytest binary find")
+endif()
 
 add_custom_command(
-    OUTPUT venv.stamp
-    DEPENDS venv requirements.txt
-    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/venv/bin/pip install -r requirements.txt
+    COMMAND ${PYTEST} -s tests/torch/test_extensions_build.py
 )
 
-# Build command line to run py.test.
-set(PYTEST
-    ${CMAKE_CURRENT_BINARY_DIR}/venv/bin/python2
-    ${CMAKE_CURRENT_BINARY_DIR}/venv/bin/py.test
-)
-
-add_custom_target(Tests ALL
-    DEPENDS venv.stamp
-    SOURCES requirements.txt
+add_custom_target(EXTENSIONS_BUILD ALL
+    DEPENDS tests/torch/test_extensions_build.py
+    SOURCES tests/torch/test_extensions_build.py
 )
 
 add_test(NAME run_tests
-    COMMAND ${PYTEST} ${CMAKE_CURRENT_SOURCE_DIR}/test_sample.py
+    COMMAND ${PYTEST} -s tests/torch/test_extensions_build.py
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+
+set (CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
+set (CUDA_INCLUDE_DIRS /usr/local/cuda/include/ ${CUDA_INCLUDE_DIRS})
+
+project (CMAKE_EXTENSIONS_BUILD)
+
+find_package (PythonInterp 3.7 REQUIRED)
+
+
+
+add_custom_command(
+    OUTPUT venv.stamp
+    DEPENDS venv requirements.txt
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/venv/bin/pip install -r requirements.txt
+)
+
+# Build command line to run py.test.
+set(PYTEST
+    ${CMAKE_CURRENT_BINARY_DIR}/venv/bin/python2
+    ${CMAKE_CURRENT_BINARY_DIR}/venv/bin/py.test
+)
+
+add_custom_target(Tests ALL
+    DEPENDS venv.stamp
+    SOURCES requirements.txt
+)
+
+add_test(NAME run_tests
+    COMMAND ${PYTEST} ${CMAKE_CURRENT_SOURCE_DIR}/test_sample.py
+)
+
+

--- a/nncf/torch/extensions/src/binarization/cpu/CMakeLists.txt
+++ b/nncf/torch/extensions/src/binarization/cpu/CMakeLists.txt
@@ -12,33 +12,34 @@ add_library(tensor_funcs.o ../../common/cpu/tensor_funcs.cpp)
 add_executable(binarized_functions_cpu.so functions_cpu.cpp)
 
 list(APPEND cflags
-    "-MMD"
-    "-MF"
-    "functions_cpu.o.d"
-    "-DTORCH_EXTENSION_NAME=binarized_functions_cpu"
-    "-DTORCH_API_INCLUDE_EXTENSION_H"
-    "-DPYBIND11_COMPILER_TYPE=\"_gcc\""
-    "-DPYBIND11_STDLIB=\"_libstdcpp\""
-    "-DPYBIND11_BUILD_ABI=\"_cxxabi1011\""
-    "-I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include"
-    "-isystem${PYTHON_SITE_PACKAGES}/torch/include"
-    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include"
-    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/TH"
-    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/THC"
-    "-isystem/localdisk/fk/venv/include/python3.7m"
-    "-D_GLIBCXX_USE_CXX11_ABI=0"
-    "-fPIC"
-    "-std=c++14"
+    -MMD
+    -MF
+    functions_cpu.o.d
+    -DTORCH_EXTENSION_NAME=binarized_functions_cuda
+    -DTORCH_API_INCLUDE_EXTENSION_H
+    -DPYBIND11_COMPILER_TYPE=\"_gcc\"
+    -DPYBIND11_STDLIB=\"_libstdcpp\"
+    -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
+    -I../../../../include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/TH
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/THC
+    -isystem/localdisk/fk/venv/include/python3.7m
+    -D_GLIBCXX_USE_CXX11_ABI=0
+    -fPIC
+    -std=c++14
     )
 
 list(APPEND ldflags
-    "-shared"
-    "-L${PYTHON_SITE_PACKAGES}/torch/lib"
-    "-lc10"
-    "-ltorch_cpu"
-    "-ltorch"
-    "-ltorch_python"
+    -shared
+    -L${PYTHON_SITE_PACKAGES}/torch/lib
+    -lc10
+    -ltorch_cpu
+    -ltorch
+    -ltorch_python
     )
+
 target_compile_options(tensor_funcs.o
     PRIVATE
         ${cflags}

--- a/nncf/torch/extensions/src/binarization/cpu/CMakeLists.txt
+++ b/nncf/torch/extensions/src/binarization/cpu/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+project(binarized_functions_cpu.so LANGUAGES CXX)
+
+find_package(PythonInterp 3.7 REQUIRED)
+execute_process (
+    COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print (get_python_lib())"
+    OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+add_library(tensor_funcs.o ../../common/cpu/tensor_funcs.cpp)
+
+add_executable(binarized_functions_cpu.so functions_cpu.cpp)
+
+list(APPEND cflags
+    "-MMD"
+    "-MF"
+    "functions_cpu.o.d"
+    "-DTORCH_EXTENSION_NAME=binarized_functions_cpu"
+    "-DTORCH_API_INCLUDE_EXTENSION_H"
+    "-DPYBIND11_COMPILER_TYPE=\"_gcc\""
+    "-DPYBIND11_STDLIB=\"_libstdcpp\""
+    "-DPYBIND11_BUILD_ABI=\"_cxxabi1011\""
+    "-I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include"
+    "-isystem${PYTHON_SITE_PACKAGES}/torch/include"
+    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include"
+    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/TH"
+    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/THC"
+    "-isystem/localdisk/fk/venv/include/python3.7m"
+    "-D_GLIBCXX_USE_CXX11_ABI=0"
+    "-fPIC"
+    "-std=c++14"
+    )
+
+list(APPEND ldflags
+    "-shared"
+    "-L${PYTHON_SITE_PACKAGES}/torch/lib"
+    "-lc10"
+    "-ltorch_cpu"
+    "-ltorch"
+    "-ltorch_python"
+    )
+target_compile_options(tensor_funcs.o
+    PRIVATE
+        ${cflags}
+    )
+
+target_compile_options(binarized_functions_cpu.so
+    PRIVATE
+
+        ${cflags}
+    )
+
+target_link_libraries(binarized_functions_cpu.so
+    PRIVATE
+        tensor_funcs.o
+        ${ldflags}
+    )

--- a/nncf/torch/extensions/src/binarization/cuda/CMakeLists.txt
+++ b/nncf/torch/extensions/src/binarization/cuda/CMakeLists.txt
@@ -1,0 +1,93 @@
+cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+
+set (CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
+set (CUDA_INCLUDE_DIRS /usr/local/cuda/include/ ${CUDA_INCLUDE_DIRS})
+
+project (binarized_functions_cuda.so LANGUAGES CXX CUDA)
+
+find_package (PythonInterp 3.7 REQUIRED)
+
+execute_process (
+    COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print (get_python_lib())"
+    OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+add_library (functions_cuda.o
+    STATIC
+    functions_cuda.cpp
+    )
+
+list (APPEND cflags
+    -MMD
+    -MF
+    functions_cuda.o.d
+    -DTORCH_EXTENSION_NAME=binarized_functions_cuda
+    -DTORCH_API_INCLUDE_EXTENSION_H
+    -DPYBIND11_COMPILER_TYPE=\"_gcc\"
+    -DPYBIND11_STDLIB=\"_libstdcpp\"
+    -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
+    -I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/TH
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/THC
+    -isystem/localdisk/fk/venv/include/python3.7m
+    -D_GLIBCXX_USE_CXX11_ABI=0
+    -fPIC
+    -std=c++14
+    )
+
+list (APPEND ldflags
+    -shared
+    -L${PYTHON_SITE_PACKAGES}/torch/lib
+    -lc10
+    -lc10_cuda
+    -ltorch_cpu
+    -ltorch_cuda
+    -ltorch
+    -ltorch_python
+    -L/usr/local/cuda/lib64
+    -lcudart
+    )
+
+target_compile_options (functions_cuda.o
+    PRIVATE
+        ${cflags}
+    )
+
+target_compile_features (functions_cuda.o PUBLIC cxx_std_14)
+set_target_properties (functions_cuda.o
+                       PROPERTIES CUDA_SEPARABLE_COMPILATION ON
+    )
+
+add_executable (binarized_functions_cuda.so functions_cuda_impl.cu)
+
+set_property (TARGET binarized_functions_cuda.so
+             PROPERTY CUDA_SEPARABLE_COMPILATION ON
+    )
+
+target_compile_options (binarized_functions_cuda.so
+    PRIVATE
+    -DTORCH_EXTENSION_NAME=binarized_functions_cuda
+    -DTORCH_API_INCLUDE_EXTENSION_H
+    -DPYBIND11_COMPILER_TYPE=\"_gcc\"
+    -DPYBIND11_STDLIB=\"_libstdcpp\"
+    -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
+    -I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include
+    --system-include ${PYTHON_SITE_PACKAGES}/torch/include,${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include,${PYTHON_SITE_PACKAGES}/torch/include/TH,${PYTHON_SITE_PACKAGES}/torch/include/THC,/localdisk/fk/venv/include/python3.7m
+    -D_GLIBCXX_USE_CXX11_ABI=0
+    -D__CUDA_NO_HALF_OPERATORS__
+    -D__CUDA_NO_HALF_CONVERSIONS__
+    -D__CUDA_NO_BFLOAT16_CONVERSIONS__
+    -D__CUDA_NO_HALF2_OPERATORS__
+    --expt-relaxed-constexpr
+    -gencode=arch=compute_75,code=compute_75
+    --compiler-options '-fPIC'
+    -std=c++14
+    )
+
+target_link_libraries(binarized_functions_cuda.so
+    PRIVATE
+        functions_cuda.o
+        ${ldflags}
+    )

--- a/nncf/torch/extensions/src/binarization/cuda/CMakeLists.txt
+++ b/nncf/torch/extensions/src/binarization/cuda/CMakeLists.txt
@@ -26,7 +26,7 @@ list (APPEND cflags
     -DPYBIND11_COMPILER_TYPE=\"_gcc\"
     -DPYBIND11_STDLIB=\"_libstdcpp\"
     -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
-    -I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include
+    -I../../../../include
     -isystem${PYTHON_SITE_PACKAGES}/torch/include
     -isystem${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include
     -isystem${PYTHON_SITE_PACKAGES}/torch/include/TH
@@ -34,6 +34,25 @@ list (APPEND cflags
     -isystem/localdisk/fk/venv/include/python3.7m
     -D_GLIBCXX_USE_CXX11_ABI=0
     -fPIC
+    -std=c++14
+    )
+
+list (APPEND cflags_cuda
+    -DTORCH_EXTENSION_NAME=binarized_functions_cuda
+    -DTORCH_API_INCLUDE_EXTENSION_H
+    -DPYBIND11_COMPILER_TYPE=\"_gcc\"
+    -DPYBIND11_STDLIB=\"_libstdcpp\"
+    -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
+    -I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include
+    --system-include ${PYTHON_SITE_PACKAGES}/torch/include,${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include,${PYTHON_SITE_PACKAGES}/torch/include/TH,${PYTHON_SITE_PACKAGES}/torch/include/THC,/localdisk/fk/venv/include/python3.7m
+    -D_GLIBCXX_USE_CXX11_ABI=0
+    -D__CUDA_NO_HALF_OPERATORS__
+    -D__CUDA_NO_HALF_CONVERSIONS__
+    -D__CUDA_NO_BFLOAT16_CONVERSIONS__
+    -D__CUDA_NO_HALF2_OPERATORS__
+    --expt-relaxed-constexpr
+    -gencode=arch=compute_75,code=compute_75
+    --compiler-options '-fPIC'
     -std=c++14
     )
 
@@ -68,22 +87,7 @@ set_property (TARGET binarized_functions_cuda.so
 
 target_compile_options (binarized_functions_cuda.so
     PRIVATE
-    -DTORCH_EXTENSION_NAME=binarized_functions_cuda
-    -DTORCH_API_INCLUDE_EXTENSION_H
-    -DPYBIND11_COMPILER_TYPE=\"_gcc\"
-    -DPYBIND11_STDLIB=\"_libstdcpp\"
-    -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
-    -I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include
-    --system-include ${PYTHON_SITE_PACKAGES}/torch/include,${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include,${PYTHON_SITE_PACKAGES}/torch/include/TH,${PYTHON_SITE_PACKAGES}/torch/include/THC,/localdisk/fk/venv/include/python3.7m
-    -D_GLIBCXX_USE_CXX11_ABI=0
-    -D__CUDA_NO_HALF_OPERATORS__
-    -D__CUDA_NO_HALF_CONVERSIONS__
-    -D__CUDA_NO_BFLOAT16_CONVERSIONS__
-    -D__CUDA_NO_HALF2_OPERATORS__
-    --expt-relaxed-constexpr
-    -gencode=arch=compute_75,code=compute_75
-    --compiler-options '-fPIC'
-    -std=c++14
+        ${cflags_cuda}
     )
 
 target_link_libraries(binarized_functions_cuda.so

--- a/nncf/torch/extensions/src/binarization/cuda/CMakeLists.txt
+++ b/nncf/torch/extensions/src/binarization/cuda/CMakeLists.txt
@@ -43,7 +43,7 @@ list (APPEND cflags_cuda
     -DPYBIND11_COMPILER_TYPE=\"_gcc\"
     -DPYBIND11_STDLIB=\"_libstdcpp\"
     -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
-    -I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include
+    -I../../../../include
     --system-include ${PYTHON_SITE_PACKAGES}/torch/include,${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include,${PYTHON_SITE_PACKAGES}/torch/include/TH,${PYTHON_SITE_PACKAGES}/torch/include/THC,/localdisk/fk/venv/include/python3.7m
     -D_GLIBCXX_USE_CXX11_ABI=0
     -D__CUDA_NO_HALF_OPERATORS__

--- a/nncf/torch/extensions/src/common/cpu/CMakeLists.txt
+++ b/nncf/torch/extensions/src/common/cpu/CMakeLists.txt
@@ -10,33 +10,33 @@ execute_process (
 
 add_executable (tensor_funcs.o tensor_funcs.cpp)
 
-list (APPEND cflags
-    "-MMD"
-    "-MF"
-    "tensor_funcs.o.d"
-    "-DTORCH_EXTENSION_NAME=binarized_functions_cpu"
-    "-DTORCH_API_INCLUDE_EXTENSION_H"
-    "-DPYBIND11_COMPILER_TYPE=\"_gcc\""
-    "-DPYBIND11_STDLIB=\"_libstdcpp\""
-    "-DPYBIND11_BUILD_ABI=\"_cxxabi1011\""
-    "-I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include"
-    "-isystem${PYTHON_SITE_PACKAGES}/torch/include"
-    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include"
-    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/TH"
-    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/THC"
-    "-isystem/localdisk/fk/venv/include/python3.7m"
-    "-D_GLIBCXX_USE_CXX11_ABI=0"
-    "-fPIC"
-    "-std=c++14"
+list(APPEND cflags
+    -MMD
+    -MF
+    tensor_funcs.o.d
+    -DTORCH_EXTENSION_NAME=binarized_functions_cuda
+    -DTORCH_API_INCLUDE_EXTENSION_H
+    -DPYBIND11_COMPILER_TYPE=\"_gcc\"
+    -DPYBIND11_STDLIB=\"_libstdcpp\"
+    -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
+    -I../../../../include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/TH
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/THC
+    -isystem/localdisk/fk/venv/include/python3.7m
+    -D_GLIBCXX_USE_CXX11_ABI=0
+    -fPIC
+    -std=c++14
     )
 
-list (APPEND ldflags
-    "-shared"
-    "-L${PYTHON_SITE_PACKAGES}/torch/lib"
-    "-lc10"
-    "-ltorch_cpu"
-    "-ltorch"
-    "-ltorch_python"
+list(APPEND ldflags
+    -shared
+    -L${PYTHON_SITE_PACKAGES}/torch/lib
+    -lc10
+    -ltorch_cpu
+    -ltorch
+    -ltorch_python
     )
 
 target_compile_options (tensor_funcs.o

--- a/nncf/torch/extensions/src/common/cpu/CMakeLists.txt
+++ b/nncf/torch/extensions/src/common/cpu/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required (VERSION 3.9 FATAL_ERROR)
+project (tensor_funcs.o LANGUAGES CXX)
+
+find_package (PythonInterp 3.7 REQUIRED)
+
+execute_process (
+    COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print (get_python_lib())"
+    OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+add_executable (tensor_funcs.o tensor_funcs.cpp)
+
+list (APPEND cflags
+    "-MMD"
+    "-MF"
+    "tensor_funcs.o.d"
+    "-DTORCH_EXTENSION_NAME=binarized_functions_cpu"
+    "-DTORCH_API_INCLUDE_EXTENSION_H"
+    "-DPYBIND11_COMPILER_TYPE=\"_gcc\""
+    "-DPYBIND11_STDLIB=\"_libstdcpp\""
+    "-DPYBIND11_BUILD_ABI=\"_cxxabi1011\""
+    "-I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include"
+    "-isystem${PYTHON_SITE_PACKAGES}/torch/include"
+    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include"
+    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/TH"
+    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/THC"
+    "-isystem/localdisk/fk/venv/include/python3.7m"
+    "-D_GLIBCXX_USE_CXX11_ABI=0"
+    "-fPIC"
+    "-std=c++14"
+    )
+
+list (APPEND ldflags
+    "-shared"
+    "-L${PYTHON_SITE_PACKAGES}/torch/lib"
+    "-lc10"
+    "-ltorch_cpu"
+    "-ltorch"
+    "-ltorch_python"
+    )
+
+target_compile_options (tensor_funcs.o
+    PRIVATE
+        ${cflags}
+    )
+
+target_link_libraries (tensor_funcs.o
+    PRIVATE
+        ${ldflags}
+    )

--- a/nncf/torch/extensions/src/quantization/cpu/CMakeLists.txt
+++ b/nncf/torch/extensions/src/quantization/cpu/CMakeLists.txt
@@ -11,34 +11,35 @@ add_library (tensor_funcs.o ../../common/cpu/tensor_funcs.cpp)
 
 add_executable (quantized_functions_cpu.so functions_cpu.cpp)
 
-list (APPEND cflags
-    "-MMD"
-    "-MF"
-    "functions_cpu.o.d"
-    "-DTORCH_EXTENSION_NAME=quantized_functions_cpu"
-    "-DTORCH_API_INCLUDE_EXTENSION_H"
-    "-DPYBIND11_COMPILER_TYPE=\"_gcc\""
-    "-DPYBIND11_STDLIB=\"_libstdcpp\""
-    "-DPYBIND11_BUILD_ABI=\"_cxxabi1011\""
-    "-I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include"
-    "-isystem${PYTHON_SITE_PACKAGES}/torch/include"
-    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include"
-    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/TH"
-    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/THC"
-    "-isystem/localdisk/fk/venv/include/python3.7m"
-    "-D_GLIBCXX_USE_CXX11_ABI=0"
-    "-fPIC"
-    "-std=c++14"
+list(APPEND cflags
+    -MMD
+    -MF
+    functions_cpu.o.d
+    -DTORCH_EXTENSION_NAME=quantized_functions_cuda
+    -DTORCH_API_INCLUDE_EXTENSION_H
+    -DPYBIND11_COMPILER_TYPE=\"_gcc\"
+    -DPYBIND11_STDLIB=\"_libstdcpp\"
+    -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
+    -I../../../../include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/TH
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/THC
+    -isystem/localdisk/fk/venv/include/python3.7m
+    -D_GLIBCXX_USE_CXX11_ABI=0
+    -fPIC
+    -std=c++14
     )
 
-list (APPEND ldflags
-    "-shared"
-    "-L${PYTHON_SITE_PACKAGES}/torch/lib"
-    "-lc10"
-    "-ltorch_cpu"
-    "-ltorch"
-    "-ltorch_python"
+list(APPEND ldflags
+    -shared
+    -L${PYTHON_SITE_PACKAGES}/torch/lib
+    -lc10
+    -ltorch_cpu
+    -ltorch
+    -ltorch_python
     )
+
 target_compile_options (tensor_funcs.o
     PRIVATE
         ${cflags}

--- a/nncf/torch/extensions/src/quantization/cpu/CMakeLists.txt
+++ b/nncf/torch/extensions/src/quantization/cpu/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required (VERSION 3.9 FATAL_ERROR)
+project (quantized_functions_cpu.so LANGUAGES CXX)
+
+find_package (PythonInterp 3.7 REQUIRED)
+execute_process (
+    COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print (get_python_lib())"
+    OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+add_library (tensor_funcs.o ../../common/cpu/tensor_funcs.cpp)
+
+add_executable (quantized_functions_cpu.so functions_cpu.cpp)
+
+list (APPEND cflags
+    "-MMD"
+    "-MF"
+    "functions_cpu.o.d"
+    "-DTORCH_EXTENSION_NAME=quantized_functions_cpu"
+    "-DTORCH_API_INCLUDE_EXTENSION_H"
+    "-DPYBIND11_COMPILER_TYPE=\"_gcc\""
+    "-DPYBIND11_STDLIB=\"_libstdcpp\""
+    "-DPYBIND11_BUILD_ABI=\"_cxxabi1011\""
+    "-I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include"
+    "-isystem${PYTHON_SITE_PACKAGES}/torch/include"
+    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include"
+    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/TH"
+    "-isystem${PYTHON_SITE_PACKAGES}/torch/include/THC"
+    "-isystem/localdisk/fk/venv/include/python3.7m"
+    "-D_GLIBCXX_USE_CXX11_ABI=0"
+    "-fPIC"
+    "-std=c++14"
+    )
+
+list (APPEND ldflags
+    "-shared"
+    "-L${PYTHON_SITE_PACKAGES}/torch/lib"
+    "-lc10"
+    "-ltorch_cpu"
+    "-ltorch"
+    "-ltorch_python"
+    )
+target_compile_options (tensor_funcs.o
+    PRIVATE
+        ${cflags}
+    )
+
+target_compile_options (quantized_functions_cpu.so
+    PRIVATE
+        ${cflags}
+    )
+
+target_link_libraries (quantized_functions_cpu.so
+    PRIVATE
+        tensor_funcs.o
+        ${ldflags}
+    )

--- a/nncf/torch/extensions/src/quantization/cuda/CMakeLists.txt
+++ b/nncf/torch/extensions/src/quantization/cuda/CMakeLists.txt
@@ -26,7 +26,7 @@ list (APPEND cflags
     -DPYBIND11_COMPILER_TYPE=\"_gcc\"
     -DPYBIND11_STDLIB=\"_libstdcpp\"
     -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
-    -I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include
+    -I../../../../include
     -isystem${PYTHON_SITE_PACKAGES}/torch/include
     -isystem${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include
     -isystem${PYTHON_SITE_PACKAGES}/torch/include/TH

--- a/nncf/torch/extensions/src/quantization/cuda/CMakeLists.txt
+++ b/nncf/torch/extensions/src/quantization/cuda/CMakeLists.txt
@@ -37,6 +37,25 @@ list (APPEND cflags
     -std=c++14
     )
 
+list (APPEND cflags_cuda
+    -DTORCH_EXTENSION_NAME=quantized_functions_cuda
+    -DTORCH_API_INCLUDE_EXTENSION_H
+    -DPYBIND11_COMPILER_TYPE=\"_gcc\"
+    -DPYBIND11_STDLIB=\"_libstdcpp\"
+    -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
+    -I../../../../include
+    --system-include ${PYTHON_SITE_PACKAGES}/torch/include,${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include,${PYTHON_SITE_PACKAGES}/torch/include/TH,${PYTHON_SITE_PACKAGES}/torch/include/THC,/localdisk/fk/venv/include/python3.7m
+    -D_GLIBCXX_USE_CXX11_ABI=0
+    -D__CUDA_NO_HALF_OPERATORS__
+    -D__CUDA_NO_HALF_CONVERSIONS__
+    -D__CUDA_NO_BFLOAT16_CONVERSIONS__
+    -D__CUDA_NO_HALF2_OPERATORS__
+    --expt-relaxed-constexpr
+    -gencode=arch=compute_75,code=compute_75
+    --compiler-options '-fPIC'
+    -std=c++14
+    )
+
 list (APPEND ldflags
     -shared
     -L${PYTHON_SITE_PACKAGES}/torch/lib
@@ -68,22 +87,7 @@ set_property (TARGET quantized_functions_cuda.so
 
 target_compile_options (quantized_functions_cuda.so
     PRIVATE
-    -DTORCH_EXTENSION_NAME=quantized_functions_cuda
-    -DTORCH_API_INCLUDE_EXTENSION_H
-    -DPYBIND11_COMPILER_TYPE=\"_gcc\"
-    -DPYBIND11_STDLIB=\"_libstdcpp\"
-    -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
-    -I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include
-    --system-include ${PYTHON_SITE_PACKAGES}/torch/include,${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include,${PYTHON_SITE_PACKAGES}/torch/include/TH,${PYTHON_SITE_PACKAGES}/torch/include/THC,/localdisk/fk/venv/include/python3.7m
-    -D_GLIBCXX_USE_CXX11_ABI=0
-    -D__CUDA_NO_HALF_OPERATORS__
-    -D__CUDA_NO_HALF_CONVERSIONS__
-    -D__CUDA_NO_BFLOAT16_CONVERSIONS__
-    -D__CUDA_NO_HALF2_OPERATORS__
-    --expt-relaxed-constexpr
-    -gencode=arch=compute_75,code=compute_75
-    --compiler-options '-fPIC'
-    -std=c++14
+        ${cflags_cuda}
     )
 
 target_link_libraries (quantized_functions_cuda.so

--- a/nncf/torch/extensions/src/quantization/cuda/CMakeLists.txt
+++ b/nncf/torch/extensions/src/quantization/cuda/CMakeLists.txt
@@ -1,0 +1,93 @@
+cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+
+set (CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
+set (CUDA_INCLUDE_DIRS /usr/local/cuda/include/ ${CUDA_INCLUDE_DIRS})
+
+project (quantized_functions_cuda.so LANGUAGES CXX CUDA)
+
+find_package (PythonInterp 3.7 REQUIRED)
+
+execute_process (
+    COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print (get_python_lib())"
+    OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+add_library (functions_cuda.o
+    STATIC
+    functions_cuda.cpp
+    )
+
+list (APPEND cflags
+    -MMD
+    -MF
+    functions_cuda.o.d
+    -DTORCH_EXTENSION_NAME=quantized_functions_cuda
+    -DTORCH_API_INCLUDE_EXTENSION_H
+    -DPYBIND11_COMPILER_TYPE=\"_gcc\"
+    -DPYBIND11_STDLIB=\"_libstdcpp\"
+    -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
+    -I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/TH
+    -isystem${PYTHON_SITE_PACKAGES}/torch/include/THC
+    -isystem/localdisk/fk/venv/include/python3.7m
+    -D_GLIBCXX_USE_CXX11_ABI=0
+    -fPIC
+    -std=c++14
+    )
+
+list (APPEND ldflags
+    -shared
+    -L${PYTHON_SITE_PACKAGES}/torch/lib
+    -lc10
+    -lc10_cuda
+    -ltorch_cpu
+    -ltorch_cuda
+    -ltorch
+    -ltorch_python
+    -L/usr/local/cuda/lib64
+    -lcudart
+    )
+
+target_compile_options (functions_cuda.o
+    PRIVATE
+        ${cflags}
+    )
+
+target_compile_features (functions_cuda.o PUBLIC cxx_std_14)
+set_target_properties (functions_cuda.o
+                       PROPERTIES CUDA_SEPARABLE_COMPILATION ON
+    )
+
+add_executable (quantized_functions_cuda.so functions_cuda_impl.cu)
+
+set_property (TARGET quantized_functions_cuda.so
+             PROPERTY CUDA_SEPARABLE_COMPILATION ON
+    )
+
+target_compile_options (quantized_functions_cuda.so
+    PRIVATE
+    -DTORCH_EXTENSION_NAME=quantized_functions_cuda
+    -DTORCH_API_INCLUDE_EXTENSION_H
+    -DPYBIND11_COMPILER_TYPE=\"_gcc\"
+    -DPYBIND11_STDLIB=\"_libstdcpp\"
+    -DPYBIND11_BUILD_ABI=\"_cxxabi1011\"
+    -I${PYTHON_SITE_PACKAGES}/nncf/torch/extensions/include
+    --system-include ${PYTHON_SITE_PACKAGES}/torch/include,${PYTHON_SITE_PACKAGES}/torch/include/torch/csrc/api/include,${PYTHON_SITE_PACKAGES}/torch/include/TH,${PYTHON_SITE_PACKAGES}/torch/include/THC,/localdisk/fk/venv/include/python3.7m
+    -D_GLIBCXX_USE_CXX11_ABI=0
+    -D__CUDA_NO_HALF_OPERATORS__
+    -D__CUDA_NO_HALF_CONVERSIONS__
+    -D__CUDA_NO_BFLOAT16_CONVERSIONS__
+    -D__CUDA_NO_HALF2_OPERATORS__
+    --expt-relaxed-constexpr
+    -gencode=arch=compute_75,code=compute_75
+    --compiler-options '-fPIC'
+    -std=c++14
+    )
+
+target_link_libraries (quantized_functions_cuda.so
+    PRIVATE
+        functions_cuda.o
+        ${ldflags}
+    )


### PR DESCRIPTION
Adding CMakeLists.txt files for NNCF extensions

- Tests:

1. nstall  nncf 
2. Proceed to an extension folder
3. execute commands
    mkdir -p build && cd build && rm -rf * && cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON .. && cmake --build .

- Expected results:

1. All builds are successful
2. Per extensions:

- binarization cpu build folder contains binarized_functions_cpu.so

    ldd binarized_functions_cpu.so
            linux-vdso.so.1 (0x00007fff46bac000)
            libc10.so => not found
            libtorch_cpu.so => not found
            libtorch_python.so => not found
            libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f524f023000)
            libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f524ee0b000)
            libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f524ea1a000)
            /lib64/ld-linux-x86-64.so.2 (0x00007f524f636000)
            libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f524e67c000)

- binarization cuda build folder contains binarized_functions_cuda.so

    ldd binarized_functions_cuda.so
          linux-vdso.so.1 (0x00007ffce3f6d000)
          libc10.so => not found
          libc10_cuda.so => not found
          libtorch_cpu.so => not found
          libcudart.so.10.2 => /usr/local/cuda-10.2/targets/x86_64-linux/lib/libcudart.so.10.2 (0x00007f45b342d000)
          libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f45b30a4000)
          libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f45b2e8c000)
          libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f45b2a9b000)
          /lib64/ld-linux-x86-64.so.2 (0x00007f45b38ea000)
          libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f45b2897000)
          libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f45b2678000)
          librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f45b2470000)
          libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f45b20d2000)

- common cpu build folder contains tensor_funcs.o

    ldd tensor_funcs.o
          linux-vdso.so.1 (0x00007ffcf45e3000)
          libc10.so => not found
          libtorch_cpu.so => not found
          libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f4843c85000)
          libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f4843a6d000)
          libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f484367c000)
          /lib64/ld-linux-x86-64.so.2 (0x00007f484422e000)
          libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f48432de000)

- quantized cpu build folder contains quantized_functions_cpu.so

    ldd quantized_functions_cpu.so
          linux-vdso.so.1 (0x00007ffefa7b0000)
          libc10.so => not found
          libtorch_cpu.so => not found
          libtorch_python.so => not found
          libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f6f3fc45000)
          libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f6f3fa2d000)
          libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6f3f63c000)
          /lib64/ld-linux-x86-64.so.2 (0x00007f6f40269000)
          libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f6f3f29e000)

- quantized cuda build folder contains quantized_functions_cuda.so

    ldd quantized_functions_cuda.so
        linux-vdso.so.1 (0x00007fffd3b0d000)
        libc10.so => not found
        libc10_cuda.so => not found
        libtorch_cpu.so => not found
        libcudart.so.10.2 => /usr/local/cuda-10.2/targets/x86_64-linux/lib/libcudart.so.10.2 (0x00007f55dded7000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f55ddb4e000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f55dd936000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f55dd545000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f55de396000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f55dd341000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f55dd122000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f55dcf1a000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f55dcb7c000)