### PR TITLE
Fix merging quantaizers

### DIFF
--- a/nncf/common/quantization/quantizer_propagation/graph.py
+++ b/nncf/common/quantization/quantizer_propagation/graph.py
@@ -301,6 +301,7 @@ class QuantizerPropagationStateGraph(nx.DiGraph):
             major_unified_scale_type = UnifiedScaleType.UNIFY_ONLY_PER_TENSOR
         return major_unified_scale_type
 
+    # pylint:disable=too-many-statements
     def merge_quantizers_for_branching_node(self, quantizers_to_merge: List[PropagatingQuantizer],
                                             merged_qconf_list: List[QuantizerConfig],
                                             branch_qconf_lists: List[Optional[List[QuantizerConfig]]],
@@ -334,7 +335,7 @@ class QuantizerPropagationStateGraph(nx.DiGraph):
             return []
 
         unified_scale_types_of_merged_branches = [pq.unified_scale_type for idx, pq in enumerate(quantizers_to_merge)
-                                      if branch_qconf_lists[idx] is None]
+                                                  if branch_qconf_lists[idx] is None]
         merge_pq_unified_scale_type = self._get_major_unified_scale_type(unified_scale_types_of_merged_branches)
 
         merge_gid = None
@@ -567,7 +568,7 @@ class QuantizerPropagationStateGraph(nx.DiGraph):
         if target_node_affecting_quantizers:
             raise RuntimeError("Cannot register a propagating quantizer into a node that is already "
                                "affected by existing propagating quantizers (ids: {})!".format(
-                [pq.id for pq in target_node_affecting_quantizers]))
+                                   [pq.id for pq in target_node_affecting_quantizers]))
 
         self._verify_nodes_and_edges_for_pq(prop_quantizer)
 

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -50,9 +50,9 @@ class PTOperatorMetatype(OperatorMetatype):
 
     # Names of functions from 'torch.nn.function', 'torch.tensor' and 'torch' modules respectively,
     # which are associated with this metatype.
-    module_to_function_names = {NamespaceTarget.TORCH_NN_FUNCTIONAL: [],  # type: Dict[NamespaceTarget, List[str]]
+    module_to_function_names = {NamespaceTarget.TORCH_NN_FUNCTIONAL: [],
                                 NamespaceTarget.TORCH_TENSOR: [],
-                                NamespaceTarget.TORCH: []}
+                                NamespaceTarget.TORCH: []}  # type: Dict[NamespaceTarget, List[str]]
 
     subtypes = []  # type: List[Type[OperatorMetatype]]
 

--- a/tests/torch/quantization/test_quantizer_propagation_graph.py
+++ b/tests/torch/quantization/test_quantizer_propagation_graph.py
@@ -29,22 +29,26 @@ from nncf.common.graph import NNCFNodeName
 from nncf.common.insertion_point_graph import InsertionPointGraph
 from nncf.common.insertion_point_graph import PostHookInsertionPoint
 from nncf.common.insertion_point_graph import PreHookInsertionPoint
-from nncf.common.quantization.quantizer_propagation.structs import PropagationPath
 from nncf.common.quantization.quantizer_propagation.graph import QuantizerPropagationStateGraph as QPSG
+from nncf.common.quantization.quantizer_propagation.structs import PropagatingQuantizer
+from nncf.common.quantization.quantizer_propagation.structs import PropagationPath
 from nncf.common.quantization.quantizer_propagation.structs import QuantizationTrait
 from nncf.common.quantization.quantizer_propagation.structs import QuantizerPropagationStateGraphNodeType
 from nncf.common.quantization.quantizer_setup import ActivationQuantizationInsertionPoint
 from nncf.common.quantization.quantizer_setup import MultiConfigQuantizationPoint
 from nncf.common.quantization.quantizer_setup import MultiConfigQuantizerSetup
 from nncf.common.quantization.quantizer_setup import WeightQuantizationInsertionPoint
+
 from nncf.common.quantization.structs import QuantizationMode
 from nncf.common.quantization.structs import QuantizerConfig
+from nncf.common.quantization.structs import UnifiedScaleType
 from nncf.torch.graph.operator_metatypes import PTCatMetatype
 from tests.torch.test_nncf_network import get_ip_graph_for_test
 from tests.torch.test_nncf_network import get_mock_nncf_node_attrs
 from tests.torch.test_nncf_network import get_nncf_graph_from_mock_nx_graph
 from tests.torch.test_nncf_network import get_two_branch_mock_model_graph
 from tests.torch.test_nncf_network import mark_input_ports_lexicographically_based_on_input_node_key
