### PR TITLE
Fix error in determine_subtype for custom module

### DIFF
--- a/nncf/torch/graph/graph_builder.py
+++ b/nncf/torch/graph/graph_builder.py
@@ -21,17 +21,18 @@ import torch
 
 from nncf.common.graph import INPUT_NOOP_METATYPES
 from nncf.common.graph import LayerName
+from nncf.common.graph.layer_attributes import GenericWeightedLayerAttributes
 from nncf.common.graph.layer_attributes import MultipleInputLayerAttributes
+from nncf.common.graph.layer_attributes import ReshapeLayerAttributes
+from nncf.common.graph.operator_metatypes import UnknownMetatype
 from nncf.common.graph.utils import get_concat_axis
 from nncf.torch.dynamic_graph.graph import DynamicGraph
 from nncf.torch.dynamic_graph.graph_tracer import GraphTracer
 from nncf.torch.dynamic_graph.graph_tracer import ModelInputInfo
 from nncf.torch.graph.graph import PTNNCFGraph
 from nncf.torch.graph.operator_metatypes import PTCatMetatype
-from nncf.torch.graph.operator_metatypes import PT_OPERATOR_METATYPES
-from nncf.common.graph.operator_metatypes import UnknownMetatype
 from nncf.torch.graph.operator_metatypes import PTReshapeMetatype
-from nncf.common.graph.layer_attributes import ReshapeLayerAttributes
+from nncf.torch.graph.operator_metatypes import PT_OPERATOR_METATYPES
 
 
 class GraphBuilder:
@@ -65,7 +66,8 @@ class GraphConverter:
             layer_name = str(dynamic_graph_node.op_exec_context.op_address.scope_in_model)
 
             metatype = PT_OPERATOR_METATYPES.get_operator_metatype_by_op_name(op_address.operator_name)
-            if metatype is not UnknownMetatype:
+            if (metatype is not UnknownMetatype and
+                    not isinstance(dynamic_graph_node.layer_attributes, GenericWeightedLayerAttributes)):
                 subtype = metatype.determine_subtype(dynamic_graph_node.layer_attributes)
             else:
                 subtype = None


### PR DESCRIPTION


### Changes

Check layer_attributes before check subtypes.


### Reason for changes

Incorrect works with custom modules like
```Python
class CustomMoudule(nn.Module):
    def __init__(self, in_features, out_features):
        ...
        self.in_features = in_features
        self.out_features = out_features
        self.weight = nn.Parameter(torch.Tensor(out_features, in_features))
        ...

    def forward(self, x):
        weight = normalize(self.weight, dim=1, p=2).view(self.out_features, self.in_features, 1, 1)
        out = F.conv2d(x, weight)
        return out
```

In with case layer_attributes is `GenericWeightedLayerAttributes` and `operator_name` is `conv2d` as result 
```
  File "nncf/torch/graph/operator_metatypes.py", line 87, in determine_subtype
    functions_kwargs):
  File "nncf/torch/graph/operator_metatypes.py", line 166, in matches
    if layer_attributes.groups == layer_attributes.in_channels and layer_attributes.in_channels > 1:
AttributeError: 'GenericWeightedLayerAttributes' object has no attribute 'groups'
```

