### PR TITLE
Corrected typo to fix broken TF pre-commit

### DIFF
--- a/tests/tensorflow/test_compressed_graph.py
+++ b/tests/tensorflow/test_compressed_graph.py
@@ -212,7 +212,7 @@ SKIP_MAP = {
         'nasnet_mobile': pytest.mark.skip(reason='gitlab issue #18'),
         'xception': pytest.mark.skip(reason='gitlab issue #28'),
         'mask_rcnn': pytest.mark.skip(reason='ticket #50605'),
-        'resnet50v2': pytest.mark.skip(resason='Several masks on one weight'),
+        'resnet50v2': pytest.mark.skip(reason='Several masks on one weight'),
         'mobilenet_v2_slim': pytest.mark.skip(reason='ticket #46349')
     },
     'rb_sparsity': {


### PR DESCRIPTION
### Changes

Corrected typo in a TF test to fix degradation in the TF precommit with new version of pytest.
Seems like previous runs was with old version of pytest (6.2.5) and it ignored this typo.
Currently, CI uses newer version - 7.0.0 and it's failing.

### Reason for changes

to fix degradation in the TF precommit

### Related tickets

### Tests

tf precommit should be green
