### PR TITLE
Fix path to config in sota for ResNet34

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ to find instruction and links to exact configuration files and final checkpoints
 |ResNet-18|DoReFa (weights), scale/threshold (activations)|ImageNet|61.61 (8.19)|
 |ResNet-18|Filter pruning, 40%, magnitude criterion|ImageNet|69.26 (0.54)|
 |ResNet-18|Filter pruning, 40%, geometric median criterion|ImageNet|69.32 (0.48)|
-|ResNet-34|Filter pruning, 40%, geometric median criterion|ImageNet|72.73 (0.57)|
+|ResNet-34|Filter pruning, 50%, geometric median criterion + KD|ImageNet|73.11 (0.19)|
 |GoogLeNet|Filter pruning, 40%, geometric median criterion|ImageNet|68.82 (0.93)|
 
 <a name="pytorch_object_detection"></a>

--- a/tests/torch/sota_checkpoints_eval.json
+++ b/tests/torch/sota_checkpoints_eval.json
@@ -259,14 +259,14 @@
                 "metric_type": "Acc@1",
                 "model_description": "ResNet-34"
             },
-            "resnet34_imagenet_filter_pruning_geomean": {
-                "config": "examples/torch/classification/configs/pruning/resnet34_pruning_geometric_median.json",
+            "resnet34_imagenet_filter_pruning_geomean_kd": {
+                "config": "examples/torch/classification/configs/pruning/resnet34_pruning_geometric_median_kd.json",
                 "reference": "resnet34_imagenet",
-                "target": 72.73,
+                "target": 73.11,
                 "metric_type": "Acc@1",
-                "resume": "resnet34_imagenet_filter_pruning_geomean.pth",
+                "resume": "resnet34_imagenet_filter_pruning_geomean_kd.pth",
                 "model_description": "ResNet-34",
-                "compression_description": "Filter pruning, 40%, geometric median criterion"
+                "compression_description": "Filter pruning, 50%, geometric median criterion + KD"
             },
             "googlenet_imagenet": {
                 "config": "examples/torch/classification/configs/pruning/googlenet_imagenet.json",


### PR DESCRIPTION
### Changes
Path to config for `resnet34_imagenet_filter_pruning_geomean` was changed. 
<!--- What was changed (briefly), how to reproduce (if applicable), what the reviewers should focus on -->

### Reason for changes
E2E test fails.
<!--- Why should the change be applied -->

### Related tickets

<!--- Post the numerical ID of the ticket, if available -->

### Tests
Please see sota_eval_pytorch build 839
<!--- How was the correctness of changes tested and whether new tests were added -->
