### PR TITLE
Changed quantity epochs for several models

### DIFF
--- a/examples/torch/object_detection/configs/ssd300_mobilenet_voc_magnitude_int8.json
+++ b/examples/torch/object_detection/configs/ssd300_mobilenet_voc_magnitude_int8.json
@@ -14,6 +14,7 @@
   },
   "max_iter": 100000,
   "batch_size": 256,
+  "epochs": 75,
   "iter_size": 1,
   "save_freq": 50,
   "optimizer": {
@@ -46,7 +47,7 @@
           "multistep_sparsity_levels": [
               0.3,
               0.5,
-              0.7,
+              0.7
           ],
           "multistep_steps": [
               40,

--- a/examples/torch/semantic_segmentation/configs/unet_mapillary_pruning_geometric_median.json
+++ b/examples/torch/semantic_segmentation/configs/unet_mapillary_pruning_geometric_median.json
@@ -20,6 +20,7 @@
         0.0679, 0.8589, 0.0389, 2.8977, 9.4937, 0.2531, 1.8852, 2.1179, 2.1978,
         5.9516, 6.4394],
     "batch_size" : 5,
+    "epochs": 10,
     "multiprocessing_distributed" : true,
     "optimizer": {
         "type": "Adam",


### PR DESCRIPTION
### Changes

Changed quantity of train epochs for ssd300_mobilenet_voc_magnitude_sparsity_int8 and unet_mapillary_pruning_geometric_median

### Reason for changes

Needed accuracy is achieved with lower epochs quantity

### Related tickets

None

### Tests

TBD
