### PR TITLE
Add NNCF repo commit hash to developer versions of the package

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -39,5 +39,13 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python setup.py sdist bdist_wheel --release
+
+        # Disallow uploading dev packages
+        for file in dist; do
+          if [[$file == *"dev"* ]]; then
+             exit 42
+          fi
+        done
+
         twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,12 @@ if "--tf" in sys.argv:
         ))
 
 
+is_installing_editable = "develop" in sys.argv
+is_building_release = not is_installing_editable and "--release" in sys.argv
+if "--release" in sys.argv:
+    sys.argv.remove("--release")
+
+
 def read(*parts):
     with codecs.open(os.path.join(here, *parts), 'r') as fp:
         return fp.read()
@@ -47,9 +53,24 @@ def find_version(*file_paths):
     version_file = read(*file_paths)
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
                               version_file, re.M)
-    if version_match:
-        return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
+    if not version_match:
+        raise RuntimeError("Unable to find version string.")
+    version_value = version_match.group(1)
+    if not is_building_release:
+        if is_installing_editable:
+            return version_value + ".dev-editable"
+        import subprocess
+        dev_version_id = "unknown_version"
+        try:
+            repo_root = os.path.dirname(os.path.realpath(__file__))
+            dev_version_id = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"],
+                                                     cwd=repo_root).strip().decode()
+        except subprocess.CalledProcessError:
+            pass
+        return version_value + f".dev-{dev_version_id}"
+
+    return version_value
+
 
 INSTALL_REQUIRES = ["ninja>=1.10.0.post2",
                     "addict>=2.4.0",


### PR DESCRIPTION
### Changes

Now any version of the NNCF package set up in an editable mode will have "dev-editable" appended to its version; otherwise, if the package is built/installed via setup.py without passing a "--release" argument, the "dev-_hash of the current repo_" commit will be appended to the package version.

### Reason for changes

This allows for more accountability as to which NNCF version is used where.

### Related tickets

74164

### Tests

test_install (to be run)
