### PR TITLE
Updated  Mixed-Precision models 

### DIFF
--- a/examples/torch/classification/README.md
+++ b/examples/torch/classification/README.md
@@ -78,12 +78,12 @@ To export a model to the OpenVINO IR and run it using the Intel® Deep Learning 
 |MobileNet V2|None|ImageNet|71.93|[mobilenet_v2_imagenet.json](configs/quantization/mobilenet_v2_imagenet.json)|-|
 |MobileNet V2|INT8|ImageNet|71.35 (0.58)|[mobilenet_v2_imagenet_int8.json](configs/quantization/mobilenet_v2_imagenet_int8.json)|[Link](https://storage.openvinotoolkit.org/repositories/nncf/models/develop/torch/mobilenet_v2_imagenet_int8.pth)|
 |MobileNet V2|INT8 (per-tensor only)|ImageNet|71.3 (0.63)|[mobilenet_v2_imagenet_int8_per_tensor.json](configs/quantization/mobilenet_v2_imagenet_int8_per_tensor.json)|[Link](https://storage.openvinotoolkit.org/repositories/nncf/models/develop/torch/mobilenet_v2_imagenet_int8_per_tensor.pth)|
-|MobileNet V2|Mixed, 46.6% INT8 / 53.4% INT4|ImageNet|70.92 (1.01)|[mobilenet_v2_imagenet_mixed_int_manual.json](configs/mixed_precision/mobilenet_v2_imagenet_mixed_int_manual.json)|[Link](https://storage.openvinotoolkit.org/repositories/nncf/models/develop/torch/mobilenet_v2_imagenet_int4_int8.pth)|
+|MobileNet V2|Mixed, 53.27% INT8 / 46.73% INT4|ImageNet|71.07 (0.86)|[mobilenet_v2_imagenet_mixed_int_hawq.json](configs/mixed_precision/mobilenet_v2_imagenet_mixed_int_hawq.json)|[Link](https://storage.openvinotoolkit.org/repositories/nncf/models/develop/torch/mobilenet_v2_imagenet_int4_int8.pth)|
 |MobileNet V2|INT8 + Sparsity 52% (RB)|ImageNet|71.11 (0.82)|[mobilenet_v2_imagenet_rb_sparsity_int8.json](configs/sparsity_quantization/mobilenet_v2_imagenet_rb_sparsity_int8.json)|[Link](https://storage.openvinotoolkit.org/repositories/nncf/models/develop/torch/mobilenet_v2_imagenet_rb_sparsity_int8.pth)|
 |SqueezeNet V1.1|None|ImageNet|58.24|[squeezenet1_1_imagenet.json](configs/quantization/squeezenet1_1_imagenet.json)|-|
 |SqueezeNet V1.1|INT8|ImageNet|58.28 (-0.04)|[squeezenet1_1_imagenet_int8.json](configs/quantization/squeezenet1_1_imagenet_int8.json)|[Link](https://storage.openvinotoolkit.org/repositories/nncf/models/develop/torch/squeezenet1_1_imagenet_int8.pth)|
 |SqueezeNet V1.1|INT8 (per-tensor only)|ImageNet|58.26 (-0.02)|[squeezenet1_1_imagenet_int8_per_tensor.json](configs/quantization/squeezenet1_1_imagenet_int8_per_tensor.json)|[Link](https://storage.openvinotoolkit.org/repositories/nncf/models/develop/torch/squeezenet1_1_imagenet_int8_per_tensor.pth)|
-|SqueezeNet V1.1|Mixed, 54.7% INT8 / 45.3% INT4|ImageNet|58.9 (-0.66)|[squeezenet1_1_imagenet_mixed_int_manual.json](configs/mixed_precision/squeezenet1_1_imagenet_mixed_int_manual.json)|[Link](https://storage.openvinotoolkit.org/repositories/nncf/models/develop/torch/squeezenet1_1_imagenet_int4_int8.pth)|
+|SqueezeNet V1.1|Mixed, 52.83% INT8 / 47.17% INT4|ImageNet|57.61 (0.63)|[squeezenet1_1_imagenet_mixed_int_hawq.json](configs/mixed_precision/squeezenet1_1_imagenet_mixed_int_hawq.json)|[Link](https://storage.openvinotoolkit.org/repositories/nncf/models/develop/torch/squeezenet1_1_imagenet_int4_int8.pth)|
 
 
 #### Binarization

--- a/examples/torch/classification/configs/mixed_precision/mobilenet_v2_imagenet_mixed_int_hawq_old_eval.json
+++ b/examples/torch/classification/configs/mixed_precision/mobilenet_v2_imagenet_mixed_int_hawq_old_eval.json
@@ -1,0 +1,13 @@
+{
+    "model": "mobilenet_v2",
+    "input_info": {
+        "sample_size": [1, 3, 224, 224]
+    },
+    "num_classes": 1000,
+    "batch_size": 256,
+    // to resume from state created with obsolete VPU Config (no padding adjustment)
+    "target_device": "TRIAL",
+    "compression": {
+        "algorithm": "quantization"
+    }
+}

--- a/examples/torch/classification/configs/mixed_precision/squeezenet1_1_imagenet_mixed_int_hawq_old_eval.json
+++ b/examples/torch/classification/configs/mixed_precision/squeezenet1_1_imagenet_mixed_int_hawq_old_eval.json
@@ -1,0 +1,13 @@
+{
+    "model": "squeezenet1_1",
+    "input_info": {
+        "sample_size": [1, 3, 224, 224]
+    },
+    "num_classes": 1000,
+    "batch_size": 256,
+    // to resume from state created with obsolete VPU Config (no padding adjustment)
+    "target_device": "TRIAL",
+    "compression": {
+        "algorithm": "quantization"
+    }
+}

--- a/nncf/torch/quantization/precision_init/manual_init.py
+++ b/nncf/torch/quantization/precision_init/manual_init.py
@@ -57,7 +57,7 @@ class ManualPrecisionInitializer(BasePrecisionInitializer):
                         q_configs = self._hw_precision_constraints.get(q_id)
                         matched_q_configs = list(filter(lambda x: x.num_bits == bitwidth, q_configs))
                         if not matched_q_configs:
-                            raise ValueError(msg.format(bitwidth, scope_name, q_configs))
+                            raise ValueError(msg.format(bitwidth, scope_name, list(map(str, q_configs))))
                         qp.qconfig = matched_q_configs[0]
                     else:
                         qp.qconfig.num_bits = bitwidth

--- a/tests/torch/sota_checkpoints_eval.json
+++ b/tests/torch/sota_checkpoints_eval.json
@@ -130,14 +130,14 @@
                 "diff_fp32_max": 0.15
             },
             "mobilenet_v2_imagenet_int4_int8": {
-                "config": "examples/torch/classification/configs/mixed_precision/mobilenet_v2_imagenet_mixed_int_manual.json",
+                "config": "examples/torch/classification/configs/mixed_precision/mobilenet_v2_imagenet_mixed_int_hawq_old_eval.json",
                 "reference": "mobilenet_v2_imagenet",
-                "target": 70.92,
+                "target": 71.07,
                 "metric_type": "Acc@1",
                 "resume": "mobilenet_v2_imagenet_int4_int8.pth",
                 "model_description": "MobileNet V2",
-                "compression_description": "Mixed, 46.6% INT8 / 53.4% INT4",
-                "diff_fp32_min": -1.05,
+                "compression_description": "Mixed, 53.27% INT8 / 46.73% INT4",
+                "diff_fp32_min": -1,
                 "diff_fp32_max": 0.1
             },
             "mobilenet_v2_imagenet_rb_sparsity_int8": {
@@ -180,14 +180,14 @@
                 "diff_fp32_max": 0.15
             },
             "squeezenet1_1_imagenet_int4_int8": {
-                "config": "examples/torch/classification/configs/mixed_precision/squeezenet1_1_imagenet_mixed_int_manual.json",
+                "config": "examples/torch/classification/configs/mixed_precision/squeezenet1_1_imagenet_mixed_int_hawq_old_eval.json",
                 "reference": "squeezenet1_1_imagenet",
-                "target": 58.9,
+                "target": 57.61,
                 "metric_type": "Acc@1",
                 "resume": "squeezenet1_1_imagenet_int4_int8.pth",
                 "model_description": "SqueezeNet V1.1",
-                "compression_description": "Mixed, 54.7% INT8 / 45.3% INT4",
-                "diff_fp32_min": -0.55,
+                "compression_description": "Mixed, 52.83% INT8 / 47.17% INT4",
+                "diff_fp32_min": -0.7,
                 "diff_fp32_max": 0.7
             },
             "resnet18_imagenet": {


### PR DESCRIPTION
### Changes

Updated mixed precision checkpoints, reference numbers in test_sota_checkpoints and README

### Reason for changes

Previous checkpoints were trained with ZP not for VPU, which is not optimal

### Related tickets

42046

### Tests

custom build number if sota_eval_pytorch will be reported later
