### PR TITLE
Introduce ANY_PATTERN_NODE_TYPE and NON_PATTERN_NODE_TYPE

### DIFF
--- a/nncf/common/graph/graph_matching.py
+++ b/nncf/common/graph/graph_matching.py
@@ -25,9 +25,11 @@ def get_edge_boundaries(match: List[str], graph: nx.DiGraph):
     return sorted(in_edge_boundary), sorted(out_edge_boundary)  # must be sorted for determinism
 
 
-def is_subgraph_has_inner_outgoing_edges(graph: nx.DiGraph, subgraph: List[str]) -> bool:
+def is_subgraph_has_inner_outgoing_edges(graph: nx.DiGraph, full_subgraph_with_non_pattern_nodes: List[str],
+                                         pattern_subgraph: List[str]) -> bool:
     """
-    Check out whether the subgraph has outgoing edges starting not from the last node.
+    Check out whether the 'pattern_subgraph' has outgoing edges which
+     aren't connected with nodes from full_subgraph_with_non_pattern_nodes
     Example:
     (conv2d + BN + ReLU pattern):
             ...
@@ -42,27 +44,28 @@ def is_subgraph_has_inner_outgoing_edges(graph: nx.DiGraph, subgraph: List[str])
              |
             ...
     :param graph: The model graph.
-    :param subgraph: A subgraph of the model graph.
+    :param full_subgraph_with_non_pattern_nodes: A subgraph of the model graph with nodes outside the patter.
+    :param pattern_subgraph: A subgraph of the model graph
     :return: True if the subgraph contains outgoing edges starting not from the last node,
         False - otherwise.
     """
-    first_node = subgraph[0]
-    last_node = subgraph[-1]
-    for node_key in subgraph:
+    first_node = pattern_subgraph[0]
+    last_node = pattern_subgraph[-1]
+    for node_key in pattern_subgraph:
         if node_key == last_node:
             predecessors = list(graph.pred[node_key].keys())
-            if any(predecessor not in subgraph for predecessor in predecessors):
+            if any(predecessor not in full_subgraph_with_non_pattern_nodes for predecessor in predecessors):
                 return True
         elif node_key == first_node:
             successors = list(graph.succ[node_key].keys())
-            if any(successor not in subgraph for successor in successors):
+            if any(successor not in full_subgraph_with_non_pattern_nodes for successor in successors):
                 return True
         else:
             successors = list(graph.succ[node_key].keys())
             predecessors = list(graph.pred[node_key].keys())
-            if any(successors_key not in subgraph for successors_key in successors):
+            if any(successors_key not in full_subgraph_with_non_pattern_nodes for successors_key in successors):
                 return True
-            if any(predecessor not in subgraph for predecessor in predecessors):
+            if any(predecessor not in full_subgraph_with_non_pattern_nodes for predecessor in predecessors):
                 return True
     return False
 
