### PR TITLE
Revert scikit-learn version to align with OpenVINO components

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ INSTALL_REQUIRES = ["ninja>=1.10.0.post2",
                     "pandas~=1.1.5; python_version<'3.7'",
                     "pandas>=1.1.5; python_version>='3.7'",
                     "scikit-learn~=0.24.0; python_version<'3.7'",
-                    "scikit-learn>=1.0; python_version>='3.7'",
+                    "scikit-learn>=0.24.0; python_version>='3.7'",
                     "wheel>=0.36.1"]
 
 


### PR DESCRIPTION
### Changes

Revert scikit-learn>=1.0 -> scikit-learn>=0.24.0 for python_version>='3.7'

### Reason for changes

Adjust scikit-learn version with OpenVINO components

### Related tickets

Bug from the validation team

### Tests

N/A
