### PR TITLE
Metatype for BatchMatMulV2

### DIFF
--- a/nncf/tensorflow/graph/metatypes/tf_ops.py
+++ b/nncf/tensorflow/graph/metatypes/tf_ops.py
@@ -153,6 +153,13 @@ class TFMatMulOpMetatype(TFOpWithWeightsMetatype):
 
 
 @TF_OPERATION_METATYPES.register()
+class TFBatchMatMulV2OpMetatype(TFOpMetatype):
+    name = 'BatchMatMulV2Op'
+    op_names = ['BatchMatMulV2']
+    hw_config_names = [HWConfigOpName.MATMUL]
+
+
+@TF_OPERATION_METATYPES.register()
 class TFConv2DOpMetatype(TFOpWithWeightsMetatype):
     name = 'Conv2DOp'
     op_names = ['Conv2D']

--- a/nncf/tensorflow/quantization/default_quantization.py
+++ b/nncf/tensorflow/quantization/default_quantization.py
@@ -50,6 +50,7 @@ DEFAULT_TF_QUANT_TRAIT_TO_OP_DICT = {
         op_metatypes.TFEluOpMetatype,
         op_metatypes.TFLeakyReluOpMetatype,
         op_metatypes.TFRelu6OpMetatype,
+        op_metatypes.TFBatchMatMulV2OpMetatype,
     ],
     QuantizationTrait.NON_QUANTIZABLE: [layer_metatypes.TFSoftmaxLayerMetatype,
                                         op_metatypes.TFSigmoidOpMetatype,


### PR DESCRIPTION
### Changes

The meta type for `BatchMatMulV2` operation was added.

### Reason for changes

Look at the picture. The FQs, which are marked red, weren't inserted without these changes. But we expect them in these points.

![pic](https://user-images.githubusercontent.com/77268007/161144433-330aa8ae-1bb4-4acf-9b3e-a2a008a545a2.PNG)

The model to reproduce is presented below
```python
class CustomModelAttention(tf.keras.Model):
    def __init__(self):
        super().__init__()
        self.query = tf.keras.layers.Dense(units=10, name='query')
        self.key = tf.keras.layers.Dense(units=10, name='key')

    def transpose_for_scores(self, tensor: tf.Tensor, batch_size: int) -> tf.Tensor:
        tensor = tf.reshape(tensor=tensor, shape=(batch_size, -1, 2, 5))
        return tf.transpose(tensor, perm=[0, 2, 1, 3])

    def call(self, inputs, training=None, mask=None):
        mixed_query_layer = self.query(inputs=inputs)
        query_layer = self.transpose_for_scores(mixed_query_layer, 5)
        key_layer = self.transpose_for_scores(self.key(inputs=inputs), 5)
        attention_scores = tf.matmul(query_layer, key_layer, transpose_b=True)
        return attention_scores
```

### Related tickets

N/A


### Tests

Changes were tested manually using the model which is provided above.