### PR TITLE
Mark and visualize integer edges in NNCF PT

### DIFF
--- a/nncf/common/graph/graph.py
+++ b/nncf/common/graph/graph.py
@@ -14,6 +14,7 @@ import os
 from collections import defaultdict
 from copy import deepcopy
 from typing import Any, Callable, Dict, KeysView, List, Tuple, Type, ValuesView
+from typing import Generator
 
 import networkx as nx
 import networkx.algorithms.isomorphism as iso
@@ -104,19 +105,22 @@ class NNCFGraphEdge:
     def __init__(self, from_node: NNCFNode, to_node: NNCFNode,
                  input_port_id: int,
                  output_port_id: int,
-                 tensor_shape: List[int]):
+                 tensor_shape: List[int],
+                 dtype: Dtype):
         """
         :param from_node: An NNCFNode that sources the directed edge.
         :param to_node: An NNCFNode that sinks the directed edge.
         :param input_port_id: The ID of the tensor input to the `to_node` that this edge corresponds to.
         :param output_port_id: The ID of the tensor output of the `from_node` that this edge corresponds to..
         :param tensor_shape: The shape of the activation tensor the edge represents.
+        :param dtype: The data type of the activation tensor the edge represents.
         """
         self.from_node = from_node
         self.to_node = to_node
         self.input_port_id = input_port_id
         self.output_port_id = output_port_id
         self.tensor_shape = tensor_shape
+        self.dtype = dtype
 
     def __str__(self):
         return str(self.from_node) + ' -> ' + str(self.tensor_shape) + ' -> ' + str(self.to_node)
@@ -136,8 +140,6 @@ class NNCFGraphPatternIO:
     def __init__(self, input_edges: List[NNCFGraphEdge], output_edges: List[NNCFGraphEdge]):
         self.input_edges = input_edges
         self.output_edges = output_edges
-
-
 
 
 #pylint:disable=too-many-public-methods
@@ -507,7 +509,12 @@ class NNCFGraph:
             out_graph.add_node(node_name, **attrs_node)
         if extended:
             for u, v in self._nx_graph.edges:
-                out_graph.add_edge(u, v, label=self._nx_graph.edges[u, v][NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR])
+                edge = self._nx_graph.edges[u, v]
+                if edge[NNCFGraph.DTYPE_EDGE_ATTR] is Dtype.INTEGER:
+                    style = 'dashed'
+                else:
+                    style = 'solid'
+                out_graph.add_edge(u, v, label=edge[NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR], style=style)
         else:
             for u, v in self._nx_graph.edges:
                 out_graph.add_edge(u, v)
@@ -527,7 +534,12 @@ class NNCFGraph:
             out_graph.add_node(node_key, **attrs_node)
 
         for u, v in self._nx_graph.edges:
-            out_graph.add_edge(u, v, label=self._nx_graph.edges[u, v][NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR])
+            edge = self._nx_graph.edges[u, v]
+            if edge[NNCFGraph.DTYPE_EDGE_ATTR] is Dtype.INTEGER:
+                style = 'dashed'
+            else:
+                style = 'solid'
+            out_graph.add_edge(u, v, label=edge[NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR], style=style)
 
         mapping = {k: v['label'] for k, v in out_graph.nodes.items()}
         out_graph = nx.relabel_nodes(out_graph, mapping)
@@ -581,7 +593,8 @@ class NNCFGraph:
                                       self._nx_node_to_nncf_node(self._nx_graph.nodes[to_node_key]),
                                       input_port_id=data[NNCFGraph.INPUT_PORT_ID_EDGE_ATTR],
                                       output_port_id=data[NNCFGraph.OUTPUT_PORT_ID_EDGE_ATTR],
-                                      tensor_shape=data[NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR])
+                                      tensor_shape=data[NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR],
+                                      dtype=data[NNCFGraph.DTYPE_EDGE_ATTR])
             if from_node_key in match:
                 output_nncf_edges.append(nncf_edge)
             elif to_node_key in match:
@@ -612,4 +625,10 @@ class NNCFGraph:
                              to_node,
                              data[NNCFGraph.INPUT_PORT_ID_EDGE_ATTR],
                              data[NNCFGraph.OUTPUT_PORT_ID_EDGE_ATTR],
-                             data[NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR])
+                             data[NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR],
+                             data[NNCFGraph.DTYPE_EDGE_ATTR])
+
+    def get_all_edges(self) -> Generator[NNCFGraphEdge, None, None]:
+        for nx_edge in self._nx_graph.edges:
+            yield self.get_edge(self.get_node_by_key(nx_edge[0]),
+                                self.get_node_by_key(nx_edge[1]))

