### PR TITLE
Execute buffer-examining operations without ONNX tracing

### DIFF
--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -131,7 +131,8 @@ class BaseQuantizer(nn.Module):
         raise NotImplementedError
 
     def is_enabled_quantization(self):
-        return self.enabled[0] == 1
+        with no_jit_trace():
+            return self.enabled[0].item() == 1
 
     def enable_quantization(self):
         self.enabled[0] = 1
@@ -201,7 +202,8 @@ class BaseQuantizer(nn.Module):
 
     @property
     def num_bits(self):
-        return self._num_bits.item()
+        with no_jit_trace():
+            return self._num_bits.item()
 
     @num_bits.setter
     def num_bits(self, num_bits: int):
@@ -411,7 +413,8 @@ class SymmetricQuantizer(BaseQuantizer):
 
     @property
     def signed(self):
-        return self.signed_tensor.item() == 1
+        with no_jit_trace():
+            return self.signed_tensor.item() == 1
 
     @signed.setter
     def signed(self, signed: bool):


### PR DESCRIPTION
### Changes

`is_enabled_quantization`, `signed_tensor` and other ops that get a constant value from a buffer now execute outside ONNX JIT trace, if currently tracing.

### Reason for changes

Allows to suppress warnings frequently seen during export:
```
/home/alexsu/work/projects/algo/nncf_tf/source/nncf-tf/github/nncf/nncf/torch/quantization/layers.py:148: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  if not self.is_enabled_quantization():
```
, improving UX.

### Related tickets

N/A

### Tests

Manual export runs using samples.