### PR TITLE
Add maximum pruning rate statistics

### DIFF
--- a/nncf/common/pruning/statistics.py
+++ b/nncf/common/pruning/statistics.py
@@ -93,7 +93,11 @@ class FilterPruningStatistics(Statistics):
                  current_flops: int,
                  full_params_num: int,
                  current_params_num: int,
-                 target_pruning_level: float):
+                 target_pruning_level: float,
+                 pruned_layers_num: int,
+                 prunable_layers_num: int,
+                 minimum_possible_flops: float,
+                 minimum_possible_params: float):
         """
         Initializes statistics of the filter pruning algorithm.
 
@@ -104,6 +108,14 @@ class FilterPruningStatistics(Statistics):
         :param current_params_num: Current number of weights.
         :param target_pruning_level: A target level of the pruning
             for the algorithm for the current epoch.
+        :param pruned_layers_num: number of layers which was actually
+            pruned.
+        :param prunable_layers_num: number of layers which have
+            prunable type.
+        :param minimum_possible_flops: number of flops for pruned
+            model with pruning rate = 1.
+        :param minimum_possible_params: number of params for pruned
+            model with pruning rate = 1.
         """
         self._giga = 1e9
         self._mega = 1e6
@@ -114,6 +126,10 @@ class FilterPruningStatistics(Statistics):
         self.full_params_num = full_params_num
         self.current_params_num = current_params_num
         self.target_pruning_level = target_pruning_level
+        self.pruned_layers_num = pruned_layers_num
+        self.prunable_layers_num = prunable_layers_num
+        self.minimum_possible_flops = minimum_possible_flops
+        self.minimum_possible_params = minimum_possible_params
 
     def to_str(self) -> str:
         algorithm_string = create_table(
@@ -125,6 +141,12 @@ class FilterPruningStatistics(Statistics):
                 ['MParams current / full', f'{self.current_params_num / self._mega:.3f} /'
                                            f' {self.full_params_num / self._mega:.3f}'],
                 ['A target level of the pruning for the algorithm for the current epoch', self.target_pruning_level],
+                ['Pruned layers count / prunable layers count', f'{self.pruned_layers_num} /'
+                                                                f' {self.prunable_layers_num}'],
+                ['GFLOPS minimum possible after pruning / full', f'{self.minimum_possible_flops / self._giga:.3f} /'
+                                                                 f' {self.full_flops / self._giga:.3f}'],
+                ['MParams minimum possible after pruning / full', f'{self.minimum_possible_params / self._mega:.3f} /'
+                                                                  f' {self.full_params_num / self._mega:.3f}'],
             ]
         )
 

--- a/nncf/common/pruning/statistics.py
+++ b/nncf/common/pruning/statistics.py
@@ -98,10 +98,10 @@ class FilterPruningStatistics(Statistics):
         Initializes statistics of the filter pruning algorithm.
 
         :param model_statistics: Statistics of the pruned model.
-        :param full_flops: Full FLOPS.
-        :param current_flops: Current FLOPS.
-        :param full_params_num: Full number of weights.
-        :param current_params_num: Current number of weights.
+        :param full_flops: The total amount of FLOPS in the model.
+        :param current_flops: Current amount of FLOPS in the model.
+        :param full_params_num: The total amount of weights in the model.
+        :param current_params_num: Current amount of weights in the model.
         :param target_pruning_level: A target level of the pruning
             for the algorithm for the current epoch.
         """
@@ -150,16 +150,16 @@ class PrunedModelTheoreticalBorderline(Statistics):
         """
         Initializes statistics of the filter pruning theoretical borderline.
 
-        :param num_pruned_layers: number of layers which was actually
+        :param num_pruned_layers: Number of layers which was actually
             pruned.
-        :param num_prunable_layers: number of layers which have
+        :param num_prunable_layers: Number of layers which have
             prunable type.
-        :param max_prunable_flops: number of flops for pruned
+        :param max_prunable_flops: Number of flops for pruned
             model with pruning rate = 1.
-        :param max_prunable_params: number of weights for pruned
+        :param max_prunable_params: Number of weights for pruned
             model with pruning rate = 1.
