### PR TITLE
Fix weight norm applied to modules

### DIFF
--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -24,6 +24,7 @@ import networkx as nx
 import pytest
 import torch
 from torch import nn
+from torch.nn.utils import weight_norm
 
 from nncf.common.graph import BaseLayerAttributes
 from nncf.common.graph import NNCFGraph
@@ -122,6 +123,30 @@ def test_check_correct_modules_replacement():
 
     _, nncf_modules = check_correct_nncf_modules_replacement(model, nncf_model)
     assert set(nncf_modules) == set(nncf_model.get_nncf_modules())
+
+
+class WeightNormedConvModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = weight_norm(torch.nn.Conv1d(1, 1, 1))
+
+    def forward(self, x):
+        return self.conv(x)
+
+
+def test_weight_normed_modules_are_replaced_correctly(mocker):
+    nncf_model = NNCFNetwork(WeightNormedConvModel(), input_infos=[ModelInputInfo([1, 1, 10])])
+
+    wrapped_conv = nncf_model.conv
+    assert hasattr(wrapped_conv, "weight_g")
+    assert hasattr(wrapped_conv, "weight_v")
+    assert hasattr(wrapped_conv, "weight")
+
+    assert isinstance(wrapped_conv.weight_g, torch.nn.Parameter)
+    assert isinstance(wrapped_conv.weight_v, torch.nn.Parameter)
+    assert not isinstance(wrapped_conv.weight, torch.nn.Parameter)
+
+    assert len(wrapped_conv._forward_pre_hooks) == 1
 
 
 @register_module()

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -134,7 +134,7 @@ class WeightNormedConvModel(torch.nn.Module):
         return self.conv(x)
 
 
-def test_weight_normed_modules_are_replaced_correctly(mocker):
+def test_weight_normed_modules_are_replaced_correctly():
     nncf_model = NNCFNetwork(WeightNormedConvModel(), input_infos=[ModelInputInfo([1, 1, 10])])
 
     wrapped_conv = nncf_model.conv
@@ -146,6 +146,7 @@ def test_weight_normed_modules_are_replaced_correctly(mocker):
     assert isinstance(wrapped_conv.weight_v, torch.nn.Parameter)
     assert not isinstance(wrapped_conv.weight, torch.nn.Parameter)
 
+    #pylint:disable=protected-access
     assert len(wrapped_conv._forward_pre_hooks) == 1
 
 


### PR DESCRIPTION
### Changes

Upon construction (i.e. during module wrapping process), NNCF* modules now reapply the torch.nn.utils.weight_norm.WeightNorm pre-hook if it has been applied to the non-NNCF wrapped module.

### Reason for changes

The WeightNorm hook replaces the existing "weight" torch.nn.Parameter of the wrapped module with a raw Tensor of the same name and instead creates two internal torch.nn.Parameters from which the original "weight" attribute is then recomputed. In order for these changes to be propagated into the NNCF-wrapped module, the hook application must be done explicitly.

### Related tickets

N/A

### Tests
Added tests.torch.test_nncf_network.test_weight_normed_modules_are_replaced_correctly