### PR TITLE
Fixed test_mapping_to_zero test failure for cpu-only-precommit

### DIFF
--- a/tests/torch/quantization/test_functions.py
+++ b/tests/torch/quantization/test_functions.py
@@ -375,6 +375,9 @@ class TestParametrized:
 @pytest.mark.parametrize('device', ['cuda', 'cpu'])
 def test_mapping_to_zero(quantization_mode, device):
     torch.manual_seed(1)
+
+    if not torch.cuda.is_available() and device == 'cuda':
+        pytest.skip("Skipping CUDA test cases for CPU only setups")
     x_zero = torch.zeros([1]).to(torch.device(device))
     levels = 256
     eps = 1e-6


### PR DESCRIPTION
### Changes

Skipping cuda cases of tests.torch.quantization.test_fucntions.test_mapping_to_zero for cpu only environment was added.

### Reason for changes

tests.torch.quantization.test_fucntions.test_mapping_to_zero was test freezing and making cpu-only-precommit run out of time.
This behavior was induced general by absence of test adaptation for cpu only environment and particularly by trying to place tensor on cuda when there is no cuda devices available.

### Related tickets

81446

### Tests

tests.torch.quantization.test_fucntions.test_mapping_to_zero