@@ -79,11 +82,22 @@ def find_subgraphs_matching_pattern(graph: nx.DiGraph, pattern_graph: GraphPatte
     def are_nodes_matching(node_1, node_2):
         for attr in node_2:
             # Special case for Input node
-            if attr == 'type' and node_1['type'] == GraphPattern.PATTERN_INPUT_NODE_TYPE or \
-                    attr == 'label':
+            if attr == 'label':
+                continue
+            if attr == 'type':
+                if GraphPattern.ANY_PATTERN_NODE_TYPE in node_2['type'] or \
+                        GraphPattern.NON_PATTERN_NODE_TYPE in node_2['type']:
+                    continue
+            if attr == 'outgoing_edges':
                 continue
             if node_1[attr] not in node_2[attr]:
                 return False
+        # Save matches between pattern nodes and graph nodes
+
+        nonlocal matches
+        # Bottleneck: the node must have 'key' attribute
+
+        matches[node_1['key']] = node_2
         return True
 
     def are_edges_matching(edge_1, edge_2):
@@ -97,23 +111,57 @@ def find_subgraphs_matching_pattern(graph: nx.DiGraph, pattern_graph: GraphPatte
     patterns = []  # type: List[nx.DiGraph]
     for c in nx.weakly_connected_components(pattern_graph.graph):
         patterns.append(pattern_graph.graph.subgraph(c))
+
     # Get all patterns sorted by their lengths
     # as we want match the longest patterns first
-    patterns = sorted(patterns, key=len, reverse=True)
+    def sort_patterns(pattern: nx.DiGraph):
+        """
+        Sort patterns by their length,
+        keeping in mind that if node type is GraphPattern.NON_PATTERN_NODE_TYPE it shouldn't count.
+        """
+        pattern_len = len(pattern)
+        for node in pattern.nodes:
+            if GraphPattern.NON_PATTERN_NODE_TYPE in pattern_graph.graph.nodes.get(node)['type']:
+                pattern_len -= 1
+        return pattern_len
+
+    patterns = sorted(patterns, key=sort_patterns, reverse=True)
+
     for pattern in patterns:
         matcher = ism.DiGraphMatcher(graph, pattern,
                                      node_match=are_nodes_matching,
                                      edge_match=are_edges_matching)
+        # Restore matches for every pattern
+
+        matches = {}
         for subgraph in matcher.subgraph_isomorphisms_iter():
             # Bottleneck that need to sort by id for result consistency
-            subgraph = list(nx.lexicographical_topological_sort(graph.subgraph(subgraph),
-                                                                key=lambda x: int(x.split()[0])))
-            is_visited_node = any(node in visited_nodes for node in subgraph)
+            pattern_subgraph = list(nx.lexicographical_topological_sort(graph.subgraph(subgraph),
+                                                                        key=lambda x: int(x.split()[0])))
+            # Remove matches from unsuccessful matched patterns
+            pattern_matches = {}
+            for node_name, node_attrs in matches.items():
+                if node_name in pattern_subgraph:
+                    pattern_matches[node_name] = node_attrs
+
+            full_subgraph_with_non_pattern_nodes = pattern_subgraph[:]
+            outside_pattern_nodes = []
+
+            # If some nodes outside the pattern - remove them from pattern_subgraph
+
+            for node_name, node_attrs in pattern_matches.items():
+                if GraphPattern.NON_PATTERN_NODE_TYPE in node_attrs['type']:
+                    outside_pattern_nodes.append(graph.nodes.get(node_name))
+            for node in outside_pattern_nodes:
+                pattern_subgraph.remove(node['key'])
+
+            matches = {}
+            is_visited_node = any(node in visited_nodes for node in pattern_subgraph)
             if is_visited_node:
                 continue
-            if is_subgraph_has_inner_outgoing_edges(graph, subgraph):
+            if is_subgraph_has_inner_outgoing_edges(graph, full_subgraph_with_non_pattern_nodes, pattern_subgraph):
                 continue
-            visited_nodes.update(subgraph)
-            subgraphs.append(subgraph)
+            visited_nodes.update(pattern_subgraph)
+            subgraphs.append(pattern_subgraph)
 
     return subgraphs if subgraphs else []

--- a/nncf/common/graph/graph_matching.py
+++ b/nncf/common/graph/graph_matching.py
@@ -28,8 +28,8 @@ def get_edge_boundaries(match: List[str], graph: nx.DiGraph):
 def is_subgraph_has_inner_outgoing_edges(graph: nx.DiGraph, full_subgraph_with_non_pattern_nodes: List[str],
                                          pattern_subgraph: List[str]) -> bool:
     """
-    Check out whether the 'pattern_subgraph' has outgoing edges which
-     aren't connected with nodes from full_subgraph_with_non_pattern_nodes
+    Checks out whether the 'pattern_subgraph' has outgoing edges,
+    that aren't connected with nodes from full_subgraph_with_non_pattern_nodes.
     Example:
     (conv2d + BN + ReLU pattern):
             ...
@@ -44,8 +44,8 @@ def is_subgraph_has_inner_outgoing_edges(graph: nx.DiGraph, full_subgraph_with_n
              |
             ...
     :param graph: The model graph.
-    :param full_subgraph_with_non_pattern_nodes: A subgraph of the model graph with nodes outside the patter.
-    :param pattern_subgraph: A subgraph of the model graph
+    :param full_subgraph_with_non_pattern_nodes: A subgraph of the model graph including the nodes outside the pattern.
+    :param pattern_subgraph: A subgraph of the model.
     :return: True if the subgraph contains outgoing edges starting not from the last node,
         False - otherwise.
     """
@@ -81,10 +81,12 @@ def find_subgraphs_matching_pattern(graph: nx.DiGraph, pattern_graph: GraphPatte
 
     def are_nodes_matching(node_1, node_2):
         for attr in node_2:
-            # Special case for Input node
             if attr == 'label':
                 continue
             if attr == 'type':
+                # GraphPattern.ANY_PATTERN_NODE_TYPE and GraphPattern.NON_PATTERN_NODE_TYPE
+                # are matched to any node type.
+
                 if GraphPattern.ANY_PATTERN_NODE_TYPE in node_2['type'] or \
                         GraphPattern.NON_PATTERN_NODE_TYPE in node_2['type']:
                     continue

--- a/nncf/common/graph/graph_matching.py
+++ b/nncf/common/graph/graph_matching.py
@@ -88,8 +88,6 @@ def find_subgraphs_matching_pattern(graph: nx.DiGraph, pattern_graph: GraphPatte
                 if GraphPattern.ANY_PATTERN_NODE_TYPE in node_2['type'] or \
                         GraphPattern.NON_PATTERN_NODE_TYPE in node_2['type']:
                     continue
-            if attr == 'outgoing_edges':
-                continue
             if node_1[attr] not in node_2[attr]:
                 return False
         return True
@@ -140,7 +138,7 @@ def find_subgraphs_matching_pattern(graph: nx.DiGraph, pattern_graph: GraphPatte
                 pattern_node = pattern_graph.graph.nodes[pattern_node_id]
                 pattern_node_types = pattern_node.get('type')
                 if GraphPattern.NON_PATTERN_NODE_TYPE in pattern_node_types:
-                    outside_pattern_nodes.append(graph.nodes.get(node))
+                    outside_pattern_nodes.append(node)
             for node in outside_pattern_nodes:
                 pattern_subgraph.remove(node)
 

--- a/nncf/common/graph/patterns.py
+++ b/nncf/common/graph/patterns.py
@@ -72,8 +72,8 @@ class GraphPattern:
     Describes layer patterns in model's graph.
     This class is used in quantizer arrangement search algorithm, representing layer fusing patterns
 
-    :param ANY_PATTERN_NODE_TYPE: Special node type, meaning any type inside the pattern
-    :param NON_PATTERN_NODE_TYPE: Special node type, meaning any type outside the pattern
+    :param ANY_PATTERN_NODE_TYPE: Special node type, meaning any type inside the pattern.
+    :param NON_PATTERN_NODE_TYPE: Special node type, meaning any type outside the pattern.
     """
     ANY_PATTERN_NODE_TYPE = 'ANY_PATTERN_NODE'
     NON_PATTERN_NODE_TYPE = 'NON_PATTERN_NODE'
@@ -166,8 +166,8 @@ class GraphPattern:
         assert second_graph.in_degree(first_node_second_graph) == 0
 
         # Special case when first node is ANY_PATTERN_NODE_TYPE or NON_PATTERN_NODE_TYPE
-        if second_graph.nodes[first_node_second_graph]['type'][0] == GraphPattern.ANY_PATTERN_NODE_TYPE or\
-                second_graph.nodes[first_node_second_graph]['type'][0] == GraphPattern.NON_PATTERN_NODE_TYPE:
+        if GraphPattern.ANY_PATTERN_NODE_TYPE in second_graph.nodes[first_node_second_graph]['type'] or \
+                GraphPattern.NON_PATTERN_NODE_TYPE in second_graph.nodes[first_node_second_graph]['type']:
             successors = self_graph.successors(first_node_second_graph)
             new_edges = list(it.product([last_node_first_graph], successors))
             self_graph.add_edges_from(new_edges)
@@ -230,6 +230,9 @@ class GraphPattern:
 
     def add_edge(self, u_name, v_name) -> None:
         self._graph.add_edge(u_name, v_name)
+
+    def add_edges_from(self, ebunch_to_add, **attr) -> None:
+        self._graph.add_edges_from(ebunch_to_add, **attr)
 
     def get_weakly_connected_subgraphs(self) -> List[nx.DiGraph]:
         return [self._graph.subgraph(c) for c in nx.weakly_connected_components(self._graph)]

--- a/nncf/common/graph/patterns.py
+++ b/nncf/common/graph/patterns.py
@@ -72,9 +72,11 @@ class GraphPattern:
     Describes layer patterns in model's graph.
     This class is used in quantizer arrangement search algorithm, representing layer fusing patterns
 
-    :param PATTERN_INPUT_NODE_TYPE: Special node type possible pattern input
+    :param ANY_PATTERN_NODE_TYPE: Special node type, meaning any type inside the pattern
+    :param NON_PATTERN_NODE_TYPE: Special node type, meaning any type outside the pattern
     """
-    PATTERN_INPUT_NODE_TYPE = 'INPUT_NODE'
+    ANY_PATTERN_NODE_TYPE = 'ANY_PATTERN_NODE'
+    NON_PATTERN_NODE_TYPE = 'NON_PATTERN_NODE'
 
     def __init__(self):
         self._graph = nx.DiGraph()
@@ -163,8 +165,9 @@ class GraphPattern:
         first_node_second_graph = list(nx.lexicographical_topological_sort(second_graph, key=int))[0]
         assert second_graph.in_degree(first_node_second_graph) == 0
 
-        # Special case when first node is PATTERN_INPUT_NODE_TYPE
-        if second_graph.nodes[first_node_second_graph]['type'][0] == GraphPattern.PATTERN_INPUT_NODE_TYPE:
+        # Special case when first node is ANY_PATTERN_NODE_TYPE or NON_PATTERN_NODE_TYPE
+        if second_graph.nodes[first_node_second_graph]['type'][0] == GraphPattern.ANY_PATTERN_NODE_TYPE or\
+                second_graph.nodes[first_node_second_graph]['type'][0] == GraphPattern.NON_PATTERN_NODE_TYPE:
             successors = self_graph.successors(first_node_second_graph)
             new_edges = list(it.product([last_node_first_graph], successors))
             self_graph.add_edges_from(new_edges)
@@ -189,8 +192,8 @@ class GraphPattern:
         last node of self's graph and first node of other's graph,
         which are found by nx.lexicographical_topological_sort().
 
-        If other starts from a node with the PATTERN_INPUT_NODE_TYPE type, the input node of the other will be
-        discarded from the final pattern.
+        If other starts from a node with ANY_PATTERN_NODE_TYPE or NON_PATTERN_NODE_TYPE types,
+        the input node of the other will be discarded from the final pattern.
 
         :param other: GraphPattern that will be added
         :param edges: List of edges between self and other graphs.

--- a/nncf/tensorflow/graph/patterns.py
+++ b/nncf/tensorflow/graph/patterns.py
@@ -17,7 +17,7 @@ from nncf.common.graph.patterns import GraphPattern
 def create_h_sigmoid_act() -> GraphPattern:
     pattern = GraphPattern()
 
-    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.PATTERN_INPUT_NODE_TYPE)
+    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
     add_node = pattern.add_node(label='ADD', type='AddV2')
     relu_node = pattern.add_node(label='RELU', type='ReLU')
     mul_node = pattern.add_node(label='TF_OP_MUL', type='Mul')
@@ -32,7 +32,7 @@ def create_h_sigmoid_act() -> GraphPattern:
 def create_h_swish_act() -> GraphPattern:
     pattern = GraphPattern()
 
-    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.PATTERN_INPUT_NODE_TYPE)
+    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
 
     # TODO (vshampor): current approach with join_patterns is deficient since it does not allow to reliably
     #  connect nodes after a pattern has been joined. Along with the label and the type, the nodes created

--- a/nncf/torch/graph/patterns.py
+++ b/nncf/torch/graph/patterns.py
@@ -16,7 +16,7 @@ from nncf.common.graph.patterns import GraphPattern
 
 def create_swish_act() -> GraphPattern:
     pattern = GraphPattern()
-    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.PATTERN_INPUT_NODE_TYPE)
+    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
     sigmoid_node = pattern.add_node(label='SIGMOID', type='sigmoid')
     mul_node = pattern.add_node(label='MUL', type='__mul__')
 
@@ -30,7 +30,7 @@ def create_h_swish_act() -> GraphPattern:
     main_pattern = GraphPattern()
 
     pattern = GraphPattern()
-    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.PATTERN_INPUT_NODE_TYPE)
+    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
     add_node = pattern.add_node(label='ADD', type='__add__')
     hardtanh_node = pattern.add_node(label='HARDTANH', type='hardtanh')
     truediv_node = pattern.add_node(label='DIV', type='__truediv__')
@@ -45,7 +45,7 @@ def create_h_swish_act() -> GraphPattern:
     main_pattern.add_pattern_alternative(pattern)
 
     pattern = GraphPattern()
-    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.PATTERN_INPUT_NODE_TYPE)
+    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
     add_node = pattern.add_node(label='ADD', type='__add__')
     hardtanh_node = pattern.add_node(label='HARDTANH', type='hardtanh')
     mul_node = pattern.add_node(label='MUL', type='__mul__')
