### PR TITLE
Add IR name for GELU. 

### DIFF
--- a/nncf/common/hardware/opset.py
+++ b/nncf/common/hardware/opset.py
@@ -55,3 +55,4 @@ class HWConfigOpName:
     EMBEDDINGBAG = 'EmbeddingBag'
     PAD ='Pad'
     STRIDEDSLICE='StridedSlice'
+    GELU = "Gelu"

--- a/nncf/common/hardware/opset.py
+++ b/nncf/common/hardware/opset.py
@@ -55,4 +55,4 @@ class HWConfigOpName:
     EMBEDDINGBAG = 'EmbeddingBag'
     PAD ='Pad'
     STRIDEDSLICE='StridedSlice'
-    GELU = "Gelu"
+    GELU = 'Gelu'

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -307,6 +307,7 @@ class PTGroupNormMetatype(PTOperatorMetatype):
 @PT_OPERATOR_METATYPES.register()
 class PTGELUMetatype(PTOperatorMetatype):
     name = "GeluOp"
+    hw_config_names = [HWConfigOpName.GELU]
     module_to_function_names = {
         NamespaceTarget.TORCH_NN_FUNCTIONAL: ["gelu"]
     }

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/ConvGeluGetItem.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/ConvGeluGetItem.dot
@@ -1,0 +1,32 @@
+strict digraph  {
+"0 /nncf_model_input_0" [id=0, type=nncf_model_input];
+"1 SymmetricQuantizer/symmetric_quantize_0" [id=1, type=symmetric_quantize];
+"2 ConvGeluGetItem/NNCFLinear[fc1]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" [id=2, type=symmetric_quantize];
+"3 ConvGeluGetItem/NNCFLinear[fc1]/linear_0" [id=3, type=linear];
+"4 ConvGeluGetItem/NNCFLinear[fc1]/SymmetricQuantizer/symmetric_quantize_0" [id=4, type=symmetric_quantize];
+"5 ConvGeluGetItem/Dropout[dp]/dropout_0" [id=5, type=dropout];
+"6 ConvGeluGetItem/transpose_0" [id=6, type=transpose];
+"7 ConvGeluGetItem/NNCFConv1d[conv1]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" [id=7, type=symmetric_quantize];
+"8 ConvGeluGetItem/NNCFConv1d[conv1]/conv1d_0" [id=8, type=conv1d];
+"9 ConvGeluGetItem/__getitem___0" [id=9, type=__getitem__];
+"10 ConvGeluGetItem/gelu_0" [id=10, type=gelu];
+"11 ConvGeluGetItem/SymmetricQuantizer/symmetric_quantize_0" [id=11, type=symmetric_quantize];
+"12 ConvGeluGetItem/transpose_1" [id=12, type=transpose];
+"13 ConvGeluGetItem/__add___0" [id=13, type=__add__];
+"14 /nncf_model_output_0" [id=14, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
+"1 SymmetricQuantizer/symmetric_quantize_0" -> "3 ConvGeluGetItem/NNCFLinear[fc1]/linear_0";
+"2 ConvGeluGetItem/NNCFLinear[fc1]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" -> "3 ConvGeluGetItem/NNCFLinear[fc1]/linear_0";
+"3 ConvGeluGetItem/NNCFLinear[fc1]/linear_0" -> "4 ConvGeluGetItem/NNCFLinear[fc1]/SymmetricQuantizer/symmetric_quantize_0";
+"4 ConvGeluGetItem/NNCFLinear[fc1]/SymmetricQuantizer/symmetric_quantize_0" -> "5 ConvGeluGetItem/Dropout[dp]/dropout_0";
+"5 ConvGeluGetItem/Dropout[dp]/dropout_0" -> "6 ConvGeluGetItem/transpose_0";
+"6 ConvGeluGetItem/transpose_0" -> "8 ConvGeluGetItem/NNCFConv1d[conv1]/conv1d_0";
+"7 ConvGeluGetItem/NNCFConv1d[conv1]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" -> "8 ConvGeluGetItem/NNCFConv1d[conv1]/conv1d_0";
+"8 ConvGeluGetItem/NNCFConv1d[conv1]/conv1d_0" -> "9 ConvGeluGetItem/__getitem___0";
+"5 ConvGeluGetItem/Dropout[dp]/dropout_0" -> "13 ConvGeluGetItem/__add___0";
+"9 ConvGeluGetItem/__getitem___0" -> "10 ConvGeluGetItem/gelu_0";
+"10 ConvGeluGetItem/gelu_0" -> "11 ConvGeluGetItem/SymmetricQuantizer/symmetric_quantize_0";
+"11 ConvGeluGetItem/SymmetricQuantizer/symmetric_quantize_0" -> "12 ConvGeluGetItem/transpose_1";
+"12 ConvGeluGetItem/transpose_1" -> "13 ConvGeluGetItem/__add___0";
+"13 ConvGeluGetItem/__add___0" -> "14 /nncf_model_output_0";
+}

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/GELU.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/GELU.dot
@@ -1,9 +1,7 @@
 strict digraph  {
 "0 /nncf_model_input_0" [id=0, type=nncf_model_input];
-"1 SymmetricQuantizer/symmetric_quantize_0" [id=1, type=symmetric_quantize];
-"2 TestModel/GELU[_layer]/gelu_0" [id=2, type=gelu];
-"3 /nncf_model_output_0" [id=3, type=nncf_model_output];
-"0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
-"1 SymmetricQuantizer/symmetric_quantize_0" -> "2 TestModel/GELU[_layer]/gelu_0";
-"2 TestModel/GELU[_layer]/gelu_0" -> "3 /nncf_model_output_0";
+"1 TestModel/GELU[_layer]/gelu_0" [id=1, type=gelu];
+"2 /nncf_model_output_0" [id=2, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "1 TestModel/GELU[_layer]/gelu_0";
+"1 TestModel/GELU[_layer]/gelu_0" -> "2 /nncf_model_output_0";
 }

--- a/tests/torch/quantization/test_hw_config.py
+++ b/tests/torch/quantization/test_hw_config.py
@@ -106,8 +106,9 @@ class TestHWConfigRules:
             ]
         }
 
