### PR TITLE
Fix pytest collection warnings

### DIFF
--- a/tests/torch/pruning/filter_pruning/test_algo.py
+++ b/tests/torch/pruning/filter_pruning/test_algo.py
@@ -34,7 +34,7 @@ from tests.torch.pruning.helpers import gen_ref_masks
 from tests.torch.pruning.helpers import get_basic_pruning_config
 from tests.torch.pruning.helpers import PruningTestModel
 from tests.torch.pruning.helpers import BigPruningTestModel
-from tests.torch.pruning.helpers import TestModelMultipleForward
+from tests.torch.pruning.helpers import MultipleForwardModel
 from tests.torch.pruning.helpers import PruningTestModelConcatBN
 from tests.torch.pruning.helpers import DisconectedGraphModel
 
@@ -415,7 +415,7 @@ def test_clusters_for_multiple_forward(repeat_seq_of_shared_convs,
     config['compression']['params']['all_weights'] = False
     config['compression']['params']['prune_first_conv'] = True
     config['compression']['pruning_init'] = 0.5
-    model = TestModelMultipleForward(repeat_seq_of_shared_convs, additional_last_shared_layers)
+    model = MultipleForwardModel(repeat_seq_of_shared_convs, additional_last_shared_layers)
     _, pruning_algo = create_compressed_model_and_algo_for_test(model, config)
 
     clusters = pruning_algo.pruned_module_groups_info.clusters

--- a/tests/torch/pruning/filter_pruning/test_layers.py
+++ b/tests/torch/pruning/filter_pruning/test_layers.py
@@ -22,7 +22,7 @@ from nncf.torch.pruning.filter_pruning.layers import FilterPruningMask, inplace_
 from tests.torch.helpers import fill_conv_weight, fill_bias
 
 
-class TestFilterPruningBlockModel(nn.Module):
+class FilterPruningBlockModel(nn.Module):
     def __init__(self, layer):
         super().__init__()
         self.layer = layer
@@ -55,7 +55,7 @@ def test_can_infer_magnitude_pruned_conv(weights_val, bias_val):
     nncf_module = NNCFConv2d(1, 1, 2)
     pytorch_module = nn.Conv2d(1, 1, 2)
 
-    sparse_model = TestFilterPruningBlockModel(nncf_module)
+    sparse_model = FilterPruningBlockModel(nncf_module)
 
     fill_conv_weight(nncf_module, weights_val)
     fill_bias(nncf_module, bias_val)

--- a/tests/torch/pruning/helpers.py
+++ b/tests/torch/pruning/helpers.py
@@ -43,7 +43,7 @@ class PruningTestModel(nn.Module):
         return x
 
 
-class TestModelDiffConvs(nn.Module):
+class DiffConvsModel(nn.Module):
     def __init__(self):
         super().__init__()
         # Usual conv
@@ -67,7 +67,7 @@ class TestModelDiffConvs(nn.Module):
         return x
 
 
-class TestModelBranching(nn.Module):
+class BranchingModel(nn.Module):
     def __init__(self):
         super().__init__()
         self.conv1 = create_conv(1, 3, 2, 1, -2)
@@ -84,7 +84,7 @@ class TestModelBranching(nn.Module):
         return x
 
 
-class TestModelResidualConnection(nn.Module):
+class ResidualConnectionModel(nn.Module):
     def __init__(self):
         super().__init__()
         self.conv1 = create_conv(1, 8, 3, 1, -2, padding=1)
@@ -105,7 +105,7 @@ class TestModelResidualConnection(nn.Module):
         return x
 
 
-class TestModelEltwiseCombination(nn.Module):
+class EltwiseCombinationModel(nn.Module):
     def __init__(self):
         super().__init__()
         self.conv1 = create_conv(1, 8, 3, 1, -2, padding=1)
@@ -290,7 +290,7 @@ class TestShuffleUnit(nn.Module):
         return x
 
 
-class TestModelShuffleNetUnit(nn.Module):
+class ShuffleNetUnitModel(nn.Module):
     def __init__(self):
         super().__init__()
         self.conv = create_conv(1, 16, 1, 1, -2)
@@ -302,7 +302,7 @@ class TestModelShuffleNetUnit(nn.Module):
         return x
 
 
-class TestModelShuffleNetUnitDW(nn.Module):
+class ShuffleNetUnitModelDW(nn.Module):
     def __init__(self):
         super().__init__()
         self.conv = create_conv(1, 16, 1, 1, -2)
@@ -314,7 +314,7 @@ class TestModelShuffleNetUnitDW(nn.Module):
         return x
 
 
-class TestModelMultipleForward(nn.Module):
+class MultipleForwardModel(nn.Module):
     def __init__(self, repeat_seq_of_shared_convs=False, additional_last_shared_layers=False):
         super().__init__()
         self.num_iter_shared_convs = 2 if repeat_seq_of_shared_convs else 1
@@ -351,7 +351,7 @@ class TestModelMultipleForward(nn.Module):
         return x1, x2, x3
 
 
-class TestModelGroupNorm(nn.Module):
+class GroupNormModel(nn.Module):
     def __init__(self):
         super().__init__()
         self.conv1 = create_conv(1, 16, 1, 1, -2)

--- a/tests/torch/pruning/test_model_pruning_analysis.py
+++ b/tests/torch/pruning/test_model_pruning_analysis.py
@@ -48,14 +48,14 @@ from tests.torch.pruning.helpers import MobilenetV3BlockSEReshape
 from tests.torch.pruning.helpers import PruningTestModelWrongDims
 from tests.torch.pruning.helpers import PruningTestModelWrongDimsElementwise
 from tests.torch.pruning.helpers import PruningTestModelStopOp
-from tests.torch.pruning.helpers import TestModelBranching
-from tests.torch.pruning.helpers import TestModelDiffConvs
-from tests.torch.pruning.helpers import TestModelEltwiseCombination
-from tests.torch.pruning.helpers import TestModelResidualConnection
-from tests.torch.pruning.helpers import TestModelShuffleNetUnit
-from tests.torch.pruning.helpers import TestModelShuffleNetUnitDW
+from tests.torch.pruning.helpers import BranchingModel
+from tests.torch.pruning.helpers import DiffConvsModel
+from tests.torch.pruning.helpers import EltwiseCombinationModel
+from tests.torch.pruning.helpers import ResidualConnectionModel
+from tests.torch.pruning.helpers import ShuffleNetUnitModel
+from tests.torch.pruning.helpers import ShuffleNetUnitModelDW
 from tests.torch.pruning.helpers import get_basic_pruning_config
-from tests.torch.pruning.helpers import TestModelGroupNorm
+from tests.torch.pruning.helpers import GroupNormModel
 
 
 # pylint: disable=protected-access
@@ -115,11 +115,11 @@ GROUP_PRUNING_MODULES_TEST_CASES = [
                                                    7: PruningAnalysisDecision(
                                                           False, [PruningAnalysisReason.LAST_CONV])},
                                   prune_params=(True, False)),
