### PR TITLE
Increased thresholds for Yolo models

### DIFF
--- a/tests/tensorflow/sota_checkpoints_eval.json
+++ b/tests/tensorflow/sota_checkpoints_eval.json
@@ -337,7 +337,8 @@
                     "batch_per_gpu": 15,
                     "reverse_input_channels": true,
                     "scale_value": "Placeholder[255]",
-                    "diff_target_max": 0.15
+                    "diff_target_max": 0.15,
+                    "diff_target_min": -0.15
                 },
                 "yolo_v4_sparsity_50": {
                     "config":"examples/tensorflow/object_detection/configs/sparsity/yolo_v4_coco_magnitude_sparsity.json",
@@ -349,7 +350,9 @@
                     "compression_description":"Sparsity50",
                     "batch_per_gpu": 15,
                     "reverse_input_channels": true,
-                    "scale_value": "Placeholder[255]"
+                    "scale_value": "Placeholder[255]",
+                    "diff_target_max": 0.15,
+                    "diff_target_min": -0.15
                 }
             }
         }


### PR DESCRIPTION
### Changes

Increased thresholds for Yolo models

### Reason for changes

In last E2E test thresholds for yolo_v4_int8_w_sym_ch_half_a_asym_t was violated

### Related tickets

None

### Tests

No needed