@@ -63,7 +63,7 @@ def create_h_swish_act() -> GraphPattern:
 def create_h_sigmoid_act() -> GraphPattern:
     pattern = GraphPattern()
 
-    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.PATTERN_INPUT_NODE_TYPE)
+    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
     add_node = pattern.add_node(label='ADD', type='__add__')
     hardtanh_node = pattern.add_node(label='HARTANH', type='hardtanh')
     truediv_node = pattern.add_node(label='DIV', type='__truediv__')

--- a/tests/common/graph/test_graph_matching.py
+++ b/tests/common/graph/test_graph_matching.py
@@ -9,8 +9,8 @@ def test_ops_combination_patterns():
     pattern = TestPattern.first_pattern + TestPattern.second_pattern
 
     ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='a')
-    ref_graph.add_node('2', type='c')
+    ref_graph.add_node('1', type='a', key='1')
+    ref_graph.add_node('2', type='c', key='2')
     ref_graph.add_edge('1', '2')
     matches = find_subgraphs_matching_pattern(ref_graph, pattern)
     assert matches == [['1', '2']]
@@ -18,8 +18,8 @@ def test_ops_combination_patterns():
     pattern = TestPattern.first_pattern + TestPattern.second_pattern | TestPattern.third_pattern
 
     ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='a')
-    ref_graph.add_node('2', type='c')
+    ref_graph.add_node('1', type='a', key='1')
+    ref_graph.add_node('2', type='c', key='2')
     ref_graph.add_edge('1', '2')
     matches = find_subgraphs_matching_pattern(ref_graph, pattern)
     assert matches == [['1', '2']]
@@ -31,9 +31,9 @@ def test_ops_combination_patterns():
     pattern.join_patterns(TestPattern.third_pattern, edges)
 
     ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='a')
-    ref_graph.add_node('2', type='c')
-    ref_graph.add_node('3', type='e')
+    ref_graph.add_node('1', type='a', key='1')
+    ref_graph.add_node('2', type='c', key='2')
+    ref_graph.add_node('3', type='e', key='3')
     ref_graph.add_edge('1', '2')
     ref_graph.add_edge('1', '3')
     ref_graph.add_edge('2', '3')
