### PR TITLE
Presume CPU device for parameter-less models

### DIFF
--- a/nncf/torch/algo_selector.py
+++ b/nncf/torch/algo_selector.py
@@ -29,13 +29,13 @@ from nncf.common.compression import NO_COMPRESSION_ALGORITHM_NAME
 from nncf.common.schedulers import StubCompressionScheduler
 from nncf.common.utils.registry import Registry
 from nncf.common.statistics import NNCFStatistics
-
+from nncf.torch.utils import get_model_device
 
 PT_COMPRESSION_ALGORITHMS = Registry('compression algorithm', add_name_as_attr=True)
 
 
 class ZeroCompressionLoss(PTCompressionLoss):
-    def __init__(self, device: str):
+    def __init__(self, device: torch.device):
         super().__init__()
         self._device = device
 
@@ -65,7 +65,8 @@ class NoCompressionAlgorithmBuilder(PTCompressionAlgorithmBuilder):
 class NoCompressionAlgorithmController(PTCompressionAlgorithmController):
     def __init__(self, target_model):
         super().__init__(target_model)
-        self._loss = ZeroCompressionLoss(next(target_model.parameters()).device)
+
+        self._loss = ZeroCompressionLoss(get_model_device(target_model))
         self._scheduler = StubCompressionScheduler()
 
     def compression_stage(self) -> CompressionStage:

--- a/nncf/torch/binarization/algo.py
+++ b/nncf/torch/binarization/algo.py
@@ -44,6 +44,7 @@ from nncf.torch.module_operations import UpdateInputs
 from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.quantization.algo import QuantizationControllerBase
 from nncf.torch.quantization.schedulers import QUANTIZATION_SCHEDULERS
+from nncf.torch.utils import get_model_device
 
 
 @PT_COMPRESSION_ALGORITHMS.register('binarization')
@@ -66,7 +67,7 @@ class BinarizationBuilder(PTCompressionAlgorithmBuilder):
         return [NNCFConv2d.__name__, ]
 
     def _binarize_weights_and_module_inputs(self, target_model: NNCFNetwork) -> List[PTInsertionCommand]:
-        device = next(target_model.parameters()).device
+        device = get_model_device(target_model)
 
         module_nodes = target_model.get_weighted_original_graph_nodes(
             nncf_module_names=self.compressed_nncf_module_names)
@@ -113,7 +114,7 @@ class BinarizationController(QuantizationControllerBase):
     def __init__(self, target_model: NNCFNetwork, config: NNCFConfig):
         super().__init__(target_model)
 
-        self._loss = ZeroCompressionLoss(next(target_model.parameters()).device)
+        self._loss = ZeroCompressionLoss(get_model_device(target_model))
         scheduler_cls = QUANTIZATION_SCHEDULERS.get("staged")
         algo_config = extract_algo_specific_config(config, "binarization")
         self._scheduler = scheduler_cls(self, algo_config.get("params", {}))

--- a/nncf/torch/dynamic_graph/graph_tracer.py
+++ b/nncf/torch/dynamic_graph/graph_tracer.py
@@ -17,6 +17,7 @@ from copy import deepcopy
 import torch
 
 from nncf.torch.dynamic_graph.graph import DynamicGraph
+from nncf.torch.utils import get_model_device
 
 
 class ModelInputInfo:
