### PR TITLE
Add ReLU6-based HSwish to fused patterns

### DIFF
--- a/nncf/tensorflow/graph/patterns.py
+++ b/nncf/tensorflow/graph/patterns.py
@@ -30,16 +30,19 @@ def create_h_sigmoid_act() -> GraphPattern:
 
 
 def create_h_swish_act() -> GraphPattern:
-    pattern = GraphPattern()
-
-    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
-
     # TODO (vshampor): current approach with join_patterns is deficient since it does not allow to reliably
     #  connect nodes after a pattern has been joined. Along with the label and the type, the nodes created
     #  in the pattern must allow a "name" or "address" attribute, which must be a unique human readable
     #  string identifier of the node even if it has been joined multiple times, or perhaps each pattern
     #  after joining must return a list of output nodes so that these can be joined to later.
     #  Currently cannot specify h_swish in terms of h_sigmoid due to this.
+
+    main_pattern = GraphPattern()
+
+    # ReLU version
+    pattern = GraphPattern()
+    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
+
     add_node = pattern.add_node(label='ADD', type='AddV2')
     relu_node = pattern.add_node(label='RELU', type='ReLU')
     mul_node = pattern.add_node(label='TF_OP_MUL', type='Mul')
@@ -51,5 +54,23 @@ def create_h_swish_act() -> GraphPattern:
     mul_2_node = pattern.add_node(label='MULTIPLY', type='Multiply')
     pattern.add_edge(input_pattern_node, mul_2_node)
     pattern.add_edge(mul_node, mul_2_node)
+    main_pattern.add_pattern_alternative(pattern)
 
-    return pattern
+    # ReLU6 version
+    pattern = GraphPattern()
+    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
+
+    add_node = pattern.add_node(label='ADD', type='AddV2')
+    relu6_node = pattern.add_node(label='RELU6', type='Relu6')
+    mul_node = pattern.add_node(label='TF_OP_MUL', type='Mul')
+
+    pattern.add_edge(input_pattern_node, add_node)
+    pattern.add_edge(add_node, relu6_node)
+    pattern.add_edge(relu6_node, mul_node)
+
+    mul_2_node = pattern.add_node(label='MULTIPLY', type='Multiply')
+    pattern.add_edge(input_pattern_node, mul_2_node)
+    pattern.add_edge(mul_node, mul_2_node)
+    main_pattern.add_pattern_alternative(pattern)
+
+    return main_pattern

--- a/nncf/torch/graph/patterns.py
+++ b/nncf/torch/graph/patterns.py
@@ -29,6 +29,7 @@ def create_swish_act() -> GraphPattern:
 def create_h_swish_act() -> GraphPattern:
     main_pattern = GraphPattern()
 
+    # Mul -> Div version
     pattern = GraphPattern()
     input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
     add_node = pattern.add_node(label='ADD', type='__add__')
@@ -41,9 +42,9 @@ def create_h_swish_act() -> GraphPattern:
     pattern.add_edge(add_node, hardtanh_node)
     pattern.add_edge(hardtanh_node, truediv_node)
     pattern.add_edge(truediv_node, mul_node)
-
     main_pattern.add_pattern_alternative(pattern)
 
+    # Div -> Mul version
     pattern = GraphPattern()
     input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
     add_node = pattern.add_node(label='ADD', type='__add__')
@@ -57,6 +58,38 @@ def create_h_swish_act() -> GraphPattern:
     pattern.add_edge(hardtanh_node, mul_node)
     pattern.add_edge(mul_node, truediv_node)
     main_pattern.add_pattern_alternative(pattern)
+
+    # ReLU6 version - Mul -> Div
+    pattern = GraphPattern()
+    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
+    add_node = pattern.add_node(label='ADD', type='__add__')
+    relu6_node = pattern.add_node(label='RELU6', type='relu6')
+    mul_node = pattern.add_node(label='MUL', type='__mul__')
+    truediv_node = pattern.add_node(label='DIV', type='__truediv__')
+
+    pattern.add_edge(input_pattern_node, add_node)
+    pattern.add_edge(input_pattern_node, mul_node)
+    pattern.add_edge(add_node, relu6_node)
+    pattern.add_edge(hardtanh_node, mul_node)
+    pattern.add_edge(mul_node, truediv_node)
+    main_pattern.add_pattern_alternative(pattern)
+
+    # ReLU6 version - Div -> Mul
+    pattern = GraphPattern()
+    input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
+    add_node = pattern.add_node(label='ADD', type='__add__')
+    relu6_node = pattern.add_node(label='RELU6', type='relu6')
+    truediv_node = pattern.add_node(label='DIV', type='__truediv__')
+    mul_node = pattern.add_node(label='MUL', type='__mul__')
+
+    pattern.add_edge(input_pattern_node, add_node)
+    pattern.add_edge(input_pattern_node, mul_node)
+    pattern.add_edge(add_node, relu6_node)
+    pattern.add_edge(relu6_node, truediv_node)
+    pattern.add_edge(truediv_node, mul_node)
+
+    main_pattern.add_pattern_alternative(pattern)
+
     return main_pattern
 
 
@@ -65,7 +98,7 @@ def create_h_sigmoid_act() -> GraphPattern:
 
     input_pattern_node = pattern.add_node(label='*INPUT_NODE*', type=GraphPattern.NON_PATTERN_NODE_TYPE)
     add_node = pattern.add_node(label='ADD', type='__add__')