@@ -50,9 +50,9 @@ def test_no_matches():
     pattern.join_patterns(TestPattern.third_pattern, edges)
 
     ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='a')
-    ref_graph.add_node('2', type='c')
-    ref_graph.add_node('3', type='e')
+    ref_graph.add_node('1', type='a', key='1')
+    ref_graph.add_node('2', type='c', key='2')
+    ref_graph.add_node('3', type='e', key='3')
     ref_graph.add_edge('1', '2')
     ref_graph.add_edge('2', '3')
     matches = find_subgraphs_matching_pattern(ref_graph, pattern)
@@ -64,12 +64,12 @@ def test_two_matches():
     pattern = TestPattern.first_pattern + TestPattern.second_pattern
 
     ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='a')
-    ref_graph.add_node('2', type='c')
-    ref_graph.add_node('3', type='e')
-    ref_graph.add_node('4', type='c')
-    ref_graph.add_node('5', type='a')
-    ref_graph.add_node('6', type='d')
+    ref_graph.add_node('1', type='a', key='1')
+    ref_graph.add_node('2', type='c', key='2')
+    ref_graph.add_node('3', type='e', key='3')
+    ref_graph.add_node('4', type='c', key='4')
+    ref_graph.add_node('5', type='a', key='5')
+    ref_graph.add_node('6', type='d', key='6')
     ref_graph.add_edge('1', '2')
     ref_graph.add_edge('2', '3')
     ref_graph.add_edge('5', '6')

--- a/tests/common/graph/test_graph_matching.py
+++ b/tests/common/graph/test_graph_matching.py
@@ -9,8 +9,8 @@ def test_ops_combination_patterns():
     pattern = TestPattern.first_pattern + TestPattern.second_pattern
 
     ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='a', key='1')
-    ref_graph.add_node('2', type='c', key='2')
+    ref_graph.add_node('1', type='a')
+    ref_graph.add_node('2', type='c')
     ref_graph.add_edge('1', '2')
     matches = find_subgraphs_matching_pattern(ref_graph, pattern)
     assert matches == [['1', '2']]
@@ -18,8 +18,8 @@ def test_ops_combination_patterns():
     pattern = TestPattern.first_pattern + TestPattern.second_pattern | TestPattern.third_pattern
 
     ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='a', key='1')
-    ref_graph.add_node('2', type='c', key='2')
+    ref_graph.add_node('1', type='a')
+    ref_graph.add_node('2', type='c')
     ref_graph.add_edge('1', '2')
     matches = find_subgraphs_matching_pattern(ref_graph, pattern)
     assert matches == [['1', '2']]
@@ -31,9 +31,9 @@ def test_ops_combination_patterns():
     pattern.join_patterns(TestPattern.third_pattern, edges)
 
     ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='a', key='1')
-    ref_graph.add_node('2', type='c', key='2')
-    ref_graph.add_node('3', type='e', key='3')
+    ref_graph.add_node('1', type='a')
+    ref_graph.add_node('2', type='c')
+    ref_graph.add_node('3', type='e')
     ref_graph.add_edge('1', '2')
     ref_graph.add_edge('1', '3')
     ref_graph.add_edge('2', '3')
@@ -50,9 +50,9 @@ def test_no_matches():
     pattern.join_patterns(TestPattern.third_pattern, edges)
 
     ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='a', key='1')
-    ref_graph.add_node('2', type='c', key='2')
-    ref_graph.add_node('3', type='e', key='3')
+    ref_graph.add_node('1', type='a')
+    ref_graph.add_node('2', type='c')
+    ref_graph.add_node('3', type='e')
     ref_graph.add_edge('1', '2')
     ref_graph.add_edge('2', '3')
     matches = find_subgraphs_matching_pattern(ref_graph, pattern)
@@ -64,12 +64,12 @@ def test_two_matches():
     pattern = TestPattern.first_pattern + TestPattern.second_pattern
 
     ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='a', key='1')
-    ref_graph.add_node('2', type='c', key='2')
-    ref_graph.add_node('3', type='e', key='3')
-    ref_graph.add_node('4', type='c', key='4')
-    ref_graph.add_node('5', type='a', key='5')
-    ref_graph.add_node('6', type='d', key='6')
+    ref_graph.add_node('1', type='a')
+    ref_graph.add_node('2', type='c')
+    ref_graph.add_node('3', type='e')
+    ref_graph.add_node('4', type='c')
+    ref_graph.add_node('5', type='a')
+    ref_graph.add_node('6', type='d')
     ref_graph.add_edge('1', '2')
     ref_graph.add_edge('2', '3')
     ref_graph.add_edge('5', '6')

--- a/tests/common/graph/test_graph_matching.py
+++ b/tests/common/graph/test_graph_matching.py
@@ -79,11 +79,39 @@ def test_two_matches():
     assert matches == [['1', '2'], ['5', '6']]
 
 
+def create_graph_with_many_nodes():
+    #     ref_graph
+    #         a
+    #         |
+    #         a
+    #         |
+    #         b   b
+    #        / \ /
+    #       a   c
+    #       |  /
+    #       | /
+    #       |/
+    #       e
+    #       |
+    #       a---c
+
+    ref_graph = nx.DiGraph()
+    nodes = {
+        '1': {'type': 'a'}, '2': {'type': 'b'}, '3': {'type': 'c'}, '4': {'type': 'a'}, '5': {'type': 'e'},
+        '6': {'type': 'a'}, '7': {'type': 'a'}, '8': {'type': 'b'}, '9': {'type': 'c'}
+    }
+    for k, attrs in nodes.items():
+        ref_graph.add_node(k, **attrs)
+    ref_graph.add_edges_from([('1', '2'), ('2', '3'), ('2', '4'), ('4', '5'), ('5', '6'),
+                              ('3', '5'), ('7', '1'), ('8', '3'), ('9', '6')])
+    return ref_graph
+
+
 def test_matches_with_non_pattern_node_type():
     pattern = TestPattern.forth_pattern + TestPattern.first_pattern + TestPattern.second_pattern
 
     ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='non')
+    ref_graph.add_node('1', type='a')
     ref_graph.add_node('2', type='a')
     ref_graph.add_node('3', type='c')
     ref_graph.add_edge('1', '2')
@@ -94,7 +122,7 @@ def test_matches_with_non_pattern_node_type():
     pattern = TestPattern.forth_pattern + TestPattern.first_pattern + TestPattern.second_pattern + TestPattern.forth_pattern
 
     ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='non')
+    ref_graph.add_node('1', type='a')
     ref_graph.add_node('2', type='a')
     ref_graph.add_node('3', type='c')
     ref_graph.add_edge('1', '2')
