### PR TITLE
Fix FQs insertion for experimental quantization

### DIFF
--- a/nncf/experimental/tensorflow/patch_tf.py
+++ b/nncf/experimental/tensorflow/patch_tf.py
@@ -22,6 +22,7 @@ import tensorflow as tf
 from tensorflow.python.eager import context
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import nn
+from tensorflow.python.ops import math_ops
 
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.tensorflow.layers.operation import NNCFOperation
@@ -216,6 +217,11 @@ class TFPatcher:
             # to remove this for new versions.
             if getattr(nn, fn_name, None) is fn:
                 setattr(nn, fn_name, tf_op_wrapper)
+
+            # TODO(andrey-churkin): This is required because `tensorflow.python.ops.math_ops` module
+            # contains following import `from tensorflow.python.ops.gen_math_ops import *`
+            if getattr(math_ops, fn_name, None) is fn:
+                setattr(math_ops, fn_name, tf_op_wrapper)
 
         ops.name_scope = TFPatcher._wrap_name_scope_internal_fn(ops.name_scope)
         ops.name_scope_v2.__enter__ = TFPatcher._wrap_name_scope_v2_enter_fn(ops.name_scope_v2.__enter__)

--- a/nncf/experimental/tensorflow/scope.py
+++ b/nncf/experimental/tensorflow/scope.py
@@ -42,7 +42,11 @@ def get_op_name(op_type_name: str, scope: Optional[str] = None) -> str:
             return scope
         op_name = scope[:-1]
     else:
-        op_name = f'{get_current_name_scope()}/{op_type_name}'
+        current_scope = get_current_name_scope()
+        if current_scope[current_scope.rfind('/') + 1:].startswith(op_type_name.lower()):
+            op_name = current_scope
+        else:
+            op_name = f'{current_scope}/{op_type_name}'
 
     # Remove `replica_*/` prefix from `op_name`.
     if op_name.startswith('replica'):


### PR DESCRIPTION
### Changes

- The `get_op_name()` method was updated.
- The additional TF module was wrapped.

### Reason for changes

Some FQs from the quantizer setup were not inserted to the graph. Look at the picture. The FQs, which are marked red, weren't inserted without these changes (but this FQs are presented in quantizer setup). 

![pic_1](https://user-images.githubusercontent.com/77268007/161215501-ab020dd0-d9ef-48a5-a61a-6393b42438e5.PNG)

The model to reproduce is presented below

```python
class CustomModelGELU(tf.keras.Model):
    def __init__(self):
        super().__init__()
        self._dense = tf.keras.layers.Dense(units=10)

    def call(self, inputs, training=None, mask=None):
        x = tf.keras.activations.gelu(inputs, approximate=False)
        x = self._dense(x)
        x = tf.keras.activations.gelu(x, approximate=False)
        return x
```

### Related tickets

N/A

### Tests

Changes were tested manually using the model which is provided above.