### PR TITLE
Add missed comma in example pruning config

### DIFF
--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -99,7 +99,6 @@ This approach allows pruning the model taking into account layer-specific sensit
         "prune_first_conv": false, // Whether to prune first Convolutional layers or not. First means that it is a convolutional layer such that there is a path from model input to this layer such that there are no other convolution operations on it. `False` by default (`True` by default in case of 'learned_ranking' interlayer_ranking_type).
         "prune_downsample_convs": false, // Whether to prune downsample Convolutional layers (with stride > 1) or not. `False` by default (`True` by default in case of 'learned_ranking' interlayer_ranking_type).
         "prune_batch_norms": true, // Whether to nullifies parameters of Batch Norm layer corresponds to zeroed filters of convolution corresponding to this Batch Norm. `True` by default.
-        "zero_grad": true, // Whether to setting gradients corresponding to zeroed filters to zero during training, `True` by default.
         "save_ranking_coeffs_path": "path/coeffs.json", // Path to save .json file with interlayer ranking coefficients.
         "load_ranking_coeffs_path": "PATH/learned_coeffs.json", // Path to loading interlayer ranking coefficients .json file, pretrained earlier.
         "legr_params": { // Set of parameters, that can be set for 'learned_ranking' interlayer_ranking_type case

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -85,7 +85,7 @@ This approach allows pruning the model taking into account layer-specific sensit
         "batchnorm_adaptation": {
             "num_bn_adaptation_samples": 2048, // Number of samples from the training dataset to pass through the model at initialization in order to update batchnorm statistics of the original model. The actual number of samples will be a closest multiple of the batch size.
         }
-    }
+    },
     "pruning_init": 0.1, // Initial value of the pruning level applied to the convolutions that can be pruned in 'create_compressed_model' function. 0.0 by default.
     "params": {
         "schedule": "exponential", // The type of scheduling to use for adjusting the target pruning level. Either `exponential`, `exponential_with_bias`,  or `baseline`, by default it is `exponential`"
@@ -99,7 +99,7 @@ This approach allows pruning the model taking into account layer-specific sensit
         "prune_first_conv": false, // Whether to prune first Convolutional layers or not. First means that it is a convolutional layer such that there is a path from model input to this layer such that there are no other convolution operations on it. `False` by default (`True` by default in case of 'learned_ranking' interlayer_ranking_type).
         "prune_downsample_convs": false, // Whether to prune downsample Convolutional layers (with stride > 1) or not. `False` by default (`True` by default in case of 'learned_ranking' interlayer_ranking_type).
         "prune_batch_norms": true, // Whether to nullifies parameters of Batch Norm layer corresponds to zeroed filters of convolution corresponding to this Batch Norm. `True` by default.
-        "zero_grad": true // Whether to setting gradients corresponding to zeroed filters to zero during training, `True` by default.
+        "zero_grad": true, // Whether to setting gradients corresponding to zeroed filters to zero during training, `True` by default.
         "save_ranking_coeffs_path": "path/coeffs.json", // Path to save .json file with interlayer ranking coefficients.
         "load_ranking_coeffs_path": "PATH/learned_coeffs.json", // Path to loading interlayer ranking coefficients .json file, pretrained earlier.
         "legr_params": { // Set of parameters, that can be set for 'learned_ranking' interlayer_ranking_type case


### PR DESCRIPTION
Also, there is an error when I try to use this config (v2.1.0):

```
jsonschema.exceptions.ValidationError: For algorithm: 'filter_pruning'
Additional properties are not allowed ('zero_grad' was unexpected)
```