@@ -122,42 +150,7 @@ def test_matches_with_non_pattern_node_type():
     matches = find_subgraphs_matching_pattern(ref_graph, pattern)
     assert not matches
 
-    """
-         ref_graph
-             a
-             |
-             a
-             |
-             b   b
-            / \ /
-           a   c
-           |  / 
-           | /
-           |/
-           e
-           |
-           a---c
-    """
-
-    ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='a')
-    ref_graph.add_node('2', type='b')
-    ref_graph.add_node('3', type='c')
-    ref_graph.add_node('4', type='a')
-    ref_graph.add_node('5', type='e')
-    ref_graph.add_node('6', type='a')
-    ref_graph.add_node('7', type='a')
-    ref_graph.add_node('8', type='b')
-    ref_graph.add_node('9', type='c')
-    ref_graph.add_edge('1', '2')
-    ref_graph.add_edge('2', '3')
-    ref_graph.add_edge('2', '4')
-    ref_graph.add_edge('4', '5')
-    ref_graph.add_edge('5', '6')
-    ref_graph.add_edge('3', '5')
-    ref_graph.add_edge('7', '1')
-    ref_graph.add_edge('8', '3')
-    ref_graph.add_edge('9', '6')
+    ref_graph = create_graph_with_many_nodes()
     matches = find_subgraphs_matching_pattern(ref_graph, pattern)
     assert matches == [['1', '2', '4', '3', '5', '6']]
 
@@ -183,41 +176,6 @@ def test_matches_with_any_pattern_node_type():
     matches = find_subgraphs_matching_pattern(ref_graph, pattern)
     assert not matches
 
-    """
-         ref_graph
-             a
-             |
-             a
-             |
-             b   b
-            / \ /
-           a   c
-           |  / 
-           | /
-           |/
-           e
-           |
-           a---c
-    """
-
-    ref_graph = nx.DiGraph()
-    ref_graph.add_node('1', type='a')
-    ref_graph.add_node('2', type='b')
-    ref_graph.add_node('3', type='c')
-    ref_graph.add_node('4', type='a')
-    ref_graph.add_node('5', type='e')
-    ref_graph.add_node('6', type='a')
-    ref_graph.add_node('7', type='a')
-    ref_graph.add_node('8', type='b')
-    ref_graph.add_node('9', type='c')
-    ref_graph.add_edge('1', '2')
-    ref_graph.add_edge('2', '3')
-    ref_graph.add_edge('2', '4')
-    ref_graph.add_edge('4', '5')
-    ref_graph.add_edge('5', '6')
-    ref_graph.add_edge('3', '5')
-    ref_graph.add_edge('7', '1')
-    ref_graph.add_edge('8', '3')
-    ref_graph.add_edge('9', '6')
+    ref_graph = create_graph_with_many_nodes()
     matches = find_subgraphs_matching_pattern(ref_graph, pattern)
     assert matches == [['7', '1', '2', '4', '8', '3', '5', '9', '6']]

--- a/tests/common/graph/test_graph_matching.py
+++ b/tests/common/graph/test_graph_matching.py
@@ -77,3 +77,147 @@ def test_two_matches():
     matches = find_subgraphs_matching_pattern(ref_graph, pattern)
     matches.sort()
     assert matches == [['1', '2'], ['5', '6']]
+
+
+def test_matches_with_non_pattern_node_type():
+    pattern = TestPattern.forth_pattern + TestPattern.first_pattern + TestPattern.second_pattern
+
+    ref_graph = nx.DiGraph()
+    ref_graph.add_node('1', type='non')
+    ref_graph.add_node('2', type='a')
+    ref_graph.add_node('3', type='c')
+    ref_graph.add_edge('1', '2')
+    ref_graph.add_edge('2', '3')
+    matches = find_subgraphs_matching_pattern(ref_graph, pattern)
+    assert matches == [['2', '3']]
+
+    pattern = TestPattern.forth_pattern + TestPattern.first_pattern + TestPattern.second_pattern + TestPattern.forth_pattern
+
+    ref_graph = nx.DiGraph()
+    ref_graph.add_node('1', type='non')
+    ref_graph.add_node('2', type='a')
+    ref_graph.add_node('3', type='c')
+    ref_graph.add_edge('1', '2')
+    ref_graph.add_edge('2', '3')
+    matches = find_subgraphs_matching_pattern(ref_graph, pattern)
+    assert matches == [['2', '3']]
+
+    pattern = TestPattern.pattern_with_non_pattern_nodes
+
+    ref_graph = nx.DiGraph()
+    ref_graph.add_node('1', type='a')
+    ref_graph.add_node('2', type='b')
+    ref_graph.add_node('3', type='c')
+    ref_graph.add_edge('1', '2')
+    ref_graph.add_edge('2', '3')
+    matches = find_subgraphs_matching_pattern(ref_graph, pattern)
+    assert not matches
+
+    ref_graph = nx.DiGraph()
+    ref_graph.add_node('1', type='a')
+    ref_graph.add_node('2', type='b')
+    ref_graph.add_node('4', type='a')
+    ref_graph.add_edge('1', '2')
+    ref_graph.add_edge('2', '4')
+    matches = find_subgraphs_matching_pattern(ref_graph, pattern)
+    assert not matches
+
+    """
+         ref_graph
+             a
+             |
+             a
+             |
+             b   b
+            / \ /
+           a   c
+           |  / 
+           | /
+           |/
+           e
+           |
+           a---c
+    """
+
+    ref_graph = nx.DiGraph()
+    ref_graph.add_node('1', type='a')
+    ref_graph.add_node('2', type='b')
+    ref_graph.add_node('3', type='c')
+    ref_graph.add_node('4', type='a')
+    ref_graph.add_node('5', type='e')
+    ref_graph.add_node('6', type='a')
+    ref_graph.add_node('7', type='a')
+    ref_graph.add_node('8', type='b')
+    ref_graph.add_node('9', type='c')
+    ref_graph.add_edge('1', '2')
+    ref_graph.add_edge('2', '3')
+    ref_graph.add_edge('2', '4')
+    ref_graph.add_edge('4', '5')
+    ref_graph.add_edge('5', '6')
+    ref_graph.add_edge('3', '5')
+    ref_graph.add_edge('7', '1')
+    ref_graph.add_edge('8', '3')
+    ref_graph.add_edge('9', '6')
+    matches = find_subgraphs_matching_pattern(ref_graph, pattern)
+    assert matches == [['1', '2', '4', '3', '5', '6']]
+
+
+def test_matches_with_any_pattern_node_type():
+    pattern = TestPattern.pattern_with_any_pattern_nodes
+
+    ref_graph = nx.DiGraph()
+    ref_graph.add_node('1', type='a')
+    ref_graph.add_node('2', type='b')
+    ref_graph.add_node('3', type='c')
+    ref_graph.add_edge('1', '2')
+    ref_graph.add_edge('2', '3')
+    matches = find_subgraphs_matching_pattern(ref_graph, pattern)
+    assert not matches
+
+    ref_graph = nx.DiGraph()
+    ref_graph.add_node('1', type='a')
+    ref_graph.add_node('2', type='b')
+    ref_graph.add_node('4', type='a')
+    ref_graph.add_edge('1', '2')
+    ref_graph.add_edge('2', '4')
+    matches = find_subgraphs_matching_pattern(ref_graph, pattern)
+    assert not matches
+
+    """
+         ref_graph
+             a
+             |
+             a
+             |
+             b   b
+            / \ /
+           a   c
+           |  / 
+           | /
+           |/
+           e
+           |
+           a---c
+    """
+
+    ref_graph = nx.DiGraph()
+    ref_graph.add_node('1', type='a')
+    ref_graph.add_node('2', type='b')
+    ref_graph.add_node('3', type='c')
+    ref_graph.add_node('4', type='a')
+    ref_graph.add_node('5', type='e')
+    ref_graph.add_node('6', type='a')
+    ref_graph.add_node('7', type='a')
+    ref_graph.add_node('8', type='b')
+    ref_graph.add_node('9', type='c')
+    ref_graph.add_edge('1', '2')
+    ref_graph.add_edge('2', '3')
+    ref_graph.add_edge('2', '4')
+    ref_graph.add_edge('4', '5')
+    ref_graph.add_edge('5', '6')
+    ref_graph.add_edge('3', '5')
+    ref_graph.add_edge('7', '1')
+    ref_graph.add_edge('8', '3')
+    ref_graph.add_edge('9', '6')
+    matches = find_subgraphs_matching_pattern(ref_graph, pattern)
+    assert matches == [['7', '1', '2', '4', '8', '3', '5', '9', '6']]

