### PR TITLE
Fix wrapping group_norm

### DIFF
--- a/nncf/torch/layers.py
+++ b/nncf/torch/layers.py
@@ -145,7 +145,10 @@ class NNCFGroupNorm(_NNCFModuleMixin, nn.GroupNorm):
     def from_module(module):
         assert module.__class__.__name__ == nn.GroupNorm.__name__
 
-        nncf_bn = NNCFGroupNorm(module.num_features)
+        nncf_bn = NNCFGroupNorm(num_groups=module.num_groups,
+                                num_channels=module.num_channels,
+                                eps=module.eps,
+                                affine=module.affine)
         dict_update(nncf_bn.__dict__, module.__dict__)
         return nncf_bn
 

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/GroupNorm.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/GroupNorm.dot
@@ -1,0 +1,9 @@
+strict digraph  {
+"0 /nncf_model_input_0" [id=0, type=nncf_model_input];
+"1 SymmetricQuantizer/symmetric_quantize_0" [id=1, type=symmetric_quantize];
+"2 TestModel/NNCFGroupNorm[_layer]/group_norm_0" [id=2, type=group_norm];
+"3 /nncf_model_output_0" [id=3, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
+"1 SymmetricQuantizer/symmetric_quantize_0" -> "2 TestModel/NNCFGroupNorm[_layer]/group_norm_0";
+"2 TestModel/NNCFGroupNorm[_layer]/group_norm_0" -> "3 /nncf_model_output_0";
+}

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -641,6 +641,8 @@ SYNTHETIC_MODEL_DESC_LIST = [
     SingleLayerModelDesc(layer=nn.BatchNorm2d(1), input_sample_sizes=([2, 1, 1, 1])),
     SingleLayerModelDesc(layer=nn.BatchNorm3d(1), input_sample_sizes=([2, 1, 1, 1, 1])),
 
+    SingleLayerModelDesc(layer=nn.GroupNorm(2, 4), input_sample_sizes=([2, 4, 1, 1])),
+
     SingleLayerModelDesc(layer=nn.AvgPool2d(1), input_sample_sizes=[1, 1, 1]),
     SingleLayerModelDesc(layer=nn.AdaptiveAvgPool2d(1), input_sample_sizes=[1, 1, 1]),
     SingleLayerModelDesc(layer=nn.AvgPool3d(1), input_sample_sizes=[1, 1, 1, 1]),


### PR DESCRIPTION
### Changes

Fix wrapping `nn.GroupNorm`

### Reason for changes


```bash
  "nncf/torch/layers.py", line 148, in from_module
  nncf_bn = NNCFGroupNorm(module.num_features)
  File "torch/nn/modules/module.py", line 947, in __getattr__
  raise AttributeError("'{}' object has no attribute '{}'".format(
  AttributeError: 'GroupNorm' object has no attribute 'num_features'
```

### Related tickets

<!--- Post the numerical ID of the ticket, if available -->

### Tests

 Add test GroupNorm in `test_synthetic_model_quantization`
