### PR TITLE
Fix pylint for tests/torch/nas/test_search.py

### DIFF
--- a/tests/torch/nas/test_search.py
+++ b/tests/torch/nas/test_search.py
@@ -27,6 +27,7 @@ from nncf import NNCFConfig
 from tests.torch.nas.test_all_elasticity import fixture_nas_model_name #pylint: disable=unused-import
 from nncf.config.structures import BNAdaptationInitArgs
 from nncf.experimental.torch.nas.bootstrapNAS import SearchAlgorithm
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_dim import ElasticityDim
 
 
 class SearchTestDesc(NamedTuple):


### PR DESCRIPTION
### Changes
Fix missing import in `tests/torch/nas/test_search.py`

### Reason for changes

The current develop fails pylint.
Please see  `NNCF/job/precommit/job/ubuntu20_precommit_pytorch/9/`

### Related tickets

### Tests
