### PR TITLE
Add instance_norm op and test.

### DIFF
--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -863,6 +863,12 @@ class PTSumMetatype(PTOperatorMetatype):
     module_to_function_names = {NamespaceTarget.TORCH_TENSOR: ["sum"], NamespaceTarget.TORCH: ["sum"]}
     hw_config_names = [HWConfigOpName.REDUCESUM]
 
+@PT_OPERATOR_METATYPES.register()
+class PTInstanceNormMetatype(PTOperatorMetatype):
+    name = "InstanceNormOp"
+    module_to_function_names = {
+        NamespaceTarget.TORCH_NN_FUNCTIONAL: ["instance_norm"]
+    }
 
 @PT_OPERATOR_METATYPES.register()
 class PTReduceL2(PTOperatorMetatype):

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -863,12 +863,12 @@ class PTSumMetatype(PTOperatorMetatype):
     module_to_function_names = {NamespaceTarget.TORCH_TENSOR: ["sum"], NamespaceTarget.TORCH: ["sum"]}
     hw_config_names = [HWConfigOpName.REDUCESUM]
 
+
 @PT_OPERATOR_METATYPES.register()
 class PTInstanceNormMetatype(PTOperatorMetatype):
     name = "InstanceNormOp"
-    module_to_function_names = {
-        NamespaceTarget.TORCH_NN_FUNCTIONAL: ["instance_norm"]
-    }
+    module_to_function_names = {NamespaceTarget.TORCH_NN_FUNCTIONAL: ["instance_norm"]}
+
 
 @PT_OPERATOR_METATYPES.register()
 class PTReduceL2(PTOperatorMetatype):

--- a/nncf/torch/graph/pattern_operations.py
+++ b/nncf/torch/graph/pattern_operations.py
@@ -45,6 +45,14 @@ LAYER_NORMALIZATION_OPERATIONS = {
     GraphPattern.LABEL_ATTR: "LAYER_NORMALIZATION",
 }
 