--- a/nncf/common/quantization/quantizer_propagation/solver.py
+++ b/nncf/common/quantization/quantizer_propagation/solver.py
@@ -934,6 +934,9 @@ class QuantizerPropagationSolver:
             edge = quant_prop_graph.edges[pred_ip_key, operator_node_key]
             if not edge[QuantizerPropagationStateGraph.IS_INTEGER_PATH_EDGE_ATTR]:
                 pred_ip_key_vs_qconf_dict[pred_ip_key] = qconf_list
+            else:
+                nncf_logger.debug("Detected integer input {} - won't set up "
+                                  "a propagating quantizer for it".format(pred_ip_key))
 
         if not pred_ip_key_vs_qconf_dict:
             # All inputs to the operator were integer

--- a/nncf/torch/dynamic_graph/graph.py
+++ b/nncf/torch/dynamic_graph/graph.py
@@ -20,6 +20,7 @@ import networkx as nx
 import networkx.algorithms.isomorphism as iso
 from torch import Tensor
 
+from nncf.common.graph import Dtype
 from nncf.common.graph.layer_attributes import BaseLayerAttributes
 from nncf.common.utils.logger import logger as nncf_logger
 from nncf.torch.dynamic_graph.scope import Scope
@@ -180,12 +181,14 @@ class DynamicGraphNode:
 
 class DynamicGraphEdge:
     def __init__(self, from_node_id: int, to_node_id: int,
-                 activation_shape: List[int], input_port_id: int, output_port_id: int):
+                 activation_shape: List[int], input_port_id: int, output_port_id: int,
+                 dtype: Dtype):
         self.from_node_id = from_node_id
         self.to_node_id = to_node_id
         self.activation_shape = activation_shape
         self.input_port_id = input_port_id
         self.output_port_id = output_port_id
+        self.dtype = dtype
 
 
 class DefaultScopeNodeMatcher:
@@ -267,6 +270,7 @@ class DefaultScopeNodeMatcher:
             self._nx_graph.edges[parent, node_key][DynamicGraph.ACTIVATION_SHAPE_EDGE_ATTR] = info.shape
             self._nx_graph.edges[parent, node_key][DynamicGraph.INPUT_PORT_ID_EDGE_ATTR] = i
             self._nx_graph.edges[parent, node_key][DynamicGraph.OUTPUT_PORT_ID_EDGE_ATTR] = info.index
+            self._nx_graph.edges[parent, node_key][DynamicGraph.ACTIVATION_DTYPE_EDGE_ATTR] = info.dtype
 
         nx_node_dict = self._nx_graph.nodes[node_key]
         node = DynamicGraphNode(node_id=nx_node_dict[DynamicGraph.ID_NODE_ATTR],
@@ -489,6 +493,7 @@ class DynamicGraph:
     LAYER_ATTRIBUTES = 'layer_attributes'
     OP_EXEC_CONTEXT_NODE_ATTR = 'op_exec_context'
     ACTIVATION_SHAPE_EDGE_ATTR = 'activation_shape'
+    ACTIVATION_DTYPE_EDGE_ATTR = 'activation_dtype'
     INPUT_PORT_ID_EDGE_ATTR = 'input_port_id'
     OUTPUT_PORT_ID_EDGE_ATTR = 'output_port_id'
     IGNORED_ALGOS_NODE_ATTR = 'ignored_algos'
@@ -571,7 +576,8 @@ class DynamicGraph:
                 to_node_id=to_node_id,
                 activation_shape=nx_edge_attrs[DynamicGraph.ACTIVATION_SHAPE_EDGE_ATTR],
                 input_port_id=nx_edge_attrs[DynamicGraph.INPUT_PORT_ID_EDGE_ATTR],
-                output_port_id=nx_edge_attrs[DynamicGraph.OUTPUT_PORT_ID_EDGE_ATTR])
+                output_port_id=nx_edge_attrs[DynamicGraph.OUTPUT_PORT_ID_EDGE_ATTR],
+                dtype=nx_edge_attrs[DynamicGraph.ACTIVATION_DTYPE_EDGE_ATTR])
 
             all_edges.append(dynamic_graph_edge)
         return all_edges

--- a/nncf/torch/dynamic_graph/trace_tensor.py
+++ b/nncf/torch/dynamic_graph/trace_tensor.py
@@ -14,9 +14,13 @@
 from typing import Iterable
 from typing import List
 from typing import Optional
+from typing import Tuple
+from typing import Union
 
 import numpy as np
 import torch
+
+from nncf.common.graph import Dtype
 
 
 class TensorMeta:
@@ -24,7 +28,8 @@ class TensorMeta:
     def default_comparator(lhs: 'TensorMeta', rhs: 'TensorMeta'):
         return lhs.index == rhs.index and lhs.creator_id == rhs.creator_id and lhs.shape[1:] == rhs.shape[1:]
 
