### PR TITLE
Add BERT-MRPC config, command line and result

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ to find instruction and links to exact configuration files and final checkpoints
 | :---: | :---: | :---: | :---: |
 |BERT-base-chinese|INT8|XNLI|77.22 (0.46)|
 |BERT-base-cased|INT8|CoNLL2003|99.18 (-0.01)|
+|BERT-base-cased|INT8|MRPC|84.8 (-0.24)|
 |BERT-large (Whole Word Masking)|INT8|SQuAD v1.1|F1: 92.68 (0.53)|
 |RoBERTa-large|INT8|MNLI|matched: 89.25 (1.35)|
 |DistilBERT-base|INT8|SST-2|90.3 (0.8)|

--- a/third_party_integration/huggingface_transformers/0001-Modifications-for-NNCF-usage.patch
+++ b/third_party_integration/huggingface_transformers/0001-Modifications-for-NNCF-usage.patch
@@ -1,4 +1,4 @@
-From bb373539de92be5faba5c2e38ec6a8a6c30ac422 Mon Sep 17 00:00:00 2001
+From 8e5d5b5798febec45bb442e96f2633ac1c2bf6ba Mon Sep 17 00:00:00 2001
 From: Vasily Shamporov <vasily.shamporov@intel.com>
 Date: Mon, 2 Aug 2021 17:46:48 +0300
 Subject: [PATCH] Modifications for NNCF usage
@@ -10,6 +10,7 @@ Subject: [PATCH] Modifications for NNCF usage
  .../pytorch/text-classification/run_xnli.py   |  70 +++++++++--
  .../pytorch/token-classification/run_ner.py   | 118 ++++++++++++++----
  nncf_bert_config_conll.json                   |  44 +++++++
+ nncf_bert_config_mrpc.json                    |  42 +++++++
  nncf_bert_config_squad.json                   |  44 +++++++
  ...config_squad_magnitude_sparsity_cubic.json |  31 +++++
  nncf_bert_config_xnli.json                    |  36 ++++++
@@ -22,8 +23,9 @@ Subject: [PATCH] Modifications for NNCF usage
  src/transformers/trainer.py                   |  74 +++++++++--
  src/transformers/trainer_callback.py          |   2 +
  src/transformers/training_args.py             |   6 +
- 18 files changed, 800 insertions(+), 73 deletions(-)
+ 19 files changed, 842 insertions(+), 73 deletions(-)
  create mode 100644 nncf_bert_config_conll.json
+ create mode 100644 nncf_bert_config_mrpc.json
  create mode 100644 nncf_bert_config_squad.json
  create mode 100644 nncf_bert_config_squad_magnitude_sparsity_cubic.json
  create mode 100644 nncf_bert_config_xnli.json
@@ -747,6 +749,54 @@ index 000000000..0f73fe368
 +        {
 +            "mode": "symmetric",
 +            "signed": true,
++            "per_channel": false
++        }
++    }
++}
+diff --git a/nncf_bert_config_mrpc.json b/nncf_bert_config_mrpc.json
+new file mode 100644
+index 000000000..f4ecbeeed
+--- /dev/null
++++ b/nncf_bert_config_mrpc.json
+@@ -0,0 +1,42 @@
++{
++    "input_info": [
++        {
++            "sample_size": [1, 128],
++            "type": "long"
++        },
++        {
++            "sample_size": [1, 128],
++            "type": "long"
++        },
++        {
++            "sample_size": [1, 128],
++            "type": "long"
++        }
++    ],
++    "compression": {
++        "algorithm": "quantization",
++        "initializer": {
++            "range": {
++                "num_init_samples": 64,
++                "type": "percentile",
++                "params":
++                {
++                    "min_percentile": 0.01,
++                    "max_percentile": 99.99
++                }
++            },
++            "batchnorm_adaptation": {
++                "num_bn_adaptation_samples": 200
++            }
++        },
++        "activations":
++        {
++            "mode": "symmetric"
++        },
++        "weights":
++        {
++            "mode": "symmetric",
 +            "per_channel": false
 +        }
 +    }

--- a/third_party_integration/huggingface_transformers/README.md
+++ b/third_party_integration/huggingface_transformers/README.md
@@ -71,6 +71,20 @@ _INT8 model (symmetric quantization)_ - 99.18% acc, 95.31% F1
 `python examples/pytorch/token-classification/run_ner.py --model_name_or_path bert_base_cased_conll_int8 --dataset_name conll2003 --output_dir bert_base_cased_conll_int8 --do_eval --nncf_config nncf_bert_config_squad.json --to_onnx bert_base_cased_conll_int8.onnx`
 
 
+### BERT-MRPC
+
+_Full-precision FP32 baseline model_ -  bert-base-cased-finetuned-mrpc, 84.56% acc
+
+_INT8 model (symmetric quantization)_ - 84.8% acc
+
+**INT8 model quantization-aware training command line (trained on 1x RTX 2080):**
+
+`python examples/pytorch/token-classification/run_glue.py --model_name_or_path bert-base-cased-finetuned-mrpc --task_name mrpc --do_train --do_eval --num_train_epochs 5.0 --per_device_eval_batch_size 1 --output_dir bert_cased_mrpc_int8 --evaluation_strategy epoch --save_strategy epoch --nncf_config nncf_bert_config_mrpc.json`
+
+**Fine-tuned INT8 model evaluation and ONNX export command line:**
+
+`python examples/pytorch/token-classification/run_ner.py --model_name_or_path bert_cased_mrpc_int8 --task_name mrpc --do_eval --per_gpu_eval_batch_size 1 --output_dir bert_cased_mrpc_int8 --nncf_config nncf_bert_config_mrpc.json --to_onnx bert_base_cased_mrpc_int8.onnx`
+
 ### RoBERTA-MNLI
 
 _Full-precision FP32 baseline model_ - roberta-large-mnli, pre-trained on MNLI - 90.6% accuracy (matched), 90.1% accuracy (mismatched)


### PR DESCRIPTION
### Changes

The third-party integration patch for NNCF was extended with results of applying NNCF quantization for BERT on MRPC.

### Reason for changes

Extending the scope of NLP application showcasing.

### Related tickets

-

### Tests

The MRPC is part of the GLUE training pipeline, which is already covered by an existing third-party sanity test.
