### PR TITLE
Formulate PT OD configs in terms of epochs only

### DIFF
--- a/examples/torch/object_detection/configs/ssd300_mobilenet_voc.json
+++ b/examples/torch/object_detection/configs/ssd300_mobilenet_voc.json
@@ -14,8 +14,8 @@
     "rgb": true
   },
   "batch_size": 128,
-  "epochs": 10,
-  "save_freq": 1,
+  "epochs": 580,
+  "save_freq": 50,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,

--- a/examples/torch/object_detection/configs/ssd300_mobilenet_voc.json
+++ b/examples/torch/object_detection/configs/ssd300_mobilenet_voc.json
@@ -14,9 +14,8 @@
     "rgb": true
   },
   "batch_size": 128,
-  "max_iter": 75000,
-  "iter_size": 1,
-  "save_freq": 50,
+  "epochs": 10,
+  "save_freq": 1,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,

--- a/examples/torch/object_detection/configs/ssd300_mobilenet_voc_magnitude_int8.json
+++ b/examples/torch/object_detection/configs/ssd300_mobilenet_voc_magnitude_int8.json
@@ -12,10 +12,9 @@
     "normalize_coef": 255,
     "rgb": true
   },
-  "max_iter": 100000,
+  "epochs": 12,
   "batch_size": 256,
-  "iter_size": 1,
-  "save_freq": 50,
+  "save_freq": 1,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,
@@ -49,8 +48,8 @@
               0.7,
           ],
           "multistep_steps": [
-              40,
-              80
+              4,
+              8
           ]
       }
     },

--- a/examples/torch/object_detection/configs/ssd300_mobilenet_voc_magnitude_int8.json
+++ b/examples/torch/object_detection/configs/ssd300_mobilenet_voc_magnitude_int8.json
@@ -12,9 +12,9 @@
     "normalize_coef": 255,
     "rgb": true
   },
-  "epochs": 12,
+  "epochs": 386,
   "batch_size": 256,
-  "save_freq": 1,
+  "save_freq": 50,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,
@@ -48,8 +48,8 @@
               0.7,
           ],
           "multistep_steps": [
-              4,
-              8
+              40,
+              80
           ]
       }
     },

--- a/examples/torch/object_detection/configs/ssd300_mobilenet_voc_rb_sparsity_int8.json
+++ b/examples/torch/object_detection/configs/ssd300_mobilenet_voc_rb_sparsity_int8.json
@@ -12,10 +12,9 @@
     "normalize_coef": 255,
     "rgb": true
   },
-  "max_iter": 100000,
+  "epochs": 12,
   "batch_size": 256,
-  "iter_size": 1,
-  "save_freq": 50,
+  "save_freq": 1,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,
@@ -44,8 +43,8 @@
       "params": {
         "schedule": "adaptive",
         "sparsity_target": 0.9,
-        "sparsity_target_epoch": 300,
-        "sparsity_freeze_epoch": 300
+        "sparsity_target_epoch": 12,
+        "sparsity_freeze_epoch": 12
       }
     },
     {

--- a/examples/torch/object_detection/configs/ssd300_mobilenet_voc_rb_sparsity_int8.json
+++ b/examples/torch/object_detection/configs/ssd300_mobilenet_voc_rb_sparsity_int8.json
@@ -12,9 +12,9 @@
     "normalize_coef": 255,
     "rgb": true
   },
-  "epochs": 12,
+  "epochs": 386,
   "batch_size": 256,
-  "save_freq": 1,
+  "save_freq": 50,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,
@@ -43,8 +43,8 @@
       "params": {
         "schedule": "adaptive",
         "sparsity_target": 0.9,
-        "sparsity_target_epoch": 12,
-        "sparsity_freeze_epoch": 12
+        "sparsity_target_epoch": 300,
+        "sparsity_freeze_epoch": 300
       }
     },
     {

--- a/examples/torch/object_detection/configs/ssd300_vgg_voc.json
+++ b/examples/torch/object_detection/configs/ssd300_vgg_voc.json
@@ -15,9 +15,8 @@
     "rgb": true
   },
   "batch_size": 256,
-  "max_iter": 75000,
-  "iter_size": 1,
-  "save_freq": 50, // in epochs
+  "epochs": 10,
+  "save_freq": 1, // in epochs
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,

