### PR TITLE
Launch BN adaptation for quantization only for non-zero sample values

### DIFF
--- a/nncf/common/compression.py
+++ b/nncf/common/compression.py
@@ -274,5 +274,5 @@ class BaseCompressionAlgorithmBuilder(CompressionAlgorithmBuilder):
             (dict, list, tuple, str, int, float, True, False, None) that represents state of the object.
         """
 
-    def _parse_bn_adapt_params(self) -> Dict:
+    def _parse_bn_adapt_params(self) -> Optional[Dict]:
         return extract_bn_adaptation_init_params(self.config, self.name)

--- a/nncf/common/compression.py
+++ b/nncf/common/compression.py
@@ -25,6 +25,7 @@ from nncf.common.utils.registry import Registry
 from nncf.common.utils.backend import BackendType
 from nncf.common.utils.backend import infer_backend_from_model
 from nncf.config.extractors import extract_algo_specific_config
+from nncf.config.extractors import extract_bn_adaptation_init_params
 
 ModelType = TypeVar('ModelType')
 
@@ -272,3 +273,6 @@ class BaseCompressionAlgorithmBuilder(CompressionAlgorithmBuilder):
         :return: Returns a dictionary with Python data structures
             (dict, list, tuple, str, int, float, True, False, None) that represents state of the object.
         """
+
+    def _parse_bn_adapt_params(self) -> Dict:
+        return extract_bn_adaptation_init_params(self.config, self.name)

--- a/nncf/config/extractors.py
+++ b/nncf/config/extractors.py
@@ -128,7 +128,7 @@ def extract_range_init_params(config: NNCFConfig) -> Optional[Dict[str, object]]
     return params
 
 
-def extract_bn_adaptation_init_params(config: NNCFConfig, algo_name: str) -> Dict[str, object]:
+def extract_bn_adaptation_init_params(config: NNCFConfig, algo_name: str) -> Optional[Dict[str, object]]:
     """
     Extracts parameters for initialization of an object of the class `BatchnormAdaptationAlgorithm`
     from the compression algorithm NNCFconfig.
@@ -136,17 +136,20 @@ def extract_bn_adaptation_init_params(config: NNCFConfig, algo_name: str) -> Dic
     :param config: An instance of the NNCFConfig.
     :param algo_name: The name of the algorithm for which the params have to be extracted.
     :return: Parameters for initialization of an object of the class `BatchnormAdaptationAlgorithm` specific
-      to the supplied algorithm.
+      to the supplied algorithm, or None if the config specified not to perform any batchnorm adaptation.
     """
     algo_config = extract_algo_specific_config(config, algo_name)
     params = algo_config.get('initializer', {}).get('batchnorm_adaptation', {})
     num_bn_adaptation_samples = params.get('num_bn_adaptation_samples', 2000)
 
+    if num_bn_adaptation_samples == 0:
+        return None
+
     try:
         args = config.get_extra_struct(BNAdaptationInitArgs)
     except KeyError:
         raise RuntimeError(
-            'There is no possibility to create the batch-norm statistics adaptation algorithm '
+            'Unable to create the batch-norm statistics adaptation algorithm '
             'because the data loader is not provided as an extra struct. Refer to the '
             '`NNCFConfig.register_extra_structs` method and the `BNAdaptationInitArgs` class.') from None
 

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -50,7 +50,6 @@ from nncf.common.stateful_classes_registry import TF_STATEFUL_CLASSES
 from nncf.common.statistics import NNCFStatistics
 from nncf.common.utils.helpers import should_consider_scope
 from nncf.common.utils.logger import logger
-from nncf.config.extractors import extract_bn_adaptation_init_params
 from nncf.config.extractors import extract_range_init_params
 from nncf.tensorflow.algorithm_selector import TF_COMPRESSION_ALGORITHMS
 from nncf.tensorflow.api.compression import TFCompressionAlgorithmBuilder
@@ -293,6 +292,7 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
 
     def _parse_init_params(self):
         self._range_init_params = self._parse_range_init_params()
+        self._bn_adapt_params = self._parse_bn_adapt_params()
 
     def _parse_range_init_params(self) -> TFRangeInitParams:
         range_init_params = extract_range_init_params(self.config)
@@ -419,8 +419,9 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
 
     def _run_batchnorm_adaptation(self, model: tf.keras.Model) -> None:
         if self._bn_adaptation is None:
-            self._bn_adaptation = BatchnormAdaptationAlgorithm(
-                **extract_bn_adaptation_init_params(self.config, self.name))
+            self._bn_adaptation = BatchnormAdaptationAlgorithm(self._bn_adapt_params['data_loader'],
+                                                               self._bn_adapt_params['num_bn_adaptation_samples'],
+                                                               self._bn_adapt_params['device'])
         self._bn_adaptation.run(model)
 
     def _get_quantizer_setup(self, model: tf.keras.Model) -> TFQuantizationSetup:

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -1172,9 +1172,11 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
 
     def initialize(self, model: NNCFNetwork) -> None:
         if is_main_process() and self.should_init:
-            bn_adaptation = BatchnormAdaptationAlgorithm(
-                **extract_bn_adaptation_init_params(self.config, 'quantization'))
-            bn_adaptation.run(model)
+            bn_adapt_params = self._parse_bn_adapt_params()
+            if bn_adapt_params is not None:
+                bn_adaptation = BatchnormAdaptationAlgorithm(
+                    **extract_bn_adaptation_init_params(self.config, 'quantization'))
+                bn_adaptation.run(model)
 
 
 class QuantizationControllerBase(PTCompressionAlgorithmController):

