### PR TITLE
Adjust kernels to switch from deprecated torch TH/THC namespaces

### DIFF
--- a/examples/torch/object_detection/layers/extensions/nms/nms_kernel.cu
+++ b/examples/torch/object_detection/layers/extensions/nms/nms_kernel.cu
@@ -1,9 +1,11 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 #include <ATen/ATen.h>
 
-#include <THC/THC.h>
+#include <c10/cuda/CUDAStream.h>
+#include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <THC/THCDeviceUtils.cuh>
 #include <ATen/DeviceGuard.h>
+#include <c10/cuda/CUDACachingAllocator.h>
 
 #include <vector>
 #include <iostream>
@@ -61,7 +63,7 @@ __global__ void nms_kernel(const int n_boxes, const float nms_overlap_thresh,
         t |= 1ULL << i;
       }
     }
-    const int col_blocks = THCCeilDiv(n_boxes, threadsPerBlock);
+    const int col_blocks = at::cuda::ATenCeilDiv(n_boxes, threadsPerBlock);
     dev_mask[cur_box_idx * col_blocks + col_start] = t;
   }
 }
@@ -77,20 +79,18 @@ at::Tensor nms_gpu(const at::Tensor& boxes, float nms_overlap_thresh, int64_t to
   auto boxes_sorted = boxes.index_select(0, order_t);
 
 
-  const int col_blocks = THCCeilDiv(boxes_num, threadsPerBlock);
+  const int col_blocks = at::cuda::ATenCeilDiv(boxes_num, threadsPerBlock);
 
   scalar_t* boxes_dev = boxes_sorted.data<scalar_t>();
 
-  THCState *state = at::globalContext().lazyInitCUDA(); // TODO replace with getTHCState
+  at::globalContext().lazyInitCUDA(); // TODO replace with getTHCState
 
-  unsigned long long* mask_dev = reinterpret_cast<unsigned long long*>(THCudaMalloc(state, boxes_num * col_blocks * sizeof(unsigned long long)));
-//  unsigned long long* mask_dev = NULL;
-//  THCudaCheck(THCudaMalloc(state, (void**) &mask_dev,
-//                        boxes_num * col_blocks * sizeof(unsigned long long)));
+  unsigned long long* mask_dev = reinterpret_cast<unsigned long long*>(
+    c10::cuda::CUDACachingAllocator::raw_alloc(boxes_num * col_blocks * sizeof(unsigned long long)));
 
 
-  dim3 blocks(THCCeilDiv(boxes_num, threadsPerBlock),
-              THCCeilDiv(boxes_num, threadsPerBlock));
+  dim3 blocks(at::cuda::ATenCeilDiv(boxes_num, threadsPerBlock),
+              at::cuda::ATenCeilDiv(boxes_num, threadsPerBlock));
   dim3 threads(threadsPerBlock);
   nms_kernel<<<blocks, threads>>>(boxes_num,
                                   nms_overlap_thresh,
@@ -98,7 +98,7 @@ at::Tensor nms_gpu(const at::Tensor& boxes, float nms_overlap_thresh, int64_t to
                                   mask_dev);
 
   std::vector<unsigned long long> mask_host(boxes_num * col_blocks);
-  THCudaCheck(cudaMemcpy(&mask_host[0],
+  C10_CUDA_CHECK(cudaMemcpy(&mask_host[0],
                         mask_dev,
                         sizeof(unsigned long long) * boxes_num * col_blocks,
                         cudaMemcpyDeviceToHost));
@@ -122,8 +122,7 @@ at::Tensor nms_gpu(const at::Tensor& boxes, float nms_overlap_thresh, int64_t to
       }
     }
   }
-
-  THCudaFree(state, mask_dev);
+  c10::cuda::CUDACachingAllocator::raw_delete(mask_dev);
   // TODO improve this part
   return std::get<0>(order_t.index({keep.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep)}).sort(0, false));
 }

--- a/nncf/torch/extensions/include/common_cuda_defs.cuh
+++ b/nncf/torch/extensions/include/common_cuda_defs.cuh
@@ -3,12 +3,12 @@
 
 #include <ATen/ATen.h>
 #include <ATen/DeviceGuard.h>
+#include <c10/cuda/CUDAStream.h>
 
 #include <cuda.h>
 #include <cuda_runtime.h>
 
 #include <vector>
-#include <THC/THC.h>
 
 const uint32_t CUDA_WARP_SIZE = 32;
 const uint32_t CUDA_TARGET_NUM_THREADS_PER_SM = 2048; // Will decide upon a number of threads per block and blocks per grid based on the workload to hit this target


### PR DESCRIPTION
### Changes

As stated in the title. torch 1.11 removed some of the headers we relied on and moved their functionality to other headers and objects.

### Reason for changes

Forward compatibility with torch 1.11.

### Related tickets

N/A

### Tests

Any tests checking CUDA-powered quantization and/or object detection samples.