### PR TITLE
Fix version issue for Python3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ INSTALL_REQUIRES = ["ninja>=1.10.0.post2",
                     "matplotlib~=3.3.4; python_version<'3.7'",
                     "matplotlib>=3.3.4; python_version>='3.7'",
                     "networkx>=2.5, <2.8.1rc1",
-                    "pillow>=9.0.0",
+                    "pillow~=8.4.0; python_version<'3.7'",
+                    "pillow>=9.0.0; python_version>='3.7'",
 
                     # The recent pyparsing major version update seems to break
                     # integration with networkx - the graphs parsed from current .dot


### PR DESCRIPTION
### Changes

Fix version issue when installing NNCF in Python3.6 environment.

### Reason for changes

`pillow>=9.0.0` is not supported in Python3.6.

```
+ python3 -m pip install -e .
Obtaining file:///opt/nncf_ws
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Collecting addict>=2.4.0
  Downloading addict-2.4.0-py3-none-any.whl (3.8 kB)
Collecting jsonschema==3.2.0
  Downloading jsonschema-3.2.0-py2.py3-none-any.whl (56 kB)
Collecting jstyleson>=0.0.2
  Downloading jstyleson-0.0.2.tar.gz (2.0 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Collecting natsort>=7.1.0
  Downloading natsort-8.1.0-py3-none-any.whl (37 kB)
Requirement already satisfied: networkx>=2.5 in /usr/local/lib/python3.6/dist-packages (from nncf==2.1.0.dev0+unknown.version) (2.5.1)
Collecting ninja>=1.10.0.post2
  Downloading ninja-1.10.2.3-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl (108 kB)
Requirement already satisfied: numpy~=1.19.2 in /usr/local/lib/python3.6/dist-packages (from nncf==2.1.0.dev0+unknown.version) (1.19.5)
ERROR: Could not find a version that satisfies the requirement pillow>=9.0.0 (from nncf) (from versions: 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7.0, 1.7.1, 1.7.2, 1.7.3, 1.7.4, 1.7.5, 1.7.6, 1.7.7, 1.7.8, 2.0.0, 2.1.0, 2.2.0, 2.2.1, 2.2.2, 2.3.0, 2.3.1, 2.3.2, 2.4.0, 2.5.0, 2.5.1, 2.5.2, 2.5.3, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.8.0, 2.8.1, 2.8.2, 2.9.0, 3.0.0, 3.1.0rc1, 3.1.0, 3.1.1, 3.1.2, 3.2.0, 3.3.0, 3.3.1, 3.3.2, 3.3.3, 3.4.0, 3.4.1, 3.4.2, 4.0.0, 4.1.0, 4.1.1, 4.2.0, 4.2.1, 4.3.0, 5.0.0, 5.1.0, 5.2.0, 5.3.0, 5.4.0, 5.4.1, 6.0.0, 6.1.0, 6.2.0, 6.2.1, 6.2.2, 7.0.0, 7.1.0, 7.1.1, 7.1.2, 7.2.0, 8.0.0, 8.0.1, 8.1.0, 8.1.1, 8.1.2, 8.2.0, 8.3.0, 8.3.1, 8.3.2, 8.4.0)
ERROR: No matching distribution found for pillow>=9.0.0
The command '/bin/bash -xo pipefail -c python3 -m pip install -e .' returned a non-zero code: 1
```

### Related tickets

### Tests
