### PR TITLE
Limit the protobuf version - tensorflow requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,9 @@ if "--torch" in sys.argv:
     sys.argv.remove("--torch")
 
 if "--tf" in sys.argv:
+    # See also: https://github.com/tensorflow/tensorflow/issues/56077
+    # This is a temporary patch, that limites the protobuf version from above
+    INSTALL_REQUIRES.extend(["protobuf>=3.9.2,<3.20"])
     INSTALL_REQUIRES.extend(EXTRAS_REQUIRE["tf"])
     sys.argv.remove("--tf")
 


### PR DESCRIPTION
### Changes

<!--- What was changed (briefly), how to reproduce (if applicable), what the reviewers should focus on -->
When installing NNCF with TF the following error pop up
`error: protobuf 4.21.1 is installed but protobuf<3.20,>=3.9.2 is required by {'tensorboard'}`
Steps to reproduce:
```
pip install -U pip
python setup.py install --tf
```

Temporary patch proposed (upper limit of protobuf version). Not sure if adding this additional explicit requirement is safe.

### Reason for changes

Protobuf releases new version, which is getting installed by TensorFlow but not supported by TensorBoard. For reference please see https://github.com/tensorflow/tensorflow/issues/56077.
Update is needed be able to install NNCF with TF.

### Related tickets

[CVS-86310]

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
