### PR TITLE
Disable TF32 presicison in tests

### DIFF
--- a/tests/tensorflow/conftest.py
+++ b/tests/tensorflow/conftest.py
@@ -18,6 +18,12 @@ except ImportError:
     tf = None
 
 
+@pytest.fixture(scope="session", autouse=True)
+def disable_tf32_precision():
+    if tf:
+        tf.config.experimental.enable_tensor_float_32_execution(False)
+
+
 @pytest.fixture(scope="function", autouse=True)
 def clear_session():
     yield

--- a/tests/torch/conftest.py
+++ b/tests/torch/conftest.py
@@ -11,12 +11,23 @@
  limitations under the License.
 """
 import os
+import pytest
+try:
+    import torch
+except:
+    torch = None
 
 from tests.common.helpers import create_venv_with_nncf
 
-import pytest
 
 pytest.register_assert_rewrite('tests.torch.helpers')
+
+
+@pytest.fixture(scope="session", autouse=True)
+def disable_tf32_precision():
+    if torch:
+        torch.backends.cuda.matmul.allow_tf32 = False
+        torch.backends.cudnn.allow_tf32 = False
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
### Changes

Tensor Float 32 precision was disabled in both TF and Torch tests

### Reason for changes

Precision of TF32 is not enough for NNCF tests. It's possible to use TF32 precision, but additional disscussion is needed

### Tests

Checked locally on machine with TF32 support (RTX 3090)

