### PR TITLE
Extend the metatypes for TF OPS

### DIFF
--- a/nncf/tensorflow/graph/metatypes/common.py
+++ b/nncf/tensorflow/graph/metatypes/common.py
@@ -73,7 +73,8 @@ LINEAR_LAYER_METATYPES = [
 
 NORMALIZATION_LAYER_METATYPES = [
     layer_metatypes.TFBatchNormalizationLayerMetatype,
-    layer_metatypes.TFLayerNormalizationLayerMetatype
+    layer_metatypes.TFLayerNormalizationLayerMetatype,
+    op_metatypes.TFFusedBatchNormV3OpMetatype,
 ]
 
 LAYER_METATYPES_AGNOSTIC_TO_DATA_PRECISION_WITH_ONE_INPUT = [
@@ -96,7 +97,14 @@ LAYER_METATYPES_AGNOSTIC_TO_DATA_PRECISION_WITH_ONE_INPUT = [
     op_metatypes.TFPackOpMetatype,
     op_metatypes.TFPadOpMetatype,
     op_metatypes.TFStridedSliceOpMetatype,
-    op_metatypes.TFReshapeOpMetatype
+    op_metatypes.TFReshapeOpMetatype,
+    op_metatypes.TFShapeOpMetatype,
+    op_metatypes.TFMaxOpMetatype,
+    op_metatypes.TFMaxPoolOpMetatype,
+    op_metatypes.TFExpandDimsOpMetatype,
+    op_metatypes.TFSqueezeOpMetatype,
+    op_metatypes.TFMaxPool3DOpMetatype,
+    op_metatypes.TFTileOpMetatype,
 ]
 
 LAYER_METATYPES_AGNOSTIC_TO_DATA_PRECISION_WITH_MULTIPLE_INPUTS = [
@@ -113,7 +121,11 @@ ELEMENTWISE_LAYER_METATYPES = [
     layer_metatypes.TFMultiplyLayerMetatype,
     layer_metatypes.TFRescalingLayerMetatype,
     op_metatypes.TFAddOpMetatype,
-    op_metatypes.TFMulOpMetatype
+    op_metatypes.TFMulOpMetatype,
+    op_metatypes.TFBiasAddOpMetatype,
+    op_metatypes.TFGreaterOpMetatype,
+    op_metatypes.TFNegOpMetatype,
+    op_metatypes.TFSubOpMetatype,
 ]
 
 RESHAPE_METATYPES = [

--- a/nncf/tensorflow/graph/metatypes/tf_ops.py
+++ b/nncf/tensorflow/graph/metatypes/tf_ops.py
@@ -188,6 +188,47 @@ class TFExpOpMetatype(TFOpMetatype):
     op_names = ['Exp']
 
 
+class TFPlaceholderOpMetatype(TFOpMetatype):
+    name = 'PlaceholderOp'
+    op_names = ['Placeholder']
+
+
+@TF_OPERATION_METATYPES.register()
+class TFShapeOpMetatype(TFOpMetatype):
+    name = 'ShapeOp'
+    op_names = ['Shape']
+
+
+@TF_OPERATION_METATYPES.register()
+class TFBiasAddOpMetatype(TFOpMetatype):
+    name = 'BiasAddOp'
+    op_names = ['BiasAdd']
+    hw_config_names = [HWConfigOpName.ADD]
+
+
+@TF_OPERATION_METATYPES.register()
+class TFMeanOpMetatype(TFOpMetatype):
+    name = 'MeanOp'
+    op_names = ['Mean']
+    hw_config_names = [
+        HWConfigOpName.REDUCEMEAN,
+        HWConfigOpName.AVGPOOL,
+    ]
+
+
+@TF_OPERATION_METATYPES.register()
+class TFFusedBatchNormV3OpMetatype(TFOpMetatype):
+    name = 'FusedBatchNormV3Op'
+    op_names = ['FusedBatchNormV3']
+
+
+@TF_OPERATION_METATYPES.register()
+class TFSqueezeOpMetatype(TFOpMetatype):
+    name = 'SqueezeOp'
+    op_names = ['Squeeze']
+    hw_config_names = [HWConfigOpName.SQUEEZE]
+
+
 @TF_OPERATION_METATYPES.register()
 class TFSigmoidOpMetatype(TFOpMetatype):
     name = 'SigmoidOp'
@@ -250,6 +291,56 @@ class TFCastOpMetatype(TFOpMetatype):
     op_names = ['Cast']
 
 
+class TFMaxOpMetatype(TFOpMetatype):
+    name = 'MaxOp'
+    op_names = ['Max']
+    hw_config_names = [HWConfigOpName.MAXIMUM]
+
+
+@TF_OPERATION_METATYPES.register()
+class TFTanhOpMetatype(TFOpMetatype):
+    name = 'TanhOp'
+    op_names = ['Tanh']
+
+
+@TF_OPERATION_METATYPES.register()
+class TFSeluOpMetatype(TFOpMetatype):
+    name = 'SeluOp'
+    op_names = ['Selu']
+
+
+@TF_OPERATION_METATYPES.register()
+class TFEluOpMetatype(TFOpMetatype):
+    name = 'EluOp'
+    op_names = ['Elu']
+
+
+@TF_OPERATION_METATYPES.register()
+class TFLeakyReluOpMetatype(TFOpMetatype):
+    name = 'LeakyReluOp'
+    op_names = ['LeakyRelu']
+
+
+@TF_OPERATION_METATYPES.register()
+class TFMaxPoolOpMetatype(TFOpMetatype):
+    name = 'MaxPoolOp'
+    op_names = ['MaxPool']
+    hw_config_names = [HWConfigOpName.MAXPOOL]
+
+
+@TF_OPERATION_METATYPES.register()
+class TFMaxPool3DOpMetatype(TFOpMetatype):
+    name = 'MaxPool3DOp'
+    op_names = ['MaxPool3D']
+    hw_config_names = [HWConfigOpName.MAXPOOL]
+
+
+@TF_OPERATION_METATYPES.register()
+class TFNegOpMetatype(TFOpMetatype):
+    name = 'NegOp'
+    op_names = ['Neg']
+
+
 @TF_OPERATION_METATYPES.register()
 class TFTileOpMetatype(TFOpMetatype):
     name = 'TileOp'
@@ -274,6 +365,19 @@ class TFTransposeOpMetatype(TFOpMetatype):
     name = 'TransposeOp'
     op_names = ['Transpose']
     hw_config_names = [HWConfigOpName.TRANSPOSE]
+
+
+class TFGreaterOpMetatype(TFOpMetatype):
+    name = 'GreaterOp'
+    op_names = ['Greater']
+    hw_config_names = [HWConfigOpName.GREATER]
+
+
+@TF_OPERATION_METATYPES.register()
+class TFResizeNearestNeighborOpMetatype(TFOpMetatype):
+    name = 'ResizeNearestNeighborOp'
+    op_names = ['ResizeNearestNeighbor']
+    hw_config_names = [HWConfigOpName.INTERPOLATE]
 
 
 WEIGHTABLE_TF_OP_METATYPES = [

--- a/nncf/tensorflow/graph/pattern_operations.py
+++ b/nncf/tensorflow/graph/pattern_operations.py
@@ -40,7 +40,8 @@ QUANTIZATION_AGNOSTIC_OPERATIONS = {
 }
 
 BATCH_NORMALIZATION_OPERATIONS = {'type': ['BatchNormalization',
-                                           'SyncBatchNormalization',],
+                                           'SyncBatchNormalization',
+                                           'FusedBatchNormV3'],
                                   'label': 'BATCH_NORMALIZATION'
                                   }
 
@@ -56,7 +57,15 @@ KERAS_ACTIVATIONS_OPERATIONS = {
 
 
 TF_ACTIVATIONS_OPERATIONS = {
-    'type': ['Relu'],
+    'type': [
+        'Relu',
+        'Elu',
+        'LeakyRelu',
+        'Relu6',
+        'Selu',
+        'Sigmoid',
+        'Tanh',
+    ],
     'label': 'TF_ACTIVATIONS'
 }
 
@@ -67,7 +76,10 @@ ATOMIC_ACTIVATIONS_OPERATIONS = merge_two_types_of_operations(KERAS_ACTIVATIONS_
 POOLING_OPERATIONS = {'type': ['AveragePooling2D',
                                'AveragePooling3D',
                                'GlobalAveragePooling2D',
-                               'GlobalAveragePooling3D'],
+                               'GlobalAveragePooling3D',
+                               'AvgPool',
+                               'AvgPool3D',
+                               'Mean',],
                       'label': 'POOLING'}
 
 SINGLE_OPS = merge_two_types_of_operations(POOLING_OPERATIONS,


### PR DESCRIPTION
### Changes
New metatypes was added

### Reason for changes
These changes are required for Keras Lambda layer support

### Related tickets
N/A

### Tests
N/A