-        _, ctrl = self.get_model_and_ctrl_with_applied_hw_config_quantization(ModelForHWConfigTest(with_hardswish=False),
-                                                                              hw_config_dict, False)
+        _, ctrl = \
+            self.get_model_and_ctrl_with_applied_hw_config_quantization(ModelForHWConfigTest(with_hardswish=False),
+                                                                        hw_config_dict, False)
         assert len(ctrl.weight_quantizers) == 0  # Conv2d weights remain unquantized
         assert len(ctrl.non_weight_quantizers) == 1  # Only the matmul input is quantized
 
@@ -191,8 +192,9 @@ class TestHWConfigRules:
             ]
         }
 
-        _, ctrl = self.get_model_and_ctrl_with_applied_hw_config_quantization(ModelForHWConfigTest(with_hardswish=False),
-                                                                              hw_config_dict, False)
+        _, ctrl = \
+            self.get_model_and_ctrl_with_applied_hw_config_quantization(ModelForHWConfigTest(with_hardswish=False),
+                                                                        hw_config_dict, False)
         assert len(ctrl.weight_quantizers) == 1  # Conv2d weights quantized
         conv2d_weight_quantizer_ref = list(ctrl.weight_quantizers.values())[0].quantizer_module_ref
         assert not self.quantizer_has_default_config(conv2d_weight_quantizer_ref)
@@ -237,8 +239,9 @@ class TestHWConfigRules:
             ]
         }
 
-        _, ctrl = self.get_model_and_ctrl_with_applied_hw_config_quantization(ModelForHWConfigTest(with_hardswish=False),
-                                                                              hw_config_dict)
+        _, ctrl = \
+            self.get_model_and_ctrl_with_applied_hw_config_quantization(ModelForHWConfigTest(with_hardswish=False),
+                                                                        hw_config_dict)
         assert len(ctrl.weight_quantizers) == 1  # Conv2d weights quantized with default config
         assert len(ctrl.non_weight_quantizers) == 2  # All inputs are quantized.
         for quantizer_ref in ctrl.all_quantizations.values():

--- a/tests/torch/quantization/test_hw_config.py
+++ b/tests/torch/quantization/test_hw_config.py
@@ -117,7 +117,7 @@ class TestHWConfigRules:
         assert key.target_node_name == ModelForHWConfigTest.CONV2D_OP_NODE_NAME
 
     def test_missing_non_ir_op_results_in_default_qconf_list(self):
-        # GELU is the non-IR op here, adjust if this no longer reflects reality
+        # Hardswish is the non-IR op here, adjust if this no longer reflects reality
         hw_config_dict = {
             "target_device": "test",
             "config": {

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -24,6 +24,7 @@ import torch
 
 from nncf.torch.utils import get_model_device
 from tests.torch.test_models.synthetic import ConvBNLeakyReLU
+from tests.torch.test_models.synthetic import ConvGeluGetItem
 from tests.torch.test_models.synthetic import ConvRelu6HSwishHSigmoid
 from tests.torch.test_models.synthetic import FC_ConstMul
 from tests.torch.test_models.synthetic import MMDivConv
@@ -732,7 +733,8 @@ SYNTHETIC_MODEL_DESC_LIST = [
     GeneralModelDesc(model_builder=MMDivConv, input_sample_sizes=([5, 5], [5, 5])),
     GeneralModelDesc(model_builder=ConvRelu6HSwishHSigmoid, input_sample_sizes=([1, 1, 5, 5],)),
     GeneralModelDesc(model_builder=ConvBNLeakyReLU, input_sample_sizes=([1, 1, 5, 5],)),
-    GeneralModelDesc(model_builder=FC_ConstMul, input_sample_sizes=[1, 3, 6])
+    GeneralModelDesc(model_builder=FC_ConstMul, input_sample_sizes=[1, 3, 6]),
+    GeneralModelDesc(model_builder=ConvGeluGetItem, input_sample_sizes=([1, 6, 6],))
 ]
 
 

--- a/tests/torch/test_models/synthetic.py
+++ b/tests/torch/test_models/synthetic.py
@@ -275,6 +275,25 @@ class ConvRelu6HSwishHSigmoid(nn.Module):
         z = self._hsigmoid(z)
         return z
 
+
+class ConvGeluGetItem(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.fc1 = nn.Linear(6, 8)
+        self.dp = nn.Dropout()
+        self.conv1 = nn.Conv1d(8, 8, kernel_size=3, padding=2)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.dp(x)
+        x1 = x.transpose(2, 1)
+        x1 = self.conv1(x1)
+        x1 = F.gelu(x1[:, :, :-2])
+
+        return x + x1.transpose(2, 1)
+
+
 class ConvBNLeakyReLU(nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
### Changes

<!--- What was changed (briefly), how to reproduce (if applicable), what the reviewers should focus on -->
 Add `hw_config_name` for `PTGeluMetatype`. As a result Gelu doesn`t spawn a FQ.
### Reason for changes
Fix bug for wec2vec model
<!--- Why should the change be applied -->

### Related tickets
78186
<!--- Post the numerical ID of the ticket, if available -->

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
`tests/torch/test_compressed_graph.py`