### PR TITLE
Test compression training fix 

### DIFF
--- a/tests/torch/data/configs/weekly/classification/cifar100/mobilenet_v2_learned_ranking.json
+++ b/tests/torch/data/configs/weekly/classification/cifar100/mobilenet_v2_learned_ranking.json
@@ -6,7 +6,7 @@
     "num_classes": 100,
     "batch_size": 256,
     "dataset": "cifar100",
-    "epochs": 1,
+    "epochs": 60,
     "optimizer": {
         "type": "SGD",
         "base_lr": 0.1,
@@ -14,9 +14,7 @@
         "schedule_type": "multistep",
         "steps": [
             20,
-            40,
-            60,
-            80
+            40
         ],
         "optimizer_params":
         {

--- a/tests/torch/test_compression_training.py
+++ b/tests/torch/test_compression_training.py
@@ -86,7 +86,7 @@ GLOBAL_CONFIG = {
                             'execution_arg': {'multiprocessing-distributed'},
                             'expected_accuracy': 68.11,
                             'weights': 'mobilenet_v2_32x32_cifar100_68.11.pth',
-                            'absolute_tolerance_train': 1.0,
+                            'absolute_tolerance_train': 1.5,
                             'absolute_tolerance_eval': 2e-2
                         },
                     }


### PR DESCRIPTION
Fixed test for compression training for LeGR algorithm. Ticket - 62532.
The number of training epochs and potential accuracy diff has been increased.

@ljaljushkin @vshampor 