### PR TITLE
Register torch.mm as a matmul operation

### DIFF
--- a/nncf/common/hardware/configs/cpu.json
+++ b/nncf/common/hardware/configs/cpu.json
@@ -202,6 +202,12 @@
             }
         },
         {
+            "type": "ReduceL2",
+            "quantization": {
+                "activations": "q8_a"
+            }
+        },
+        {
             "type": "ReduceMean",
             "quantization": {
                 "activations": "q8_a"

--- a/nncf/common/hardware/opset.py
+++ b/nncf/common/hardware/opset.py
@@ -39,6 +39,7 @@ class HWConfigOpName:
     MAXPOOL = 'MaxPool'
     REDUCEMAX = 'ReduceMax'
     REDUCESUM = 'ReduceSum'
+    REDUCEL2 = 'ReduceL2'
     INTERPOLATE = 'Interpolate'
     MVN = 'MVN'
     RESHAPE = 'Reshape'

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -399,7 +399,7 @@ class PTMatMulMetatype(PTOperatorMetatype):
     name = "MatMulOp"
     module_to_function_names = {
         NamespaceTarget.TORCH_TENSOR: ["matmul"],
-        NamespaceTarget.TORCH: ["matmul", "bmm"]
+        NamespaceTarget.TORCH: ["matmul", "bmm", "mm"],
     }
     hw_config_names = [HWConfigOpName.MATMUL]
 

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -759,6 +759,15 @@ class PTSumMetatype(PTOperatorMetatype):
     hw_config_names = [HWConfigOpName.REDUCESUM]
 
 
+@PT_OPERATOR_METATYPES.register()
+class PTReduceL2(PTOperatorMetatype):
+    name = "ReduceL2"
+    module_to_function_names = {
+        NamespaceTarget.TORCH_NN_FUNCTIONAL: ["normalize"],  # note: normalize is for general L_p normalization
+    }
+    hw_config_names = [HWConfigOpName.REDUCEL2]
+
+
 def get_operator_metatypes() -> List[Type[OperatorMetatype]]:
     """
     Returns a list of the operator metatypes.

--- a/nncf/torch/graph/pattern_operations.py
+++ b/nncf/torch/graph/pattern_operations.py
@@ -71,6 +71,7 @@ POOLING_OPERATIONS = {'type': ['adaptive_avg_pool2d',
                       'label': 'POOLING'}
 
 MATMUL_OPERATIONS = {'type': ['bmm',
-                              'matmul'
+                              'matmul',
+                              'mm'
                               ],
                      'label': 'MATMUL'}

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/MMDivConv.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/MMDivConv.dot
@@ -1,0 +1,25 @@
+strict digraph  {
+"0 /nncf_model_input_0" [id=0, type=nncf_model_input];
+"1 SymmetricQuantizer/symmetric_quantize_0" [id=1, type=symmetric_quantize];
+"2 /nncf_model_input_1" [id=2, type=nncf_model_input];
+"3 SymmetricQuantizer/symmetric_quantize_1" [id=3, type=symmetric_quantize];
+"4 MMDivConv/mm_0" [id=4, type=mm];
+"5 MMDivConv/__truediv___0" [id=5, type=__truediv__];
+"6 MMDivConv/SymmetricQuantizer/symmetric_quantize_0" [id=6, type=symmetric_quantize];
+"7 MMDivConv/unsqueeze_0" [id=7, type=unsqueeze];
+"8 MMDivConv/unsqueeze_1" [id=8, type=unsqueeze];
+"9 MMDivConv/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" [id=9, type=symmetric_quantize];
+"10 MMDivConv/NNCFConv2d[conv]/conv2d_0" [id=10, type=conv2d];
+"11 /nncf_model_output_0" [id=11, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
+"1 SymmetricQuantizer/symmetric_quantize_0" -> "4 MMDivConv/mm_0";
+"2 /nncf_model_input_1" -> "3 SymmetricQuantizer/symmetric_quantize_1";
+"3 SymmetricQuantizer/symmetric_quantize_1" -> "4 MMDivConv/mm_0";
+"4 MMDivConv/mm_0" -> "5 MMDivConv/__truediv___0";
+"5 MMDivConv/__truediv___0" -> "6 MMDivConv/SymmetricQuantizer/symmetric_quantize_0";
+"6 MMDivConv/SymmetricQuantizer/symmetric_quantize_0" -> "7 MMDivConv/unsqueeze_0";
+"7 MMDivConv/unsqueeze_0" -> "8 MMDivConv/unsqueeze_1";
+"8 MMDivConv/unsqueeze_1" -> "10 MMDivConv/NNCFConv2d[conv]/conv2d_0";
+"9 MMDivConv/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" -> "10 MMDivConv/NNCFConv2d[conv]/conv2d_0";
+"10 MMDivConv/NNCFConv2d[conv]/conv2d_0" -> "11 /nncf_model_output_0";
+}

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/normalize.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/normalize.dot
@@ -1,0 +1,9 @@
+strict digraph  {
+"0 /nncf_model_input_0" [id=0, type=nncf_model_input];
+"1 SymmetricQuantizer/symmetric_quantize_0" [id=1, type=symmetric_quantize];
+"2 TestModel/normalize_0" [id=2, type=normalize];
+"3 /nncf_model_output_0" [id=3, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
+"1 SymmetricQuantizer/symmetric_quantize_0" -> "2 TestModel/normalize_0";
+"2 TestModel/normalize_0" -> "3 /nncf_model_output_0";
+}

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -24,6 +24,7 @@ import torch
 
 from nncf.torch.utils import get_model_device
 from tests.torch.test_models.synthetic import ConvRelu6HSwishHSigmoid
+from tests.torch.test_models.synthetic import MMDivConv
 from tests.torch.test_models.synthetic import MatMulDivConv
 from torch import nn
 import torch.nn.functional as F
@@ -724,6 +725,7 @@ SYNTHETIC_MODEL_DESC_LIST = [
                                                                   "filler": "zeros"}),
     GeneralModelDesc(model_builder=MultiOutputSameTensorModel),
     GeneralModelDesc(model_builder=MatMulDivConv, input_sample_sizes=([1, 1, 5, 5], [1, 1, 5, 5])),
+    GeneralModelDesc(model_builder=MMDivConv, input_sample_sizes=([5, 5], [5, 5])),
     GeneralModelDesc(model_builder=ConvRelu6HSwishHSigmoid, input_sample_sizes=([1, 1, 5, 5],))
 ]
 

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -635,6 +635,8 @@ SYNTHETIC_MODEL_DESC_LIST = [
     TensorBinaryMethodsDesc(model_name='MatMul', tensor_method='matmul'),
 
     SingleLayerModelDesc(model_name='Mean', layer=torch.mean),
+    SingleLayerModelDesc(model_name='normalize', layer=partial(torch.nn.functional.normalize, p=2),
+                         input_sample_sizes=([1, 1, 1, 1], )),
 
     TensorUnaryMethodsDesc(tensor_method='round'),
 

--- a/tests/torch/test_models/synthetic.py
+++ b/tests/torch/test_models/synthetic.py
@@ -239,6 +239,18 @@ class MatMulDivConv(nn.Module):
         return self.conv(z)
 
 
+class MMDivConv(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = create_conv(1, 1, 1, 2)
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor):
+        z = torch.mm(x, y) / 2
+        z = z.unsqueeze(0)
+        z = z.unsqueeze(0)
+        return self.conv(z)
+
+
 class ConvRelu6HSwishHSigmoid(nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
### Changes

As stated in the title. Enables models that utilize `torch.mm` to have the `torch.mm` inputs quantized.

### Reason for changes

Generalization of NNCF PT applicability.

### Related tickets

76378

### Tests

tests.torch.test_compressed_graph.test_synthetic_model_quantization
