### PR TITLE
`disable-compression` command line option

### DIFF
--- a/examples/tensorflow/classification/README.md
+++ b/examples/tensorflow/classification/README.md
@@ -50,20 +50,37 @@ The ImageNet dataset in TFRecords format should be specified in the configuratio
 
 - If you did not install the package, add the repository root folder to the `PYTHONPATH` environment variable.
 - Go to the `examples/tensorflow/classification` folder.
-- Run the following command to start compression with fine-tuning on all available GPUs on the machine:
-    ```bash
-    python main.py \
-    --mode=train \
-    --config=configs/quantization/mobilenet_v2_imagenet_int8.json \
-    --data=<path_to_imagenet_dataset> \
-    --log-dir=../../results/quantization/mobilenet_v2_int8
-    ```
-    It may take a few epochs to get the baseline accuracy results.
-- Use the `--resume` flag with the path to the checkpoint to resume training from the defined checkpoint or folder with checkpoints to resume training from the last checkpoint.
+
+#### Test Pretrained Model
+
+Before compressing a model, it is highly recommended checking the accuracy of the pretrained model. All models which are supported in the sample has pretrained weights for ImageNet. 
+
+To load pretrained weights into a model and then evaluate the accuracy of that model, make sure that the pretrained=True option is set in the configuration file and use the following command:
+```bash
+python main.py \
+--mode=test \
+--config=configs/quantization/mobilenet_v2_imagenet_int8.json \
+--data=<path_to_imagenet_dataset> \
+--disable-compression 
+```
+
+#### Compress Pretrained Model
+
+Run the following command to start compression with fine-tuning on all available GPUs on the machine:
+  ```bash
+  python main.py \
+  --mode=train \
+  --config=configs/quantization/mobilenet_v2_imagenet_int8.json \
+  --data=<path_to_imagenet_dataset> \
+  --log-dir=../../results/quantization/mobilenet_v2_int8
+  ```
+It may take a few epochs to get the baseline accuracy results.
+
+Use the `--resume` flag with the path to the checkpoint to resume training from the defined checkpoint or folder with checkpoints to resume training from the last checkpoint.
 
 ### Validate Your Model Checkpoint
 
-To estimate the test scores of your model checkpoint, use the following command:
+To estimate the test scores of your trained model checkpoint, use the following command:
 ```bash
 python main.py \
 --mode=test \
@@ -71,7 +88,6 @@ python main.py \
 --data=<path_to_imagenet_dataset> \
 --resume=<path_to_trained_model_checkpoint>
 ```
-To validate an model checkpoint, make sure the compression algorithm settings are empty in the configuration file and `pretrained=True` is set.
 
 ### Export Compressed Model
 

--- a/examples/tensorflow/common/argparser.py
+++ b/examples/tensorflow/common/argparser.py
@@ -217,6 +217,12 @@ def get_common_argument_parser(**flags):
             metavar='N',
             help='Print frequency (batch iterations). Default: 10)'))
 
+    parser.add_argument(
+        "--disable-compression",
+        help="Disable compression",
+        action="store_true",
+    )
+
     return parser
 
 

--- a/examples/tensorflow/common/sample_config.py
+++ b/examples/tensorflow/common/sample_config.py
@@ -104,6 +104,9 @@ class SampleConfig(Dict):
 def create_sample_config(args, parser) -> SampleConfig:
     nncf_config = NNCFConfig.from_json(args.config)
 
+    if args.disable_compression and 'compression' in nncf_config:
+        del nncf_config['compression']
+
     sample_config = SampleConfig.from_json(args.config)
     sample_config.update_from_args(args, parser)
     sample_config.nncf_config = nncf_config

--- a/examples/tensorflow/object_detection/README.md
+++ b/examples/tensorflow/object_detection/README.md
@@ -67,7 +67,16 @@ The [COCO2017](https://cocodataset.org/) dataset in TFRecords format should be s
 - Download the pre-trained weights in H5 format and provide the path to them using `--weights` flag. The link to the 
 archive with pre-trained weights can be found in the `TensorFlow checkpoint` column of the [results](#results) table. 
 Select the checkpoint corresponding to the `None` compression algorithm, which includes the pre-trained weights for the 
-FP32 model, without applying any compression algorithms.  
+FP32 model, without applying any compression algorithms.
+- (Optional) Before compressing a model, it is highly recommended checking the accuracy of the pretrained model, use the following command: 
+  ```bash
+  python main.py \
+  --mode=test \
+  --config=configs/quantization/retinanet_coco_int8.json \
+  --weights=<path_to_H5_file_with_pretrained_weights>
+  --data=<path_to_dataset> \
+  --disable-compression 
+  ```
 - Run the following command to start compression with fine-tuning on all available GPUs on the machine:
     ```bash
     python main.py \
@@ -81,7 +90,7 @@ FP32 model, without applying any compression algorithms.
 
 ### Validate Your Model Checkpoint
 
-To estimate the test scores of your model checkpoint, use the following command:
+To estimate the test scores of your trained model checkpoint, use the following command:
 ```bash
 python main.py \
 --mode=test \
@@ -89,8 +98,6 @@ python main.py \
 --data=<path_to_dataset> \
 --resume=<path_to_trained_model_checkpoint>
 ```
-
-To validate an model checkpoint, make sure the compression algorithm settings are empty in the configuration file and path to`.h5` file with model weights is provided in command line argument `--weights`.
 
 ### Export Compressed Model
 

--- a/examples/tensorflow/segmentation/README.md
+++ b/examples/tensorflow/segmentation/README.md
@@ -54,6 +54,16 @@ archive with pre-trained weights can be found in the `TensorFlow checkpoint` col
 Select the checkpoint corresponding to the `None` compression algorithm, which includes the pre-trained weights for the 
 FP32 model, without applying any compression algorithms.
 - Specify the GPUs to be used for training by setting the environment variable [`CUDA_VISIBLE_DEVICES`](https://developer.nvidia.com/blog/cuda-pro-tip-control-gpu-visibility-cuda_visible_devices/). This is necessary because training and validation during training must be performed on different GPU devices. Please note that usually only one GPU is required for validation during training.
+- (Optional) Before compressing a model, it is highly recommended checking the accuracy of the pretrained model, use the following command:
+  ```bash
+  python evaluation.py \
+  --mode=test \
+  --config=configs/quantization/mask_rcnn_coco_int8.json \
+  --weights=<path_to_ckpt_file_with_pretrained_weights> \
+  --data=<path_to_dataset> \
+  --batch-size=1 \
+  --disable-compression
+  ```
 - Run the following command to start compression with fine-tuning on all available GPUs on the machine:
     ```bash
     python train.py \
@@ -80,7 +90,7 @@ To start checkpoints validation during training follow these steps:
 
 ### Validate Your Model Checkpoint
 
-To estimate the test scores of your model checkpoint, use the following command
+To estimate the test scores of your trained model checkpoint, use the following command
 ```bash
 python evaluation.py \
 --mode=test \
@@ -89,8 +99,6 @@ python evaluation.py \
 --batch-size=1 \
 --resume=<path_to_trained_model_checkpoint>
 ```
-
-To validate an model checkpoint, make sure the compression algorithm settings are empty in the configuration file and path to checkpoint file with model weights is provided in command line argument `--weights`
 
 ### Export Compressed Model
 


### PR DESCRIPTION
### Changes

Simplify scenario of evaluation pre-trained model.  I suggest using the `disable-compression` option instead of removing the compression section from the config file.

### Reason for changes

Customer request

### Related tickets

N/A

### Tests

N/A
