### PR TITLE
Fixed requirements for Ubuntu 18.04

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ INSTALL_REQUIRES = ["ninja>=1.10.0.post2",
                     "natsort>=7.1.0",
                     "pandas~=1.1.5; python_version<'3.7'",
                     "pandas>=1.1.5; python_version>='3.7'",
-                    "scikit-learn>=0.24.0",
+                    "scikit-learn~=0.24.0; python_version<'3.7'",
+                    "scikit-learn>=1.0; python_version>='3.7'",
                     "wheel>=0.36.1"]
 
 


### PR DESCRIPTION
### Changes

Fixed requirements for Ubuntu 18.04 and python 3.6

### Reason for changes

`python setup.py install` fails with error "UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1413: ordinal not in range(128)"

### Related tickets

ref: 67932

### Tests

install_tf: build 105