-        :param full_flops: Full FLOPS.
-        :param full_params_num: Full number of weights.
+        :param full_flops: The total amount of FLOPS in the model.
+        :param full_params_num: The total amount of weights in the model.
         """
         self._giga = 1e9
         self._mega = 1e6

--- a/nncf/common/pruning/statistics.py
+++ b/nncf/common/pruning/statistics.py
@@ -145,8 +145,8 @@ class PrunedModelTheoreticalBorderline(Statistics):
                  num_prunable_layers: int,
                  max_prunable_flops: float,
                  max_prunable_params: float,
-                 full_flops: int,
-                 full_params_num: int):
+                 total_flops: int,
+                 total_params: int):
         """
         Initializes statistics of the filter pruning theoretical borderline.
 
@@ -158,8 +158,8 @@ class PrunedModelTheoreticalBorderline(Statistics):
             model with pruning rate = 1.
         :param max_prunable_params: Number of weights for pruned
             model with pruning rate = 1.
-        :param full_flops: The total amount of FLOPS in the model.
-        :param full_params_num: The total amount of weights in the model.
+        :param total_flops: The total amount of FLOPS in the model.
+        :param total_params: The total amount of weights in the model.
         """
         self._giga = 1e9
         self._mega = 1e6
@@ -167,8 +167,8 @@ class PrunedModelTheoreticalBorderline(Statistics):
         self.prunable_layers_num = num_prunable_layers
         self.minimum_possible_flops = max_prunable_flops
         self.minimum_possible_params = max_prunable_params
-        self.full_flops = full_flops
-        self.full_params_num = full_params_num
+        self.total_flops = total_flops
+        self.total_params = total_params
 
     def to_str(self) -> str:
         algorithm_string = create_table(
@@ -176,10 +176,10 @@ class PrunedModelTheoreticalBorderline(Statistics):
             rows=[
                 ['Pruned layers count / prunable layers count', f'{self.pruned_layers_num} /'
                                                                 f' {self.prunable_layers_num}'],
-                ['GFLOPS minimum possible after pruning / full', f'{self.minimum_possible_flops / self._giga:.3f} /'
-                                                                 f' {self.full_flops / self._giga:.3f}'],
-                ['MParams minimum possible after pruning / full', f'{self.minimum_possible_params / self._mega:.3f} /'
-                                                                  f' {self.full_params_num / self._mega:.3f}'],
+                ['GFLOPS minimum possible after pruning / total', f'{self.minimum_possible_flops / self._giga:.3f} /'
+                                                                  f' {self.total_flops / self._giga:.3f}'],
+                ['MParams minimum possible after pruning / total', f'{self.minimum_possible_params / self._mega:.3f} /'
+                                                                   f' {self.total_params / self._mega:.3f}'],
             ]
         )
 

--- a/nncf/common/pruning/statistics.py
+++ b/nncf/common/pruning/statistics.py
@@ -93,11 +93,7 @@ class FilterPruningStatistics(Statistics):
                  current_flops: int,
                  full_params_num: int,
                  current_params_num: int,
-                 target_pruning_level: float,
-                 pruned_layers_num: int,
-                 prunable_layers_num: int,
-                 minimum_possible_flops: float,
-                 minimum_possible_params: float):
+                 target_pruning_level: float):
         """
         Initializes statistics of the filter pruning algorithm.
 
@@ -108,14 +104,6 @@ class FilterPruningStatistics(Statistics):
         :param current_params_num: Current number of weights.
         :param target_pruning_level: A target level of the pruning
             for the algorithm for the current epoch.
