### PR TITLE
Add a workaround for torch<1.11.0 bug with tensor indexing

### DIFF
--- a/nncf/torch/__init__.py
+++ b/nncf/torch/__init__.py
@@ -17,15 +17,15 @@ from nncf.version import BKC_TORCHVISION_VERSION
 
 import torch
 from pkg_resources import parse_version
-torch_version = parse_version(torch.__version__).base_version
-if parse_version(BKC_TORCH_VERSION).base_version != torch_version:
+CURRENT_TORCH_VERSION = parse_version(torch.__version__)
+if parse_version(BKC_TORCH_VERSION).base_version != CURRENT_TORCH_VERSION.base_version:
     import warnings
     warnings.warn("NNCF provides best results with torch=={bkc}, "
                    "while current torch version is {curr} - consider switching to torch=={bkc}".format(
          bkc=BKC_TORCH_VERSION,
          curr=torch.__version__
     ))
-elif torch_version < '1.5.0' or torch_version == '1.8.0':
+elif CURRENT_TORCH_VERSION < parse_version('1.5.0') or CURRENT_TORCH_VERSION.base_version == '1.8.0':
     raise RuntimeError(
         "NNCF supports torch>=1.5.0, <=1.8.1, !=1.8.0, while current torch version is {curr}".format(
         curr=torch.__version__

--- a/nncf/torch/dynamic_graph/graph.py
+++ b/nncf/torch/dynamic_graph/graph.py
@@ -332,8 +332,7 @@ class IterationScopeNodeMatcher(DefaultScopeNodeMatcher):
                 untraced_tensor_inputs = []
                 traced_tensor_inputs = []
                 non_tensor_inputs = []
-                for i in inputs:
-                    input_obj = i.getter()
+                for input_obj in inputs:
                     if isinstance(input_obj, Tensor):
                         if not isinstance(input_obj, TracedTensor):
                             untraced_tensor_inputs.append(input_obj)

--- a/nncf/torch/dynamic_graph/op_input_processing.py
+++ b/nncf/torch/dynamic_graph/op_input_processing.py
@@ -13,6 +13,8 @@
 from collections import OrderedDict
 from functools import partial
 from itertools import islice
+from typing import Dict
+from typing import List
 
 from nncf.torch.nested_objects_traversal import NestedObjectIndex
 from nncf.torch.nested_objects_traversal import InputIndexEntry
@@ -23,7 +25,7 @@ def nth(iterable, n, default=None):
 
 
 class OperatorInput:
-    def __init__(self, op_args, op_kwargs):
+    def __init__(self, op_args: List, op_kwargs: Dict):
         self.op_args = op_args
         self.op_kwargs = op_kwargs
         self._index = OrderedDict()  # type: Dict[int, InputIndexEntry]
@@ -37,7 +39,7 @@ class OperatorInput:
                                  op_kwargs_index_entries.get_flat_nested_obj_indexing())}
 
     def __iter__(self):
-        return iter(self._index.values())
+        return OperatorInputIterator(self)
 
     def __getitem__(self, n):
         return self._index[n].getter()
@@ -47,3 +49,16 @@ class OperatorInput:
 
     def __len__(self):
         return len(self._index)
+
+
+class OperatorInputIterator:
+    def __init__(self, op_input: OperatorInput):
+        self._op_input = op_input
+        self._current_element_ordinal = 0
+
+    def __next__(self):
+        if self._current_element_ordinal >= len(self._op_input):
+            raise StopIteration
+        retval = self._op_input[self._current_element_ordinal]
+        self._current_element_ordinal += 1
+        return retval

--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -259,8 +259,8 @@ def patch_torch_operators():
     patch_op_in_namespace(TracedTensor, op_info)
 
     # Ticket 82065 - consider removing this when we drop support for torch versions other than >=1.11.0
-    op_info = PatchedOperatorInfo("__getitem__", NamespaceTarget.TORCH_TENSOR, skip_trace=True)
-    patch_op_in_namespace(torch.Tensor, op_info)
+    # op_info = PatchedOperatorInfo("__getitem__", NamespaceTarget.TORCH_TENSOR, skip_trace=True)
+    # patch_op_in_namespace(torch.Tensor, op_info)
 
     ORIGINAL_OPERATORS.append(OriginalOpInfo("__call__", torch.nn.Module, torch.nn.Module.__call__))
     torch.nn.Module.__call__ = wrap_module_call(torch.nn.Module.__call__)

--- a/nncf/torch/dynamic_graph/trace_tensor.py
+++ b/nncf/torch/dynamic_graph/trace_tensor.py
@@ -65,8 +65,8 @@ class TracedTensor(torch.Tensor):
         """
         Note that this does not return a copy, but modifies the original tensor by reference!
         """