--- a/tests/common/graph/test_graph_matching.py
+++ b/tests/common/graph/test_graph_matching.py
@@ -119,7 +119,8 @@ def test_matches_with_non_pattern_node_type():
     matches = find_subgraphs_matching_pattern(ref_graph, pattern)
     assert matches == [['2', '3']]
 
-    pattern = TestPattern.forth_pattern + TestPattern.first_pattern + TestPattern.second_pattern + TestPattern.forth_pattern
+    pattern = TestPattern.forth_pattern + TestPattern.first_pattern + \
+              TestPattern.second_pattern + TestPattern.forth_pattern
 
     ref_graph = nx.DiGraph()
     ref_graph.add_node('1', type='a')

--- a/tests/common/graph/test_graph_pattern.py
+++ b/tests/common/graph/test_graph_pattern.py
@@ -23,22 +23,20 @@ class TestPattern:
     fifth_pattern = GraphPattern()
     fifth_pattern.add_node(label='fifth', type=fifth_pattern)
 
-    """
-    pattern_with_non_pattern_nodes
-            NON
-             |
-             1
-             |
-             2  NON
-            / \ /
-           4   3
-           |  / 
-           | /
-           |/
-           5
-           |
-           6---NON
-    """
+    # pattern_with_non_pattern_nodes
+    #        NON
+    #         |
+    #         1
+    #         |
+    #         2  NON
+    #        / \ /
+    #       4   3
+    #       |  /
+    #       | /
+    #       |/
+    #       5
+    #       |
+    #       6---NON
 
     pattern_with_non_pattern_nodes = GraphPattern()
     first = pattern_with_non_pattern_nodes.add_node(label='1', type=['a'])
@@ -60,22 +58,20 @@ class TestPattern:
     pattern_with_non_pattern_nodes.add_edge(eighth, third)
     pattern_with_non_pattern_nodes.add_edge(nineth, sixth)
 
-    """
-    pattern_with_any_pattern_nodes
-            ANY
-             |
-             1
-             |
-             2  ANY
-            / \ /
-           4   3
-           |  / 
-           | /
-           |/
-           5
-           |
-           6---ANY
-    """
+    # pattern_with_any_pattern_nodes
+    #        ANY
+    #         |
+    #         1
+    #         |
+    #         2  ANY
+    #        / \ /
+    #       4   3
+    #       |  /
+    #       | /
+    #       |/
+    #       5
+    #       |
+    #       6---ANY
 
     pattern_with_any_pattern_nodes = GraphPattern()
     first = pattern_with_any_pattern_nodes.add_node(label='1', type=['a'])
@@ -84,9 +80,9 @@ class TestPattern:
     forth = pattern_with_any_pattern_nodes.add_node(label='4', type=['a'])
     fifth = pattern_with_any_pattern_nodes.add_node(label='5', type=['e'])
     sixth = pattern_with_any_pattern_nodes.add_node(label='6', type=['a'])
-    seventh = pattern_with_any_pattern_nodes.add_node(label='7', type=[GraphPattern.NON_PATTERN_NODE_TYPE])
-    eighth = pattern_with_any_pattern_nodes.add_node(label='8', type=[GraphPattern.NON_PATTERN_NODE_TYPE])
-    nineth = pattern_with_any_pattern_nodes.add_node(label='9', type=[GraphPattern.NON_PATTERN_NODE_TYPE])
+    seventh = pattern_with_any_pattern_nodes.add_node(label='7', type=[GraphPattern.ANY_PATTERN_NODE_TYPE])
+    eighth = pattern_with_any_pattern_nodes.add_node(label='8', type=[GraphPattern.ANY_PATTERN_NODE_TYPE])
+    nineth = pattern_with_any_pattern_nodes.add_node(label='9', type=[GraphPattern.ANY_PATTERN_NODE_TYPE])
     pattern_with_any_pattern_nodes.add_edge(first, second)
     pattern_with_any_pattern_nodes.add_edge(second, third)
     pattern_with_any_pattern_nodes.add_edge(second, forth)
@@ -96,6 +92,7 @@ class TestPattern:
     pattern_with_any_pattern_nodes.add_edge(seventh, first)
     pattern_with_any_pattern_nodes.add_edge(eighth, third)
     pattern_with_any_pattern_nodes.add_edge(nineth, sixth)
+
 
 def test_ops_combination_two_patterns():
     pattern = TestPattern.first_pattern + TestPattern.second_pattern

