### PR TITLE
New "saturation_fix" config option

### DIFF
--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -133,7 +133,8 @@ This leads to accuracy degradation.
 
 To fix this issue inside NNCF, by default, all weight tensors are quantized in 8 bits but only 7 bits are effectively used.
 This regime is used when `"target_device": "CPU"` or `"target_device": "ANY"` set. This fix, potentially, requires longer fine-tuning.
-To apply the saturation issue fix only to the first layer use `"saturation_fix": "enable_for_first_conv_layer"`. To disable the saturation issue fix for all layers use `"saturation_fix": "disable"`.
+
+To control the application of saturation fix, `"saturation_fix"` config option is introduced. The default value is `"saturation_fix": "enable"`. To apply the saturation issue fix only to the first layer, use `"saturation_fix": "enable_for_first_conv_layer"`. To disable the saturation issue fix for all layers, use `"saturation_fix": "disable"`.
 
 ---
 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -129,12 +129,12 @@ For symmetric:
 
 There is a known issue with AVX2 and AVX512 CPU devices. The issue appears with 8-bit matrix calculations with tensors which elements are close to the maximum or saturated.
 AVX2 and AVX512 utilize a 16-bit register to store the result of operations on tensors. In case when tensors are saturated the buffer overflow happens.
-This leads to accuracy degradation.
+This leads to accuracy degradation. For more details of the overflow issue please refer [here](https://www.intel.com/content/www/us/en/developer/articles/technical/lower-numerical-precision-deep-learning-inference-and-training.html).
 
 To fix this issue inside NNCF, by default, all weight tensors are quantized in 8 bits but only 7 bits are effectively used.
 This regime is used when `"target_device": "CPU"` or `"target_device": "ANY"` set. This fix, potentially, requires longer fine-tuning.
 
-To control the application of saturation fix, `"saturation_fix"` config option is introduced. The default value is `"saturation_fix": "enable"`. To apply the saturation issue fix only to the first layer, use `"saturation_fix": "enable_for_first_conv_layer"`. To disable the saturation issue fix for all layers, use `"saturation_fix": "disable"`.
+To control the application of overflow fix, `"overflow_fix"` config option is introduced. The default value is `"overflow_fix": "enable"`. To apply the overflow issue fix only to the first layer, use `"overflow_fix": "first_layer_only"`. To disable the overflow issue fix for all layers, use `"overflow_fix": "disable"`.
 
 ---
 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -132,7 +132,8 @@ AVX2 and AVX512 utilize a 16-bit register to store the result of operations on t
 This leads to accuracy degradation.
 
 To fix this issue inside NNCF, by default, all weight tensors are quantized in 8 bits but only 7 bits are effectively used.
-This regime is used when `"target_device": "CPU"` or `"target_device": "ANY"` set. This fix, potentially, requires longer fine-tuning. To apply saturation issue fix only to the first layer use `"apply_saturation_fix_only_to_first_layer": true`. To disable saturation issue fix for all layers use `"disable_saturation_fix": true`.
+This regime is used when `"target_device": "CPU"` or `"target_device": "ANY"` set. This fix, potentially, requires longer fine-tuning.
+To apply the saturation issue fix only to the first layer use `"saturation_fix": "enable_for_first_conv_layer"`. To disable the saturation issue fix for all layers use `"saturation_fix": "disable"`.
 
 ---
 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -131,8 +131,8 @@ There is a known issue with AVX2 and AVX512 CPU devices. The issue appears with 
 AVX2 and AVX512 utilize a 16-bit register to store the result of operations on tensors. In case when tensors are saturated the buffer overflow happens.
 This leads to accuracy degradation.
 
-To fix this issue inside NNCF, weight tensors are quantized in 8 bits but only 7 bits are effectively used.
-This regime is used when `"target_device": "CPU"` or `"target_device": "ANY"` set.
+To fix this issue inside NNCF, by default, all weight tensors are quantized in 8 bits but only 7 bits are effectively used.
+This regime is used when `"target_device": "CPU"` or `"target_device": "ANY"` set. This fix, potentially, requires longer fine-tuning. To apply saturation issue fix only to the first layer use `"apply_saturation_fix_only_to_first_layer": true`. To disable saturation issue fix for all layers use `"disable_saturation_fix": true`.
 
 ---
 

--- a/nncf/common/pruning/node_selector.py
+++ b/nncf/common/pruning/node_selector.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Optional
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode
 from nncf.common.pruning.utils import get_sources_of_node
-from nncf.common.pruning.utils import get_first_nodes_of_type
+from nncf.common.graph.utils import get_first_nodes_of_type
 from nncf.common.pruning.utils import get_previous_convs
 from nncf.common.pruning.utils import is_grouped_conv
 from nncf.common.pruning.utils import PruningAnalysisDecision

--- a/nncf/common/pruning/utils.py
+++ b/nncf/common/pruning/utils.py
@@ -136,29 +136,6 @@ def traverse_function(node: NNCFNode, output: List[NNCFNode], type_check_fn, vis
     return True, output
 
 
-def get_first_nodes_of_type(graph: NNCFGraph, op_types: List[str]) -> List[NNCFNode]:
-    """
-    Looking for first node in graph with type in `op_types`.
-    First == layer with type in `op_types`, that there is a path from the input such that there are no other
-    operations with type in `op_types` on it.
-
-    :param op_types: Types of modules to track.
-    :param graph: Graph to work with.
-    :return: List of all first nodes with type in `op_types`.
-    """
-    graph_roots = graph.get_input_nodes()  # NNCFNodes here
-
-    visited = {node_id: False for node_id in graph.get_all_node_ids()}
-    partial_traverse_function = partial(traverse_function,
-                                        type_check_fn=lambda x: x in op_types,
-                                        visited=visited)
-
-    first_nodes_of_type = []
-    for root in graph_roots:
-        first_nodes_of_type.extend(graph.traverse_graph(root, partial_traverse_function))
-    return first_nodes_of_type
-
-
 def get_last_nodes_of_type(graph: NNCFGraph, op_types: List[str]) -> List[NNCFNode]:
     """
     Looking for last node in graph with type in `op_types`.

--- a/nncf/config/schema.py
+++ b/nncf/config/schema.py
@@ -543,11 +543,11 @@ QUANTIZATION_SCHEMA = {
                                                                    "standard QuantizeLinear-DequantizeLinear "
                                                                    "node pairs (8-bit quantization only in the latter "
                                                                    "case). Default: false"),
-        "saturation_fix": with_attributes(_STRING,
-                                          description="Option controls whether to apply the saturation "
+        "overflow_fix": with_attributes(_STRING,
+                                          description="Option controls whether to apply the overflow "
                                                       "issue fix for the appropriate NNCF config or not. "
                                                       "If set to 'disable', the fix will not be applied. "
-                                                      "If set to 'enable' or 'enable_for_first_conv_layer', "
+                                                      "If set to 'enable' or 'first_layer_only', "
                                                       "while appropriate target_devices are chosen, "
                                                       "the fix will be applied to the all layers or to the first"
                                                       "convolutional layer respectively."),

--- a/nncf/config/schema.py
+++ b/nncf/config/schema.py
@@ -543,6 +543,14 @@ QUANTIZATION_SCHEMA = {
                                                                    "standard QuantizeLinear-DequantizeLinear "
                                                                    "node pairs (8-bit quantization only in the latter "
                                                                    "case). Default: false"),
+        "apply_saturation_fix_only_to_first_layer": with_attributes(
+            _BOOLEAN,
+            description="Option controls whether to apply the saturation "
+                        "issue fix only for the first layer or to all layers. "
+                        "This option has effect while saturation fix is enabled. "
+                        "If set to True, the fix will be applied only to the first layer. "
+                        "If set to False, the fix will be applied only to all layer. "
+                        "For a detailed information, please, take look at the docs"),
         "disable_saturation_fix": with_attributes(_BOOLEAN,
                                                   description="Option controls whether to apply the saturation "
                                                               "issue fix for the appropriate NNCF config or not"

--- a/nncf/config/schema.py
+++ b/nncf/config/schema.py
@@ -543,22 +543,14 @@ QUANTIZATION_SCHEMA = {
                                                                    "standard QuantizeLinear-DequantizeLinear "
                                                                    "node pairs (8-bit quantization only in the latter "
                                                                    "case). Default: false"),
-        "apply_saturation_fix_only_to_first_layer": with_attributes(
-            _BOOLEAN,
-            description="Option controls whether to apply the saturation "
-                        "issue fix only for the first layer or to all layers. "
-                        "This option has effect while saturation fix is enabled. "
-                        "If set to True, the fix will be applied only to the first layer. "
-                        "If set to False, the fix will be applied only to all layer. "
-                        "For a detailed information, please, take look at the docs"),
-        "disable_saturation_fix": with_attributes(_BOOLEAN,
-                                                  description="Option controls whether to apply the saturation "
-                                                              "issue fix for the appropriate NNCF config or not"
-                                                              "If set to True, the fix will not be applied. "
-                                                              "If set to False while "
-                                                              "appropriate target_devices are chosen "
-                                                              "the fix will be applied. For a detailed information "
-                                                              ", please, take look at the docs"),
+        "saturation_fix": with_attributes(_STRING,
+                                          description="Option controls whether to apply the saturation "
+                                                      "issue fix for the appropriate NNCF config or not. "
+                                                      "If set to 'disable', the fix will not be applied. "
+                                                      "If set to 'enable' or 'enable_for_first_conv_layer', "
+                                                      "while appropriate target_devices are chosen, "
+                                                      "the fix will be applied to the all layers or to the first"
+                                                      "convolutional layer respectively."),
         **STAGED_QUANTIZATION_PARAMS,
         **COMMON_COMPRESSION_ALGORITHM_PROPERTIES,
     },

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -244,9 +244,7 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
 
         self.quantize_inputs = self._algo_config.get('quantize_inputs', True)
         self.quantize_outputs = self._algo_config.get('quantize_outputs', False)
-        self._disable_saturation_fix = self._algo_config.get('disable_saturation_fix', False)
-        self._apply_saturation_fix_only_to_first_layer = self._algo_config.get(
-            'apply_saturation_fix_only_to_first_layer', False)
+        self._saturation_fix = self._algo_config.get('saturation_fix', 'enable')
         self._target_device = config.get('target_device', 'ANY')
         algo_config = self._get_algo_specific_config_section()
         if self._target_device == 'VPU' and 'preset' in algo_config:
@@ -327,7 +325,7 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
         return qconfig
 
     def _get_half_range(self, qconfig: QuantizerConfig) -> bool:
-        if not self._disable_saturation_fix:
+        if self._saturation_fix in ['enable', 'enable_for_first_conv_layer']:
             if self._target_device in ['CPU', 'ANY'] and qconfig.num_bits == 8:
                 return True
         return False
@@ -467,7 +465,7 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
                     self._op_names.append(op_name)
 
                     half_range = self._get_half_range(qconfig)
-                    if self._apply_saturation_fix_only_to_first_layer:
+                    if self._saturation_fix == 'enable_for_first_conv_layer':
                         half_range = half_range and not applied_saturation_fix
                     applied_saturation_fix = applied_saturation_fix or half_range
                     quantizer_spec = TFQuantizerSpec.from_config(qconfig,

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -330,7 +330,7 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
         if self._target_device in ['CPU', 'ANY'] and qconfig.num_bits == 8:
             if self._saturation_fix == 'enable':
                 return True
-            elif self._saturation_fix == 'enable_for_first_conv_layer':
+            if self._saturation_fix == 'enable_for_first_conv_layer':
                 if target_node in first_conv_nodes:
                     return True
         return False
@@ -509,6 +509,11 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
 
         setup = self._generate_unified_scale_groups(model, quantizer_setup, qp_id_to_index, setup)
 
+        self._raise_saturation_fix_warning(applied_saturation_fix)
+
+        return setup
+
+    def _raise_saturation_fix_warning(self, applied_saturation_fix: bool):
         if applied_saturation_fix:
             if self._saturation_fix == 'enable':
                 logger.warning('The saturation issue fix will be applied. '
@@ -517,10 +522,9 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
                                'Please take a look at the documentation for a detailed information.')
             elif self._saturation_fix == 'enable_for_first_conv_layer':
                 logger.warning('The saturation issue fix will be applied. '
-                               'Now first convolustion weight quantizers will effectively use only 7 bits out of '
+                               'Now first convolution weight quantizers will effectively use only 7 bits out of '
                                '8 bits. This resolves the saturation issue problem on AVX2 and AVX-512 machines. '
                                'Please take a look at the documentation for a detailed information.')
-        return setup
 
     def _generate_unified_scale_groups(self,
                                        model: tf.keras.Model,

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -465,10 +465,10 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
                     self._op_names.append(op_name)
 
                     half_range = self._get_half_range(qconfig)
-                    applied_saturation_fix = applied_saturation_fix or half_range
                     quantizer_spec = TFQuantizerSpec.from_config(qconfig,
                                                                  narrow_range=not half_range,
-                                                                 half_range=half_range)
+                                                                 half_range=(half_range and not applied_saturation_fix))
+                    applied_saturation_fix = applied_saturation_fix or half_range
                     target_point = TFLayerWeight(layer_info.layer_name, weight_def.weight_attr_name)
                     qpoint = TFQuantizationPoint(op_name, quantizer_spec, target_point)
             else:

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -516,15 +516,14 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
     def _raise_saturation_fix_warning(self, applied_saturation_fix: bool):
         if applied_saturation_fix:
             if self._saturation_fix == 'enable':
-                logger.warning('The saturation issue fix will be applied. '
-                               'Now all weight quantizers will effectively use only 7 bits out of 8 bits. '
-                               'This resolves the saturation issue problem on AVX2 and AVX-512 machines. '
-                               'Please take a look at the documentation for a detailed information.')
+                quantizers_with_saturation_fix_str = 'all weight quantizers'
             elif self._saturation_fix == 'enable_for_first_conv_layer':
-                logger.warning('The saturation issue fix will be applied. '
-                               'Now first convolution weight quantizers will effectively use only 7 bits out of '
-                               '8 bits. This resolves the saturation issue problem on AVX2 and AVX-512 machines. '
-                               'Please take a look at the documentation for a detailed information.')
+                quantizers_with_saturation_fix_str = 'first convolution weight quantizers'
+            logger.warning('The saturation issue fix will be applied. '
+                           'Now {} will effectively use only 7 bits out of '
+                           '8 bits. This resolves the saturation issue problem on AVX2 and AVX-512 machines. '
+                           'Please take a look at the documentation for a detailed information.'
+                           .format(quantizers_with_saturation_fix_str))
 
     def _generate_unified_scale_groups(self,
                                        model: tf.keras.Model,

--- a/nncf/tensorflow/quantization/quantizers.py
+++ b/nncf/tensorflow/quantization/quantizers.py
@@ -324,9 +324,9 @@ class SymmetricQuantizer(Quantizer):
             'signed_var': signed
         }
 
-    def apply_saturation_fix(self, weights):
+    def apply_overflow_fix(self, weights):
         if self.num_bits != 8 or not self._half_range:
-            raise RuntimeError('Attempt to apply saturation issue fix '
+            raise RuntimeError('Attempt to apply overflow issue fix '
                                'to quantizer which is not configured for that.')
 
         # Multiplier to expand scale from 7 bit to 8 bit
@@ -449,9 +449,9 @@ class AsymmetricQuantizer(Quantizer):
             'input_range_var': input_range
         }
 
-    def apply_saturation_fix(self, weights):
+    def apply_overflow_fix(self, weights):
         if self.num_bits != 8 or not self._half_range:
-            raise RuntimeError('Attempt to apply saturation issue fix '
+            raise RuntimeError('Attempt to apply overflow issue fix '
                                'to quantizer which is not configured for that.')
 
         # Low value shift to expand quantize range from 7 bit to 8 bit properly

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -452,7 +452,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
             params_dict = self._algo_config.get(group_name, {})
             self._use_logarithm_scale_per_group[quantizer_group] = params_dict.get('logarithm_scale', False)
 
-        self._saturation_fix = self._algo_config.get('saturation_fix', 'enable')
+        self._overflow_fix = self._algo_config.get('overflow_fix', 'enable')
         self._device_for_callable_obj_creation = 'cpu'
         self._single_config_quantizer_setup = None  # type: Optional[SingleConfigQuantizerSetup]
 
@@ -590,7 +590,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
                 stats_for_range_init,
                 target_model_graph)
 
-        dup_filter = DuplicateFilter()  # so that the saturation fix warning is only logged once
+        dup_filter = DuplicateFilter()  # so that the overflow fix warning is only logged once
         nncf_logger.addFilter(dup_filter)
         insertion_commands, setup_to_module_id_translation_dict = \
             self._build_insertion_commands_list_for_quantizer_setup(self._single_config_quantizer_setup,
@@ -1028,19 +1028,19 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
         half_range = False
         if self.hw_config and is_weights(primary_ip):
             if self.hw_config.target_device in ['CPU', 'ANY'] and qconfig.num_bits == 8:
-                if self._saturation_fix == 'enable':
+                if self._overflow_fix == 'enable':
                     half_range = True
-                    quantizers_with_saturation_fix_str = 'all weight quantizers'
-                elif self._saturation_fix == 'enable_for_first_conv_layer':
+                    quantizers_with_overflow_fix_str = 'all weight quantizers'
+                elif self._overflow_fix == 'first_layer_only':
                     if target_node in get_first_nodes_of_type(target_model_graph, ['conv2d']):
                         half_range = True
-                        quantizers_with_saturation_fix_str = 'first convolution weight quantizers'
+                        quantizers_with_overflow_fix_str = 'first convolution weight quantizers'
                 if half_range:
-                    nncf_logger.warning('The saturation issue fix will be applied. '
+                    nncf_logger.warning('The overflow issue fix will be applied. '
                                         'Now {} will effectively use only 7 bits out of 8 bits. '
-                                        'This resolves the saturation issue problem on AVX2 and AVX-512 machines. '
+                                        'This resolves the overflow issue problem on AVX2 and AVX-512 machines. '
                                         'Please take a look at the documentation for a detailed information.'
-                                        .format(quantizers_with_saturation_fix_str))
+                                        .format(quantizers_with_overflow_fix_str))
 
         qspec = PTQuantizerSpec.from_config(qconfig,
                                             narrow_range=narrow_range,

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -1030,17 +1030,17 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
             if self.hw_config.target_device in ['CPU', 'ANY'] and qconfig.num_bits == 8:
                 if self._saturation_fix == 'enable':
                     half_range = True
-                    nncf_logger.warning('The saturation issue fix will be applied. '
-                                        'Now all weight quantizers will effectively use only 7 bits out of 8 bits. '
-                                        'This resolves the saturation issue problem on AVX2 and AVX-512 machines. '
-                                        'Please take a look at the documentation for a detailed information.')
+                    quantizers_with_saturation_fix_str = 'all weight quantizers'
                 elif self._saturation_fix == 'enable_for_first_conv_layer':
                     if target_node in get_first_nodes_of_type(target_model_graph, ['conv2d']):
                         half_range = True
-                        nncf_logger.warning('The saturation issue fix will be applied. Now first convolution '
-                                            'weight quantizers will effectively use only 7 bits out of 8 bits. '
-                                            'This resolves the saturation issue problem on AVX2 and AVX-512 machines. '
-                                            'Please take a look at the documentation for a detailed information.')
+                        quantizers_with_saturation_fix_str = 'first convolution weight quantizers'
+                if half_range:
+                    nncf_logger.warning('The saturation issue fix will be applied. '
+                                        'Now {} will effectively use only 7 bits out of 8 bits. '
+                                        'This resolves the saturation issue problem on AVX2 and AVX-512 machines. '
+                                        'Please take a look at the documentation for a detailed information.'
+                                        .format(quantizers_with_saturation_fix_str))
 
         qspec = PTQuantizerSpec.from_config(qconfig,
                                             narrow_range=narrow_range,

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -1037,7 +1037,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
                 elif self._saturation_fix == 'enable_for_first_conv_layer':
                     if target_node in get_first_nodes_of_type(target_model_graph, ['conv2d']):
                         half_range = True
-                        nncf_logger.warning('The saturation issue fix will be applied. Now first convolustion '
+                        nncf_logger.warning('The saturation issue fix will be applied. Now first convolution '
                                             'weight quantizers will effectively use only 7 bits out of 8 bits. '
                                             'This resolves the saturation issue problem on AVX2 and AVX-512 machines. '
                                             'Please take a look at the documentation for a detailed information.')

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -452,6 +452,9 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
             self._use_logarithm_scale_per_group[quantizer_group] = params_dict.get('logarithm_scale', False)
 
         self._disable_saturation_fix = self._algo_config.get('disable_saturation_fix', False)
+        self._applied_saturation_fix = False
+        self._apply_saturation_fix_only_to_first_layer = self._algo_config.get(
+            'apply_saturation_fix_only_to_first_layer', False)
         self._device_for_callable_obj_creation = 'cpu'
         self._single_config_quantizer_setup = None  # type: Optional[SingleConfigQuantizerSetup]
 
@@ -1032,6 +1035,9 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
                                     'This resolves the saturation issue problem on AVX2 and AVX-512 machines. '
                                     'Please take a look at the documentation for a detailed information.')
                 half_range = True
+                if self._apply_saturation_fix_only_to_first_layer:
+                    half_range = half_range and not self._applied_saturation_fix
+                self._applied_saturation_fix = True
 
         qspec = PTQuantizerSpec.from_config(qconfig,
                                             narrow_range=narrow_range,

--- a/tests/tensorflow/quantization/test_algorithm_quantization.py
+++ b/tests/tensorflow/quantization/test_algorithm_quantization.py
@@ -168,10 +168,7 @@ def test_export_saturation_fix(sf_mode):
     config['compression'].update({
         'saturation_fix': sf_mode
     })
-    if sf_mode in ['enable', 'enable_for_first_conv_layer']:
-        enabled = True
-    else:
-        enabled = False
+    enabled = sf_mode in ['enable', 'enable_for_first_conv_layer']
 
     compression_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config, force_no_init=True)
     activation_quantizers_be, weight_quantizers_be = get_quantizers(compression_model)
@@ -196,10 +193,7 @@ def test_export_saturation_fix(sf_mode):
     for wq in activation_quantizers_be:
         compare_qspecs(ref_activation_qspec, wq)
 
-    if sf_mode in ['enable', 'enable_for_first_conv_layer']:
-        enabled = True
-    else:
-        enabled = False
+    enabled = sf_mode in ['enable', 'enable_for_first_conv_layer']
     compression_ctrl.export_model('/tmp/test.pb')
     activation_quantizers_ae, weight_quantizers_ae = get_quantizers(compression_model)
 

--- a/tests/tensorflow/quantization/test_builder_state.py
+++ b/tests/tensorflow/quantization/test_builder_state.py
@@ -95,7 +95,7 @@ def test_quantization_configs__disable_saturation_fix_and_resume_from_compressio
 
     config = get_basic_quantization_config()
     config['compression'].update({
-        'disable_saturation_fix': True
+        'saturation_fix': 'disable'
     })
     compression_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config, force_no_init=True)
 

--- a/tests/tensorflow/quantization/test_builder_state.py
+++ b/tests/tensorflow/quantization/test_builder_state.py
@@ -39,7 +39,7 @@ from tests.common.serialization import check_serialization
 from tests.tensorflow.helpers import create_compressed_model_and_algo_for_test
 from tests.tensorflow.helpers import get_basic_conv_test_model
 from tests.tensorflow.quantization.test_algorithm_quantization import check_default_qspecs
-from tests.tensorflow.quantization.test_algorithm_quantization import check_specs_for_disabled_saturation_fix
+from tests.tensorflow.quantization.test_algorithm_quantization import check_specs_for_disabled_overflow_fix
 from tests.tensorflow.quantization.utils import get_basic_quantization_config
 from tests.tensorflow.test_bn_adaptation import get_dataset_for_test
 from tests.tensorflow.test_callbacks import REF_CKPT_DIR
@@ -90,12 +90,12 @@ def _save_and_load_compression_state(compression_ctrl, tmp_path):
     return compression_state
 
 
-def test_quantization_configs__disable_saturation_fix_and_resume_from_compression_state(tmp_path):
+def test_quantization_configs__disable_overflow_fix_and_resume_from_compression_state(tmp_path):
     model = get_basic_conv_test_model()
 
     config = get_basic_quantization_config()
     config['compression'].update({
-        'saturation_fix': 'disable'
+        'overflow_fix': 'disable'
     })
     compression_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config, force_no_init=True)
 
@@ -104,7 +104,7 @@ def test_quantization_configs__disable_saturation_fix_and_resume_from_compressio
     compression_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config,
                                                                                     compression_state_to_load)
     assert isinstance(compression_ctrl, QuantizationController)
-    check_specs_for_disabled_saturation_fix(compression_model)
+    check_specs_for_disabled_overflow_fix(compression_model)
 
 
 def test_checkpoint_callback_make_checkpoints(mocker, tmp_path):

--- a/tests/torch/pruning/test_utils.py
+++ b/tests/torch/pruning/test_utils.py
@@ -14,7 +14,7 @@ import pytest
 
 from nncf.torch.pruning.filter_pruning.algo import FilterPruningBuilder
 from nncf.common.pruning.utils import get_rounded_pruned_element_number
-from nncf.common.pruning.utils import get_first_nodes_of_type
+from nncf.common.graph.utils import get_first_nodes_of_type
 from nncf.common.pruning.utils import get_last_nodes_of_type
 from nncf.torch.pruning.utils import get_bn_for_conv_node_by_name
 from tests.torch.pruning.helpers import get_basic_pruning_config, BigPruningTestModel, \

--- a/tests/torch/test_utils.py
+++ b/tests/torch/test_utils.py
@@ -9,7 +9,7 @@ from nncf.torch.layer_utils import CompressionParameter
 from nncf.torch.initialization import DataLoaderBNAdaptationRunner
 
 from tests.torch.helpers import BasicConvTestModel, TwoConvTestModel, MockModel
-from tests.torch.quantization.test_saturation_issue_export import DepthWiseConvTestModel, EightConvTestModel
+from tests.torch.quantization.test_overflow_issue_export import DepthWiseConvTestModel, EightConvTestModel
 # pylint:disable=unused-import
 from tests.torch.modules.test_rnn import _seed
 


### PR DESCRIPTION
### Changes

<!--- What was changed (briefly), how to reproduce (if applicable), what the reviewers should focus on -->
New config option "saturation_fix" was introduced. Which have choices for SF mode: `disable`, `enable`, `enable_for_first_conv_layer`. `enable` is the default option.
### Reason for changes

<!--- Why should the change be applied -->
In order to short the tuning time and at the same time partially compensate for the saturation issue by using `enable_for_first_conv_layer` option.
### Related tickets

<!--- Post the numerical ID of the ticket, if available -->
71400
### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
Tests are updated to validate all three options.