@@ -128,7 +129,7 @@ def create_dummy_forward_fn(input_infos: List[ModelInputInfo], with_input_tracin
         from nncf.torch.dynamic_graph.io_handling import wrap_nncf_model_outputs_with_objwalk
         from nncf.torch.dynamic_graph.io_handling import replicate_same_tensors
 
-        device = next(model.parameters()).device
+        device = get_model_device(model)
         args_list = [create_mock_tensor(info, device) for info in input_infos if info.keyword is None]
         kwargs = OrderedDict()
         for info in input_infos:

--- a/nncf/torch/dynamic_graph/io_handling.py
+++ b/nncf/torch/dynamic_graph/io_handling.py
@@ -9,6 +9,7 @@ from nncf.common.graph.definitions import MODEL_INPUT_OP_NAME
 from nncf.common.graph.definitions import MODEL_OUTPUT_OP_NAME
 from nncf.torch.dynamic_graph.patch_pytorch import register_operator
 from nncf.torch.dynamic_graph.graph_tracer import ModelInputInfo, create_mock_tensor
+from nncf.torch.utils import get_model_device
 from nncf.torch.utils import is_tensor, is_traced_tensor
 from nncf.torch.nested_objects_traversal import objwalk
 from nncf.common.utils.logger import logger as nncf_logger
@@ -112,7 +113,7 @@ class InputInfoWrapManager:
                 info_for_missing_input = self._fwd_params_to_input_infos_odict[param_name]
                 device = 'cuda'
                 if self._module_ref_for_device is not None:
-                    device = next(self._module_ref_for_device.parameters()).device
+                    device = get_model_device(self._module_ref_for_device)
                 dummy_tensor = create_mock_tensor(info_for_missing_input, device)
                 _ = nncf_model_input(dummy_tensor)
 

--- a/nncf/torch/initialization.py
+++ b/nncf/torch/initialization.py
@@ -20,6 +20,7 @@ from nncf.config.structures import QuantizationRangeInitArgs
 from nncf.torch.nested_objects_traversal import objwalk
 from nncf.torch.structures import AutoQPrecisionInitArgs, LeGRInitArgs, DistributedCallbacksArgs
 from nncf.torch.structures import QuantizationPrecisionInitArgs
+from nncf.torch.utils import get_model_device
 from nncf.torch.utils import is_tensor, default_distributed_wrapper, default_distributed_unwrapper
 
 
@@ -132,11 +133,11 @@ class DataLoaderBaseRunner:
 
     def run(self, data_loader, num_init_steps):
         if self.init_device is not None:
-            original_device = next(iter(self.model.parameters())).device
+            original_device = get_model_device(self.model)
             self.model.to(self.init_device)
 
         self._prepare_initialization()
-        device = next(self.model.parameters()).device
+        device = get_model_device(self.model)
         data_loader = wrap_dataloader_for_init(data_loader)
 
         with torch.no_grad():

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -70,6 +70,7 @@ from nncf.torch.module_operations import UpdateWeight
 from nncf.torch.quantization.layers import QUANTIZATION_MODULES
 from nncf.torch.utils import compute_FLOPs_hook
 from nncf.torch.utils import get_all_modules_by_type
+from nncf.torch.utils import get_model_device
 from nncf.torch.utils import get_state_dict_names_with_modules
 from nncf.torch.nested_objects_traversal import objwalk
 
@@ -171,11 +172,7 @@ class NNCFNetwork(nn.Module, PostGraphBuildActing):
         self._user_dummy_forward_fn = dummy_forward_fn
         self._kd_loss_handler = None
 
-        try:
-            device = next(module.parameters()).device
-        except StopIteration:
-            # Param-less model, assume CPU
-            device = 'cpu'
+        device = get_model_device(module)
 
         if wrap_inputs_fn is not None:
             self._wrap_inputs_fn = wrap_inputs_fn
@@ -281,7 +278,7 @@ class NNCFNetwork(nn.Module, PostGraphBuildActing):
         :param calculate_fn: function used to parse model outputs and calculate knowledge distillation loss
         :return: KnowledgeDistillationLossHandler instance
         """
-        device = next(self.get_nncf_wrapped_model().parameters()).device
+        device = get_model_device(self.get_nncf_wrapped_model())
         self._kd_loss_handler = KnowledgeDistillationLossHandler(self._compressed_context,
                                                                  kd_original_model,
                                                                  calculate_fn,

--- a/nncf/torch/pruning/base_algo.py
+++ b/nncf/torch/pruning/base_algo.py
@@ -37,6 +37,7 @@ from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.pruning.operations import PT_PRUNING_OPERATOR_METATYPES
 from nncf.torch.pruning.structs import PrunedModuleInfo
 from nncf.torch.pruning.utils import init_output_masks_in_graph
+from nncf.torch.utils import get_model_device
 
 
 class BasePruningAlgoBuilder(PTCompressionAlgorithmBuilder):
@@ -97,7 +98,7 @@ class BasePruningAlgoBuilder(PTCompressionAlgorithmBuilder):
         target_model_graph = target_model.get_original_graph()
         groups_of_nodes_to_prune = self.pruning_node_selector.create_pruning_groups(target_model_graph)
 
-        device = next(target_model.parameters()).device
+        device = get_model_device(target_model)
         insertion_commands = []
         self.pruned_module_groups_info = Clusterization[PrunedModuleInfo](lambda x: x.node_name)
 
@@ -193,7 +194,7 @@ class BasePruningAlgoController(PTCompressionAlgorithmController):
                  pruned_module_groups_info: Clusterization[PrunedModuleInfo],
                  config: NNCFConfig):
         super().__init__(target_model)
-        self._loss = ZeroCompressionLoss(next(target_model.parameters()).device)
+        self._loss = ZeroCompressionLoss(get_model_device(target_model))
         self._prunable_types = prunable_types
         self.config = config
         self.pruning_config = extract_algo_specific_config(config, 'filter_pruning')

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -128,6 +128,7 @@ from nncf.torch.tensor_statistics.collectors import ReductionShape
 from nncf.torch.tensor_statistics.statistics import MinMaxTensorStatistic
 from nncf.torch.tensor_statistics.statistics import pt_convert_stat_to_min_max_tensor_stat
 from nncf.torch.tensor_statistics.statistics import TensorStatistic
+from nncf.torch.utils import get_model_device
 from nncf.torch.utils import get_state_dict_names_with_modules
 from nncf.torch.utils import is_main_process
 from torch import nn
@@ -586,7 +587,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
         # TODO (vshampor): a simpler solution would be to always create callables on CPU and
         # to move these to model-specific device upon actual application, but would this impact
         # the time required to create a compressed model?
-        self._device_for_callable_obj_creation = next(target_model.parameters()).device
+        self._device_for_callable_obj_creation = get_model_device(target_model)
         target_model_graph = target_model.get_original_graph()
         target_model.register_compression_module_type(ExtraCompressionModuleType.EXTERNAL_QUANTIZER)
         if self._single_config_quantizer_setup is None:
@@ -1204,7 +1205,7 @@ class QuantizationController(QuantizationControllerBase):
                  build_time_metric_info: QuantizationShareBuildTimeInfo = None,
                  build_time_range_init_params: PTRangeInitParams = None):
         super().__init__(target_model)
-        self._loss = ZeroCompressionLoss(next(target_model.parameters()).device)
+        self._loss = ZeroCompressionLoss(get_model_device(target_model))
         self._scheduler = BaseCompressionScheduler()
         self.debug_interface = debug_interface
         self.config = config

--- a/nncf/torch/quantization/hessian_trace.py
+++ b/nncf/torch/quantization/hessian_trace.py
@@ -14,6 +14,8 @@ from functools import partial
 from typing import List, Union, Any, Callable
 
 import torch
+
+from nncf.torch.utils import get_model_device
 from nncf.torch.utils import is_tensor
 from nncf.torch.nested_objects_traversal import objwalk
 from torch import Tensor
@@ -76,7 +78,7 @@ class GradientsCalculator:
         self.num_iter += 1
         dataloader_output = next(self.data_loader_iter)
 
-        device = next(self._model.parameters()).device
+        device = get_model_device(self._model)
         to_device_fn = partial(torch.Tensor.to, device=device)
         dataloader_output = objwalk(dataloader_output, is_tensor, to_device_fn)
         args, kwargs = self._data_loader.get_inputs(dataloader_output)

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -33,6 +33,7 @@ from nncf.torch.quantization.quantize_functions import symmetric_quantize, asymm
 from nncf.torch.layer_utils import COMPRESSION_MODULES, CompressionParameter
 from nncf.common.utils.registry import Registry
 from nncf.torch.utils import get_flat_tensor_contents_string, no_jit_trace, is_tracing_state
+from nncf.torch.utils import get_model_device
 
 QUANTIZATION_MODULES = Registry('quantization_modules')
 INITIALIZABLE_MODULES = Registry('initializable_modules')
@@ -181,7 +182,7 @@ class BaseQuantizer(nn.Module):
             return
         if torch.any(torch.eq(min_values, np.inf)) or torch.any(torch.eq(max_values, -np.inf)):
             raise AttributeError('Statistics is not collected for {}'.format(log_module_name))
-        own_device = next(self.parameters()).device
+        own_device = get_model_device(self)
         min_values = min_values.to(own_device)
         max_values = max_values.to(own_device)
         self._apply_minmax_init(min_values, max_values, log_module_name)

--- a/nncf/torch/quantization/precision_init/hawq_init.py
+++ b/nncf/torch/quantization/precision_init/hawq_init.py
@@ -49,6 +49,7 @@ from nncf.common.quantization.quantizer_setup import QuantizationPointId
 from nncf.common.quantization.quantizer_setup import SingleConfigQuantizerSetup
 from nncf.torch.quantization.structs import WeightQuantizerInfo
 from nncf.torch.structures import QuantizationPrecisionInitArgs
+from nncf.torch.utils import get_model_device
 
 
 class BitwidthAssignmentMode(Enum):
@@ -240,7 +241,7 @@ class HAWQPrecisionInitializer(BasePrecisionInitializer):
             if self._hw_precision_constraints else params.bitwidths
         self._init_device = init_args.device
         if self._init_device is None:
-            self._init_device = next(self._model.parameters()).device
+            self._init_device = get_model_device(self._model)
         current_quantizer_setup = self._algo.get_quantizer_setup_for_current_state()
         flops_per_module = self._model.get_flops_per_module()
         self._compression_ratio_calculator = CompressionRatioCalculator(
@@ -253,7 +254,7 @@ class HAWQPrecisionInitializer(BasePrecisionInitializer):
         if not self._weight_quantizations_by_execution_order:
             return self._algo.get_quantizer_setup_for_current_state()
 
-        original_device = next(self._model.parameters()).device
+        original_device = get_model_device(self._model)
         self._model.to(self._init_device)
 
         traces_per_layer = self._calc_traces(self._criterion_fn, self._criterion, self._iter_number, self._tolerance)

--- a/nncf/torch/sparsity/base_algo.py
+++ b/nncf/torch/sparsity/base_algo.py
@@ -33,6 +33,7 @@ from nncf.torch.graph.transformations.commands import PTTargetPoint
 from nncf.torch.graph.transformations.commands import TransformationPriority
 from nncf.torch.graph.transformations.layout import PTTransformationLayout
 from nncf.torch.nncf_network import NNCFNetwork
+from nncf.torch.utils import get_model_device
 
 
 class SparseModuleInfo:
@@ -56,7 +57,7 @@ class BaseSparsityAlgoBuilder(PTCompressionAlgorithmBuilder):
         return layout
 
     def _sparsify_weights(self, target_model: NNCFNetwork) -> List[PTInsertionCommand]:
-        device = next(target_model.parameters()).device
+        device = get_model_device(target_model)
         sparsified_module_nodes = target_model.get_weighted_original_graph_nodes(
             nncf_module_names=self.compressed_nncf_module_names)
         insertion_commands = []
@@ -93,7 +94,7 @@ class BaseSparsityAlgoController(PTCompressionAlgorithmController, SparsityContr
     def __init__(self, target_model: NNCFNetwork,
                  sparsified_module_info: List[SparseModuleInfo]):
         super().__init__(target_model)
-        self._loss = ZeroCompressionLoss(next(target_model.parameters()).device)
+        self._loss = ZeroCompressionLoss(get_model_device(target_model))
         self._scheduler = BaseCompressionScheduler()
         self.sparsified_module_info = sparsified_module_info
 

--- a/nncf/torch/sparsity/rb/algo.py
+++ b/nncf/torch/sparsity/rb/algo.py
@@ -26,6 +26,7 @@ from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.sparsity.base_algo import BaseSparsityAlgoBuilder, BaseSparsityAlgoController, SparseModuleInfo
 from nncf.torch.sparsity.rb.layers import RBSparsifyingWeight
 from nncf.torch.sparsity.rb.loss import SparseLoss, SparseLossForPerLayerSparsity
+from nncf.torch.utils import get_model_device
 from nncf.torch.utils import get_world_size
 from nncf.common.accuracy_aware_training.training_loop import ADAPTIVE_COMPRESSION_CONTROLLERS
 from nncf.torch.sparsity.collector import PTSparseModelStatisticsCollector
@@ -96,7 +97,7 @@ class RBSparsityController(BaseSparsityAlgoController):
             raise KeyError('Could not set distributed mode for the compression algorithm '
                            'because the default process group has not been initialized.')
 
-        if next(self._model.parameters()).is_cuda:
+        if 'cuda' in get_model_device(self._model).type:
             state = torch.cuda.get_rng_state()
             if dist.get_backend() == dist.Backend.NCCL:
                 state = state.cuda()

--- a/nncf/torch/utils.py
+++ b/nncf/torch/utils.py
@@ -342,3 +342,12 @@ def maybe_convert_legacy_names_in_compress_state(compression_state: Dict[str, An
         warnings.warn('Legacy Batch Norm layer names was detected in quantization setup target point names.'
                       ' All occurrences of `BatchNorm2d` in nodes names was replaced by `NNCFBatchNorm`',
                       category=DeprecationWarning)
+
+
+def get_model_device(model: torch.nn.Module) -> torch.device:
+    try:
+        device = next(model.parameters()).device
+    except StopIteration:
+        # The model had no parameters at all, doesn't matter which device to choose
+        device = torch.device('cpu')
+    return device

--- a/tests/torch/modules/test_rnn.py
+++ b/tests/torch/modules/test_rnn.py
@@ -33,6 +33,7 @@ from nncf.torch.dynamic_graph.context import TracingContext
 from nncf.torch.dynamic_graph.transform_graph import replace_modules
 from nncf.torch.layers import LSTMCellNNCF, NNCF_RNN, ITERATION_MODULES
 from nncf.torch.model_creation import create_compressed_model
+from nncf.torch.utils import get_model_device
 from nncf.torch.utils import manual_seed
 from tests.torch.modules.seq2seq.gnmt import GNMT
 from tests.torch.helpers import get_empty_config, get_grads, create_compressed_model_and_algo_for_test
@@ -50,7 +51,7 @@ def replace_lstm(model):
     def replace_fn(module_):
         if not isinstance(module_, nn.LSTM):
             return module_
-        device = next(module_.parameters()).device
+        device = get_model_device(module_)
         custom_lstm = NNCF_RNN('LSTM', input_size=module_.input_size, hidden_size=module_.hidden_size,
                                num_layers=module_.num_layers, bidirectional=module_.bidirectional,
                                batch_first=module_.batch_first, dropout=module_.dropout,

--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -45,6 +45,7 @@ from nncf.torch.quantization.layers import AsymmetricQuantizer
 from nncf.common.quantization.structs import NonWeightQuantizerId
 from nncf.common.quantization.structs import WeightQuantizerId
 from nncf.torch.utils import get_all_modules_by_type
+from nncf.torch.utils import get_model_device
 from tests.torch.helpers import BasicConvTestModel
 from tests.torch.helpers import TwoConvTestModel
 from tests.torch.helpers import create_compressed_model_and_algo_for_test
@@ -560,7 +561,7 @@ def test_debug_mode():
     with nncf_debug():
         model, _ = create_compressed_model_and_algo_for_test(model, config)
         model.forward(torch.zeros(BasicConvTestModel.INPUT_SIZE,
-                                  device=next(model.parameters()).device))
+                                  device=get_model_device(model)))
 
 
 class SharedLayersModel(torch.nn.Module):

--- a/tests/torch/quantization/test_hawq_precision_init.py
+++ b/tests/torch/quantization/test_hawq_precision_init.py
@@ -41,6 +41,7 @@ from nncf.common.graph import NNCFNodeName
 from nncf.common.hardware.config import HWConfigType
 from nncf.common.quantization.structs import QuantizerGroup
 from nncf.common.utils.debug import set_debug_log_dir
+from nncf.torch.utils import get_model_device
 from nncf.torch.dynamic_graph.graph_tracer import create_input_infos
 from nncf.torch.initialization import default_criterion_fn
 from nncf.torch.quantization.adjust_padding import add_adjust_padding_nodes
@@ -461,7 +462,7 @@ def test_hawq_on_single_conv_without_quantizers(_seed, dataset_dir, tmp_path, pa
     if not dataset_dir:
         dataset_dir = str(tmp_path)
     data_loader, _ = create_test_dataloaders(config, dataset_dir)
-    device = next(model.parameters()).device
+    device = get_model_device(model)
 
     for _, param in model.named_parameters():
         param.requires_grad = False

--- a/tests/torch/quantization/test_unified_scales.py
+++ b/tests/torch/quantization/test_unified_scales.py
@@ -409,8 +409,6 @@ def test_insertion_point_coalescing(input_insertion_points: List[PTTargetPoint],
 class EltwiseQuantizerLinkingTestModel(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self._dummy_trainable_param = torch.nn.Parameter(torch.ones([1]))
-
         class Path(torch.nn.Module):
             def forward(self, input_1, input_2):
                 retval0 = input_1 + input_2

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -21,6 +21,8 @@ from typing import Callable, Dict, List, Tuple, Union
 import networkx as nx
 import pytest
 import torch
+
+from nncf.torch.utils import get_model_device
 from tests.torch.test_models.synthetic import ConvRelu6HSwishHSigmoid
 from tests.torch.test_models.synthetic import MatMulDivConv
 from torch import nn
@@ -170,7 +172,7 @@ def gnmt_wrap_inputs_fn(model_args, model_kwargs):
 
 def gnmt_forward_fn(seq_len, batch_size, vocab_size):
     def forward_fn(model, seq_len_, batch_size_, vocab_size_, batch_first_):
-        device = next(model.parameters()).device
+        device = get_model_device(model)
 
         def gen_packed_sequence():
             seq_list = []
@@ -221,7 +223,7 @@ def sr_wrap_inputs_fn(model_args, model_kwargs):
 
 
 def sr_dummy_forward_fn(model_, input_sample_sizes: Tuple[List[int]]):
-    device = next(model_.parameters()).device
+    device = get_model_device(model_)
     config = {'input_info': [{"sample_size": sizes} for sizes in input_sample_sizes]}
     input_info_list = create_input_infos(config)
     tensor_list = [create_mock_tensor(info, device) for info in input_info_list]

--- a/tests/torch/test_models/synthetic.py
+++ b/tests/torch/test_models/synthetic.py
@@ -207,10 +207,6 @@ class EmbeddingCatLinearModel(nn.Module):
         return self.linear(z)
 
 class MultiOutputSameTensorModel(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-        self._dummy_param = torch.nn.Parameter(torch.ones([1]))
-
     def forward(self, x):
         return x, x*x, x
 


### PR DESCRIPTION
### Changes

Refactored the code for determining the model's device based on its parameters and unified it across the codebase.

### Reason for changes

Previously the parameter-less models would fail to be processed by NNCF; such models aren't exactly practical, but are convenient to have in tests. The new behaviour also increases NNCF generality somewhat.

### Related tickets

N/A

### Tests

Existing tests that work with paramless models, such as tests.torch.test_compressed_graph.test_synthetic_model_quantization