--- a/examples/torch/object_detection/configs/ssd300_vgg_voc.json
+++ b/examples/torch/object_detection/configs/ssd300_vgg_voc.json
@@ -15,14 +15,14 @@
     "rgb": true
   },
   "batch_size": 256,
-  "epochs": 10,
-  "save_freq": 1, // in epochs
+  "epochs": 290,
+  "save_freq": 50,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,
     "weight_decay": 5e-4,
     "schedule_type": "multistep",
-    "steps": [2, 3, 4] // in epochs
+    "steps": [2, 3, 4]
   },
   "ssd_params": {
     "clip": false,

--- a/examples/torch/object_detection/configs/ssd300_vgg_voc_int8.json
+++ b/examples/torch/object_detection/configs/ssd300_vgg_voc_int8.json
@@ -13,12 +13,10 @@
     "normalize_coef": 255,
     "rgb": true
   },
-  "max_iter": 3000,
-  "batch_size": 128,
-  "test_interval": 500, // in iterations
-  "iter_size": 1,
-  "save_freq": 3, // in epochs
   "epochs": 3,
+  "batch_size": 128,
+  "test_interval": 1,
+  "save_freq": 1,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-5,

--- a/examples/torch/object_detection/configs/ssd300_vgg_voc_int8.json
+++ b/examples/torch/object_detection/configs/ssd300_vgg_voc_int8.json
@@ -13,10 +13,10 @@
     "normalize_coef": 255,
     "rgb": true
   },
-  "epochs": 3,
+  "epochs": 24,
   "batch_size": 128,
   "test_interval": 1,
-  "save_freq": 1,
+  "save_freq": 3,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-5,

--- a/examples/torch/object_detection/configs/ssd300_vgg_voc_int8_accuracy_aware.json
+++ b/examples/torch/object_detection/configs/ssd300_vgg_voc_int8_accuracy_aware.json
@@ -13,10 +13,10 @@
         "normalize_coef": 255,
         "rgb": true
     },
-    "epochs": 1,
+    "epochs": 24,
     "batch_size": 128,
     "test_interval": 1,
-    "save_freq": 1,
+    "save_freq": 3,
     "optimizer": {
         "type": "Adam",
         "base_lr": 1e-5,

--- a/examples/torch/object_detection/configs/ssd300_vgg_voc_int8_accuracy_aware.json
+++ b/examples/torch/object_detection/configs/ssd300_vgg_voc_int8_accuracy_aware.json
@@ -13,12 +13,10 @@
         "normalize_coef": 255,
         "rgb": true
     },
-    "max_iter": 3000,
+    "epochs": 1,
     "batch_size": 128,
-    "test_interval": 500, // in iterations
-    "iter_size": 1,
-    "save_freq": 3, // in epochs
-    "epochs": 3,
+    "test_interval": 1,
+    "save_freq": 1,
     "optimizer": {
         "type": "Adam",
         "base_lr": 1e-5,

--- a/examples/torch/object_detection/configs/ssd300_vgg_voc_magnitude_sparsity_int8.json
+++ b/examples/torch/object_detection/configs/ssd300_vgg_voc_magnitude_sparsity_int8.json
@@ -12,11 +12,9 @@
     "normalize_coef": 255,
     "rgb": true
   },
-  "max_iter": 30000,
+  "epochs": 4,
   "batch_size": 128,
-  "iter_size": 1,
-  "save_freq": 10,
-  "epochs": 130,
+  "save_freq": 1,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,
@@ -46,8 +44,8 @@
               0.7
           ],
           "multistep_steps": [
-              40,
-              80
+              2,
+              3
           ]
       }
     },

--- a/examples/torch/object_detection/configs/ssd300_vgg_voc_magnitude_sparsity_int8.json
+++ b/examples/torch/object_detection/configs/ssd300_vgg_voc_magnitude_sparsity_int8.json
@@ -12,9 +12,9 @@
     "normalize_coef": 255,
     "rgb": true
   },
-  "epochs": 4,
+  "epochs": 232,
   "batch_size": 128,
-  "save_freq": 1,
+  "save_freq": 10,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,
@@ -44,8 +44,8 @@
               0.7
           ],
           "multistep_steps": [
-              2,
-              3
+              40,
+              80
           ]
       }
     },