-        tensor.tensor_meta = tensor_meta
         tensor.__class__ = TracedTensor
+        tensor.tensor_meta = tensor_meta
         return tensor
 
     def as_subclass(self, cls: 'TracedTensor') -> 'TracedTensor':

--- a/nncf/torch/dynamic_graph/trace_tensor.py
+++ b/nncf/torch/dynamic_graph/trace_tensor.py
@@ -58,7 +58,6 @@ class TracedTensor(torch.Tensor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.tensor_meta = None
-        self.original_cls = None
 
     @staticmethod
     def from_torch_tensor(tensor: torch.Tensor, tensor_meta: TensorMeta):

--- a/nncf/torch/dynamic_graph/trace_tensor.py
+++ b/nncf/torch/dynamic_graph/trace_tensor.py
@@ -58,10 +58,15 @@ class TracedTensor(torch.Tensor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.tensor_meta = None
+        self.original_cls = None
 
     @staticmethod
-    def from_torch_tensor(tensor, tensor_meta: TensorMeta):
+    def from_torch_tensor(tensor: torch.Tensor, tensor_meta: TensorMeta):
+        """
+        Note that this does not return a copy, but modifies the original tensor by reference!
+        """
         tensor.tensor_meta = tensor_meta
+        tensor.original_cls = tensor.__class__
         tensor.__class__ = TracedTensor
         return tensor
 

--- a/nncf/torch/dynamic_graph/trace_tensor.py
+++ b/nncf/torch/dynamic_graph/trace_tensor.py
@@ -66,7 +66,6 @@ class TracedTensor(torch.Tensor):
         Note that this does not return a copy, but modifies the original tensor by reference!
         """
         tensor.tensor_meta = tensor_meta
-        tensor.original_cls = tensor.__class__
         tensor.__class__ = TracedTensor
         return tensor
 
@@ -130,8 +129,7 @@ def trace_tensors(operator_output, node: 'DynamicGraphNode'):
 
 def make_tensor_metas(inputs: 'OperatorInput') -> List[Optional[TensorMeta]]:
     tensor_metas = []
-    for i, node_input_index_entry in enumerate(inputs):
-        node_input = node_input_index_entry.getter()
+    for i, node_input in enumerate(inputs):
         if isinstance(node_input, TracedTensor):
             tensor_metas.append(node_input.tensor_meta)
         elif isinstance(node_input, torch.Tensor) and not isinstance(node_input, TracedTensor):

--- a/nncf/torch/dynamic_graph/wrappers.py
+++ b/nncf/torch/dynamic_graph/wrappers.py
@@ -69,15 +69,6 @@ OP_NAMES_REQUIRING_MODULE_ATTRS = [v.op_func_name for v in NNCF_MODULES_DICT] + 
 
 
 @contextmanager
-def no_torch_patch():
-    from nncf.torch.dynamic_graph.patch_pytorch import unpatch_torch_operators
-    unpatch_torch_operators()
-    yield
-    from nncf.torch import patch_torch_operators
-    patch_torch_operators()
-
-
-@contextmanager
 def _handle_torch_indexing_bug(operator_name: str, args: List, kwargs: Dict):
     """
     Wraps any tensor indices in [torch.Tensor.]__getitem__ into a tuple to

--- a/nncf/torch/quantization/quantize_functions.py
+++ b/nncf/torch/quantization/quantize_functions.py
@@ -192,7 +192,7 @@ class TuneRange(torch.autograd.Function):
         input_low_copy[input_low_copy > 0] = 0
         input_high[input_high < 0] = 0
         n = levels - 1
-        # Need a cast here because fp16 division yileds fp32 results sometimes
+        # Need a cast here because fp16 division yields fp32 results sometimes
         scale = (levels / (input_high - input_low_copy)).to(dtype=input_high.dtype)
         zp = torch.round(-input_low_copy * scale)
 

--- a/tests/torch/test_graph_building.py
+++ b/tests/torch/test_graph_building.py
@@ -529,7 +529,8 @@ class ModelWithIntegerPaths(torch.nn.Module):
         sz = torch.tensor(x.shape).to(x.device)
         sz_tensor = torch.cat([sz])
         idx_tensor = sz_tensor // sz_tensor
-        x = x[idx_tensor] * torch.ones([1, 1]).to(x.device)
+        single_idx = idx_tensor[0]
+        x = x[single_idx] * torch.ones([1, 1]).to(x.device)
         x = self.linear(x)
         return x
 


### PR DESCRIPTION
### Changes

For torch < 1.11.0, additionally wrap tensor indices for torch.Tensor in a tuple so that indexing a tensor using `TracedTensor` indices has correct behaviour.

### Reason for changes

Fixes incorrect behaviour of NNCF for clients with torch < 1.11.0.

### Related tickets

82065

### Tests

TBA