-    def __init__(self, creator_id: int, index: int, shape):
+    def __init__(self, creator_id: int, index: int, shape: Union[List[int], Tuple[torch.Tensor, ...]],
+                 dtype: Dtype = Dtype.FLOAT):
         """
         :param creator_id: An ID of the node in DynamicGraph that corresponds to an operation that created the
             tensor.
@@ -34,6 +39,7 @@ class TensorMeta:
         self.creator_id = creator_id
         self.index = index
         self.shape = tuple(int(dim) for dim in shape)  # Handle cases when shape is a tuple of Tensors
+        self.dtype = dtype
 
     def __eq__(self, other):
         if not isinstance(other, TensorMeta):
@@ -94,15 +100,21 @@ def flatten_args(args, kwargs):
     return list(flatten(args)) + list(flatten(kwargs))
 
 
+def get_dtype(x: torch.Tensor) -> Dtype:
+    if x.dtype in [torch.float, torch.float16, torch.float32, torch.float64]:
+        return Dtype.FLOAT
+    return Dtype.INTEGER
+
+
 def trace_tensors(operator_output, node: 'DynamicGraphNode'):
     if isinstance(operator_output, (list, tuple)):
         output_ = []
         for i, x in enumerate(operator_output):
-            meta = TensorMeta(node.node_id, i, x.shape)
+            meta = TensorMeta(node.node_id, i, x.shape, get_dtype(x))
             output_.append(TracedTensor.from_torch_tensor(x, meta))
         return operator_output.__class__(output_)
     if isinstance(operator_output, torch.Tensor):
-        meta = TensorMeta(node.node_id, 0, operator_output.shape)
+        meta = TensorMeta(node.node_id, 0, operator_output.shape, get_dtype(operator_output))
         return TracedTensor.from_torch_tensor(operator_output, meta)
     raise ValueError("Unknown return type. Can not trace function call")
 

--- a/nncf/torch/graph/graph_builder.py
+++ b/nncf/torch/graph/graph_builder.py
@@ -21,7 +21,6 @@ import torch
 
 from nncf.common.graph import INPUT_NOOP_METATYPES
 from nncf.common.graph import LayerName
-from nncf.common.graph.layer_attributes import Dtype
 from nncf.torch.dynamic_graph.graph import DynamicGraph
 from nncf.torch.dynamic_graph.graph_tracer import GraphTracer
 from nncf.torch.dynamic_graph.graph_tracer import ModelInputInfo
@@ -89,6 +88,6 @@ class GraphConverter:
                 tensor_shape=dynamic_graph_edge.activation_shape,
                 input_port_id=dynamic_graph_edge.input_port_id,
                 output_port_id=dynamic_graph_edge.output_port_id,
-                dtype=Dtype.FLOAT
+                dtype=dynamic_graph_edge.dtype
             )
         return nncf_graph

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -337,6 +337,14 @@ class DivMetatype(PTOperatorMetatype):
 
 
 @PT_OPERATOR_METATYPES.register()
+class FloorDivMetatype(PTOperatorMetatype):
+    name = "floordiv"
+    torch_tensor_patch_spec = PTPatchSpec(["__floordiv__",
+                                           "__ifloordiv__",
+                                           "__rfloordiv__"])
+
+
+@PT_OPERATOR_METATYPES.register()
 class ExpMetatype(PTOperatorMetatype):
     name = "exp"
     torch_module_patch_spec = PTPatchSpec([name])

--- a/tests/torch/test_graph_analysis.py
+++ b/tests/torch/test_graph_analysis.py
@@ -14,6 +14,7 @@ from collections import Counter
 
 import networkx as nx
 
+from nncf.common.graph import Dtype
 from nncf.common.graph import NNCFGraphEdge
 from nncf.common.graph import NNCFGraphPatternIO
 from nncf.common.graph import NNCFNodeName
@@ -53,7 +54,8 @@ def test_graph_pattern_io_building():
                              get_node(to_node_name),
                              input_port_id=input_port_id,
                              output_port_id=output_port_id,
-                             tensor_shape=[1, 1, 1, 1])
+                             tensor_shape=[1, 1, 1, 1],
+                             dtype=Dtype.FLOAT)
 
     def get_node(name: NNCFNodeName):
         return graph.get_node_by_name(name)


### PR DESCRIPTION
### Changes

The integer edges are now being properly marked in NNCFGraph generated for the PyTorch backend, so that the solver can utilize this information. Furthermore the integer edges are now being displayed as dashed in `compressed_graph.dot` and `original_graph.dot` representations.

### Reason for changes

The models with integer tensors within their control flow graph will now be quantized properly - with less chance of a quantizer ending up quantizing an integer branch.

### Related tickets

N/A

### Tests

Added a test to build a graph on a toy model with integer tensors in the CFG, count the number of detected integer tensors and compare against the expected number.
