### PR TITLE
Cast scale to the input_low/input_range dtype

### DIFF
--- a/nncf/torch/quantization/quantize_functions.py
+++ b/nncf/torch/quantization/quantize_functions.py
@@ -192,7 +192,8 @@ class TuneRange(torch.autograd.Function):
         input_low_copy[input_low_copy > 0] = 0
         input_high[input_high < 0] = 0
         n = levels - 1
-        scale = levels / (input_high - input_low_copy)
+        # Need a cast here because fp16 division yileds fp32 results sometimes
+        scale = (levels / (input_high - input_low_copy)).to(dtype=input_high.dtype)
         zp = torch.round(-input_low_copy * scale)
 
         new_input_low = torch.where(zp < n, zp / (zp - n) * input_high, input_low_copy)


### PR DESCRIPTION
### Changes

In the asymmetric quantizer execution, add a safety cast of the intermediate calculations to the precision of the tensors that are input into the quantizer.

### Reason for changes

Due to unknown reason the intermediate calculations with FP16 torch values result in FP32 outputs, which breaks downstream code that expects that all values involved have one and the same dtype.

### Related tickets

70246

### Tests

Cannot be reproduced in laboratory conditions even if the same tensor values are used.