--- a/examples/torch/object_detection/configs/ssd300_vgg_voc_pruning_geometric_median.json
+++ b/examples/torch/object_detection/configs/ssd300_vgg_voc_pruning_geometric_median.json
@@ -15,16 +15,15 @@
     "rgb": true
   },
   "batch_size": 256,
-  "test_interval": 5000, // in iterations
-  "max_iter": 100000,
-  "iter_size": 1,
-  "save_freq": 50, // in epochs
+  "test_interval": 1,
+  "epochs": 12,
+  "save_freq": 1,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-3,
     "weight_decay": 5e-4,
     "schedule_type": "multistep",
-    "steps": [100, 200, 300, 400] // in epochs
+    "steps": [2, 4, 8, 10]
   },
   "ssd_params": {
     "clip": false,
@@ -41,7 +40,7 @@
     "pruning_init": 0.05,
     "params": {
       "schedule": "exponential",
-      "pruning_steps": 50,
+      "pruning_steps": 12,
       "pruning_target": 0.4,
       "filter_importance": "geometric_median"
     },

--- a/examples/torch/object_detection/configs/ssd300_vgg_voc_pruning_geometric_median.json
+++ b/examples/torch/object_detection/configs/ssd300_vgg_voc_pruning_geometric_median.json
@@ -15,15 +15,15 @@
     "rgb": true
   },
   "batch_size": 256,
-  "test_interval": 1,
-  "epochs": 12,
-  "save_freq": 1,
+  "test_interval": 50,
+  "epochs": 780,
+  "save_freq": 50,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-3,
     "weight_decay": 5e-4,
     "schedule_type": "multistep",
-    "steps": [2, 4, 8, 10]
+    "steps": [100, 200, 300, 400]
   },
   "ssd_params": {
     "clip": false,
@@ -40,7 +40,7 @@
     "pruning_init": 0.05,
     "params": {
       "schedule": "exponential",
-      "pruning_steps": 12,
+      "pruning_steps": 50,
       "pruning_target": 0.4,
       "filter_importance": "geometric_median"
     },

--- a/examples/torch/object_detection/configs/ssd512_vgg_voc.json
+++ b/examples/torch/object_detection/configs/ssd512_vgg_voc.json
@@ -15,9 +15,8 @@
     "rgb": true
   },
   "batch_size": 160,
-  "max_iter": 120000,
-  "iter_size": 1,
-  "save_freq": 50, // in epochs
+  "epochs": 15,
+  "save_freq": 1,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,

--- a/examples/torch/object_detection/configs/ssd512_vgg_voc.json
+++ b/examples/torch/object_detection/configs/ssd512_vgg_voc.json
@@ -15,8 +15,8 @@
     "rgb": true
   },
   "batch_size": 160,
-  "epochs": 15,
-  "save_freq": 1,
+  "epochs": 740,
+  "save_freq": 50,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,

--- a/examples/torch/object_detection/configs/ssd512_vgg_voc_int8.json
+++ b/examples/torch/object_detection/configs/ssd512_vgg_voc_int8.json
@@ -13,9 +13,9 @@
     "normalize_coef": 255,
     "rgb": true
   },
-  "epochs": 1,
+  "epochs": 78,
   "batch_size": 64,
-  "save_freq": 1,
+  "save_freq": 3,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,

--- a/examples/torch/object_detection/configs/ssd512_vgg_voc_int8.json
+++ b/examples/torch/object_detection/configs/ssd512_vgg_voc_int8.json
@@ -13,10 +13,9 @@
     "normalize_coef": 255,
     "rgb": true
   },
-  "max_iter": 5000,
+  "epochs": 1,
   "batch_size": 64,
-  "iter_size": 1,
-  "save_freq": 3, // in epochs
+  "save_freq": 1,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,

--- a/examples/torch/object_detection/configs/ssd512_vgg_voc_magnitude_sparsity_int8.json
+++ b/examples/torch/object_detection/configs/ssd512_vgg_voc_magnitude_sparsity_int8.json
@@ -13,9 +13,9 @@
     "normalize_coef": 255,
     "rgb": true
   },
-  "epochs": 4,
+  "epochs": 310,
   "batch_size": 96,
-  "save_freq": 3,
+  "save_freq": 30,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,
@@ -44,8 +44,8 @@
               0.7
           ],
           "multistep_steps": [
-              2,
-              3
+              40,
+              80
           ]
       }
     },