-        :param pruned_layers_num: number of layers which was actually
-            pruned.
-        :param prunable_layers_num: number of layers which have
-            prunable type.
-        :param minimum_possible_flops: number of flops for pruned
-            model with pruning rate = 1.
-        :param minimum_possible_params: number of params for pruned
-            model with pruning rate = 1.
         """
         self._giga = 1e9
         self._mega = 1e6
@@ -126,10 +114,6 @@ class FilterPruningStatistics(Statistics):
         self.full_params_num = full_params_num
         self.current_params_num = current_params_num
         self.target_pruning_level = target_pruning_level
-        self.pruned_layers_num = pruned_layers_num
-        self.prunable_layers_num = prunable_layers_num
-        self.minimum_possible_flops = minimum_possible_flops
-        self.minimum_possible_params = minimum_possible_params
 
     def to_str(self) -> str:
         algorithm_string = create_table(
@@ -141,6 +125,53 @@ class FilterPruningStatistics(Statistics):
                 ['MParams current / full', f'{self.current_params_num / self._mega:.3f} /'
                                            f' {self.full_params_num / self._mega:.3f}'],
                 ['A target level of the pruning for the algorithm for the current epoch', self.target_pruning_level],
+            ]
+        )
+
+        pretty_string = (
+            f'{self.model_statistics.to_str()}\n\n'
+            f'Statistics of the filter pruning algorithm:\n{algorithm_string}'
+        )
+        return pretty_string
+
+
+class PrunedModelTheoreticalBorderline(Statistics):
+    """
+    Contains theoretical borderline statistics of the filter pruning algorithm.
+    """
+
+    def __init__(self,
+                 pruned_layers_num: int,
+                 prunable_layers_num: int,
+                 minimum_possible_flops: float,
+                 minimum_possible_params: float,
+                 full_flops: int,
+                 full_params_num: int):
+        """
+        Initializes statistics of the filter pruning theoretical borderline.
+
+        :param pruned_layers_num: number of layers which was actually
+            pruned.
+        :param prunable_layers_num: number of layers which have
+            prunable type.
+        :param minimum_possible_flops: number of flops for pruned
+            model with pruning rate = 1.
+        :param minimum_possible_params: number of params for pruned
+            model with pruning rate = 1.
+        """
+        self._giga = 1e9
+        self._mega = 1e6
+        self.pruned_layers_num = pruned_layers_num
+        self.prunable_layers_num = prunable_layers_num
+        self.minimum_possible_flops = minimum_possible_flops
+        self.minimum_possible_params = minimum_possible_params
+        self.full_flops = full_flops
+        self.full_params_num = full_params_num
+
+    def to_str(self) -> str:
+        algorithm_string = create_table(
+            header=['Statistic\'s name', 'Value'],
+            rows=[
                 ['Pruned layers count / prunable layers count', f'{self.pruned_layers_num} /'
                                                                 f' {self.prunable_layers_num}'],
                 ['GFLOPS minimum possible after pruning / full', f'{self.minimum_possible_flops / self._giga:.3f} /'
@@ -151,7 +182,6 @@ class FilterPruningStatistics(Statistics):
         )
 
         pretty_string = (
-            f'{self.model_statistics.to_str()}\n\n'
-            f'Statistics of the filter pruning algorithm:\n{algorithm_string}'
+            f'Theoretical borderline of the filter pruning algorithm\nfor current model:\n{algorithm_string}'
         )
         return pretty_string

--- a/nncf/common/pruning/statistics.py
+++ b/nncf/common/pruning/statistics.py
@@ -141,30 +141,32 @@ class PrunedModelTheoreticalBorderline(Statistics):
     """
 
     def __init__(self,
-                 pruned_layers_num: int,
-                 prunable_layers_num: int,
-                 minimum_possible_flops: float,
-                 minimum_possible_params: float,
+                 num_pruned_layers: int,
+                 num_prunable_layers: int,
+                 max_prunable_flops: float,
+                 max_prunable_params: float,
                  full_flops: int,
                  full_params_num: int):
         """
         Initializes statistics of the filter pruning theoretical borderline.
 
-        :param pruned_layers_num: number of layers which was actually
+        :param num_pruned_layers: number of layers which was actually
             pruned.
-        :param prunable_layers_num: number of layers which have
+        :param num_prunable_layers: number of layers which have
             prunable type.
-        :param minimum_possible_flops: number of flops for pruned
+        :param max_prunable_flops: number of flops for pruned
             model with pruning rate = 1.
-        :param minimum_possible_params: number of params for pruned
+        :param max_prunable_params: number of weights for pruned
             model with pruning rate = 1.
+        :param full_flops: Full FLOPS.
+        :param full_params_num: Full number of weights.
         """
         self._giga = 1e9
         self._mega = 1e6
