### PR TITLE
Improvements of the quantizers code

### DIFF
--- a/nncf/tensorflow/quantization/quantizers.py
+++ b/nncf/tensorflow/quantization/quantizers.py
@@ -336,32 +336,16 @@ class SymmetricQuantizer(Quantizer):
         self._half_range = False
 
     def quantize(self, inputs, weights, _):
-        def _half_range_quantize():
-            return symmetric_quantize(
-                inputs,
-                weights['scale_var'],
-                weights['signed_var'],
-                num_bits=self.num_bits - 1,
-                per_channel=self.per_channel,
-                narrow_range=self.narrow_range,
-                eps=self._eps
-            )
-
-        def _default_quantize():
-            return symmetric_quantize(
-                inputs,
-                weights['scale_var'],
-                weights['signed_var'],
-                num_bits=self.num_bits,
-                per_channel=self.per_channel,
-                narrow_range=self.narrow_range,
-                eps=self._eps
-            )
-
-        if self._half_range:
-            return _half_range_quantize()
-
-        return _default_quantize()
+        num_bits = self.num_bits - 1 if self._half_range else self.num_bits
+        return symmetric_quantize(
+            inputs,
+            weights['scale_var'],
+            weights['signed_var'],
+            num_bits=num_bits,
+            per_channel=self.per_channel,
+            narrow_range=self.narrow_range,
+            eps=self._eps
+        )
 
     def apply_range_initialization(self, weights, min_values, max_values, min_range=0.1, eps=0.01):
         if self.signedness_to_force is None:
@@ -466,32 +450,16 @@ class AsymmetricQuantizer(Quantizer):
         self._half_range = False
 
     def quantize(self, inputs, weights, _):
-        def _half_range_quantize():
-            return asymmetric_quantize(
-                inputs,
-                weights['input_low_var'],
-                weights['input_range_var'],
-                num_bits=self.num_bits - 1,
-                per_channel=self.per_channel,
-                narrow_range=self.narrow_range,
-                eps=self._eps
-            )
-
-        def _default_quantize():
-            return asymmetric_quantize(
-                inputs,
-                weights['input_low_var'],
-                weights['input_range_var'],
-                num_bits=self.num_bits,
-                per_channel=self.per_channel,
-                narrow_range=self.narrow_range,
-                eps=self._eps
-            )
-
-        if self._half_range:
-            return _half_range_quantize()
-
-        return _default_quantize()
+        num_bits = self.num_bits - 1 if self._half_range else self.num_bits
+        return asymmetric_quantize(
+            inputs,
+            weights['input_low_var'],
+            weights['input_range_var'],
+            num_bits=num_bits,
+            per_channel=self.per_channel,
+            narrow_range=self.narrow_range,
+            eps=self._eps
+        )
 
     def apply_range_initialization(self, weights, min_values, max_values, min_range=0.1, eps=0.01):
         ranges = max_values - min_values

--- a/tests/tensorflow/quantization/test_algorithm_quantization.py
+++ b/tests/tensorflow/quantization/test_algorithm_quantization.py
@@ -625,7 +625,9 @@ def test_quantize_pre_post_processing(layer_name, input_type, data_type):
     layer_metatype = get_keras_layer_metatype(layer_desk.layer, determine_subtype=False)
     assert len(layer_metatype.weight_definitions) == 1
     layer_name = layer_metatype.weight_definitions[0].weight_attr_name
-    q = Quantizer(name='quantizer')
+    qspec = TFQuantizerSpec(num_bits=8, mode=QuantizationMode.SYMMETRIC, signedness_to_force=None,
+                            narrow_range=False, half_range=False, per_channel=False)
+    q = Quantizer('quantizer', qspec)
     q.setup_input_transformation(layer_desk.shape, layer_desk.input_type,
                                  layer_name, layer_desk.layer)
     # pylint: disable=protected-access


### PR DESCRIPTION
### Changes

- Redundant code was removed from the `SymmetricQuantizer.quantize()` and `AsymmetricQuantizer.quantize()` methods
- Implementation of the `get_quantizer_config()`, `get_config()`, `from_config()` methods was moved from the `SymmetricQuantizer` and `AsymmetricQuantizer` classes to the `Quantizer` superclass.

### Reason for changes

Removing the code duplication increases the quality of code. The code becomes more readable and maintainable.

### Related tickets

N/A

### Tests

One test was changed.
Reason: new `qspec` parameter was added to the `Quantizer.__init__()` method.

Additional tests are not required.
