### PR TITLE
Freeze pyparsing version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,14 @@ INSTALL_REQUIRES = ["ninja>=1.10.0.post2",
                     "matplotlib~=3.3.4; python_version<'3.7'",
                     "matplotlib>=3.3.4; python_version>='3.7'",
                     "networkx>=2.5",
+
+                    # The recent pyparsing major version update seems to break
+                    # integration with networkx - the graphs parsed from current .dot
+                    # reference files no longer match against the graphs produced in tests.
+                    # Using 2.x versions of pyparsing seems to fix the issue.
+                    # Ticket: 69520
+                    "pyparsing<3.0",
+
                     "jsonschema==3.2.0",
                     "pydot>=1.4.1",
                     "jstyleson>=0.0.2",

--- a/tests/tensorflow/requirements.txt
+++ b/tests/tensorflow/requirements.txt
@@ -6,3 +6,6 @@ pytest-dependency
 yattag>=1.14.0
 prettytable>=2.0.0
 pydot
+
+# Ticket 69520
+pyparsing<3.0

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -6,3 +6,6 @@ onnx>=1.8.0
 onnxruntime==1.6.0
 pytest-mock>=3.3.1
 pytest-dependency>=0.5.1
+
+# Ticket 69520
+pyparsing<3.0


### PR DESCRIPTION
### Changes

The pyparsing version has been frozen at 2.x.

### Reason for changes

The recent major version update of pyparsing breaks the loading/matching of reference .dot files representing the NNCF graph structure which are used in tests.

### Related tickets

69520

### Tests

test_build_graph and related precommit failures should be passing now.