-    GroupPruningModulesTestStruct(model=TestModelBranching,
+    GroupPruningModulesTestStruct(model=BranchingModel,
                                   non_pruned_module_nodes=[],
-                                  pruned_groups=[['TestModelBranching/NNCFConv2d[conv1]/conv2d_0',
-                                                  'TestModelBranching/NNCFConv2d[conv2]/conv2d_0',
-                                                  'TestModelBranching/NNCFConv2d[conv3]/conv2d_0']],
+                                  pruned_groups=[['BranchingModel/NNCFConv2d[conv1]/conv2d_0',
+                                                  'BranchingModel/NNCFConv2d[conv2]/conv2d_0',
+                                                  'BranchingModel/NNCFConv2d[conv3]/conv2d_0']],
                                   pruned_groups_by_node_id=[[1, 2, 4]],
                                   can_prune_after_analysis={0: True, 1: True, 2: True, 3: True, 4: True,
                                                             5: True, 6: True, 7: True, 8: True, 9: True, 10: True},
@@ -131,13 +131,13 @@ GROUP_PRUNING_MODULES_TEST_CASES = [
                                                    8: PruningAnalysisDecision(
                                                           False, [PruningAnalysisReason.LAST_CONV])},
                                   prune_params=(True, False)),
-    GroupPruningModulesTestStruct(model=TestModelBranching,
+    GroupPruningModulesTestStruct(model=BranchingModel,
                                   non_pruned_module_nodes=[
-                                                      'TestModelBranching/NNCFConv2d[conv1]/conv2d_0',
-                                                      'TestModelBranching/NNCFConv2d[conv2]/conv2d_0',
-                                                      'TestModelBranching/NNCFConv2d[conv3]/conv2d_0',
-                                                      'TestModelBranching/NNCFConv2d[conv4]/conv2d_0',
-                                                      'TestModelBranching/NNCFConv2d[conv5]/conv2d_0'],
+                                                      'BranchingModel/NNCFConv2d[conv1]/conv2d_0',
+                                                      'BranchingModel/NNCFConv2d[conv2]/conv2d_0',
+                                                      'BranchingModel/NNCFConv2d[conv3]/conv2d_0',
+                                                      'BranchingModel/NNCFConv2d[conv4]/conv2d_0',
+                                                      'BranchingModel/NNCFConv2d[conv5]/conv2d_0'],
                                   pruned_groups=[],
                                   pruned_groups_by_node_id=[],
                                   can_prune_after_analysis={0: True, 1: False, 2: False, 3: True, 4: False,
@@ -153,12 +153,12 @@ GROUP_PRUNING_MODULES_TEST_CASES = [
                                                    8: PruningAnalysisDecision(
                                                            False, [PruningAnalysisReason.LAST_CONV])},
                                   prune_params=(False, False)),
-    GroupPruningModulesTestStruct(model=TestModelBranching,
-                                  non_pruned_module_nodes=['TestModelBranching/NNCFConv2d[conv4]/conv2d_0',
-                                                      'TestModelBranching/NNCFConv2d[conv5]/conv2d_0'],
-                                  pruned_groups=[['TestModelBranching/NNCFConv2d[conv1]/conv2d_0',
-                                                  'TestModelBranching/NNCFConv2d[conv2]/conv2d_0',
-                                                  'TestModelBranching/NNCFConv2d[conv3]/conv2d_0']],
+    GroupPruningModulesTestStruct(model=BranchingModel,
+                                  non_pruned_module_nodes=['BranchingModel/NNCFConv2d[conv4]/conv2d_0',
+                                                      'BranchingModel/NNCFConv2d[conv5]/conv2d_0'],
+                                  pruned_groups=[['BranchingModel/NNCFConv2d[conv1]/conv2d_0',
+                                                  'BranchingModel/NNCFConv2d[conv2]/conv2d_0',
+                                                  'BranchingModel/NNCFConv2d[conv3]/conv2d_0']],
                                   pruned_groups_by_node_id=[[1, 2, 4]],
                                   can_prune_after_analysis={0: True, 1: True, 2: True, 3: True, 4: True,
                                                             5: True, 6: True, 7: True, 8: True, 9: True, 10: True},
@@ -170,12 +170,12 @@ GROUP_PRUNING_MODULES_TEST_CASES = [
                                                    8: PruningAnalysisDecision(
                                                           False, [PruningAnalysisReason.LAST_CONV])},
                                   prune_params=(True, False)),
-    GroupPruningModulesTestStruct(model=TestModelResidualConnection,
-                                  non_pruned_module_nodes=['TestModelResidualConnection/NNCFConv2d[conv4]/conv2d_0',
-                                                      'TestModelResidualConnection/NNCFConv2d[conv5]/conv2d_0'],
-                                  pruned_groups=[['TestModelResidualConnection/NNCFConv2d[conv1]/conv2d_0',
-                                                  'TestModelResidualConnection/NNCFConv2d[conv2]/conv2d_0',
-                                                  'TestModelResidualConnection/NNCFConv2d[conv3]/conv2d_0']],
+    GroupPruningModulesTestStruct(model=ResidualConnectionModel,
+                                  non_pruned_module_nodes=['ResidualConnectionModel/NNCFConv2d[conv4]/conv2d_0',
+                                                      'ResidualConnectionModel/NNCFConv2d[conv5]/conv2d_0'],
+                                  pruned_groups=[['ResidualConnectionModel/NNCFConv2d[conv1]/conv2d_0',
+                                                  'ResidualConnectionModel/NNCFConv2d[conv2]/conv2d_0',
+                                                  'ResidualConnectionModel/NNCFConv2d[conv3]/conv2d_0']],
                                   pruned_groups_by_node_id=[[1, 2, 4]],
                                   can_prune_after_analysis={0: True, 1: True, 2: True, 3: True, 4: True,
                                                             5: True, 6: True, 7: False, 8: False, 9: False,
@@ -188,14 +188,14 @@ GROUP_PRUNING_MODULES_TEST_CASES = [
                                                    8: PruningAnalysisDecision(
                                                           False, [PruningAnalysisReason.CLOSING_CONV_MISSING])},
                                   prune_params=(True, False)),
-    GroupPruningModulesTestStruct(model=TestModelEltwiseCombination,
+    GroupPruningModulesTestStruct(model=EltwiseCombinationModel,
                                   non_pruned_module_nodes=[
-                                                  'TestModelEltwiseCombination/NNCFConv2d[conv5]/conv2d_0',
-                                                  'TestModelEltwiseCombination/NNCFConv2d[conv6]/conv2d_0'],
-                                  pruned_groups=[['TestModelEltwiseCombination/NNCFConv2d[conv1]/conv2d_0',
-                                                  'TestModelEltwiseCombination/NNCFConv2d[conv2]/conv2d_0',
-                                                  'TestModelEltwiseCombination/NNCFConv2d[conv4]/conv2d_0',
-                                                  'TestModelEltwiseCombination/NNCFConv2d[conv3]/conv2d_0',],
+                                                  'EltwiseCombinationModel/NNCFConv2d[conv5]/conv2d_0',
+                                                  'EltwiseCombinationModel/NNCFConv2d[conv6]/conv2d_0'],
+                                  pruned_groups=[['EltwiseCombinationModel/NNCFConv2d[conv1]/conv2d_0',
+                                                  'EltwiseCombinationModel/NNCFConv2d[conv2]/conv2d_0',
+                                                  'EltwiseCombinationModel/NNCFConv2d[conv4]/conv2d_0',
+                                                  'EltwiseCombinationModel/NNCFConv2d[conv3]/conv2d_0',],
                                                  ],
                                   pruned_groups_by_node_id=[[1, 2, 4, 6]],
                                   can_prune_after_analysis={0: True, 1: True, 2: True, 3: True, 4: True,
@@ -347,9 +347,9 @@ GROUP_PRUNING_MODULES_TEST_CASES = [
         final_can_prune={1: PruningAnalysisDecision(False, PruningAnalysisReason.CLOSING_CONV_MISSING)},
         prune_params=(True, True)),
     GroupPruningModulesTestStruct(
-        model=TestModelGroupNorm,
-        non_pruned_module_nodes=['TestModelGroupNorm/NNCFConv2d[conv2]/conv2d_0'],
-        pruned_groups=[['TestModelGroupNorm/NNCFConv2d[conv1]/conv2d_0']],
+        model=GroupNormModel,
+        non_pruned_module_nodes=['GroupNormModel/NNCFConv2d[conv2]/conv2d_0'],
+        pruned_groups=[['GroupNormModel/NNCFConv2d[conv1]/conv2d_0']],
         pruned_groups_by_node_id=[[1]],
         can_prune_after_analysis={0: True, 1: True, 2: True, 3: False, 4: False, 5: False},
         final_can_prune={1: PruningAnalysisDecision(True),
@@ -465,15 +465,15 @@ class GroupSpecialModulesTestStruct:
 
 GROUP_SPECIAL_MODULES_TEST_CASES = [
     GroupSpecialModulesTestStruct(
-        model=TestModelBranching,
+        model=BranchingModel,
         eltwise_clusters=[[3, 5], [9]],
     ),
     GroupSpecialModulesTestStruct(
-        model=TestModelResidualConnection,
+        model=ResidualConnectionModel,
         eltwise_clusters=[[3, 5], [9]],
     ),
     GroupSpecialModulesTestStruct(
-        model=TestModelEltwiseCombination,
+        model=EltwiseCombinationModel,
         eltwise_clusters=[[3, 5, 7], [10]]
     )
 ]
@@ -506,7 +506,7 @@ class ModelAnalyserTestStruct:
 
 MODEL_ANALYSER_TEST_CASES = [
     ModelAnalyserTestStruct(
-        model=TestModelResidualConnection,
+        model=ResidualConnectionModel,
         ref_can_prune={0: True, 1: True, 2: True, 3: True, 4: True, 5: True, 6: True, 7: False, 8: False, 9: False,
                        10: False, 11: False, 12: False}
     ),
@@ -548,65 +548,65 @@ class ModulePrunableTestStruct:
 
 IS_MODULE_PRUNABLE_TEST_CASES = [
     ModulePrunableTestStruct(
-        model=TestModelDiffConvs,
+        model=DiffConvsModel,
         config_params={},
-        is_module_prunable={'TestModelDiffConvs/NNCFConv2d[conv1]/conv2d_0': False,
-                            'TestModelDiffConvs/NNCFConv2d[conv2]/conv2d_0': True,
-                            'TestModelDiffConvs/NNCFConv2d[conv3]/conv2d_0': False,
-                            'TestModelDiffConvs/NNCFConv2d[conv4]/conv2d_0': False},
+        is_module_prunable={'DiffConvsModel/NNCFConv2d[conv1]/conv2d_0': False,
+                            'DiffConvsModel/NNCFConv2d[conv2]/conv2d_0': True,
+                            'DiffConvsModel/NNCFConv2d[conv3]/conv2d_0': False,
+                            'DiffConvsModel/NNCFConv2d[conv4]/conv2d_0': False},
     ),
     ModulePrunableTestStruct(
-        model=TestModelDiffConvs,
+        model=DiffConvsModel,
         config_params={'prune_first_conv': True},
-        is_module_prunable={'TestModelDiffConvs/NNCFConv2d[conv1]/conv2d_0': True,
-                            'TestModelDiffConvs/NNCFConv2d[conv2]/conv2d_0': True,
-                            'TestModelDiffConvs/NNCFConv2d[conv3]/conv2d_0': False,
-                            'TestModelDiffConvs/NNCFConv2d[conv4]/conv2d_0': False},
+        is_module_prunable={'DiffConvsModel/NNCFConv2d[conv1]/conv2d_0': True,
+                            'DiffConvsModel/NNCFConv2d[conv2]/conv2d_0': True,
+                            'DiffConvsModel/NNCFConv2d[conv3]/conv2d_0': False,
+                            'DiffConvsModel/NNCFConv2d[conv4]/conv2d_0': False},
     ),
     ModulePrunableTestStruct(
-        model=TestModelDiffConvs,
+        model=DiffConvsModel,
         config_params={'prune_first_conv': True, 'prune_downsample_convs': True},
-        is_module_prunable={'TestModelDiffConvs/NNCFConv2d[conv1]/conv2d_0': True,
-                            'TestModelDiffConvs/NNCFConv2d[conv2]/conv2d_0': True,
-                            'TestModelDiffConvs/NNCFConv2d[conv3]/conv2d_0': True,
-                            'TestModelDiffConvs/NNCFConv2d[conv4]/conv2d_0': False},
+        is_module_prunable={'DiffConvsModel/NNCFConv2d[conv1]/conv2d_0': True,
+                            'DiffConvsModel/NNCFConv2d[conv2]/conv2d_0': True,
+                            'DiffConvsModel/NNCFConv2d[conv3]/conv2d_0': True,
+                            'DiffConvsModel/NNCFConv2d[conv4]/conv2d_0': False},
     ),
     ModulePrunableTestStruct(
-        model=TestModelBranching,
+        model=BranchingModel,
         config_params={},
-        is_module_prunable={'TestModelBranching/NNCFConv2d[conv1]/conv2d_0': False,
-                            'TestModelBranching/NNCFConv2d[conv2]/conv2d_0': False,
-                            'TestModelBranching/NNCFConv2d[conv3]/conv2d_0': False,
-                            'TestModelBranching/NNCFConv2d[conv4]/conv2d_0': True,
-                            'TestModelBranching/NNCFConv2d[conv5]/conv2d_0': True},
+        is_module_prunable={'BranchingModel/NNCFConv2d[conv1]/conv2d_0': False,
+                            'BranchingModel/NNCFConv2d[conv2]/conv2d_0': False,
+                            'BranchingModel/NNCFConv2d[conv3]/conv2d_0': False,
+                            'BranchingModel/NNCFConv2d[conv4]/conv2d_0': True,
+                            'BranchingModel/NNCFConv2d[conv5]/conv2d_0': True},
     ),
     ModulePrunableTestStruct(
-        model=TestModelBranching,
+        model=BranchingModel,
         config_params={'prune_first_conv': True},
-        is_module_prunable={'TestModelBranching/NNCFConv2d[conv1]/conv2d_0': True,
-                            'TestModelBranching/NNCFConv2d[conv2]/conv2d_0': True,
-                            'TestModelBranching/NNCFConv2d[conv3]/conv2d_0': True,
-                            'TestModelBranching/NNCFConv2d[conv4]/conv2d_0': True,
-                            'TestModelBranching/NNCFConv2d[conv5]/conv2d_0': True},
+        is_module_prunable={'BranchingModel/NNCFConv2d[conv1]/conv2d_0': True,
+                            'BranchingModel/NNCFConv2d[conv2]/conv2d_0': True,
+                            'BranchingModel/NNCFConv2d[conv3]/conv2d_0': True,
+                            'BranchingModel/NNCFConv2d[conv4]/conv2d_0': True,
+                            'BranchingModel/NNCFConv2d[conv5]/conv2d_0': True},
     ),
     ModulePrunableTestStruct(
-        model=TestModelShuffleNetUnitDW,
+        model=ShuffleNetUnitModelDW,
         config_params={'prune_first_conv': True},
         is_module_prunable={
-            'TestModelShuffleNetUnitDW/NNCFConv2d[conv]/conv2d_0': True,
-            'TestModelShuffleNetUnitDW/TestShuffleUnit[unit1]/NNCFConv2d[dw_conv4]/conv2d_0': False,
-            'TestModelShuffleNetUnitDW/TestShuffleUnit[unit1]/NNCFConv2d[expand_conv5]/conv2d_0': True,
-            'TestModelShuffleNetUnitDW/TestShuffleUnit[unit1]/NNCFConv2d[compress_conv1]/conv2d_0': True,
-            'TestModelShuffleNetUnitDW/TestShuffleUnit[unit1]/NNCFConv2d[dw_conv2]/conv2d_0': False,
-            'TestModelShuffleNetUnitDW/TestShuffleUnit[unit1]/NNCFConv2d[expand_conv3]/conv2d_0': True},
+            'ShuffleNetUnitModelDW/NNCFConv2d[conv]/conv2d_0': True,
+            'ShuffleNetUnitModelDW/TestShuffleUnit[unit1]/NNCFConv2d[dw_conv4]/conv2d_0': False,
+            'ShuffleNetUnitModelDW/TestShuffleUnit[unit1]/NNCFConv2d[expand_conv5]/conv2d_0': True,
+            'ShuffleNetUnitModelDW/TestShuffleUnit[unit1]/NNCFConv2d[compress_conv1]/conv2d_0': True,
+            'ShuffleNetUnitModelDW/TestShuffleUnit[unit1]/NNCFConv2d[dw_conv2]/conv2d_0': False,
+            'ShuffleNetUnitModelDW/TestShuffleUnit[unit1]/NNCFConv2d[expand_conv3]/conv2d_0': True},
     ),
     ModulePrunableTestStruct(
-        model=TestModelShuffleNetUnit,
+        model=ShuffleNetUnitModel,
         config_params={'prune_first_conv': True},
-        is_module_prunable={'TestModelShuffleNetUnit/NNCFConv2d[conv]/conv2d_0': True,
-                            'TestModelShuffleNetUnit/TestShuffleUnit[unit1]/NNCFConv2d[compress_conv1]/conv2d_0': True,
-                            'TestModelShuffleNetUnit/TestShuffleUnit[unit1]/NNCFConv2d[dw_conv2]/conv2d_0': True,
-                            'TestModelShuffleNetUnit/TestShuffleUnit[unit1]/NNCFConv2d[expand_conv3]/conv2d_0': True},
+        is_module_prunable={'ShuffleNetUnitModel/NNCFConv2d[conv]/conv2d_0': True,
+                            'ShuffleNetUnitModel/TestShuffleUnit[unit1]/NNCFConv2d[compress_conv1]/conv2d_0': True,
+                            'ShuffleNetUnitModel/TestShuffleUnit[unit1]/NNCFConv2d[dw_conv2]/conv2d_0': True,
+                            'ShuffleNetUnitModel/TestShuffleUnit[unit1]/NNCFConv2d[expand_conv3]/conv2d_0': True},
     ),
     ModulePrunableTestStruct(
         model=MultipleDepthwiseConvolutionModel,

--- a/tests/torch/pruning/test_onnx_export.py
+++ b/tests/torch/pruning/test_onnx_export.py
@@ -13,7 +13,7 @@
 import pytest
 
 from tests.torch.pruning.helpers import BigPruningTestModel, get_basic_pruning_config, \
-    PruningTestModelConcat, PruningTestModelEltwise, TestModelDiffConvs, TestModelGroupNorm
+    PruningTestModelConcat, PruningTestModelEltwise, DiffConvsModel, GroupNormModel
 from tests.torch.helpers import load_exported_onnx_version
 
 pytestmark = pytest.mark.skip(reason="Export as actually deleting filters from the model is currently disabled.")
@@ -99,7 +99,7 @@ def test_pruning_export_eltwise_model(tmp_path, prune_first, ref_shapes):
                           (True, [[[16, 1, 2, 2], [16]], [[16, 1, 1, 1], [16]], [[32, 16, 3, 3], [32]],
                                   [[16, 4, 1, 1], [16]]])])
 def test_pruning_export_diffconvs_model(tmp_path, prune_first, ref_shapes):
-    model = TestModelDiffConvs()
+    model = DiffConvsModel()
     nncf_config = get_basic_pruning_config(input_sample_size=[1, 1, 8, 8])
     nncf_config['compression']['algorithm'] = 'filter_pruning'
 
@@ -113,7 +113,7 @@ def test_pruning_export_diffconvs_model(tmp_path, prune_first, ref_shapes):
 
 
 def test_pruning_export_groupnorm_model(tmp_path):
-    model = TestModelGroupNorm()
+    model = GroupNormModel()
     nncf_config = get_basic_pruning_config(input_sample_size=[1, 1, 8, 8])
     nncf_config['compression']['algorithm'] = 'filter_pruning'
 

--- a/tests/torch/pruning/test_utils.py
+++ b/tests/torch/pruning/test_utils.py
@@ -18,7 +18,7 @@ from nncf.common.graph.utils import get_first_nodes_of_type
 from nncf.common.pruning.utils import get_last_nodes_of_type
 from nncf.torch.pruning.utils import get_bn_for_conv_node_by_name
 from tests.torch.pruning.helpers import get_basic_pruning_config, BigPruningTestModel, \
-    TestModelBranching
+    BranchingModel
 from tests.torch.helpers import create_compressed_model_and_algo_for_test
 
 
@@ -65,7 +65,7 @@ def test_get_bn_for_conv_node():
 
 @pytest.mark.parametrize(('model', 'ref_first_module_names'),
                          [(BigPruningTestModel, ['conv1']),
-                          (TestModelBranching, ['conv1', 'conv2', 'conv3']),
+                          (BranchingModel, ['conv1', 'conv2', 'conv3']),
                           ],
                          )
 def test_get_first_pruned_layers(model, ref_first_module_names):
@@ -83,7 +83,7 @@ def test_get_first_pruned_layers(model, ref_first_module_names):
 
 @pytest.mark.parametrize(('model', 'ref_last_module_names'),
                          [(BigPruningTestModel, ['conv3']),
-                          (TestModelBranching, ['conv4', 'conv5']
+                          (BranchingModel, ['conv4', 'conv5']
                            ),
                           ],
                          )

--- a/tests/torch/pytest.ini
+++ b/tests/torch/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+markers = 
+    oveval
+    eval
+    convert
+    train

--- a/tests/torch/quantization/test_manual_precision_init.py
+++ b/tests/torch/quantization/test_manual_precision_init.py
@@ -181,7 +181,7 @@ def test_manual_single_conv(params):
         check_bitwidth_graph(ctrl, model, path_to_dot, graph_dir)
 
 
-class TestPrecisionInitDesc:
+class PrecisionInitTestDesc:
     def __init__(self):
         self.model_creator = AddTwoConv
         config = get_quantization_config_without_range_init()
@@ -251,7 +251,7 @@ class TestPrecisionInitDesc:
 
 
 def test_quantization_configs__with_precisions_list():
-    desc = TestPrecisionInitDesc()
+    desc = PrecisionInitTestDesc()
     model = desc.model_creator()
     config = desc.config
     register_bn_adaptation_init_args(config)

--- a/tests/torch/quantization/test_quantization_metric.py
+++ b/tests/torch/quantization/test_quantization_metric.py
@@ -55,12 +55,12 @@ def as_dict(obj):
     return obj
 
 
-TestStruct = namedtuple(
-    'TestStruct', ('initializers', 'activations', 'weights', 'ignored_scopes', 'target_device', 'expected'))
+CaseStruct = namedtuple(
+    'CaseStruct', ('initializers', 'activations', 'weights', 'ignored_scopes', 'target_device', 'expected'))
 
 
 QUANTIZATION_SHARE_AND_BITWIDTH_DISTR_STATS_TEST_CASES = [
-    TestStruct(
+    CaseStruct(
         initializers={},
         activations={},
         weights={},
@@ -95,7 +95,7 @@ QUANTIZATION_SHARE_AND_BITWIDTH_DISTR_STATS_TEST_CASES = [
             }
         }
     ),
-    TestStruct(
+    CaseStruct(
         initializers={},
         activations={},
         weights={},
@@ -152,7 +152,7 @@ def test_quantization_share_and_bitwidth_distribution_stats(data):
 
 
 MEMORY_CONSUMPTION_STATS_TEST_CASES = [
-    TestStruct(
+    CaseStruct(
         initializers={},
         activations={},
         weights={},
@@ -166,7 +166,7 @@ MEMORY_CONSUMPTION_STATS_TEST_CASES = [
             'weight_memory_consumption_decrease': 4.0
         }
     ),
-    TestStruct(
+    CaseStruct(
         initializers={
             'precision': {
                 'bitwidth_per_scope': [
@@ -189,7 +189,7 @@ MEMORY_CONSUMPTION_STATS_TEST_CASES = [
             'weight_memory_consumption_decrease': 4.05
         }
     ),
-    TestStruct(
+    CaseStruct(
         initializers={},
         activations={},
         weights={},
@@ -227,7 +227,7 @@ def test_memory_consumption_stats(data):
 
 
 QUANTIZATION_CONFIGURATION_STATS_TEST_CASES = [
-    TestStruct(
+    CaseStruct(
         initializers={},
         activations={},
         weights={},
@@ -238,7 +238,7 @@ QUANTIZATION_CONFIGURATION_STATS_TEST_CASES = [
             'total_edges_in_cfg': 177
         }
     ),
-    TestStruct(
+    CaseStruct(
         initializers={},
         activations={},
         weights={},

--- a/tests/torch/sparsity/magnitude/test_modules.py
+++ b/tests/torch/sparsity/magnitude/test_modules.py
@@ -22,7 +22,7 @@ from nncf.torch.sparsity.magnitude.functions import normed_magnitude, abs_magnit
 from tests.torch.helpers import fill_conv_weight, fill_linear_weight, fill_bias
 
 
-class TestModel(nn.Module):
+class SingleLayerModel(nn.Module):
     def __init__(self, layer):
         super().__init__()
         self.layer = layer
@@ -53,7 +53,7 @@ class TestModel(nn.Module):
 )
 def test_can_infer_magnitude_sparse_conv(weight_importance, threshold, ref_output):
     nncf_module = NNCFConv2d(1, 1, 2)
-    sparse_model = TestModel(nncf_module)
+    sparse_model = SingleLayerModel(nncf_module)
     sparsifier = sparse_model.sparsifier
     fill_conv_weight(nncf_module, 9)
     fill_bias(nncf_module, 0)
@@ -83,7 +83,7 @@ def test_can_infer_magnitude_sparse_conv(weight_importance, threshold, ref_outpu
 )
 def test_can_infer_magnitude_sparse_linear(weight_importance, threshold, ref_output):
     nncf_module = NNCFLinear(4, 1)
-    sparse_model = TestModel(nncf_module)
+    sparse_model = SingleLayerModel(nncf_module)
     sparsifier = sparse_model.sparsifier
     fill_linear_weight(nncf_module, 9)
     fill_bias(nncf_module, 0)

--- a/tests/torch/sparsity/rb/test_components.py
+++ b/tests/torch/sparsity/rb/test_components.py
@@ -21,7 +21,7 @@ from nncf.torch.sparsity.rb.layers import RBSparsifyingWeight
 from nncf.torch.sparsity.rb.loss import SparseLoss
 
 
-class TestModel(nn.Module):
+class SingleLayerModel(nn.Module):
     def __init__(self, layer, frozen, size=1):
         super().__init__()
         self.size = size
@@ -42,7 +42,7 @@ class TestModel(nn.Module):
 
 def sparse_model(module, frozen, size=1):
     layer = module(size, size, size)
-    return TestModel(layer, frozen, size)
+    return SingleLayerModel(layer, frozen, size)
 
 
 @pytest.mark.parametrize('module',

--- a/tests/torch/sparsity/test_common.py
+++ b/tests/torch/sparsity/test_common.py
@@ -317,14 +317,14 @@ REF_DEFAULT_STATE = {
 }
 
 
-class TestLoss:
+class MockLoss:
     def __init__(self):
         self.current_sparsity = 0.5
 
 
-class TestCompressionController:
+class MockCompressionController:
     def __init__(self):
-        self.loss = TestLoss()
+        self.loss = MockLoss()
 
     def set_sparsity_level(self, level):
         pass
@@ -334,7 +334,7 @@ class TestCompressionController:
                                            MultiStepSparsityScheduler, AdaptiveSparsityScheduler],
                          ids=['Polynomial', 'Exponential', 'Multistep', 'Adaptive'])
 def test_scheduler_get_state(scheduler_cls):
-    args = (TestCompressionController(), {'sparsity_init': 0.3, 'update_per_optimizer_step': True, 'patience': 2})
+    args = (MockCompressionController(), {'sparsity_init': 0.3, 'update_per_optimizer_step': True, 'patience': 2})
     scheduler = scheduler_cls(*args)
 
     # Test init state

--- a/tests/torch/test_algo_common.py
+++ b/tests/torch/test_algo_common.py
@@ -83,7 +83,7 @@ class TestCompressionAlgos:
         assert os.path.exists(test_path)
 
 
-class TestConfigCreator:
+class ConfigCreator:
     def __init__(self):
         self._config = get_empty_config()
         self._algorithm_sections = {}
@@ -106,7 +106,7 @@ class TestConfigCreator:
 
 
 class CompressionStageTestStruct:
-    def __init__(self, config_provider: 'TestConfigCreator', compression_stages: List[CompressionStage]):
+    def __init__(self, config_provider: 'ConfigCreator', compression_stages: List[CompressionStage]):
         self.config_provider = config_provider
         self.compression_stages = compression_stages
 
@@ -123,30 +123,30 @@ FFF_levels = [CompressionStage.FULLY_COMPRESSED] * 3
 NPF_levels = [CompressionStage.UNCOMPRESSED, CompressionStage.PARTIALLY_COMPRESSED, CompressionStage.FULLY_COMPRESSED]
 LIST_OF_TEST_PARAMS = [
     CompressionStageTestStruct(
-        config_provider=TestConfigCreator().add_algo('quantization'),
+        config_provider=ConfigCreator().add_algo('quantization'),
         compression_stages=FFF_levels
     ),
     CompressionStageTestStruct(
-        config_provider=TestConfigCreator().add_algo('quantization', staged_quantization_params),
+        config_provider=ConfigCreator().add_algo('quantization', staged_quantization_params),
         compression_stages=NPF_levels
     ),
     CompressionStageTestStruct(
-        config_provider=TestConfigCreator().add_algo('const_sparsity'),
+        config_provider=ConfigCreator().add_algo('const_sparsity'),
         compression_stages=FFF_levels
     ),
     CompressionStageTestStruct(
-        config_provider=TestConfigCreator().add_algo('magnitude_sparsity', magnitude_sparsity_params),
+        config_provider=ConfigCreator().add_algo('magnitude_sparsity', magnitude_sparsity_params),
         compression_stages=NPF_levels
     ),
     CompressionStageTestStruct(
-        config_provider=TestConfigCreator().add_algo('rb_sparsity', {
+        config_provider=ConfigCreator().add_algo('rb_sparsity', {
             'sparsity_target': 0.61,
             'sparsity_target_epoch': 2,
         }),
         compression_stages=NPF_levels
     ),
     CompressionStageTestStruct(
-        config_provider=TestConfigCreator().add_algo('filter_pruning', {
+        config_provider=ConfigCreator().add_algo('filter_pruning', {
             'num_init_steps': 1,
             'pruning_steps': 2,
             'schedule': 'baseline'
@@ -156,26 +156,26 @@ LIST_OF_TEST_PARAMS = [
                             CompressionStage.FULLY_COMPRESSED]
     ),
     CompressionStageTestStruct(
-        config_provider=TestConfigCreator().add_algo('filter_pruning', filter_pruning_params),
+        config_provider=ConfigCreator().add_algo('filter_pruning', filter_pruning_params),
         compression_stages=NPF_levels
     ),
     CompressionStageTestStruct(
-        config_provider=TestConfigCreator().add_algo('magnitude_sparsity', magnitude_sparsity_params).add_algo(
+        config_provider=ConfigCreator().add_algo('magnitude_sparsity', magnitude_sparsity_params).add_algo(
             'quantization'),
         compression_stages=[CompressionStage.PARTIALLY_COMPRESSED] * 2 + [CompressionStage.FULLY_COMPRESSED],
     ),
     CompressionStageTestStruct(
-        config_provider=TestConfigCreator().add_algo('magnitude_sparsity', magnitude_sparsity_params).add_algo(
+        config_provider=ConfigCreator().add_algo('magnitude_sparsity', magnitude_sparsity_params).add_algo(
             'quantization', staged_quantization_params),
         compression_stages=NPF_levels,
     ),
     CompressionStageTestStruct(
-        config_provider=TestConfigCreator().add_algo('quantization', staged_quantization_params).add_algo(
+        config_provider=ConfigCreator().add_algo('quantization', staged_quantization_params).add_algo(
             'filter_pruning', filter_pruning_params),
         compression_stages=NPF_levels,
     ),
     CompressionStageTestStruct(
-        config_provider=TestConfigCreator().add_algo('magnitude_sparsity', magnitude_sparsity_params).add_algo(
+        config_provider=ConfigCreator().add_algo('magnitude_sparsity', magnitude_sparsity_params).add_algo(
             'quantization', staged_quantization_params).add_algo('filter_pruning', filter_pruning_params),
         compression_stages=NPF_levels,
     ),

--- a/tests/torch/test_distributed_data_parallel_mode.py
+++ b/tests/torch/test_distributed_data_parallel_mode.py
@@ -11,7 +11,7 @@ from nncf.torch import register_default_init_args
 from tests.torch.helpers import create_random_mock_dataloader
 
 
-class TestModelWithChangedTrain(nn.Module):
+class ModelWithChangedTrain(nn.Module):
     def __init__(self, in_out_channels: Tuple[Tuple[int, int]] = ((1, 3), (3, 5), (5, 7), (7, 10)),
                  freezing_stages: int = -1):
         super().__init__()
@@ -41,7 +41,7 @@ class TestModelWithChangedTrain(nn.Module):
 def worker(rank: int, world_size: int) -> None:
     torch.distributed.init_process_group(backend="nccl", init_method='tcp://127.0.0.1:8999',
                                          world_size=world_size, rank=rank)
-    model = TestModelWithChangedTrain(freezing_stages=1)
+    model = ModelWithChangedTrain(freezing_stages=1)
     model.cuda()
     model.to(rank)
 

--- a/tests/torch/test_frozen_layers.py
+++ b/tests/torch/test_frozen_layers.py
@@ -216,7 +216,7 @@ TEST_PARAMS = [
 ]
 
 
-@pytest.yield_fixture()
+@pytest.fixture()
 def _nncf_caplog(caplog):
     nncf_logger.propagate = True
     yield caplog

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -896,7 +896,7 @@ def test_temporary_clean_view():
     assert graph_after_tmp_clean_view == old_graph
 
 
-class TestModelMultipleForward(nn.Module):
+class MultipleForwardModel(nn.Module):
     def __init__(self):
         super().__init__()
         self.conv = nn.Conv2d(1, 1, 1, 1)
@@ -912,7 +912,7 @@ class TestModelMultipleForward(nn.Module):
 def test_multiple_forward():
     # Check that all convolution nodes in model have op_address and layer_attributes
     # for case with multiple forward of one module
-    model = TestModelMultipleForward()
+    model = MultipleForwardModel()
     config = get_basic_sparsity_plus_quantization_config()
     register_bn_adaptation_init_args(config)
     sparse_quantized_model, _ = create_compressed_model_and_algo_for_test(model, config)

--- a/tests/torch/test_resume_from_checkpoint.py
+++ b/tests/torch/test_resume_from_checkpoint.py
@@ -26,11 +26,11 @@ from tests.torch.helpers import create_compressed_model_and_algo_for_test
 from tests.torch.helpers import create_ones_mock_dataloader
 from tests.torch.helpers import get_empty_config
 from tests.torch.helpers import register_bn_adaptation_init_args
-from tests.torch.quantization.test_manual_precision_init import TestPrecisionInitDesc
+from tests.torch.quantization.test_manual_precision_init import PrecisionInitTestDesc
 from tests.torch.sparsity.rb.test_algo import get_basic_sparsity_config
 
 
-@pytest.yield_fixture()
+@pytest.fixture()
 def _nncf_caplog(caplog):
     nncf_logger.propagate = True
     yield caplog
@@ -38,8 +38,8 @@ def _nncf_caplog(caplog):
 
 
 LIST_MANUAL_INIT_CASES = [
-    TestPrecisionInitDesc().config_with_all_inits().resume_with_the_same_config(),
-    TestPrecisionInitDesc().config_with_all_inits().resume_with_the_same_config_without_init()
+    PrecisionInitTestDesc().config_with_all_inits().resume_with_the_same_config(),
+    PrecisionInitTestDesc().config_with_all_inits().resume_with_the_same_config_without_init()
 ]
 
 
@@ -81,7 +81,7 @@ def test_can_resume_with_manual_init(mocker, desc, _nncf_caplog):
 @pytest.mark.skip('algo mixing is not supported')
 @pytest.mark.parametrize('is_strict', (True, False))
 def test_can_resume_with_algo_mixing(mocker, is_strict):
-    desc = TestPrecisionInitDesc().config_with_all_inits()
+    desc = PrecisionInitTestDesc().config_with_all_inits()
     all_quantization_init_spies = desc.setup_init_spies(mocker)
     sparsity_config = get_basic_sparsity_config()
     sparsity_config['target_device'] = 'TRIAL'


### PR DESCRIPTION
### Changes

When collecting tests, pytest checks for entities called Test* and considers these to be namespaces for test cases. There were many entities which in fact do not serve that purpose, and therefore have been renamed.

### Reason for changes

The collection failure warnings take up several console screens and make it harder to understand the pytest output.

### Related tickets

N/A

### Tests

PT precommit test scope launch