--- a/examples/torch/object_detection/configs/ssd512_vgg_voc_magnitude_sparsity_int8.json
+++ b/examples/torch/object_detection/configs/ssd512_vgg_voc_magnitude_sparsity_int8.json
@@ -13,11 +13,9 @@
     "normalize_coef": 255,
     "rgb": true
   },
-  "max_iter": 30000,
+  "epochs": 4,
   "batch_size": 96,
-  "iter_size": 1,
-  "save_freq": 3, // in epochs
-  "epochs": 111,
+  "save_freq": 3,
   "optimizer": {
     "type": "Adam",
     "base_lr": 1e-4,
@@ -46,8 +44,8 @@
               0.7
           ],
           "multistep_steps": [
-              40,
-              80
+              2,
+              3
           ]
       }
     },

--- a/examples/torch/object_detection/main.py
+++ b/examples/torch/object_detection/main.py
@@ -350,28 +350,27 @@ def train_step(batch_iterator, compression_ctrl, config, criterion, net, train_d
     batch_loss_l = torch.tensor(0.).to(config.device)
     batch_loss_c = torch.tensor(0.).to(config.device)
     batch_loss = torch.tensor(0.).to(config.device)
-    for _ in range(0, config.iter_size):
-        # load train data
-        try:
-            images, targets = next(batch_iterator)
-        except StopIteration:
-            logger.debug("StopIteration: can not load batch")
-            batch_iterator = iter(train_data_loader)
-            break
+    # load train data
+    try:
+        images, targets = next(batch_iterator)
+    except StopIteration:
+        logger.debug("StopIteration: can not load batch")
+        batch_iterator = iter(train_data_loader)
 
-        images = images.to(config.device)
-        targets = [anno.requires_grad_(False).to(config.device) for anno in targets]
+    images = images.to(config.device)
+    targets = [anno.requires_grad_(False).to(config.device) for anno in targets]
 
-        # forward
-        out = net(images)
-        # backprop
-        loss_l, loss_c = criterion(out, targets)
-        loss_comp = compression_ctrl.loss()
-        loss = loss_l + loss_c + loss_comp
-        batch_loss += loss
-        loss.backward()
-        batch_loss_l += loss_l
-        batch_loss_c += loss_c
+    # forward
+    out = net(images)
+    # backprop
+    loss_l, loss_c = criterion(out, targets)
+    loss_comp = compression_ctrl.loss()
+    loss = loss_l + loss_c + loss_comp
+    batch_loss += loss
+    loss.backward()
+    batch_loss_l += loss_l
+    batch_loss_c += loss_c
+
     return batch_iterator, batch_loss, batch_loss_c, batch_loss_l, loss_comp
 
 
@@ -386,9 +385,11 @@ def train(net, compression_ctrl, train_data_loader, test_data_loader, criterion,
 
     best_mAp = 0
     best_compression_stage = CompressionStage.UNCOMPRESSED
-    test_freq_in_epochs = max(config.test_interval // epoch_size, 1)
+    test_freq_in_epochs = config.test_interval
+    if config.test_interval is None:
+        test_freq_in_epochs = 1
 
-    max_epochs = config['max_iter'] // epoch_size
+    max_epochs = config['epochs']
 
     for epoch in range(config.start_epoch, max_epochs):
         compression_ctrl.scheduler.epoch_step(epoch)
@@ -489,10 +490,7 @@ def train_epoch(compression_ctrl, net, config, train_data_loader, criterion, opt
         )
         optimizer.step()
 
-        batch_loss_l = batch_loss_l / config.iter_size
-        batch_loss_c = batch_loss_c / config.iter_size
-        model_loss = (batch_loss_l + batch_loss_c) / config.iter_size
-        batch_loss = batch_loss / config.iter_size
+        model_loss = batch_loss_l + batch_loss_c
 
         loc_loss += batch_loss_l.item()
         conf_loss += batch_loss_c.item()


### PR DESCRIPTION
### Changes

The config values in PyTorch object detection samples are modified to use epochs instead of iterations; `iter_size` parameter is removed. 

### Reason for changes

The current object detection sample configs mix up epoch-based and iteration-based specifications for test/save intervals and sparsity application. This leads to confusion and in fact we currently cannot tell if the configs are even correct w.r.t. the scheduling and training length.

### Related tickets

71329

### Tests

test_sanity_sample
