### PR TITLE
Clear current scope on TracingContext exit

### DIFF
--- a/nncf/torch/dynamic_graph/context.py
+++ b/nncf/torch/dynamic_graph/context.py
@@ -84,6 +84,8 @@ class TracingContext:
 
     def __exit__(self, *args):
         self.reset_scope_operator_call_counters()
+        self.relative_scopes_stack.clear()
+        self.module_call_stack.clear()
         self.leave()
 
     def find_operator_node(self, tensor_metas: List[Optional[TensorMeta]],

--- a/tests/torch/test_graph_building.py
+++ b/tests/torch/test_graph_building.py
@@ -511,3 +511,37 @@ def test_integer_path_marking():
     edges = list(nncf_graph.get_all_edges())
     num_integer_edges = sum([1 for edge in edges if edge.dtype is Dtype.INTEGER])
     assert num_integer_edges == 2  # cat -> __floordiv__ and __floordiv__ -> __getitem__
+
+
+class ModelSpecificException(Exception):
+    pass
+
+
+class ExceptionRaisingModule(torch.nn.Module):
+    class Inner(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.dummy_param = torch.nn.Parameter(torch.ones([1]))
+
+        def forward(self, *args, **kwargs):
+            _ = torch.cat((torch.ones([1]), torch.ones([1])))
+            raise ModelSpecificException
+
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(self.Inner(), self.Inner())
+
+    def forward(self, *args, **kwargs):
+        return self.seq(*args, **kwargs)
+
+
+def test_scope_and_call_counters_are_reset_on_exceptions():
+    ctx = TracingContext()
+    model = ExceptionRaisingModule()
+    with pytest.raises(ModelSpecificException):
+        with ctx:
+            model(torch.ones([1]))
+    assert not ctx.module_call_stack
+    assert not ctx.relative_scopes_stack
+    #pylint:disable=protected-access
+    assert not ctx._thread_local.operator_counters


### PR DESCRIPTION
### Changes

The `TracingContext` object now clears the current scope stack upon triggering `__exit__`

### Reason for changes

A bug was discovered - when an exception is triggered within an NNCF-compressed model and successfully handled outside it, the activation FQs would become unlinked from the model execution, in a sense that the actual fake quantization for activations would not be triggered in subsequent forward calls to the compressed models.

### Related tickets

65372

### Tests

Added the `test_scope_and_call_counters_are_reset_on_exceptions` case.