--- a/tests/common/graph/test_graph_pattern.py
+++ b/tests/common/graph/test_graph_pattern.py
@@ -9,6 +9,8 @@ class TestPattern:
     first_type = ['a', 'b']
     second_type = ['c', 'd']
     third_type = ['e']
+    forth_type = [GraphPattern.NON_PATTERN_NODE_TYPE]
+    fifth_type = [GraphPattern.ANY_PATTERN_NODE_TYPE]
 
     first_pattern = GraphPattern()
     first_pattern.add_node(label='first', type=first_type)
@@ -16,7 +18,84 @@ class TestPattern:
     second_pattern.add_node(label='second', type=second_type)
     third_pattern = GraphPattern()
     third_pattern.add_node(label='third', type=third_type)
+    forth_pattern = GraphPattern()
+    forth_pattern.add_node(label='forth', type=forth_type)
+    fifth_pattern = GraphPattern()
+    fifth_pattern.add_node(label='fifth', type=fifth_pattern)
 
+    """
+    pattern_with_non_pattern_nodes
+            NON
+             |
+             1
+             |
+             2  NON
+            / \ /
+           4   3
+           |  / 
+           | /
+           |/
+           5
+           |
+           6---NON
+    """
+
+    pattern_with_non_pattern_nodes = GraphPattern()
+    first = pattern_with_non_pattern_nodes.add_node(label='1', type=['a'])
+    second = pattern_with_non_pattern_nodes.add_node(label='2', type=['b'])
+    third = pattern_with_non_pattern_nodes.add_node(label='3', type=['c'])
+    forth = pattern_with_non_pattern_nodes.add_node(label='4', type=['a'])
+    fifth = pattern_with_non_pattern_nodes.add_node(label='5', type=['e'])
+    sixth = pattern_with_non_pattern_nodes.add_node(label='6', type=['a'])
+    seventh = pattern_with_non_pattern_nodes.add_node(label='7', type=[GraphPattern.NON_PATTERN_NODE_TYPE])
+    eighth = pattern_with_non_pattern_nodes.add_node(label='8', type=[GraphPattern.NON_PATTERN_NODE_TYPE])
+    nineth = pattern_with_non_pattern_nodes.add_node(label='9', type=[GraphPattern.NON_PATTERN_NODE_TYPE])
+    pattern_with_non_pattern_nodes.add_edge(first, second)
+    pattern_with_non_pattern_nodes.add_edge(second, third)
+    pattern_with_non_pattern_nodes.add_edge(second, forth)
+    pattern_with_non_pattern_nodes.add_edge(forth, fifth)
+    pattern_with_non_pattern_nodes.add_edge(third, fifth)
+    pattern_with_non_pattern_nodes.add_edge(fifth, sixth)
+    pattern_with_non_pattern_nodes.add_edge(seventh, first)
+    pattern_with_non_pattern_nodes.add_edge(eighth, third)
+    pattern_with_non_pattern_nodes.add_edge(nineth, sixth)
+
+    """
+    pattern_with_any_pattern_nodes
+            ANY
+             |
+             1
+             |
+             2  ANY
+            / \ /
+           4   3
+           |  / 
+           | /
+           |/
+           5
+           |
+           6---ANY
+    """
+
+    pattern_with_any_pattern_nodes = GraphPattern()
+    first = pattern_with_any_pattern_nodes.add_node(label='1', type=['a'])
+    second = pattern_with_any_pattern_nodes.add_node(label='2', type=['b'])
+    third = pattern_with_any_pattern_nodes.add_node(label='3', type=['c'])
+    forth = pattern_with_any_pattern_nodes.add_node(label='4', type=['a'])
+    fifth = pattern_with_any_pattern_nodes.add_node(label='5', type=['e'])
+    sixth = pattern_with_any_pattern_nodes.add_node(label='6', type=['a'])
+    seventh = pattern_with_any_pattern_nodes.add_node(label='7', type=[GraphPattern.NON_PATTERN_NODE_TYPE])
+    eighth = pattern_with_any_pattern_nodes.add_node(label='8', type=[GraphPattern.NON_PATTERN_NODE_TYPE])
+    nineth = pattern_with_any_pattern_nodes.add_node(label='9', type=[GraphPattern.NON_PATTERN_NODE_TYPE])
+    pattern_with_any_pattern_nodes.add_edge(first, second)
+    pattern_with_any_pattern_nodes.add_edge(second, third)
+    pattern_with_any_pattern_nodes.add_edge(second, forth)
+    pattern_with_any_pattern_nodes.add_edge(forth, fifth)
+    pattern_with_any_pattern_nodes.add_edge(third, fifth)
+    pattern_with_any_pattern_nodes.add_edge(fifth, sixth)
+    pattern_with_any_pattern_nodes.add_edge(seventh, first)
+    pattern_with_any_pattern_nodes.add_edge(eighth, third)
+    pattern_with_any_pattern_nodes.add_edge(nineth, sixth)
 
 def test_ops_combination_two_patterns():
     pattern = TestPattern.first_pattern + TestPattern.second_pattern

--- a/tests/common/graph/test_graph_pattern.py
+++ b/tests/common/graph/test_graph_pattern.py
@@ -113,7 +113,7 @@ def test_join_patterns_func_three_patterns():
 def test_join_pattern_with_special_input_node():
     pattern = TestPattern.first_pattern
     second_pattern = GraphPattern()
-    second_pattern.add_node(label='second', type=GraphPattern.PATTERN_INPUT_NODE_TYPE)
+    second_pattern.add_node(label='second', type=GraphPattern.ANY_PATTERN_NODE_TYPE)
     pattern.join_patterns(second_pattern)
     pattern.join_patterns(TestPattern.third_pattern)
 

--- a/tests/common/graph/test_graph_pattern.py
+++ b/tests/common/graph/test_graph_pattern.py
@@ -23,75 +23,51 @@ class TestPattern:
     fifth_pattern = GraphPattern()
     fifth_pattern.add_node(label='fifth', type=fifth_pattern)
 
-    # pattern_with_non_pattern_nodes
-    #        NON
-    #         |
-    #         1
-    #         |
-    #         2  NON
-    #        / \ /
-    #       4   3
-    #       |  /
-    #       | /
-    #       |/
-    #       5
-    #       |
-    #       6---NON
+    # pattern_with_non_pattern_nodes |  pattern_with_any_pattern_nodes
+    #        NON                     |            ANY
+    #         |                      |             |
+    #         1                      |             1
+    #         |                      |             |
+    #         2  NON                 |             2  ANY
+    #        / \ /                   |            / \ /
+    #       4   3                    |           4   3
+    #       |  /                     |           |  /
+    #       | /                      |           | /
+    #       |/                       |           |/
+    #       5                        |           5
+    #       |                        |           |
+    #       6---NON                  |           6---ANY
 
     pattern_with_non_pattern_nodes = GraphPattern()