+INSTANCE_NORMALIZATION_OPERATIONS = {'type': ['instance_norm',
+                                              'instance_norm1d',
+                                              'instance_norm2d',
+                                              'instance_norm3d'
+                                           ],
+                                  'label': 'INSTANCE_NORMALIZATION'
+                                  }
+
 RELU_OPERATIONS = {GraphPattern.METATYPE_ATTR: ["relu", "relu_", "hardtanh"], GraphPattern.LABEL_ATTR: "RELU"}
 
 NON_RELU_ACTIVATIONS_OPERATIONS = {

--- a/nncf/torch/graph/pattern_operations.py
+++ b/nncf/torch/graph/pattern_operations.py
@@ -45,13 +45,10 @@ LAYER_NORMALIZATION_OPERATIONS = {
     GraphPattern.LABEL_ATTR: "LAYER_NORMALIZATION",
 }
 
-INSTANCE_NORMALIZATION_OPERATIONS = {'type': ['instance_norm',
-                                              'instance_norm1d',
-                                              'instance_norm2d',
-                                              'instance_norm3d'
-                                           ],
-                                  'label': 'INSTANCE_NORMALIZATION'
-                                  }
+INSTANCE_NORMALIZATION_OPERATIONS = {
+    "type": ["instance_norm", "instance_norm1d", "instance_norm2d", "instance_norm3d"],
+    "label": "INSTANCE_NORMALIZATION",
+}
 
 RELU_OPERATIONS = {GraphPattern.METATYPE_ATTR: ["relu", "relu_", "hardtanh"], GraphPattern.LABEL_ATTR: "RELU"}
 

--- a/nncf/torch/graph/pattern_operations.py
+++ b/nncf/torch/graph/pattern_operations.py
@@ -47,7 +47,7 @@ LAYER_NORMALIZATION_OPERATIONS = {
 
 INSTANCE_NORMALIZATION_OPERATIONS = {
     "type": ["instance_norm", "instance_norm1d", "instance_norm2d", "instance_norm3d"],
-    "label": "INSTANCE_NORMALIZATION",
+    GraphPattern.LABEL_ATTR: "INSTANCE_NORMALIZATION",
 }
 
 RELU_OPERATIONS = {GraphPattern.METATYPE_ATTR: ["relu", "relu_", "hardtanh"], GraphPattern.LABEL_ATTR: "RELU"}

--- a/nncf/torch/layers.py
+++ b/nncf/torch/layers.py
@@ -261,7 +261,6 @@ class NNCFGroupNorm(_NNCFModuleMixin, nn.GroupNorm):
         nncf_bn = align_module_internals(module, nncf_bn)
         return nncf_bn
 
-
 class NNCFLayerNorm(_NNCFModuleMixin, nn.LayerNorm):
     op_func_name = "layer_norm"
     ignored_algorithms = ["magnitude_sparsity", "rb_sparsity", "const_sparsity", "quantization"]
@@ -273,6 +272,53 @@ class NNCFLayerNorm(_NNCFModuleMixin, nn.LayerNorm):
         nncf_ln = NNCFLayerNorm(module.normalized_shape, hasattr(module, "eps"))
         nncf_ln = align_module_internals(module, nncf_ln)
         return nncf_ln
+
+class NNCFInstanceNorm1d(_NNCFModuleMixin, nn.InstanceNorm1d):
+    op_func_name = "instance_norm"
+    ignored_algorithms = ['magnitude_sparsity', 'rb_sparsity', 'const_sparsity', 'quantization']
+
+    @staticmethod
+    def from_module(module):
+        assert module.__class__.__name__ == nn.InstanceNorm1d.__name__
+
+        nncf_in = NNCFInstanceNorm1d(num_features=module.num_features,
+                                     affine=module.affine,
+                                     momentum=module.momentum,
+                                     eps=module.eps)
+        dict_update(nncf_in.__dict__, module.__dict__)
+        return nncf_in
+
+
+class NNCFInstanceNorm2d(_NNCFModuleMixin, nn.InstanceNorm2d):
+    op_func_name = "instance_norm"
+    ignored_algorithms = ['magnitude_sparsity', 'rb_sparsity', 'const_sparsity', 'quantization']
+
+    @staticmethod
+    def from_module(module):
+        assert module.__class__.__name__ == nn.InstanceNorm2d.__name__
+
+        nncf_in = NNCFInstanceNorm2d(num_features=module.num_features,
+                                     affine=module.affine,
+                                     momentum=module.momentum,
+                                     eps=module.eps)
+        dict_update(nncf_in.__dict__, module.__dict__)
+        return nncf_in
+
+
+class NNCFInstanceNorm3d(_NNCFModuleMixin, nn.InstanceNorm3d):
+    op_func_name = "instance_norm"
+    ignored_algorithms = ['magnitude_sparsity', 'rb_sparsity', 'const_sparsity', 'quantization']
+
+    @staticmethod
+    def from_module(module):
+        assert module.__class__.__name__ == nn.InstanceNorm3d.__name__
+
+        nncf_in = NNCFInstanceNorm3d(num_features=module.num_features,
+                                     affine=module.affine,
+                                     momentum=module.momentum,
+                                     eps=module.eps)
+        dict_update(nncf_in.__dict__, module.__dict__)
+        return nncf_in
 
 
 class NNCFConvTranspose2d(_NNCFModuleMixin, nn.ConvTranspose2d):
@@ -408,6 +454,9 @@ NNCF_MODULES_DICT = {
     NNCFConvTranspose3d: nn.ConvTranspose3d,
     NNCFEmbedding: nn.Embedding,
     NNCFEmbeddingBag: nn.EmbeddingBag,
+    NNCFInstanceNorm1d: nn.InstanceNorm1d,
+    NNCFInstanceNorm2d: nn.InstanceNorm2d,
+    NNCFInstanceNorm3d: nn.InstanceNorm3d
 }
 
 NNCF_MODULES_MAP = {k.__name__: v.__name__ for k, v in NNCF_MODULES_DICT.items()}

--- a/nncf/torch/layers.py
+++ b/nncf/torch/layers.py
@@ -261,6 +261,7 @@ class NNCFGroupNorm(_NNCFModuleMixin, nn.GroupNorm):
         nncf_bn = align_module_internals(module, nncf_bn)
         return nncf_bn
 
+
 class NNCFLayerNorm(_NNCFModuleMixin, nn.LayerNorm):
     op_func_name = "layer_norm"
     ignored_algorithms = ["magnitude_sparsity", "rb_sparsity", "const_sparsity", "quantization"]
@@ -273,50 +274,48 @@ class NNCFLayerNorm(_NNCFModuleMixin, nn.LayerNorm):
         nncf_ln = align_module_internals(module, nncf_ln)
         return nncf_ln
 
+
 class NNCFInstanceNorm1d(_NNCFModuleMixin, nn.InstanceNorm1d):
     op_func_name = "instance_norm"
-    ignored_algorithms = ['magnitude_sparsity', 'rb_sparsity', 'const_sparsity', 'quantization']
+    ignored_algorithms = ["magnitude_sparsity", "rb_sparsity", "const_sparsity", "quantization"]
 
     @staticmethod
     def from_module(module):
         assert module.__class__.__name__ == nn.InstanceNorm1d.__name__
 
-        nncf_in = NNCFInstanceNorm1d(num_features=module.num_features,
-                                     affine=module.affine,
-                                     momentum=module.momentum,
-                                     eps=module.eps)
+        nncf_in = NNCFInstanceNorm1d(
+            num_features=module.num_features, affine=module.affine, momentum=module.momentum, eps=module.eps
+        )
         dict_update(nncf_in.__dict__, module.__dict__)
         return nncf_in
 
 
 class NNCFInstanceNorm2d(_NNCFModuleMixin, nn.InstanceNorm2d):
     op_func_name = "instance_norm"
-    ignored_algorithms = ['magnitude_sparsity', 'rb_sparsity', 'const_sparsity', 'quantization']
+    ignored_algorithms = ["magnitude_sparsity", "rb_sparsity", "const_sparsity", "quantization"]
 
     @staticmethod
     def from_module(module):
         assert module.__class__.__name__ == nn.InstanceNorm2d.__name__
 
-        nncf_in = NNCFInstanceNorm2d(num_features=module.num_features,
-                                     affine=module.affine,
-                                     momentum=module.momentum,
-                                     eps=module.eps)
+        nncf_in = NNCFInstanceNorm2d(
+            num_features=module.num_features, affine=module.affine, momentum=module.momentum, eps=module.eps
+        )
         dict_update(nncf_in.__dict__, module.__dict__)
         return nncf_in
 
 
 class NNCFInstanceNorm3d(_NNCFModuleMixin, nn.InstanceNorm3d):
     op_func_name = "instance_norm"
-    ignored_algorithms = ['magnitude_sparsity', 'rb_sparsity', 'const_sparsity', 'quantization']
+    ignored_algorithms = ["magnitude_sparsity", "rb_sparsity", "const_sparsity", "quantization"]
 
     @staticmethod
     def from_module(module):
         assert module.__class__.__name__ == nn.InstanceNorm3d.__name__
 
-        nncf_in = NNCFInstanceNorm3d(num_features=module.num_features,
-                                     affine=module.affine,
-                                     momentum=module.momentum,
-                                     eps=module.eps)
+        nncf_in = NNCFInstanceNorm3d(
+            num_features=module.num_features, affine=module.affine, momentum=module.momentum, eps=module.eps
+        )
         dict_update(nncf_in.__dict__, module.__dict__)
         return nncf_in
 
@@ -456,7 +455,7 @@ NNCF_MODULES_DICT = {
     NNCFEmbeddingBag: nn.EmbeddingBag,
     NNCFInstanceNorm1d: nn.InstanceNorm1d,
     NNCFInstanceNorm2d: nn.InstanceNorm2d,
-    NNCFInstanceNorm3d: nn.InstanceNorm3d
+    NNCFInstanceNorm3d: nn.InstanceNorm3d,
 }
 
 NNCF_MODULES_MAP = {k.__name__: v.__name__ for k, v in NNCF_MODULES_DICT.items()}

--- a/nncf/torch/pruning/operations.py
+++ b/nncf/torch/pruning/operations.py
@@ -180,7 +180,7 @@ class PTIdentityMaskForwardPruningOp(IdentityMaskForwardPruningOp, PTPruner):
         PTHardSigmoidMetatype,
         PTNoopMetatype,
         PTInterpolateMetatype,
-        PTInstanceNormMetatype
+        PTInstanceNormMetatype,
     ]
     additional_types = ["h_sigmoid", "h_swish", "RELU"]
 

--- a/nncf/torch/pruning/operations.py
+++ b/nncf/torch/pruning/operations.py
@@ -57,6 +57,7 @@ from nncf.torch.graph.operator_metatypes import PTHardSigmoidMetatype
 from nncf.torch.graph.operator_metatypes import PTHardSwishMetatype
 from nncf.torch.graph.operator_metatypes import PTHardTanhMetatype
 from nncf.torch.graph.operator_metatypes import PTInputNoopMetatype
+from nncf.torch.graph.operator_metatypes import PTInstanceNormMetatype
 from nncf.torch.graph.operator_metatypes import PTInterpolateMetatype
 from nncf.torch.graph.operator_metatypes import PTLayerNormMetatype
 from nncf.torch.graph.operator_metatypes import PTLeakyRELUMetatype
@@ -179,6 +180,7 @@ class PTIdentityMaskForwardPruningOp(IdentityMaskForwardPruningOp, PTPruner):
         PTHardSigmoidMetatype,
         PTNoopMetatype,
         PTInterpolateMetatype,
+        PTInstanceNormMetatype
     ]
     additional_types = ["h_sigmoid", "h_swish", "RELU"]
 