+
 
 
 #pylint:disable=too-many-lines
@@ -1070,6 +1074,87 @@ class TestRedundantQuantizerMerge:
             assert pq.current_location_node_key in ref_remaining_pq_positions
 
         assert len(remaining_pqs) == len(ref_remaining_pq_positions)
+
+
+class TestUnifinedScaleTypeAfterMergeQuantizers:
+    @staticmethod
+    def get_merged_pq(qpsg: QPSG) -> PropagatingQuantizer:
+
+        pq_1 = qpsg.add_propagating_quantizer([QuantizerConfig(per_channel=True)],
+                                              InsertionPointGraph.get_pre_hook_node_key('4 /E_0', input_port_id=0),
+                                              unified_scale_type=UnifiedScaleType.UNIFY_ALWAYS)
+        g_id = qpsg.get_unified_scale_group_id_by_propagating_quantizer_id(pq_1.id)
+        pq_2 = qpsg.add_propagating_quantizer([QuantizerConfig(per_channel=True)],
+                                              InsertionPointGraph.get_pre_hook_node_key('4 /E_0', input_port_id=1),
+                                              unified_scale_type=UnifiedScaleType.UNIFY_ALWAYS,
+                                              unified_scale_group_id_override=g_id)
+
+
+        paths_1 = get_edge_paths_for_propagation(qpsg,
+                                                 InsertionPointGraph.get_pre_hook_node_key('2 /C_0'),
+                                                 InsertionPointGraph.get_pre_hook_node_key('4 /E_0', input_port_id=0))
+
+        paths_2 = get_edge_paths_for_propagation(qpsg,
+                                                 InsertionPointGraph.get_pre_hook_node_key('3 /D_0'),
+                                                 InsertionPointGraph.get_pre_hook_node_key('4 /E_0', input_port_id=1))
+
+        qpsg.propagate_quantizer_via_path(pq_1, paths_1[0])
+        qpsg.propagate_quantizer_via_path(pq_2, paths_2[0])
+
+        merged_qp = qpsg.merge_quantizers_for_branching_node([pq_1, pq_2],
+                                                             [QuantizerConfig(per_channel=True)],
+                                                             [None, None],
+                                                             '1 /B_0')
+
+        return merged_qp[0]
+
+    @staticmethod
+    def get_model_graph_with_split_node():
+        mock_graph = nx.DiGraph()
+
+        #         (0 /A_0)
+        #            |
+        #         (1 /B_0)
+        #        /        \
+        #    (2 /C_0)   (3 /D_0)
+        #        \        /
+        #         (4 /E_0)
+
+        node_keys = ['A', 'B', 'C', 'D', 'E']
+        for node_key in node_keys:
+            mock_node_attrs = get_mock_nncf_node_attrs(op_name=node_key)
+            if node_key == "B":
+                # Split have no POST_HOOK
+                mock_node_attrs[NNCFGraph.NODE_TYPE_ATTR] = "split"
+            mock_graph.add_node(node_key, **mock_node_attrs)
+
+        mock_graph.add_edges_from([('A', 'B'), ('B', 'C'), ('B', 'D'), ('C', 'E'), ('D', 'E')])
+        mark_input_ports_lexicographically_based_on_input_node_key(mock_graph)
+        mock_graph = get_nncf_graph_from_mock_nx_graph(mock_graph)
+
+        ip_graph = get_ip_graph_for_test(mock_graph)
+        qpsg = QPSG(ip_graph)
+
+        operator_node_key_vs_trait_dict = {
+            '0 /A_0': QuantizationTrait.QUANTIZATION_AGNOSTIC,
+            '1 /B_0': QuantizationTrait.QUANTIZATION_AGNOSTIC,
+            '2 /C_0': QuantizationTrait.INPUTS_QUANTIZABLE,
+            '3 /D_0': QuantizationTrait.CONCAT,
+            '4 /E_0': QuantizationTrait.QUANTIZATION_AGNOSTIC,
+        }
+        model_graph_qpsg = TestQuantizerPropagationStateGraph.mark_nodes_with_traits(
+            qpsg, operator_node_key_vs_trait_dict
+        )
+        return model_graph_qpsg
+
+
+    def test_unifined_scale_type_for_split_node(self):
+
+        model_graph_qpsg = self.get_model_graph_with_split_node()
+        merged_pq = self.get_merged_pq(model_graph_qpsg)
+
+        assert merged_pq.unified_scale_type == UnifiedScaleType.UNIFY_ALWAYS
+
 
 def create_graph_for_output_quant_as_weights() -> NNCFGraph:
     mock_graph = nx.DiGraph()

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -903,8 +903,9 @@ def get_ip_graph_for_test(nncf_graph: NNCFGraph,
             ip = PreHookInsertionPoint(node.node_name, in_edge.input_port_id)
             pre_hooks.append(ip)
 
-        ip = PostHookInsertionPoint(node.node_name)
-        post_hooks.append(ip)
+        if node.node_type != 'split':
+            ip = PostHookInsertionPoint(node.node_name)
+            post_hooks.append(ip)
     weighted_target_points = None
     if weighted_node_names is not None:
         weighted_target_points = []

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -33,6 +33,7 @@ from nncf.common.graph.definitions import MODEL_INPUT_OP_NAME
 from nncf.common.graph.definitions import MODEL_OUTPUT_OP_NAME
 from nncf.common.graph.layer_attributes import ConvolutionLayerAttributes
 from nncf.common.graph.layer_attributes import Dtype
+from nncf.common.graph.operator_metatypes import UnknownMetatype
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.transformations.commands import TransformationPriority
 from nncf.common.insertion_point_graph import InsertionPointGraph
@@ -48,9 +49,9 @@ from nncf.torch.graph.graph import PTNNCFGraph
 from nncf.torch.graph.graph_builder import GraphBuilder
 from nncf.torch.graph.operator_metatypes import PTInputNoopMetatype
 from nncf.torch.graph.operator_metatypes import PTOutputNoopMetatype
-from nncf.common.graph.operator_metatypes import UnknownMetatype
-from nncf.torch.graph.operator_metatypes import PT_OPERATOR_METATYPES
 from nncf.torch.graph.operator_metatypes import PTReshapeMetatype
+from nncf.torch.graph.operator_metatypes import PTSplitMetatype
+from nncf.torch.graph.operator_metatypes import PT_OPERATOR_METATYPES
 from nncf.torch.graph.transformations.commands import PTInsertionCommand
 from nncf.torch.graph.transformations.commands import PTTargetPoint
 from nncf.torch.graph.transformations.layout import PTTransformationLayout
@@ -62,6 +63,7 @@ from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.nncf_network import PTInsertionPoint
 from nncf.torch.nncf_network import PTInsertionType
 from nncf.torch.nncf_network import PTModelTransformer
+
 from tests.common.helpers import TEST_ROOT
 from tests.torch.composite.test_sparsity_quantization import get_basic_sparsity_plus_quantization_config
 from tests.torch.helpers import BasicConvTestModel
@@ -903,9 +905,11 @@ def get_ip_graph_for_test(nncf_graph: NNCFGraph,
             ip = PreHookInsertionPoint(node.node_name, in_edge.input_port_id)
             pre_hooks.append(ip)
 
-        if node.node_type != 'split':
-            ip = PostHookInsertionPoint(node.node_name)
-            post_hooks.append(ip)
+        if issubclass(node.metatype, PTSplitMetatype):
+            continue
+        ip = PostHookInsertionPoint(node.node_name)
+        post_hooks.append(ip)
+
     weighted_target_points = None
     if weighted_node_names is not None:
         weighted_target_points = []


### PR DESCRIPTION
### Changes

Change merging qunatizers logic for pre_hooks. 

### Reason for changes

```python
  File "nncf/common/quantization/quantizer_propagation/solver.py", line 355, in run_on_ip_graph
    quantizer_setup = quant_prop_graph.create_quantizer_setup(self._weight_quantizable_node_names_vs_qconfigs)
  File "nncf/common/quantization/quantizer_propagation/graph.py", line 1115, in create_quantizer_setup
    setup.register_unified_scale_group_with_types([pqid_vs_qpid[pq.id] for pq in pq_set],
  File "nncf/common/quantization/quantizer_propagation/graph.py", line 1115, in <listcomp>
    setup.register_unified_scale_group_with_types([pqid_vs_qpid[pq.id] for pq in pq_set],
KeyError: 1193
```

For subgraph with split/chunk node that does not have POST_HOOK.  
```
         (add)
           |
        (split)
      /         \
  (conv)   (conv/concat)
```

It happened because `unified_scale_type` and `unified_scale_group_id_override` was not set for `merge_pq` in case of merging in PRE_HOOK.

### Related tickets

72029

### Tests

Added `TestUnifinedScaleTypeAfterMergeQuantizers` that check unified_scale_type for QP after merge branches.