-    first = pattern_with_non_pattern_nodes.add_node(label='1', type=['a'])
-    second = pattern_with_non_pattern_nodes.add_node(label='2', type=['b'])
-    third = pattern_with_non_pattern_nodes.add_node(label='3', type=['c'])
-    forth = pattern_with_non_pattern_nodes.add_node(label='4', type=['a'])
-    fifth = pattern_with_non_pattern_nodes.add_node(label='5', type=['e'])
-    sixth = pattern_with_non_pattern_nodes.add_node(label='6', type=['a'])
-    seventh = pattern_with_non_pattern_nodes.add_node(label='7', type=[GraphPattern.NON_PATTERN_NODE_TYPE])
-    eighth = pattern_with_non_pattern_nodes.add_node(label='8', type=[GraphPattern.NON_PATTERN_NODE_TYPE])
-    nineth = pattern_with_non_pattern_nodes.add_node(label='9', type=[GraphPattern.NON_PATTERN_NODE_TYPE])
-    pattern_with_non_pattern_nodes.add_edge(first, second)
-    pattern_with_non_pattern_nodes.add_edge(second, third)
-    pattern_with_non_pattern_nodes.add_edge(second, forth)
-    pattern_with_non_pattern_nodes.add_edge(forth, fifth)
-    pattern_with_non_pattern_nodes.add_edge(third, fifth)
-    pattern_with_non_pattern_nodes.add_edge(fifth, sixth)
-    pattern_with_non_pattern_nodes.add_edge(seventh, first)
-    pattern_with_non_pattern_nodes.add_edge(eighth, third)
-    pattern_with_non_pattern_nodes.add_edge(nineth, sixth)
-
-    # pattern_with_any_pattern_nodes
-    #        ANY
-    #         |
-    #         1
-    #         |
-    #         2  ANY
-    #        / \ /
-    #       4   3
-    #       |  /
-    #       | /
-    #       |/
-    #       5
-    #       |
-    #       6---ANY
-
     pattern_with_any_pattern_nodes = GraphPattern()
-    first = pattern_with_any_pattern_nodes.add_node(label='1', type=['a'])
-    second = pattern_with_any_pattern_nodes.add_node(label='2', type=['b'])
-    third = pattern_with_any_pattern_nodes.add_node(label='3', type=['c'])
-    forth = pattern_with_any_pattern_nodes.add_node(label='4', type=['a'])
-    fifth = pattern_with_any_pattern_nodes.add_node(label='5', type=['e'])
-    sixth = pattern_with_any_pattern_nodes.add_node(label='6', type=['a'])
-    seventh = pattern_with_any_pattern_nodes.add_node(label='7', type=[GraphPattern.ANY_PATTERN_NODE_TYPE])
-    eighth = pattern_with_any_pattern_nodes.add_node(label='8', type=[GraphPattern.ANY_PATTERN_NODE_TYPE])
-    nineth = pattern_with_any_pattern_nodes.add_node(label='9', type=[GraphPattern.ANY_PATTERN_NODE_TYPE])
-    pattern_with_any_pattern_nodes.add_edge(first, second)
-    pattern_with_any_pattern_nodes.add_edge(second, third)
-    pattern_with_any_pattern_nodes.add_edge(second, forth)
-    pattern_with_any_pattern_nodes.add_edge(forth, fifth)
-    pattern_with_any_pattern_nodes.add_edge(third, fifth)
-    pattern_with_any_pattern_nodes.add_edge(fifth, sixth)
-    pattern_with_any_pattern_nodes.add_edge(seventh, first)
-    pattern_with_any_pattern_nodes.add_edge(eighth, third)
-    pattern_with_any_pattern_nodes.add_edge(nineth, sixth)
+    common_nodes = {
+        '1': {'type': 'a'}, '2': {'type': 'b'}, '3': {'type': 'c'},
+        '4': {'type': 'a'}, '5': {'type': 'e'}, '6': {'type': 'a'}
+    }
+    non_pattern_nodes = {'7': {'type': GraphPattern.NON_PATTERN_NODE_TYPE},
+                         '8': {'type': GraphPattern.NON_PATTERN_NODE_TYPE},
+                         '9': {'type': GraphPattern.NON_PATTERN_NODE_TYPE}}
+    any_pattern_nodes = {'7': {'type': GraphPattern.ANY_PATTERN_NODE_TYPE},
+                         '8': {'type': GraphPattern.ANY_PATTERN_NODE_TYPE},
+                         '9': {'type': GraphPattern.ANY_PATTERN_NODE_TYPE}}
+    label_to_non_pattern_nodes = {}
+    label_to_any_pattern_nodes = {}
+    for label, attrs in common_nodes.items():
+        label_to_non_pattern_nodes[label] = pattern_with_non_pattern_nodes.add_node(label=label, **attrs)
+        label_to_any_pattern_nodes[label] = pattern_with_any_pattern_nodes.add_node(label=label, **attrs)
+    for label, attrs in non_pattern_nodes.items():
+        label_to_non_pattern_nodes[label] = pattern_with_non_pattern_nodes.add_node(label=label, **attrs)
+    for label, attrs in any_pattern_nodes.items():
+        label_to_any_pattern_nodes[label] = pattern_with_any_pattern_nodes.add_node(label=label, **attrs)
+
+    edges = [('1', '2'), ('2', '3'), ('2', '4'),
+             ('4', '5'), ('5', '6'), ('3', '5'),
+             ('7', '1'), ('8', '3'), ('9', '6')]
+    for edge in edges:
+        pattern_with_non_pattern_nodes.add_edge(label_to_non_pattern_nodes[edge[0]],
+                                                label_to_non_pattern_nodes[edge[1]])
+        pattern_with_any_pattern_nodes.add_edge(label_to_any_pattern_nodes[edge[0]],
+                                                label_to_any_pattern_nodes[edge[1]])
 
 
 def test_ops_combination_two_patterns():


### PR DESCRIPTION
### Changes

Introduced ANY_PATTERN_NODE_TYPE and NON_PATTERN_NODE_TYPE. ANY_PATTERN_NODE_TYPE  is a node inside the pattern, that matches on any node type, while NON_PATTERN_NODE_TYPE is outside the pattern node. NON_PATTERN_NODE_TYPE is used to reflect some outgoing edges inside the pattern

### Reason for changes

These changes allow adding the L2Norm pattern.

### Related tickets

67283

### Tests

The current tests were updated with new logic.