-        self.pruned_layers_num = pruned_layers_num
-        self.prunable_layers_num = prunable_layers_num
-        self.minimum_possible_flops = minimum_possible_flops
-        self.minimum_possible_params = minimum_possible_params
+        self.pruned_layers_num = num_pruned_layers
+        self.prunable_layers_num = num_prunable_layers
+        self.minimum_possible_flops = max_prunable_flops
+        self.minimum_possible_params = max_prunable_params
         self.full_flops = full_flops
         self.full_params_num = full_params_num
 

--- a/nncf/tensorflow/pruning/filter_pruning/algorithm.py
+++ b/nncf/tensorflow/pruning/filter_pruning/algorithm.py
@@ -130,7 +130,7 @@ class FilterPruningController(BasePruningAlgoController):
         self.current_params_num = self.full_params_num
         self._pruned_layers_num = len(self._pruned_layer_groups_info.get_all_nodes())
         self._prunable_layers_num = len(self._original_graph.get_nodes_by_types(self._prunable_types))
-        self._minimum_possible_flops, self._minimum_possible_params = \
+        self._max_prunable_flops, self._max_prunable_params = \
             self._calculate_flops_and_weights_in_uniformly_pruned_model(1.)
 
         self._weights_normalizer = tensor_l2_normalizer  # for all weights in common case
@@ -170,8 +170,8 @@ class FilterPruningController(BasePruningAlgoController):
     def statistics(self, quickly_collected_only: bool = False) -> NNCFStatistics:
         if not quickly_collected_only and is_debug():
             stats = PrunedModelTheoreticalBorderline(
-                self._pruned_layers_num, self._prunable_layers_num, self._minimum_possible_flops,
-                self._minimum_possible_params, self.full_flops, self.full_params_num)
+                self._pruned_layers_num, self._prunable_layers_num, self._max_prunable_flops,
+                self._max_prunable_params, self.full_flops, self.full_params_num)
 
             nncf_logger.debug(stats.to_str())
 

--- a/nncf/tensorflow/pruning/filter_pruning/algorithm.py
+++ b/nncf/tensorflow/pruning/filter_pruning/algorithm.py
@@ -126,6 +126,10 @@ class FilterPruningController(BasePruningAlgoController):
         self.current_flops = self.full_flops
         self.full_params_num = sum(self._nodes_params_num.values())
         self.current_params_num = self.full_params_num
+        self._pruned_layers_num = len(self._pruned_layer_groups_info.get_all_nodes())
+        self._prunable_layers_num = len(self._original_graph.get_nodes_by_types(self._prunable_types))
+        self._minimum_possible_flops, self._minimum_possible_params = \
+            self._calculate_flops_and_weights_in_uniformly_pruned_model(1.)
 
         self._weights_normalizer = tensor_l2_normalizer  # for all weights in common case
         self._filter_importance = FILTER_IMPORTANCE_FUNCTIONS.get(params.get('filter_importance', 'L2'))
@@ -167,7 +171,9 @@ class FilterPruningController(BasePruningAlgoController):
         target_pruning_level = self.scheduler.current_pruning_level
 
         stats = FilterPruningStatistics(model_statistics, self.full_flops, self.current_flops,
-                                        self.full_params_num, self.current_params_num, target_pruning_level)
+                                        self.full_params_num, self.current_params_num, target_pruning_level,
+                                        self._pruned_layers_num, self._prunable_layers_num,
+                                        self._minimum_possible_flops, self._minimum_possible_params)
 
         nncf_stats = NNCFStatistics()
         nncf_stats.register('filter_pruning', stats)

--- a/nncf/torch/pruning/filter_pruning/algo.py
+++ b/nncf/torch/pruning/filter_pruning/algo.py
@@ -145,7 +145,7 @@ class FilterPruningController(BasePruningAlgoController):
         self.current_params_num = self.full_params_num
         self._pruned_layers_num = len(self.pruned_module_groups_info.get_all_nodes())
         self._prunable_layers_num = len(self._model.get_graph().get_nodes_by_types(self._prunable_types))
