### PR TITLE
Completely removed input masks for mask propagation

### DIFF
--- a/nncf/common/pruning/operations.py
+++ b/nncf/common/pruning/operations.py
@@ -224,7 +224,6 @@ class ElementwisePruningOp(BasePruningOp):
         if output_mask is not None:
             output_mask = tensor_processor.elementwise_mask_propagation(input_masks)
 
-        node.data['input_masks'] = input_masks
         node.data['output_mask'] = output_mask
 
 

--- a/nncf/common/pruning/utils.py
+++ b/nncf/common/pruning/utils.py
@@ -581,5 +581,4 @@ def identity_mask_propagation(node: NNCFNode, graph: NNCFGraph) -> None:
         # In case for disconnected NNCFGraph
         input_masks = [None]
     assert len(input_masks) == 1
-    node.data['input_masks'] = input_masks
     node.data['output_mask'] = input_masks[0]

--- a/nncf/torch/pruning/utils.py
+++ b/nncf/torch/pruning/utils.py
@@ -49,13 +49,12 @@ def get_bn_for_conv_node_by_name(target_model: NNCFNetwork, conv_node_name: NNCF
 
 def init_output_masks_in_graph(graph: NNCFGraph, nodes: List):
     """
-    Initialize masks in groph for mask propagation algorithm
+    Initialize masks in graph for mask propagation algorithm
 
     :param graph: NNCFNetwork
     :param nodes: list with pruned nodes
     """
     for node in graph.get_all_nodes():
-        node.data.pop('input_masks', None)
         node.data.pop('output_mask', None)
 
     for minfo in nodes:


### PR DESCRIPTION
### Changes

Removed adding `input_masks` attribute to node.data for mask propagation algorithm
**Still keep it for deprecated export utils** - the attribute pops up in the `input_prune` methods.


### Reason for changes

Mask propagation doesn't actually use `input_masks` anymore, It keeps `output_mask` only and calculate input masks based on output masks of previous nodes. It was done to avoid duplication and errors related to inconsistent input and output masks.
Without this change mask propagation algorithm may look misleading in terms of using input_masks

### Related tickets


### Tests

just should be no regression in current test scope, new tests are not needed
