### PR TITLE
Handle dimensionless tensor unstack in NNCFCollectorTensorProcessor

### DIFF
--- a/nncf/common/tensor.py
+++ b/nncf/common/tensor.py
@@ -27,6 +27,9 @@ class NNCFTensor:
     def __init__(self, tensor: Optional[TensorType]):
         self._tensor = tensor
 
+    def __eq__(self, other: 'NNCFTensor') -> bool:
+        return self._tensor == other.tensor
+
     @property
     def tensor(self) -> TensorType:
         return self._tensor

--- a/nncf/tensorflow/tensor_statistics/collectors.py
+++ b/nncf/tensorflow/tensor_statistics/collectors.py
@@ -69,7 +69,10 @@ class TFNNCFCollectorTensorProcessor(NNCFCollectorTensorProcessor):
 
     @staticmethod
     def unstack(x: NNCFTensor, axis: int = 0) -> List[NNCFTensor]:
-        tensor_list = tf.unstack(x.tensor, axis=axis)
+        tensor = x.tensor
+        if list(tensor.shape) == []:
+            tensor = tf.expand_dims(tensor, 0)
+        tensor_list = tf.unstack(tensor, axis=axis)
         return [TFNNCFTensor(t) for t in tensor_list]
 
     @staticmethod

--- a/nncf/torch/tensor_statistics/collectors.py
+++ b/nncf/torch/tensor_statistics/collectors.py
@@ -70,7 +70,10 @@ class PTNNCFCollectorTensorProcessor(NNCFCollectorTensorProcessor):
 
     @staticmethod
     def unstack(x: NNCFTensor, axis: int = 0) -> List[NNCFTensor]:
-        tensor_list = torch.unbind(x.tensor, dim=axis)
+        tensor = x.tensor
+        if list(tensor.shape) == []:
+            tensor = tensor.unsqueeze(0)
+        tensor_list = torch.unbind(tensor, dim=axis)
         return [PTNNCFTensor(t) for t in tensor_list]
 
     @staticmethod

--- a/tests/tensorflow/tensor_statistics/test_tensor_statistics.py
+++ b/tests/tensorflow/tensor_statistics/test_tensor_statistics.py
@@ -22,12 +22,14 @@ from nncf.common.tensor_statistics.collectors import TensorStatisticCollectorBas
     StatisticsNotCollectedError, OfflineTensorStatisticCollector
 from nncf.tensorflow.tensor_statistics.collectors import TFMinMaxStatisticCollector
 from nncf.tensorflow.tensor_statistics.collectors import TFMedianMADStatisticCollector
+from nncf.tensorflow.tensor_statistics.collectors import TFNNCFCollectorTensorProcessor
 from nncf.tensorflow.tensor_statistics.collectors import TFPercentileStatisticCollector
 from nncf.tensorflow.tensor_statistics.collectors import TFMeanPercentileStatisticCollector
 from nncf.tensorflow.tensor_statistics.collectors import TFMixedMinMaxStatisticCollector
 from nncf.tensorflow.tensor_statistics.collectors import TFMeanMinMaxStatisticCollector
 from nncf.tensorflow.tensor_statistics.statistics import TFMinMaxTensorStatistic, TFMedianMADTensorStatistic, \
     TFPercentileTensorStatistic
+from nncf.tensorflow.tensor import TFNNCFTensor
 
 
 class TestCollectedStatistics:
@@ -265,3 +267,18 @@ class TestCollectedStatistics:
         for input_ in TestCollectedStatistics.REF_INPUTS * 10:
             collector_for_num_samples_test.register_input(input_)
         assert collector_for_num_samples_test.collected_samples() == TestCollectedStatistics.REF_NUM_SAMPLES
+
+
+class TestCollectorTensorProcessor:
+    tensor_processor = TFNNCFCollectorTensorProcessor()
+
+    def test_unstack(self):
+        # Unstack tensor with dimensions
+        tensor1 = tf.constant([1.0])
+        tensor_unstacked1 = TestCollectorTensorProcessor.tensor_processor.unstack(TFNNCFTensor(tensor1))
+
+        # Unstack dimensionless tensor
+        tensor2 = tf.constant(1.0)
+        tensor_unstacked2 = TestCollectorTensorProcessor.tensor_processor.unstack(TFNNCFTensor(tensor2))
+
+        assert tensor_unstacked1 == tensor_unstacked2 == [TFNNCFTensor(tf.constant(1.0))]

--- a/tests/torch/tensor_statistics/test_tensor_statistics.py
+++ b/tests/torch/tensor_statistics/test_tensor_statistics.py
@@ -23,8 +23,10 @@ from nncf.common.tensor_statistics.collectors import TensorStatisticCollectorBas
 from nncf.torch.tensor_statistics.collectors import PTMinMaxStatisticCollector, PTMixedMinMaxStatisticCollector, \
     PTMeanMinMaxStatisticCollector, PTMedianMADStatisticCollector, PTPercentileStatisticCollector, \
     PTMeanPercentileStatisticCollector
+from nncf.torch.tensor_statistics.collectors import PTNNCFCollectorTensorProcessor
 from nncf.torch.tensor_statistics.statistics import PTMinMaxTensorStatistic, \
     PTMedianMADTensorStatistic, PTPercentileTensorStatistic
+from nncf.torch.tensor import PTNNCFTensor
 
 
 class TestCollectedStatistics:
@@ -270,3 +272,18 @@ class TestCollectedStatistics:
         for input_ in TestCollectedStatistics.REF_INPUTS * 10:
             collector_for_num_samples_test.register_input(input_)
         assert collector_for_num_samples_test.collected_samples() == TestCollectedStatistics.REF_NUM_SAMPLES
+
+
+class TestCollectorTensorProcessor:
+    tensor_processor = PTNNCFCollectorTensorProcessor()
+
+    def test_unstack(self):
+        # Unstack tensor with dimensions
+        tensor1 = torch.tensor([1.0])
+        tensor_unstacked1 = TestCollectorTensorProcessor.tensor_processor.unstack(PTNNCFTensor(tensor1))
+
+        # Unstack dimensionless tensor
+        tensor2 = torch.tensor(1.0)
+        tensor_unstacked2 = TestCollectorTensorProcessor.tensor_processor.unstack(PTNNCFTensor(tensor2))
+
+        assert tensor_unstacked1 == tensor_unstacked2 == [PTNNCFTensor(torch.tensor(1.0))]


### PR DESCRIPTION
### Changes

As in the title.

### Related tickets

79156

### Tests

Added test for the unstack op of NNCFCollectorTensorProcessor 