### PR TITLE
Fix bug in __getattr__ of NNCFNetwork

### DIFF
--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -341,7 +341,7 @@ class NNCFNetwork(nn.Module, PostGraphBuildActing):
         class NotFound:
             pass
 
-        def get_NNCFNetwork_attr(self, name):
+        def get_nncf_network_attr(self, name):
             if name in self.__dict__:
                 return self.__dict__[name]
             return NotFound
@@ -360,7 +360,7 @@ class NNCFNetwork(nn.Module, PostGraphBuildActing):
         def get_nn_module_attr(self, name):
             return super().__getattr__(name)
 
-        attr = get_NNCFNetwork_attr(self, name)
+        attr = get_nncf_network_attr(self, name)
         if attr != NotFound:
             return attr
         attr = get_nncf_module_attr(self, name)

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -338,10 +338,34 @@ class NNCFNetwork(nn.Module, PostGraphBuildActing):
             raise RuntimeError("Unsupported insertion type: {}".format(point.insertion_type))
 
     def __getattr__(self, name):
-        wrapped_module = super().__getattr__(MODEL_WRAPPED_BY_NNCF_ATTR_NAME)
-        if hasattr(wrapped_module, name):
-            return getattr(wrapped_module, name)
-        return super().__getattr__(name)
+        def get_NNCFNetwork_attr(self, name):
+            if name in self.__dict__:
+                return self.__dict__[name]
+            return None
+
+        def get_nncf_module_attr(self, name):
+            if hasattr(self.__dict__['_modules'][MODEL_WRAPPED_BY_NNCF_ATTR_NAME], name):
+                attr = getattr(self.__dict__['_modules'][MODEL_WRAPPED_BY_NNCF_ATTR_NAME], name)
+                if hasattr(attr, '__self__'):  # If it is a bound function
+                    from functools import partial
+                    attr = partial(attr, self)
+                    return attr
+                else:
+                    # If it is not a bound function
+                    return attr
+            return None
+
+        def get_nn_module_attr(self, name):
+            return super().__getattr__(name)
+
+        attr = get_NNCFNetwork_attr(self, name)
+        if attr is not None:
+            return attr
+        attr = get_nncf_module_attr(self, name)
+        if attr is not None:
+            return attr
+        return get_nn_module_attr(self, name)
+
 
     def get_graph(self) -> PTNNCFGraph:
         if self._compressed_context.graph.get_nodes_count() == 0 or self._compressed_graph is None:

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -339,7 +339,7 @@ class NNCFNetwork(nn.Module, PostGraphBuildActing):
 
     def __getattr__(self, name):
         class NotFound:
-            ...
+            pass
 
         def get_NNCFNetwork_attr(self, name):
             if name in self.__dict__:

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -353,9 +353,8 @@ class NNCFNetwork(nn.Module, PostGraphBuildActing):
                     from functools import partial
                     attr = partial(attr.__func__, self)
                     return attr
-                else:
-                    # If it is not a bound function
-                    return attr
+                # If it is not a bound function
+                return attr
             return NotFound
 
         def get_nn_module_attr(self, name):

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -802,11 +802,11 @@ class TwoConvTestModelWithUniqueFunction(TwoConvTestModel):
         self.non_unique_attr = 'model_non_unique_attr'
 
     def train_step(self):
-        ...
+        pass
 
     @staticmethod
     def static_func():
-        ...
+        pass
 
 
 def test_get_attr():


### PR DESCRIPTION
Add a capability to change the bound functions of a wrapped module by passing NNCFNetwork instance as a first argument