### PR TITLE
Fix pruning compression stage check

### DIFF
--- a/nncf/torch/pruning/filter_pruning/algo.py
+++ b/nncf/torch/pruning/filter_pruning/algo.py
@@ -609,7 +609,7 @@ class FilterPruningController(BasePruningAlgoController):
 
     def compression_stage(self) -> CompressionStage:
         target_pruning_level = self.scheduler.target_level
-        actual_pruning_level = self._pruning_level
+        actual_pruning_level = self.compression_rate
         if actual_pruning_level == 0:
             return CompressionStage.UNCOMPRESSED
         if actual_pruning_level >= target_pruning_level:


### PR DESCRIPTION
### Changes

Filter pruning algorithm now uses proper calculation of current pruning level to determine compression stage.
Affects SC.

### Reason for changes

Compression stage of the model pruned by flops was calculated incorrectly. 
Affects Adaptive Compression training as best checkpoints were not saved.

### Related tickets
103420
-

### Tests

-
