### PR TITLE
Make dev versions conform to PEP 440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def find_version(*file_paths):
     version_value = version_match.group(1)
     if not is_building_release:
         if is_installing_editable:
-            return version_value + ".dev-editable"
+            return version_value + ".dev0+editable"
         import subprocess
         dev_version_id = "unknown_version"
         try:
@@ -67,7 +67,7 @@ def find_version(*file_paths):
                                                      cwd=repo_root).strip().decode()
         except subprocess.CalledProcessError:
             pass
-        return version_value + f".dev-{dev_version_id}"
+        return version_value + f".dev0+{dev_version_id}"
 
     return version_value
 

--- a/tests/common/helpers.py
+++ b/tests/common/helpers.py
@@ -11,22 +11,26 @@
  limitations under the License.
 """
 
-from abc import ABC
-from abc import abstractmethod
-from pathlib import Path
-
-import numpy as np
 import os
-from typing import Callable, List, TypeVar, Union
 import shutil
 import subprocess
 import sys
+from abc import ABC
+from abc import abstractmethod
+from pathlib import Path
+from typing import Callable
+from typing import List
+from typing import TypeVar
+from typing import Union
+
+import numpy as np
 
 TensorType = TypeVar('TensorType')
 
 TEST_ROOT = Path(__file__).absolute().parents[1]
 PROJECT_ROOT = TEST_ROOT.parent.absolute()
 EXAMPLES_DIR = PROJECT_ROOT / 'examples'
+GITHUB_REPO_URL = 'https://github.com/openvinotoolkit/nncf/'
 
 
 def get_cli_dict_args(args):
@@ -66,6 +70,15 @@ def create_venv_with_nncf(tmp_path, package_type, venv_type, extra_reqs):
     elif package_type == 'pip_e_local':
         subprocess.run(
             f'{pip_with_venv} install -e {PROJECT_ROOT}[{extra_reqs}]', check=True, shell=True)
+    elif package_type == 'pip_git_commit':
+        current_commit_sha = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"],
+                                                     cwd=PROJECT_ROOT).strip().decode()
+        subprocess.run(
+            f'{pip_with_venv} install git+{GITHUB_REPO_URL}@{current_commit_sha}#egg=nncf[{extra_reqs}]',
+            check=True, shell=True)
+    elif package_type == 'pip_git_branch':
+        subprocess.run(
+            f'{pip_with_venv} install git+{GITHUB_REPO_URL}@develop#egg=nncf[{extra_reqs}]', check=True, shell=True)
     else:
         subprocess.run(
             '{python} {nncf_repo_root}/setup.py {package_type} {options}'.format(

--- a/tests/common/helpers.py
+++ b/tests/common/helpers.py
@@ -70,13 +70,7 @@ def create_venv_with_nncf(tmp_path, package_type, venv_type, extra_reqs):
     elif package_type == 'pip_e_local':
         subprocess.run(
             f'{pip_with_venv} install -e {PROJECT_ROOT}[{extra_reqs}]', check=True, shell=True)
-    elif package_type == 'pip_git_commit':
-        current_commit_sha = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"],
-                                                     cwd=PROJECT_ROOT).strip().decode()
-        subprocess.run(
-            f'{pip_with_venv} install git+{GITHUB_REPO_URL}@{current_commit_sha}#egg=nncf[{extra_reqs}]',
-            check=True, shell=True)
-    elif package_type == 'pip_git_branch':
+    elif package_type == 'pip_git_develop':
         subprocess.run(
             f'{pip_with_venv} install git+{GITHUB_REPO_URL}@develop#egg=nncf[{extra_reqs}]', check=True, shell=True)
     else:

--- a/tests/tensorflow/test_install.py
+++ b/tests/tensorflow/test_install.py
@@ -26,7 +26,7 @@ def venv_type_(request):
 
 @pytest.fixture(name="package_type",
                 params=["install", "develop", "sdist", "bdist_wheel",
-                        "pip_pypi", "pip_local", "pip_e_local"])
+                        "pip_pypi", "pip_local", "pip_e_local", "pip_git_commit", "pip_git_branch"])
 def package_type_(request):
     return request.param
 

--- a/tests/tensorflow/test_install.py
+++ b/tests/tensorflow/test_install.py
@@ -26,7 +26,7 @@ def venv_type_(request):
 
 @pytest.fixture(name="package_type",
                 params=["install", "develop", "sdist", "bdist_wheel",
-                        "pip_pypi", "pip_local", "pip_e_local", "pip_git_commit", "pip_git_branch"])
+                        "pip_pypi", "pip_local", "pip_e_local", "pip_git_develop"])
 def package_type_(request):
     return request.param
 

--- a/tests/torch/test_install.py
+++ b/tests/torch/test_install.py
@@ -23,7 +23,7 @@ def venv_type_(request):
 
 @pytest.fixture(name="package_type",
                 params=["install", "develop", "sdist", "bdist_wheel",
-                        "pip_pypi", "pip_local", "pip_e_local", "pip_git_commit", "pip_git_branch"])
+                        "pip_pypi", "pip_local", "pip_e_local", "pip_git_develop"])
 def package_type_(request):
     return request.param
 

--- a/tests/torch/test_install.py
+++ b/tests/torch/test_install.py
@@ -23,7 +23,7 @@ def venv_type_(request):
 
 @pytest.fixture(name="package_type",
                 params=["install", "develop", "sdist", "bdist_wheel",
-                        "pip_pypi", "pip_local", "pip_e_local"])
+                        "pip_pypi", "pip_local", "pip_e_local", "pip_git_commit", "pip_git_branch"])
 def package_type_(request):
     return request.param
 


### PR DESCRIPTION
### Changes

The '-' in dev versions containing commit hash was changed to '+'.

### Reason for changes

Previous version format was not conforming to PEP 440, and the `pip install git+` path of installation failed to install from a wheel. This was not fatal, but a nasty warning was being spawned and a deprecated installation path had to be involved.

### Related tickets

N/A

### Tests

Extended test_install with the `pip install git+` scenarios.