-    hardtanh_node = pattern.add_node(label='HARTANH', type='hardtanh')
+    hardtanh_node = pattern.add_node(label='HARDTANH', type='hardtanh')
     truediv_node = pattern.add_node(label='DIV', type='__truediv__')
 
     pattern.add_edge(input_pattern_node, add_node)

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/ConvRelu6HSwish.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/ConvRelu6HSwish.dot
@@ -1,0 +1,20 @@
+strict digraph  {
+"0 /nncf_model_input_0" [id=0, type=nncf_model_input];
+"1 SymmetricQuantizer/symmetric_quantize_0" [id=1, type=symmetric_quantize];
+"2 ConvRelu6HSwish/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" [id=2, type=symmetric_quantize];
+"3 ConvRelu6HSwish/NNCFConv2d[conv]/conv2d_0" [id=3, type=conv2d];
+"4 ConvRelu6HSwish/__add___0" [id=4, type=__add__];
+"5 ConvRelu6HSwish/relu6_0" [id=5, type=relu6];
+"6 ConvRelu6HSwish/__mul___0" [id=6, type=__mul__];
+"7 ConvRelu6HSwish/__truediv___0" [id=7, type=__truediv__];
+"8 /nncf_model_output_0" [id=8, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
+"1 SymmetricQuantizer/symmetric_quantize_0" -> "3 ConvRelu6HSwish/NNCFConv2d[conv]/conv2d_0";
+"2 ConvRelu6HSwish/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" -> "3 ConvRelu6HSwish/NNCFConv2d[conv]/conv2d_0";
+"3 ConvRelu6HSwish/NNCFConv2d[conv]/conv2d_0" -> "4 ConvRelu6HSwish/__add___0";
+"3 ConvRelu6HSwish/NNCFConv2d[conv]/conv2d_0" -> "6 ConvRelu6HSwish/__mul___0";
+"4 ConvRelu6HSwish/__add___0" -> "5 ConvRelu6HSwish/relu6_0";
+"5 ConvRelu6HSwish/relu6_0" -> "6 ConvRelu6HSwish/__mul___0";
+"6 ConvRelu6HSwish/__mul___0" -> "7 ConvRelu6HSwish/__truediv___0";
+"7 ConvRelu6HSwish/__truediv___0" -> "8 /nncf_model_output_0";
+}

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -21,6 +21,7 @@ from typing import Callable, Dict, List, Tuple, Union
 import networkx as nx
 import pytest
 import torch
+from tests.torch.test_models.synthetic import ConvRelu6HSwish
 from tests.torch.test_models.synthetic import MatMulDivConv
 from torch import nn
 import torch.nn.functional as F
@@ -710,7 +711,7 @@ SYNTHETIC_MODEL_DESC_LIST = [
     SingleLayerModelDesc(model_name='pixel_shuffle', layer=partial(F.pixel_shuffle, upscale_factor=1),
                          input_sample_sizes=([1, 1, 1, 1])),
 
-    GeneralModelDesc(model_builder=ManyNonEvalModules, input_sample_sizes=([1, 1, 1, 1])),
+    GeneralModelDesc(model_builder=ManyNonEvalModules, input_sample_sizes=([1, 1, 1, 1],)),
     GeneralModelDesc(model_builder=EmbeddingSumModel, input_info={"sample_size": [1, 1],
                                                                   "type": "long",
                                                                   "filler": "zeros"}),
@@ -718,7 +719,8 @@ SYNTHETIC_MODEL_DESC_LIST = [
                                                                   "type": "long",
                                                                   "filler": "zeros"}),
     GeneralModelDesc(model_builder=MultiOutputSameTensorModel),
-    GeneralModelDesc(model_builder=MatMulDivConv, input_sample_sizes=([1, 1, 5, 5], [1, 1, 5, 5]))
+    GeneralModelDesc(model_builder=MatMulDivConv, input_sample_sizes=([1, 1, 5, 5], [1, 1, 5, 5])),
+    GeneralModelDesc(model_builder=ConvRelu6HSwish, input_sample_sizes=([1, 1, 5, 5],))
 ]
 
 

--- a/tests/torch/test_models/synthetic.py
+++ b/tests/torch/test_models/synthetic.py
@@ -241,3 +241,17 @@ class MatMulDivConv(nn.Module):
     def forward(self, x: torch.Tensor, y: torch.Tensor):
         z = torch.matmul(x, y) / 2
         return self.conv(z)
+
+
+class ConvRelu6HSwish(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = create_conv(1, 2, 2, 2)
+
+    @staticmethod
+    def _hswish(x: torch.Tensor) -> torch.Tensor:
+        return x * torch.nn.functional.relu6(x + 3) / 6
+
+    def forward(self, x: torch.Tensor):
+        z = self.conv(x)
+        return self._hswish(z)


### PR DESCRIPTION
### Changes

As stated in the title.

### Reason for changes

Certain MobileNetV3 variations in PyTorch use an explicit custom HSwish module instead of the `hardswish` function from torch.nn.functional, and this custom module uses ReLU6 internally.

### Related tickets

74044

### Tests

Extended tests.torch.test_compressed_graph.test_synthetic_model_quantization, created ticket 74092 for the TF implementation of synthetic tests in bulk.