--- a/tests/tensorflow/quantization/test_builder_state.py
+++ b/tests/tensorflow/quantization/test_builder_state.py
@@ -110,6 +110,14 @@ def test_quantization_configs__disable_overflow_fix_and_resume_from_compression_
 def test_checkpoint_callback_make_checkpoints(mocker, tmp_path):
     save_freq = 2
     config = get_basic_quantization_config()
+    config['compression']['initializer'] = {
+        'range': {
+            'num_init_samples': 0
+        },
+        'batchnorm_adaptation': {
+            'num_bn_adaptation_samples': 0
+        }
+    }
     gen_setup_spy = mocker.spy(QuantizationBuilder, '_get_quantizer_setup')
 
     model, compression_ctrl = create_compressed_model_and_algo_for_test(get_basic_conv_test_model(),

--- a/tests/tensorflow/test_bn_adaptation.py
+++ b/tests/tensorflow/test_bn_adaptation.py
@@ -11,16 +11,17 @@
  limitations under the License.
 """
 
-from addict import Dict
 from copy import deepcopy
 
 import tensorflow as tf
+from addict import Dict
 
 from nncf import NNCFConfig
 from nncf.common.initialization.batchnorm_adaptation import BatchnormAdaptationAlgorithm
 from nncf.config.extractors import extract_bn_adaptation_init_params
 from nncf.tensorflow.graph.metatypes.keras_layers import TFBatchNormalizationLayerMetatype
 from nncf.tensorflow.graph.metatypes.matcher import get_keras_layer_metatype
+from nncf.tensorflow.initialization import TFInitializingDataLoader
 from nncf.tensorflow.initialization import register_default_init_args
 
 
@@ -104,7 +105,7 @@ def test_parameter_update():
             compare_params(original_param_values[layer], layer.weights)
 
 
-def test_all_parameter_keep():
+def test_all_parameter_are_unchanged_for_zero_bn_adapt_samples():
     original_all_param_values = {}
 
     model = get_model_for_test()
@@ -112,10 +113,10 @@ def test_all_parameter_keep():
     for layer in model.layers:
         original_all_param_values[layer] = deepcopy(layer.weights)
 
-    config = get_config_for_test(num_bn_adaptation_samples=0)
-
-    bn_adaptation = BatchnormAdaptationAlgorithm(**extract_bn_adaptation_init_params(config,
-                                                                                     "quantization"))
+    bn_adaptation = BatchnormAdaptationAlgorithm(TFInitializingDataLoader(get_dataset_for_test(),
+                                                                          2),
+                                                 0,
+                                                 None)
     bn_adaptation.run(model)
 
     for layer in model.layers:

--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -21,6 +21,7 @@ import torch.utils.data
 from torchvision.models import resnet50
 from torchvision.models import squeezenet1_1
 
+from nncf import NNCFConfig
 from nncf.common.utils.debug import nncf_debug
 from nncf.api.compression import CompressionScheduler
 from nncf.torch.checkpoint_loading import load_state
@@ -662,3 +663,24 @@ def test_quantization_preset_with_scope_overrides():
 
     for aq_info in compression_ctrl.non_weight_quantizers.values():
         assert isinstance(aq_info.quantizer_module_ref, AsymmetricQuantizer)
+
+
+def test_quantization_can_be_run_with_no_data_loaders_if_zero_init_samples():
+    model = BasicConvTestModel()
+    # Should complete successfully even though no loaders have been registered into the config.
+    _, _ = create_compressed_model_and_algo_for_test(model, NNCFConfig.from_dict({
+        "input_info": {
+            "sample_size": [1, 1, 4, 4]
+        },
+        "compression": {
+            "algorithm": "quantization",
+            "initializer": {
+                "range": {
+                    "num_init_samples": 0
+                },
+                "batchnorm_adaptation": {
+                    "num_bn_adaptation_samples": 0
+                }
+            }
+        }
+    }))

--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -669,17 +669,17 @@ def test_quantization_can_be_run_with_no_data_loaders_if_zero_init_samples():
     model = BasicConvTestModel()
     # Should complete successfully even though no loaders have been registered into the config.
     _, _ = create_compressed_model_and_algo_for_test(model, NNCFConfig.from_dict({
-        "input_info": {
-            "sample_size": [1, 1, 4, 4]
+        'input_info': {
+            'sample_size': [1, 1, 4, 4]
         },
-        "compression": {
-            "algorithm": "quantization",
-            "initializer": {
-                "range": {
-                    "num_init_samples": 0
+        'compression': {
+            'algorithm': 'quantization',
+            'initializer': {
+                'range': {
+                    'num_init_samples': 0
                 },
-                "batchnorm_adaptation": {
-                    "num_bn_adaptation_samples": 0
+                'batchnorm_adaptation': {
+                    'num_bn_adaptation_samples': 0
                 }
             }
         }


### PR DESCRIPTION
### Changes

NNCFConfig will no longer require to have a BN adaptation data loader registered if the number of BN adaptation samples is set to 0 in the quantization algorithm (and if the only required compression is quantization).

### Reason for changes

This makes for easier debug/reproducer runs of quantization algo in a scratch file or a temporary Python console.

### Related tickets

N/A

### Tests

tests.torch.quantization.test_algo_quantization.test_quantization_can_be_run_with_no_data_loaders_if_zero_init_samples