--- a/tests/torch/helpers.py
+++ b/tests/torch/helpers.py
@@ -96,15 +96,17 @@ def create_bn(num_features, dim=2):
 
 def create_instance_norm(num_features, dim=2, affine=True):
     in_dim_map = {
-         1: nn.InstanceNorm1d,
-         2: nn.InstanceNorm2d,
-         3: nn.InstanceNorm3d,
-     }
+        1: nn.InstanceNorm1d,
+        2: nn.InstanceNorm2d,
+        3: nn.InstanceNorm3d,
+    }
 
     return in_dim_map[dim](num_features, affine=affine)
 
-def create_grouped_conv(in_channels, out_channels, kernel_size, groups,
-                        weight_init=1, bias_init=0, padding=0, stride=1):
+
+def create_grouped_conv(
+    in_channels, out_channels, kernel_size, groups, weight_init=1, bias_init=0, padding=0, stride=1
+):
     if in_channels % groups != 0 or out_channels % groups != 0:
         raise RuntimeError(
             "Cannot create grouped convolution. Either `in_channels` or `out_channels` are not divisible by `groups`"

--- a/tests/torch/helpers.py
+++ b/tests/torch/helpers.py
@@ -94,9 +94,17 @@ def create_bn(num_features, dim=2):
     return bn_dim_map[dim](num_features)
 
 
-def create_grouped_conv(
-    in_channels, out_channels, kernel_size, groups, weight_init=1, bias_init=0, padding=0, stride=1
-):
+def create_instance_norm(num_features, dim=2, affine=True):
+    in_dim_map = {
+         1: nn.InstanceNorm1d,
+         2: nn.InstanceNorm2d,
+         3: nn.InstanceNorm3d,
+     }
+
+    return in_dim_map[dim](num_features, affine=affine)
+
+def create_grouped_conv(in_channels, out_channels, kernel_size, groups,
+                        weight_init=1, bias_init=0, padding=0, stride=1):
     if in_channels % groups != 0 or out_channels % groups != 0:
         raise RuntimeError(
             "Cannot create grouped convolution. Either `in_channels` or `out_channels` are not divisible by `groups`"

--- a/tests/torch/pruning/filter_pruning/test_algo.py
+++ b/tests/torch/pruning/filter_pruning/test_algo.py
@@ -109,7 +109,7 @@ def test_valid_modules_replacement_and_pruning(prune_first, prune_batch_norms):
         assert len(module.pre_ops) == 0
         assert len(module.post_ops) == 0
 
-    config = get_basic_pruning_config(input_sample_size=[1, 1, 8, 8])
+    config = get_basic_pruning_config(input_sample_size=[2, 1, 8, 8])
     config["compression"]["params"]["prune_first_conv"] = prune_first
     config["compression"]["params"]["prune_batch_norms"] = prune_batch_norms
 
@@ -217,7 +217,7 @@ def test_pruning_masks_correctness(all_weights, prune_by_flops, pruning_init, pr
         # print(x, y)
         assert torch.allclose(pruning_op.binary_filter_pruning_mask, ref_masks[dim][num])
 
-    config = get_basic_pruning_config(input_sample_size=[1, 1] + [8] * dim)
+    config = get_basic_pruning_config(input_sample_size=[2, 1] + [8] * dim)
     config["compression"]["params"]["all_weights"] = all_weights
     config["compression"]["params"]["prune_first_conv"] = prune_first
 
@@ -307,7 +307,7 @@ def test_pruning_masks_applying_correctness(all_weights, prune_by_flops, pruning
         for key in ref_state_dict.keys():
             assert torch.allclose(model_state_dict[key], ref_state_dict[key])
 
-    config = get_basic_pruning_config(input_sample_size=[1, 1] + [8] * dim)
+    config = get_basic_pruning_config(input_sample_size=[2, 1] + [8] * dim)
     config["compression"]["algorithm"] = "filter_pruning"
     config["compression"]["params"]["all_weights"] = all_weights
     config["compression"]["params"]["prune_first_conv"] = prune_first
@@ -380,7 +380,7 @@ def test_pruning_masks_applying_correctness(all_weights, prune_by_flops, pruning
 
 @pytest.mark.parametrize("prune_bn", (False, True))
 def test_valid_masks_for_bn_after_concat(prune_bn):
-    config = get_basic_pruning_config(input_sample_size=[1, 1, 8, 8])
+    config = get_basic_pruning_config(input_sample_size=[2, 1, 8, 8])
     config["compression"]["algorithm"] = "filter_pruning"
     config["compression"]["params"]["prune_batch_norms"] = prune_bn
     config["compression"]["params"]["prune_first_conv"] = True
@@ -706,7 +706,7 @@ PruningTestModelDiffChInPruningClusterRef = {
 
      ])  # fmt: skip
 def test_flops_calculator(model_module, all_weights, pruning_flops_target, ref_flops, ref_params_num, refs):
-    config = get_basic_pruning_config(input_sample_size=[1, 1, 8, 8])
+    config = get_basic_pruning_config(input_sample_size=[2, 1, 8, 8])
     config["compression"]["algorithm"] = "filter_pruning"
     config["compression"]["params"]["all_weights"] = all_weights
     config["compression"]["params"]["prune_first_conv"] = True
@@ -782,7 +782,7 @@ def test_flops_calculator(model_module, all_weights, pruning_flops_target, ref_f
 )
 @pytest.mark.parametrize("additional_last_shared_layers", [True, False])
 def test_clusters_for_multiple_forward(repeat_seq_of_shared_convs, ref_second_cluster, additional_last_shared_layers):
-    config = get_basic_pruning_config(input_sample_size=[1, 2, 8, 8])
+    config = get_basic_pruning_config(input_sample_size=[2, 2, 8, 8])
     config["compression"]["algorithm"] = "filter_pruning"
     config["compression"]["params"]["all_weights"] = False
     config["compression"]["params"]["prune_first_conv"] = True
@@ -811,7 +811,7 @@ def test_clusters_for_multiple_forward(repeat_seq_of_shared_convs, ref_second_cl
 )
 def test_func_calculation_flops_for_conv(model):
     # Check _calculate_output_shape that used for disconnected graph
-    config = get_basic_pruning_config([1, 1, 8, 8])
+    config = get_basic_pruning_config([2, 1, 8, 8])
     config["compression"]["algorithm"] = "filter_pruning"
     config["compression"]["pruning_init"] = 0.0
     config["compression"]["params"]["pruning_flops_target"] = 0.0

--- a/tests/torch/pruning/filter_pruning/test_set_pruning_rate.py
+++ b/tests/torch/pruning/filter_pruning/test_set_pruning_rate.py
@@ -46,7 +46,7 @@ def test_setting_pruning_level(all_weights, pruning_level_to_set, ref_pruning_le
     Test setting global and groupwise pruning levels via the set_pruning_level method.
     """
     # Creating algorithm with empty config
-    config = get_basic_pruning_config(input_sample_size=[1, 1, 8, 8])
+    config = get_basic_pruning_config(input_sample_size=[2, 1, 8, 8])
     config["compression"]["pruning_init"] = 0.2
     config["compression"]["params"]["all_weights"] = all_weights
 
@@ -64,7 +64,7 @@ def test_can_set_compression_rate_in_filter_pruning_algo():
     Test setting the global pruning level via the compression_rate property.
     """
     # Creating algorithm with empty config
-    config = get_basic_pruning_config(input_sample_size=[1, 1, 8, 8])
+    config = get_basic_pruning_config(input_sample_size=[2, 1, 8, 8])
     config["compression"]["pruning_init"] = 0.2
 
     _, pruning_controller, _ = create_pruning_algo_with_config(config)

--- a/tests/torch/pruning/helpers.py
+++ b/tests/torch/pruning/helpers.py
@@ -12,14 +12,16 @@
 import copy
 
 import torch
-from torch import nn
 import torch.nn.functional as F
+from torch import nn
 
 from nncf.config import NNCFConfig
 from nncf.torch.dynamic_graph.context import no_nncf_trace
-from tests.torch.helpers import create_bn, create_conv, fill_linear_weight
+from tests.torch.helpers import create_bn
+from tests.torch.helpers import create_conv
 from tests.torch.helpers import create_depthwise_conv
 from tests.torch.helpers import create_grouped_conv
+from tests.torch.helpers import create_instance_norm
 from tests.torch.helpers import create_transpose_conv
 from tests.torch.helpers import fill_linear_weight
 from tests.torch.test_models.pnasnet import CellB

--- a/tests/torch/pruning/test_model_pruning_analysis.py
+++ b/tests/torch/pruning/test_model_pruning_analysis.py
@@ -72,9 +72,9 @@ from tests.torch.pruning.helpers import SplitReshapeModel
 from tests.torch.pruning.helpers import get_basic_pruning_config
 
 
-def create_nncf_model_and_pruning_builder(model: torch.nn.Module,
-                                          config_params: Dict,
-                                          input_sample_size: List[int] = None) -> Tuple[NNCFNetwork, FilterPruningBuilder]:
+def create_nncf_model_and_pruning_builder(
+    model: torch.nn.Module, config_params: Dict, input_sample_size: List[int] = None
+) -> Tuple[NNCFNetwork, FilterPruningBuilder]:
     if input_sample_size is None:
         input_sample_size = [1, 1, 8, 8]
     nncf_config = get_basic_pruning_config(input_sample_size=input_sample_size)
@@ -96,7 +96,7 @@ class GroupPruningModulesTestStruct:
         final_can_prune: Dict[int, PruningAnalysisDecision],
         prune_params: Tuple[bool, bool],
         name: Optional[str] = None,
-        input_sample_size: List[int] = None
+        input_sample_size: List[int] = None,
     ):
         self.model = model
         self.non_pruned_module_nodes = non_pruned_module_nodes
@@ -104,7 +104,7 @@ class GroupPruningModulesTestStruct:
         self.pruned_groups_by_node_id = pruned_groups_by_node_id
         self.can_prune_after_analysis = can_prune_after_analysis
         self.final_can_prune = final_can_prune
-        self.prune_params = prune_params # Prune first, Prune downsample
+        self.prune_params = prune_params  # Prune first, Prune downsample
         self.input_sample_size = input_sample_size if input_sample_size is not None else [1, 1, 8, 8]
         self.name = name
 
@@ -750,7 +750,9 @@ def test_pruning_node_selector(test_input_info_struct_: GroupPruningModulesTestS
     )
     model = model()
     model.eval()
-    nncf_network = NNCFNetwork(model, input_info=FillerInputInfo([FillerInputElement(test_input_info_struct_.input_sample_size)]))
+    nncf_network = NNCFNetwork(
+        model, input_info=FillerInputInfo([FillerInputElement(test_input_info_struct_.input_sample_size)])
+    )
     graph = nncf_network.nncf.get_original_graph()
     pruning_groups = pruning_node_selector.create_pruning_groups(graph)
 
@@ -774,8 +776,9 @@ def test_pruning_node_selector(test_input_info_struct_: GroupPruningModulesTestS
 def test_symbolic_mask_propagation(test_input_info_struct_):
     model = test_input_info_struct_.model()
     prune_first, *_ = test_input_info_struct_.prune_params
-    nncf_model, _ = create_nncf_model_and_pruning_builder(model, {"prune_first_conv": prune_first},
-     input_sample_size=test_input_info_struct_.input_sample_size)
+    nncf_model, _ = create_nncf_model_and_pruning_builder(
+        model, {"prune_first_conv": prune_first}, input_sample_size=test_input_info_struct_.input_sample_size
+    )
     pruning_types = [v.op_func_name for v in NNCF_PRUNING_MODULES_DICT]
     nncf_model.eval()
     graph = nncf_model.nncf.get_graph()

--- a/tests/torch/pruning/test_utils.py
+++ b/tests/torch/pruning/test_utils.py
@@ -37,7 +37,7 @@ def test_get_rounded_pruned_element_number(total, sparsity_rate, multiple_of, re
 
 
 def test_get_bn_for_conv_node():
-    config = get_basic_pruning_config(input_sample_size=[1, 1, 8, 8])
+    config = get_basic_pruning_config(input_sample_size=[2, 1, 8, 8])
     config["compression"]["algorithm"] = "filter_pruning"
     pruned_model, _ = create_compressed_model_and_algo_for_test(BigPruningTestModel(), config)
 
@@ -66,7 +66,7 @@ def test_get_bn_for_conv_node():
     ],
 )
 def test_get_first_pruned_layers(model, ref_first_module_names):
-    config = get_basic_pruning_config(input_sample_size=[1, 1, 8, 8])
+    config = get_basic_pruning_config(input_sample_size=[2, 1, 8, 8])
     config["compression"]["algorithm"] = "filter_pruning"
     pruned_model, _ = create_compressed_model_and_algo_for_test(model(), config)
 


### PR DESCRIPTION
### Changes
The  torch.nn.InstanceNorm3d layer is wrapping by NNCF. 

<!--- What was changed (briefly), how to reproduce (if applicable), what the reviewers should focus on -->

### Reason for changes
This is necessary for correct pruning of models with conv3d and InstanceNorm3d
<!--- Why should the change be applied -->

### Related tickets
#77188
<!--- Post the numerical ID of the ticket, if available -->

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
 tests/torch/pruning/test_model_pruning_analysis.py