### PR TITLE
Fix wrong device in test_model_is_inited_with_own_device_by_default

### DIFF
--- a/tests/torch/test_api_behavior.py
+++ b/tests/torch/test_api_behavior.py
@@ -127,7 +127,7 @@ class DeviceCheckingModel(torch.nn.Module):
         return self.model.forward(x)
 
 
-@pytest.mark.parametrize('original_device', ["cpu", "cuda", "cuda:0", "cuda:1"])
+@pytest.mark.parametrize('original_device', ["cpu", "cuda", "cuda:0"])
 def test_model_is_inited_with_own_device_by_default(nncf_config_with_default_init_args, original_device):
     if not torch.cuda.is_available() and 'cuda' in original_device:
         pytest.skip("Skipping for CPU-only setups")


### PR DESCRIPTION
### Changes

Remove redundant Cuda device from test_model_is_inited_with_own_device_by_default test

### Reason for changes

Broken test
