### PR TITLE
Add matmul patterns for fusing

### DIFF
--- a/nncf/torch/graph/pattern_operations.py
+++ b/nncf/torch/graph/pattern_operations.py
@@ -55,7 +55,8 @@ ATOMIC_ACTIVATIONS_OPERATIONS = merge_two_types_of_operations(RELU_OPERATIONS,
 ARITHMETIC_OPERATIONS = {'type': ['__iadd__',
                                   '__add__',
                                   '__mul__',
-                                  '__rmul__'],
+                                  '__rmul__',
+                                  '__truediv__'],
                          'label': 'ARITHMETIC'}
 
 # This type may be useful in the future
@@ -65,3 +66,8 @@ POOLING_OPERATIONS = {'type': ['adaptive_avg_pool2d',
                                'avg_pool2d',
                                'avg_pool3d'],
                       'label': 'POOLING'}
+
+MATMUL_OPERATIONS = {'type': ['bmm',
+                              'matmul'
+                              ],
+                     'label': 'MATMUL'}

--- a/nncf/torch/hardware/fused_patterns.py
+++ b/nncf/torch/hardware/fused_patterns.py
@@ -5,6 +5,7 @@ from nncf.torch.graph.pattern_operations import ATOMIC_ACTIVATIONS_OPERATIONS
 from nncf.torch.graph.pattern_operations import BATCH_NORMALIZATION_OPERATIONS
 from nncf.torch.graph.pattern_operations import GROUP_NORMALIZATION_OPERATIONS
 from nncf.torch.graph.pattern_operations import LINEAR_OPERATIONS
+from nncf.torch.graph.pattern_operations import MATMUL_OPERATIONS
 from nncf.torch.graph.pattern_operations import RELU_OPERATIONS
 from nncf.torch.graph.patterns import create_h_sigmoid_act
 from nncf.torch.graph.patterns import create_h_swish_act
@@ -16,6 +17,10 @@ def _get_torch_hw_fused_patterns() -> HWFusedPatterns:
     linear_ops = GraphPattern()
     linear_ops.add_node(**LINEAR_OPERATIONS)
     retval.register(linear_ops, LINEAR_OPERATIONS['label'], match=False)
+
+    matmul_ops = GraphPattern()
+    matmul_ops.add_node(**MATMUL_OPERATIONS)
+    retval.register(linear_ops, MATMUL_OPERATIONS['label'], match=False)
 
     batch_norm = GraphPattern()
     batch_norm.add_node(**BATCH_NORMALIZATION_OPERATIONS)
@@ -36,6 +41,8 @@ def _get_torch_hw_fused_patterns() -> HWFusedPatterns:
     batch_norm_activations_permutation = batch_norm + activations | activations + batch_norm | batch_norm | activations
 
     retval.register(linear_ops + batch_norm_activations_permutation, 'LINEAR + BN_ACT_PERM',
+                    match=True)
+    retval.register(matmul_ops + arithmetic_ops, 'MATMUL + ARITHMETIC',
                     match=True)
     retval.register(batch_norm + activations, 'BN + ACTIVATIONS', match=True)
     retval.register(activations + batch_norm, 'ACTIVATIONS + BN', match=True)

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/MatMulDivConv.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/MatMulDivConv.dot
@@ -1,0 +1,21 @@
+strict digraph  {
+"0 /nncf_model_input_0" [id=0, type=nncf_model_input];
+"1 SymmetricQuantizer/symmetric_quantize_0" [id=1, type=symmetric_quantize];
+"2 /nncf_model_input_1" [id=2, type=nncf_model_input];
+"3 SymmetricQuantizer/symmetric_quantize_1" [id=3, type=symmetric_quantize];
+"4 MatMulDivConv/matmul_0" [id=4, type=matmul];
+"5 MatMulDivConv/__truediv___0" [id=5, type=__truediv__];
+"6 MatMulDivConv/SymmetricQuantizer/symmetric_quantize_0" [id=6, type=symmetric_quantize];
+"7 MatMulDivConv/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" [id=7, type=symmetric_quantize];
+"8 MatMulDivConv/NNCFConv2d[conv]/conv2d_0" [id=8, type=conv2d];
+"9 /nncf_model_output_0" [id=9, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
+"1 SymmetricQuantizer/symmetric_quantize_0" -> "4 MatMulDivConv/matmul_0";
+"2 /nncf_model_input_1" -> "3 SymmetricQuantizer/symmetric_quantize_1";
+"3 SymmetricQuantizer/symmetric_quantize_1" -> "4 MatMulDivConv/matmul_0";
+"4 MatMulDivConv/matmul_0" -> "5 MatMulDivConv/__truediv___0";
+"5 MatMulDivConv/__truediv___0" -> "6 MatMulDivConv/SymmetricQuantizer/symmetric_quantize_0";
+"6 MatMulDivConv/SymmetricQuantizer/symmetric_quantize_0" -> "8 MatMulDivConv/NNCFConv2d[conv]/conv2d_0";
+"7 MatMulDivConv/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" -> "8 MatMulDivConv/NNCFConv2d[conv]/conv2d_0";
+"8 MatMulDivConv/NNCFConv2d[conv]/conv2d_0" -> "9 /nncf_model_output_0";
+}

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -21,6 +21,7 @@ from typing import Callable, Dict, List, Tuple, Union
 import networkx as nx
 import pytest
 import torch
+from tests.torch.test_models.synthetic import MatMulDivConv
 from torch import nn
 import torch.nn.functional as F
 import torchvision
@@ -708,7 +709,8 @@ SYNTHETIC_MODEL_DESC_LIST = [
     GeneralModelDesc(model_builder=EmbeddingCatLinearModel, input_info={"sample_size": [1, 1],
                                                                   "type": "long",
                                                                   "filler": "zeros"}),
-    GeneralModelDesc(model_builder=MultiOutputSameTensorModel)
+    GeneralModelDesc(model_builder=MultiOutputSameTensorModel),
+    GeneralModelDesc(model_builder=MatMulDivConv, input_sample_sizes=([1, 1, 5, 5], [1, 1, 5, 5]))
 ]
 
 

--- a/tests/torch/test_models/synthetic.py
+++ b/tests/torch/test_models/synthetic.py
@@ -231,3 +231,13 @@ class AddTwoConv(nn.Module):
 
     def forward(self, x):
         return self.conv1(x) + self.conv2(x)
+
+
+class MatMulDivConv(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = create_conv(1, 2, 2, 2)
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor):
+        z = torch.matmul(x, y) / 2
+        return self.conv(z)


### PR DESCRIPTION
### Changes 
The patterns were added for fusing matmul and elementwise operations for PT quantization

### Reason for changes 
BERT exhibits this type of operations and currently an extra FQ is being inserted between matmul and add etc., which is unnecessary.

### Related tickets 
-

### Tests 
Examination of the resulting BERT-SQuAD model obtained with the transformers repo. SOTA PT eval build 539.