-        self._minimum_possible_flops, self._minimum_possible_params =\
+        self._max_prunable_flops, self._max_prunable_params =\
             self._calculate_flops_and_weights_in_uniformly_pruned_model(1.)
 
         self.weights_normalizer = tensor_l2_normalizer  # for all weights in common case
@@ -218,8 +218,8 @@ class FilterPruningController(BasePruningAlgoController):
     def statistics(self, quickly_collected_only: bool = False) -> NNCFStatistics:
         if not quickly_collected_only and is_debug():
             stats = PrunedModelTheoreticalBorderline(
-                self._pruned_layers_num, self._prunable_layers_num, self._minimum_possible_flops,
-                self._minimum_possible_params, self.full_flops, self.full_params_num)
+                self._pruned_layers_num, self._prunable_layers_num, self._max_prunable_flops,
+                self._max_prunable_params, self.full_flops, self.full_params_num)
 
             nncf_logger.debug(stats.to_str())
 

--- a/nncf/torch/pruning/filter_pruning/algo.py
+++ b/nncf/torch/pruning/filter_pruning/algo.py
@@ -31,6 +31,7 @@ from nncf.common.pruning.clusterization import Clusterization
 from nncf.common.pruning.mask_propagation import MaskPropagationAlgorithm
 from nncf.common.pruning.schedulers import PRUNING_SCHEDULERS
 from nncf.common.pruning.statistics import FilterPruningStatistics
+from nncf.common.pruning.statistics import PrunedModelTheoreticalBorderline
 from nncf.common.pruning.statistics import PrunedLayerSummary
 from nncf.common.pruning.statistics import PrunedModelStatistics
 from nncf.common.pruning.utils import calculate_in_out_channels_in_uniformly_pruned_model
@@ -41,6 +42,7 @@ from nncf.common.pruning.utils import get_conv_in_out_channels
 from nncf.common.pruning.utils import get_rounded_pruned_element_number
 from nncf.common.schedulers import StubCompressionScheduler
 from nncf.common.statistics import NNCFStatistics
+from nncf.common.utils.debug import is_debug
 from nncf.common.utils.logger import logger as nncf_logger
 from nncf.config.extractors import extract_bn_adaptation_init_params
 from nncf.torch.algo_selector import PT_COMPRESSION_ALGORITHMS
@@ -214,6 +216,13 @@ class FilterPruningController(BasePruningAlgoController):
         minfo.operand.binary_filter_pruning_mask = mask
 
     def statistics(self, quickly_collected_only: bool = False) -> NNCFStatistics:
+        if not quickly_collected_only and is_debug():
+            stats = PrunedModelTheoreticalBorderline(
+                self._pruned_layers_num, self._prunable_layers_num, self._minimum_possible_flops,
+                self._minimum_possible_params, self.full_flops, self.full_params_num)
+
+            nncf_logger.debug(stats.to_str())
+
         pruned_layers_summary = {}
         for minfo in self.pruned_module_groups_info.get_all_nodes():
             layer_name = str(minfo.module_scope)
@@ -229,9 +238,7 @@ class FilterPruningController(BasePruningAlgoController):
         target_pruning_level = self.scheduler.current_pruning_level
 
         stats = FilterPruningStatistics(model_statistics, self.full_flops, self.current_flops,
-                                        self.full_params_num, self.current_params_num, target_pruning_level,
-                                        self._pruned_layers_num, self._prunable_layers_num,
-                                        self._minimum_possible_flops, self._minimum_possible_params)
+                                        self.full_params_num, self.current_params_num, target_pruning_level)
 
         nncf_stats = NNCFStatistics()
         nncf_stats.register('filter_pruning', stats)


### PR DESCRIPTION
Add three new pruning statistics:
* Pruned layers count / prunable layers count (means number of layers which have prunable type)
* GFLOPS minimum possible after pruning / full (means number of flops for pruned
            model with pruning rate = 1.)
* MParams minimum possible after pruning / full (means number of params for pruned
            model with pruning rate = 1.)
            
This statistics useful in case maximum possible flops removal is really small thus pruning won't give any significant speedup after compression (ex mobilent-v3 with 2 stride) 