### PR TITLE
Fix kd for bert

### DIFF
--- a/tests/torch/test_knowledge_distillation.py
+++ b/tests/torch/test_knowledge_distillation.py
@@ -15,11 +15,9 @@ from copy import deepcopy
 from functools import reduce
 from collections.abc import Iterable
 from typing import List, Tuple
-from unittest.mock import MagicMock
 
 from nncf.torch.dynamic_graph.graph_tracer import ModelInputInfo
 from nncf.torch.knowledge_distillation.algo import KnowledgeDistillationBuilder
-from nncf.torch.knowledge_distillation.knowledge_distillation_loss import KnowledgeDistillationLoss
 from nncf.torch.nncf_network import NNCFNetwork
 from nncf import NNCFConfig
 from tests.torch.test_models.synthetic import PartlyNonDifferentialOutputsModel
@@ -384,4 +382,3 @@ def test_kd_softmax_loss_ignores_incompatible_outputs(shape_list: List[Tuple[int
     kd_ctrl = kd_builder.build_controller(compressed_model)
     compressed_model.forward(torch.ones_like(compressed_model.mock_param))
     kd_ctrl.loss()  # Should succeed - the loss for the incompatible outputs will be equal to 0
-


### PR DESCRIPTION
### Changes

A check was added to only calculate softmax loss for tensors of compatible shape (which is any 2-dimensional shape). The incompatible tensors are set up not to add any loss into the resulting loss value reduced across outputs.

### Reason for changes

BERT from transformers outputs loss along with the logits as its outputs, and the softmax KD fails upon trying to distill that BERT loss in a softmax fashion since BERT loss is a 0-D tensor while softmax loss expects a 2-D tensor.

### Related tickets

N/A

### Tests

Added a test to check that softmax KD loss calculation succeeds in case of unconventional outputs.
