### PR TITLE
Changed normalization parameters for CIFAR-10 images

### DIFF
--- a/examples/torch/classification/main.py
+++ b/examples/torch/classification/main.py
@@ -384,7 +384,10 @@ def create_datasets(config):
     elif dataset_config == 'cifar100':
         normalize = transforms.Normalize(mean=(0.5071, 0.4865, 0.4409),
                                          std=(0.2673, 0.2564, 0.2761))
-    elif dataset_config in ['cifar10', 'mock_32x32', 'mock_299x299']:
+    elif dataset_config == 'cifar10':
+        normalize = transforms.Normalize(mean=(0.4914, 0.4822, 0.4465),
+                                         std=(0.2471, 0.2435, 0.2616))
+    elif dataset_config in ['mock_32x32', 'mock_299x299']:
         normalize = transforms.Normalize(mean=(0.5, 0.5, 0.5),
                                          std=(0.5, 0.5, 0.5))
 


### PR DESCRIPTION

### Changes

Changed mean/std values for pre-processing input images from CIFAR10 dataset

### Reason for changes

It helps to reuse models pretrained on CIFAR10 from:
https://github.com/huyvnphan/PyTorch_CIFAR10/blob/master/data.py#L16
This models are used for e2e validation of BootstrapNAS feature #1079 

### Related tickets

### Tests

It affects backward compatibility tests that compare actual test accuracy with 'best_acc1' value in the checkpoint.
The `best_acc1` value was overridden to correspond to the introduced pre-processing.
