### PR TITLE
Enable Yolov5s through ONNX Post-Training quantization POC

### DIFF
--- a/examples/experimental/onnx/README.md
+++ b/examples/experimental/onnx/README.md
@@ -2,7 +2,12 @@
 
 This examples shows how to quantize ONNX formated NN model (FP32) into the quantized NN model (INT8) using NNCF PTQ API with ONNXRuntime framework.
 
-## Docker image build
+## Installation
+### Pip installation
+
+Firstly, you would better to prepare a Python virtual environment with Python3.8. Then, please refer to [installation guide for developers](../../../CONTRIBUTING.md#experimental-onnxruntime-openvino) to configure the environment.
+
+### Docker image build
 
 You should make an environment including [ONNXRuntime](https://onnxruntime.ai/docs) with [OpenVINOExecutionProvider](https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html). We officially support `onnxruntime==1.11.0` and `openvino==2022.1.0`. You can use use a docker image build script we provided in `./docker/onnx/openvinoep/build.sh` to configure the environment easily.
 
@@ -398,3 +403,30 @@ After benchmark is done, outputs are located in `/output` which is a mounted dir
 
 * `nan` means that NNCF PTQ API failed to generate proper quantized onnx model. We are working on these defects.
 * `MaskRCNN-12` can be used two task types detection (`det`) and instance segmentation (`inst-seg`).
+
+# Support ONNXRuntime PTQ for Yolov5 models
+
+## Prerequisite
+
+1. Follow the [installation step](#installation)
+2. Clone [Yolov5 repository](https://github.com/ultralytics/yolov5.git) and patch it.
+
+```bash
+$ cd examples/experimental/onnx/yolov5
+$ git init
+$ git remote add origin https://github.com/ultralytics/yolov5.git
+$ git fetch origin
+$ git checkout 34df5032a7d2e83fe3d16770a03bd129b115d184
+$ git apply 0001-Add-NNCF-ONNX-PTQ-example-notebook.patch
+```
+
+## Run NNCF ONNXRuntime PTQ
+
+After [prerequisite](#prerequisite) is done, you can find `run_notebook.ipynb` notebook file in `examples/experimental/onnx/yolov5`. If you finish running all notebook cells, you will obtain the following PTQ benchmark results.
+
+```
+# Model latency
+FP32 latency: 23.7ms, INT8 latency: 19.7ms, FP32/INT8: 1.21x
+# Model accuracy
+FP32 mAP: 37.1%, INT8 mAP: 36.4%, mAP difference: 0.8%
+```

--- a/examples/experimental/onnx/yolov5/0001-Add-NNCF-ONNX-PTQ-example-notebook.patch
+++ b/examples/experimental/onnx/yolov5/0001-Add-NNCF-ONNX-PTQ-example-notebook.patch
@@ -1,0 +1,1622 @@
+From 0fce6142e10078db462c44db09047146a09510da Mon Sep 17 00:00:00 2001
+From: "Kim, Vinnam" <vinnam.kim@intel.com>
+Date: Wed, 29 Jun 2022 16:13:26 +0900
+Subject: [PATCH] Add NNCF ONNX PTQ example notebook
+
+Signed-off-by: Kim, Vinnam <vinnam.kim@intel.com>
+---
+ models/common.py                  |   6 +-
+ ptq_notebook.ipynb                | 803 ++++++++++++++++++++++++++++++
+ ptq_notebook_no_ignore_head.ipynb | 771 ++++++++++++++++++++++++++++
+ 3 files changed, 1577 insertions(+), 3 deletions(-)
+ create mode 100644 ptq_notebook.ipynb
+ create mode 100644 ptq_notebook_no_ignore_head.ipynb
+
+diff --git a/models/common.py b/models/common.py
+index 7690f71..6c0e496 100644
+--- a/models/common.py
++++ b/models/common.py
+@@ -350,11 +350,11 @@ class DetectMultiBackend(nn.Module):
+             net = cv2.dnn.readNetFromONNX(w)
+         elif onnx:  # ONNX Runtime
+             LOGGER.info(f'Loading {w} for ONNX Runtime inference...')
+-            cuda = torch.cuda.is_available()
+-            check_requirements(('onnx', 'onnxruntime-gpu' if cuda else 'onnxruntime'))
++            check_requirements(('onnxruntime-openvino',))
+             import onnxruntime
+-            providers = ['CUDAExecutionProvider', 'CPUExecutionProvider'] if cuda else ['CPUExecutionProvider']
++            providers = ['OpenVINOExecutionProvider']
+             session = onnxruntime.InferenceSession(w, providers=providers)
++            LOGGER.info(f'Use ORT providers: {providers}')
+             meta = session.get_modelmeta().custom_metadata_map  # metadata
+             if 'stride' in meta:
+                 stride, names = int(meta['stride']), eval(meta['names'])
+diff --git a/ptq_notebook.ipynb b/ptq_notebook.ipynb
+new file mode 100644
+index 0000000..7d6bfd7
+--- /dev/null
++++ b/ptq_notebook.ipynb
+@@ -0,0 +1,803 @@
++{
++ "cells": [
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "# NNCF PTQ for YoloV5"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Installation\n",
++    "\n",
++    "**You should install [NNCF ONNX experimental](https://github.com/openvinotoolkit/nncf#installation) before running this notebook**"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 1,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stderr",
++     "output_type": "stream",
++     "text": [
++      "/home/vinnamki/venv_nncf/lib/python3.8/site-packages/torch/cuda/__init__.py:106: UserWarning: \n",
++      "NVIDIA GeForce RTX 3090 with CUDA capability sm_86 is not compatible with the current PyTorch installation.\n",
++      "The current PyTorch install supports CUDA capabilities sm_37 sm_50 sm_60 sm_70.\n",
++      "If you want to use the NVIDIA GeForce RTX 3090 GPU with PyTorch, please check the instructions at https://pytorch.org/get-started/locally/\n",
++      "\n",
++      "  warnings.warn(incompatible_device_warn.format(device_name, capability, \" \".join(arch_list), device_name))\n",
++      "YOLOv5 🚀 v6.1-266-g34df503 Python-3.8.10 torch-1.9.1+cu102 CUDA:0 (NVIDIA GeForce RTX 3090, 24268MiB)\n"
++     ]
++    },
++    {
++     "name": "stdout",
++     "output_type": "stream",
++     "text": [
++      "Setup complete ✅ (36 CPUs, 125.5 GB RAM, 1561.2/1832.3 GB disk)\n"
++     ]
++    }
++   ],
++   "source": [
++    "%pip install -qr requirements.txt  # install\n",
++    "\n",
++    "import torch\n",
++    "from yolov5 import utils\n",
++    "display = utils.notebook_init()  # checks"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Download COCO validation dataset"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 2,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stderr",
++     "output_type": "stream",
++     "text": [
++      "100%|██████████| 780M/780M [01:22<00:00, 9.91MB/s]  \n"
++     ]
++    }
++   ],
++   "source": [
++    "# Download COCO val\n",
++    "torch.hub.download_url_to_file('https://ultralytics.com/assets/coco2017val.zip', 'tmp.zip')\n",
++    "!unzip -q tmp.zip -d ../datasets && rm tmp.zip"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Export yolov5s model to ONNX format"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 29,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stdout",
++     "output_type": "stream",
++     "text": [
++      "\u001b[34m\u001b[1mexport: \u001b[0mdata=data/coco128.yaml, weights=['yolov5s.pt'], imgsz=[640, 640], batch_size=1, device=cpu, half=False, inplace=False, train=False, keras=False, optimize=False, int8=False, dynamic=False, simplify=False, opset=12, verbose=False, workspace=4, nms=False, agnostic_nms=False, topk_per_class=100, topk_all=100, iou_thres=0.45, conf_thres=0.25, include=['onnx']\n",
++      "YOLOv5 🚀 v6.1-266-g34df503 Python-3.8.10 torch-1.9.1+cu102 CPU\n",
++      "\n",
++      "Downloading https://github.com/ultralytics/yolov5/releases/download/v6.1/yolov5s.pt to yolov5s.pt...\n",
++      "100%|██████████████████████████████████████| 14.1M/14.1M [00:03<00:00, 4.82MB/s]\n",
++      "\n",
++      "Fusing layers... \n",
++      "YOLOv5s summary: 213 layers, 7225885 parameters, 0 gradients, 16.4 GFLOPs\n",
++      "\n",
++      "\u001b[34m\u001b[1mPyTorch:\u001b[0m starting from yolov5s.pt with output shape (1, 25200, 85) (14.1 MB)\n",
++      "\n",
++      "\u001b[34m\u001b[1mONNX:\u001b[0m starting export with onnx 1.12.0...\n",
++      "\u001b[34m\u001b[1mONNX:\u001b[0m export success, saved as yolov5s.onnx (28.0 MB)\n",
++      "\n",
++      "Export complete (8.62s)\n",
++      "Results saved to \u001b[1m/home/vinnamki/nncf/examples/experimental/onnx/yolov5\u001b[0m\n",
++      "Detect:          python detect.py --weights yolov5s.onnx\n",
++      "PyTorch Hub:     model = torch.hub.load('ultralytics/yolov5', 'custom', 'yolov5s.onnx')\n",
++      "Validate:        python val.py --weights yolov5s.onnx\n",
++      "Visualize:       https://netron.app\n"
++     ]
++    }
++   ],
++   "source": [
++    "!python export.py --weights yolov5s.pt --include onnx"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Quantize yolov5s model"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "### Build PTQ API dataset"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 2,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stderr",
++     "output_type": "stream",
++     "text": [
++      "Scanning '../datasets/coco/labels/val2017.cache' images and labels... 4952 found, 48 missing, 0 empty, 0 corrupt: 100%|██████████| 5000/5000 [00:00<?, ?it/s]\n"
++     ]
++    }
++   ],
++   "source": [
++    "import onnx\n",
++    "\n",
++    "from nncf.experimental.post_training.compression_builder import CompressionBuilder\n",
++    "from nncf.experimental.post_training.algorithms.quantization import PostTrainingQuantization\n",
++    "from nncf.experimental.post_training.algorithms.quantization import PostTrainingQuantizationParameters\n",
++    "from nncf.common.utils.logger import logger as nncf_logger\n",
++    "from nncf.experimental.post_training.api import dataset as ptq_api_dataset\n",
++    "\n",
++    "from utils.dataloaders import LoadImagesAndLabels\n",
++    "\n",
++    "class YoloV5Dataset(ptq_api_dataset.Dataset):\n",
++    "    def __init__(self, path, batch_size, shuffle):\n",
++    "        super().__init__(batch_size, shuffle)\n",
++    "        self.load_images = LoadImagesAndLabels(path)\n",
++    "\n",
++    "    def __getitem__(self, item):\n",
++    "        img, _, _, _ = self.load_images[item]\n",
++    "        # Input should be in [0,1].\n",
++    "        img = (1 / 255.) * img\n",
++    "        return img.numpy(), 1 # Add dummy label = 1\n",
++    "\n",
++    "    def __len__(self):\n",
++    "        return len(self.load_images)\n",
++    "\n",
++    "dataset = YoloV5Dataset(\"../datasets/coco/images/val2017\", 1, True)"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "### Run PTQ"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 3,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stdout",
++     "output_type": "stream",
++     "text": [
++      "INFO:nncf:Post-Training Quantization has just started!\n",
++      "INFO:nncf:Original opset = 12\n",
++      "INFO:nncf:Original ir_version = 6\n",
++      "INFO:nncf:Successfully converted the model to the opset = 13\n",
++      "ERROR:nncf:The tensor 344 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 345 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 346 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 347 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 348 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 349 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 351 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 353 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 355 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 357 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 359 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 361 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 362 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 369 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 388 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 389 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 390 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 391 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 392 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 393 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 395 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 397 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 399 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 401 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 403 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 405 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 406 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 413 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 432 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 433 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 434 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 435 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 436 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 437 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 439 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 441 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 443 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 445 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 447 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 449 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 450 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 457 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 211 Mul_217\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 212 Add_219\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 213 Mul_221\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 214 Mul_223\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 216 Mul_227\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 236 Mul_251\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 237 Add_253\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 238 Mul_255\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 239 Mul_257\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 241 Mul_261\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 261 Mul_285\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 262 Add_287\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 263 Mul_289\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 264 Mul_291\n",
++      "INFO:nncf:Ignored adding Activation input quantizer for: 266 Mul_295\n",
++      "INFO:nncf:Using Shuffled dataset\n"
++     ]
++    },
++    {
++     "name": "stderr",
++     "output_type": "stream",
++     "text": [
++      "2022-06-29 15:45:43.853577343 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.0.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853603340 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.0.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853610075 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853614965 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853619625 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853624863 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853629540 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853633986 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853638615 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853643076 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853647618 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853652894 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853657482 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853662417 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853667107 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853671638 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853676187 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853680951 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853685573 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853690187 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853695925 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853700477 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853705199 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853710093 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853714595 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853719179 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853723808 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853728290 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853732832 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853738797 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853743619 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.5.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853748107 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.5.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853752770 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853757275 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853761776 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853766467 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853770913 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853775355 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853780786 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853785329 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853789847 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853794300 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853798813 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853803280 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853807802 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853812324 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853817840 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853822410 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853826882 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853831444 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853836011 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.7.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853840510 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.7.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853845092 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853849570 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853854412 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853859597 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853864205 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853868662 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853873382 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853879220 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853884337 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853888877 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853893614 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853898225 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853903491 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853907975 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853912475 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.10.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853916931 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.10.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853921974 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853926582 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853931272 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853935845 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853940387 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853946020 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853950740 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853955859 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853961117 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853965665 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853970377 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.14.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853974960 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.14.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853979697 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853984186 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853989304 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853994139 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.853998752 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854003216 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854007960 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854012467 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854017036 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854021537 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854026345 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.18.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854032247 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.18.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854036808 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854041296 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854045915 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854050552 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854055134 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854059993 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854064707 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854069865 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854075060 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854079829 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854084485 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.21.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854089117 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.21.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854093725 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854098399 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854102982 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854107653 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854112297 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854117768 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854127670 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854132484 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854137074 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854141739 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854146327 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.0.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854151107 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.0.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854156067 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.1.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854160882 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.1.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854166342 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.2.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854170844 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.2.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854175419 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 459 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854180149 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 460 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854184524 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 461 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854188869 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 462 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854193249 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 463 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854197717 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 464 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854202117 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 465 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854212395 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 466 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854216937 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 467 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854221320 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 468 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854225732 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 469 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854230120 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 470 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854234503 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 471 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:45:43.854238989 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 472 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "  2%|▏         | 100/5000 [00:10<08:56,  9.13it/s]\n"
++     ]
++    },
++    {
++     "name": "stdout",
++     "output_type": "stream",
++     "text": [
++      "INFO:nncf:The quantized model is saved on yolov5s-quantized.onnx\n"
++     ]
++    }
++   ],
++   "source": [
++    "original_model = onnx.load(\"yolov5s.onnx\")\n",
++    "num_init_samples = 100\n",
++    "# We'll ignore detector head not to quantize them\n",
++    "ignored_scopes = [\n",
++    "    # Head branch 1\n",
++    "    \"Mul_217\",\n",
++    "    \"Add_219\",\n",
++    "    \"Mul_221\",\n",
++    "    \"Mul_223\",\n",
++    "    \"Mul_227\",\n",
++    "    # Head branch 2\n",
++    "    \"Mul_251\",\n",
++    "    \"Add_253\",\n",
++    "    \"Mul_255\",\n",
++    "    \"Mul_257\",\n",
++    "    \"Mul_261\",\n",
++    "    # Head branch 3\n",
++    "    \"Mul_285\",\n",
++    "    \"Add_287\",\n",
++    "    \"Mul_289\",\n",
++    "    \"Mul_291\",\n",
++    "    \"Mul_295\",\n",
++    "]\n",
++    "output_model_path = \"yolov5s-quantized.onnx\"\n",
++    "\n",
++    "# Step 1: Create a pipeline of compression algorithms.\n",
++    "builder = CompressionBuilder()\n",
++    "\n",
++    "# Step 2: Create the quantization algorithm and add to the builder.\n",
++    "quantization_parameters = PostTrainingQuantizationParameters(\n",
++    "    number_samples=num_init_samples,\n",
++    "    ignored_scopes=ignored_scopes\n",
++    ")\n",
++    "quantization = PostTrainingQuantization(quantization_parameters)\n",
++    "builder.add_algorithm(quantization)\n",
++    "\n",
++    "# Step 4: Execute the pipeline.\n",
++    "nncf_logger.info(\"Post-Training Quantization has just started!\")\n",
++    "quantized_model = builder.apply(original_model, dataset)\n",
++    "\n",
++    "# Step 5: Save the quantized model.\n",
++    "onnx.save(quantized_model, output_model_path)\n",
++    "nncf_logger.info(\n",
++    "    \"The quantized model is saved on {}\".format(output_model_path))\n",
++    "\n",
++    "onnx.checker.check_model(output_model_path)"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Benchmark"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "### Original (FP32) model"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 4,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stderr",
++     "output_type": "stream",
++     "text": [
++      "YOLOv5 🚀 v6.1-266-g34df503 Python-3.8.10 torch-1.9.1+cu102 CPU\n",
++      "\n",
++      "Loading yolov5s.onnx for ONNX Runtime inference...\n",
++      "Use ORT providers: ['OpenVINOExecutionProvider']\n",
++      "Forcing --batch-size 1 square inference (1,3,640,640) for non-PyTorch models\n",
++      "\u001b[34m\u001b[1mval: \u001b[0mScanning '/home/vinnamki/nncf/examples/experimental/onnx/datasets/coco/val2017.cache' images and labels... 4952 found, 48 missing, 0 empty, 0 corrupt: 100%|██████████| 5000/5000 [00:00<?, ?it/s]\n",
++      "               Class     Images     Labels          P          R     mAP@.5 mAP@.5:.95: 100%|██████████| 5000/5000 [03:05<00:00, 26.98it/s]\n",
++      "                 all       5000      36335      0.668      0.516      0.561      0.371\n",
++      "Speed: 0.2ms pre-process, 23.6ms inference, 5.2ms NMS per image at shape (1, 3, 640, 640)\n",
++      "Results saved to \u001b[1mruns/val/exp23\u001b[0m\n"
++     ]
++    }
++   ],
++   "source": [
++    "from val import run\n",
++    "\n",
++    "o_results = run(\n",
++    "    data=\"data/coco.yaml\",\n",
++    "    weights=\"yolov5s.onnx\",\n",
++    "    imgsz=640,\n",
++    "    iou_thres=0.65,\n",
++    "    device=\"cpu\"\n",
++    ")"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "### Quantized (INT8) model"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 5,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stderr",
++     "output_type": "stream",
++     "text": [
++      "YOLOv5 🚀 v6.1-266-g34df503 Python-3.8.10 torch-1.9.1+cu102 CPU\n",
++      "\n",
++      "Loading yolov5s-quantized.onnx for ONNX Runtime inference...\n",
++      "2022-06-29 15:49:21.314751483 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.0.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "Use ORT providers: ['OpenVINOExecutionProvider']\n",
++      "2022-06-29 15:49:21.314782941 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.0.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314789991 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314796365 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.1.conv.bias appearForcing --batch-size 1 square inference (1,3,640,640) for non-PyTorch models\n",
++      "s in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314802510 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314810060 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314815999 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314822019 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314828152 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314834131 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314840273 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314847700 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314853714 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314860077 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314866044 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314871986 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314877870 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314884006 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314890120 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314895968 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314902435 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314908696 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314915130 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314921007 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314926938 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314932937 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314938976 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314944730 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314950843 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314958530 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314964515 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.5.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314970482 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.5.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314976534 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314982755 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314988622 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.314994452 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315000313 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315006259 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315013918 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315019958 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315025841 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315031759 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315037661 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315043606 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315049853 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315055851 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315062645 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315068527 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315074409 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315080252 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315086111 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.7.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315091904 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.7.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315097861 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315103734 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315109861 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315116548 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315122477 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315128185 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315134200 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315141497 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315147536 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315153450 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315159342 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315165132 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315171831 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315177624 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315183419 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.10.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315189166 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.10.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315195811 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315201874 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315207825 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315213886 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315219724 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315226437 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315233154 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315239173 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315245315 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315251414 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315257384 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.14.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315263418 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.14.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315269470 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315275344 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315281769 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315287648 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315293853 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315300018 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315306025 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315312002 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315317845 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315323777 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315329890 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.18.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315336528 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.18.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315343452 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315349526 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315355524 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315361394 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315367502 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315373482 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315379525 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315385436 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315392296 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315398409 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315404458 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.21.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315410476 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.21.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315416277 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315422562 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315428593 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315434620 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315440549 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315447586 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315453511 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315459829 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315465829 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315471945 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315477937 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.0.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315483729 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.0.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315490050 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.1.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315495877 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.1.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315502531 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.2.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315508484 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.2.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315514398 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 459 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315520653 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 460 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315526594 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 461 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315532350 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 462 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315539123 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 463 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315544830 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 464 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315550714 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 465 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315559619 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 466 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315565675 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 467 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315571283 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 468 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315577081 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 469 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315582926 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 470 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315588605 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 471 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:49:21.315594306 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 472 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "\u001b[34m\u001b[1mval: \u001b[0mScanning '/home/vinnamki/nncf/examples/experimental/onnx/datasets/coco/val2017.cache' images and labels... 4952 found, 48 missing, 0 empty, 0 corrupt: 100%|██████████| 5000/5000 [00:00<?, ?it/s]\n",
++      "               Class     Images     Labels          P          R     mAP@.5 mAP@.5:.95:  69%|██████▊   | 3436/5000 [01:52<01:01, 25.49it/s]WARNING: NMS time limit 0.330s exceeded\n",
++      "               Class     Images     Labels          P          R     mAP@.5 mAP@.5:.95: 100%|██████████| 5000/5000 [02:43<00:00, 30.60it/s]\n",
++      "                 all       5000      36335       0.68      0.502      0.556      0.364\n",
++      "Speed: 0.2ms pre-process, 19.3ms inference, 5.0ms NMS per image at shape (1, 3, 640, 640)\n",
++      "Results saved to \u001b[1mruns/val/exp24\u001b[0m\n"
++     ]
++    }
++   ],
++   "source": [
++    "from val import run\n",
++    "\n",
++    "q_results = run(\n",
++    "    data=\"data/coco.yaml\",\n",
++    "    weights=\"yolov5s-quantized.onnx\",\n",
++    "    imgsz=640,\n",
++    "    iou_thres=0.65,\n",
++    "    device=\"cpu\"\n",
++    ")"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "### Model latency comparison"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 6,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stdout",
++     "output_type": "stream",
++     "text": [
++      "FP32 latency: 23.6ms, INT8 latency: 19.3ms, FP32/INT8: 1.23x\n"
++     ]
++    }
++   ],
++   "source": [
++    "o_latency = o_results[2][1]\n",
++    "q_latency = q_results[2][1]\n",
++    "\n",
++    "print(f\"FP32 latency: {o_latency:.1f}ms, INT8 latency: {q_latency:.1f}ms, FP32/INT8: {o_latency / q_latency:.2f}x\")"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "### Model accuracy comparison"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 7,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stdout",
++     "output_type": "stream",
++     "text": [
++      "FP32 mAP: 37.1%, INT8 mAP: 36.4%, mAP difference: 0.8%\n"
++     ]
++    }
++   ],
++   "source": [
++    "o_map = o_results[0][3] * 100.0\n",
++    "q_map = q_results[0][3] * 100.0\n",
++    "\n",
++    "print(f\"FP32 mAP: {o_map:.1f}%, INT8 mAP: {q_map:.1f}%, mAP difference: {o_map - q_map:.1f}%\")"
++   ]
++  }
++ ],
++ "metadata": {
++  "kernelspec": {
++   "display_name": "Python 3.8.10 ('venv_nncf')",
++   "language": "python",
++   "name": "python3"
++  },
++  "language_info": {
++   "codemirror_mode": {
++    "name": "ipython",
++    "version": 3
++   },
++   "file_extension": ".py",
++   "mimetype": "text/x-python",
++   "name": "python",
++   "nbconvert_exporter": "python",
++   "pygments_lexer": "ipython3",
++   "version": "3.8.10"
++  },
++  "orig_nbformat": 4,
++  "vscode": {
++   "interpreter": {
++    "hash": "75220ca69b28c67a71fa579310ced1c62db7505e5120c61c1b6a8dc6ee480ac9"
++   }
++  }
++ },
++ "nbformat": 4,
++ "nbformat_minor": 2
++}
+diff --git a/ptq_notebook_no_ignore_head.ipynb b/ptq_notebook_no_ignore_head.ipynb
+new file mode 100644
+index 0000000..0f655c6
+--- /dev/null
++++ b/ptq_notebook_no_ignore_head.ipynb
+@@ -0,0 +1,771 @@
++{
++ "cells": [
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "# NNCF PTQ for YoloV5"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Installation\n",
++    "\n",
++    "**You should install [NNCF ONNX experimental](https://github.com/openvinotoolkit/nncf#installation) before running this notebook**"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 1,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stderr",
++     "output_type": "stream",
++     "text": [
++      "/home/vinnamki/venv_nncf/lib/python3.8/site-packages/torch/cuda/__init__.py:106: UserWarning: \n",
++      "NVIDIA GeForce RTX 3090 with CUDA capability sm_86 is not compatible with the current PyTorch installation.\n",
++      "The current PyTorch install supports CUDA capabilities sm_37 sm_50 sm_60 sm_70.\n",
++      "If you want to use the NVIDIA GeForce RTX 3090 GPU with PyTorch, please check the instructions at https://pytorch.org/get-started/locally/\n",
++      "\n",
++      "  warnings.warn(incompatible_device_warn.format(device_name, capability, \" \".join(arch_list), device_name))\n",
++      "YOLOv5 🚀 v6.1-266-g34df503 Python-3.8.10 torch-1.9.1+cu102 CUDA:0 (NVIDIA GeForce RTX 3090, 24268MiB)\n"
++     ]
++    },
++    {
++     "name": "stdout",
++     "output_type": "stream",
++     "text": [
++      "Setup complete ✅ (36 CPUs, 125.5 GB RAM, 1561.2/1832.3 GB disk)\n"
++     ]
++    }
++   ],
++   "source": [
++    "%pip install -qr requirements.txt  # install\n",
++    "\n",
++    "import torch\n",
++    "from yolov5 import utils\n",
++    "display = utils.notebook_init()  # checks"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Download COCO validation dataset"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 2,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stderr",
++     "output_type": "stream",
++     "text": [
++      "100%|██████████| 780M/780M [01:22<00:00, 9.91MB/s]  \n"
++     ]
++    }
++   ],
++   "source": [
++    "# Download COCO val\n",
++    "torch.hub.download_url_to_file('https://ultralytics.com/assets/coco2017val.zip', 'tmp.zip')\n",
++    "!unzip -q tmp.zip -d ../datasets && rm tmp.zip"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Export yolov5s model to ONNX format"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 29,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stdout",
++     "output_type": "stream",
++     "text": [
++      "\u001b[34m\u001b[1mexport: \u001b[0mdata=data/coco128.yaml, weights=['yolov5s.pt'], imgsz=[640, 640], batch_size=1, device=cpu, half=False, inplace=False, train=False, keras=False, optimize=False, int8=False, dynamic=False, simplify=False, opset=12, verbose=False, workspace=4, nms=False, agnostic_nms=False, topk_per_class=100, topk_all=100, iou_thres=0.45, conf_thres=0.25, include=['onnx']\n",
++      "YOLOv5 🚀 v6.1-266-g34df503 Python-3.8.10 torch-1.9.1+cu102 CPU\n",
++      "\n",
++      "Downloading https://github.com/ultralytics/yolov5/releases/download/v6.1/yolov5s.pt to yolov5s.pt...\n",
++      "100%|██████████████████████████████████████| 14.1M/14.1M [00:03<00:00, 4.82MB/s]\n",
++      "\n",
++      "Fusing layers... \n",
++      "YOLOv5s summary: 213 layers, 7225885 parameters, 0 gradients, 16.4 GFLOPs\n",
++      "\n",
++      "\u001b[34m\u001b[1mPyTorch:\u001b[0m starting from yolov5s.pt with output shape (1, 25200, 85) (14.1 MB)\n",
++      "\n",
++      "\u001b[34m\u001b[1mONNX:\u001b[0m starting export with onnx 1.12.0...\n",
++      "\u001b[34m\u001b[1mONNX:\u001b[0m export success, saved as yolov5s.onnx (28.0 MB)\n",
++      "\n",
++      "Export complete (8.62s)\n",
++      "Results saved to \u001b[1m/home/vinnamki/nncf/examples/experimental/onnx/yolov5\u001b[0m\n",
++      "Detect:          python detect.py --weights yolov5s.onnx\n",
++      "PyTorch Hub:     model = torch.hub.load('ultralytics/yolov5', 'custom', 'yolov5s.onnx')\n",
++      "Validate:        python val.py --weights yolov5s.onnx\n",
++      "Visualize:       https://netron.app\n"
++     ]
++    }
++   ],
++   "source": [
++    "!python export.py --weights yolov5s.pt --include onnx"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Quantize yolov5s model"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "### Build PTQ API dataset"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 9,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stderr",
++     "output_type": "stream",
++     "text": [
++      "/home/vinnamki/venv_nncf/lib/python3.8/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
++      "  from .autonotebook import tqdm as notebook_tqdm\n",
++      "Scanning '../datasets/coco/labels/val2017.cache' images and labels... 4952 found, 48 missing, 0 empty, 0 corrupt: 100%|██████████| 5000/5000 [00:00<?, ?it/s]\n"
++     ]
++    }
++   ],
++   "source": [
++    "import onnx\n",
++    "\n",
++    "from nncf.experimental.post_training.compression_builder import CompressionBuilder\n",
++    "from nncf.experimental.post_training.algorithms.quantization import PostTrainingQuantization\n",
++    "from nncf.experimental.post_training.algorithms.quantization import PostTrainingQuantizationParameters\n",
++    "from nncf.common.utils.logger import logger as nncf_logger\n",
++    "from nncf.experimental.post_training.api import dataset as ptq_api_dataset\n",
++    "\n",
++    "from utils.dataloaders import LoadImagesAndLabels\n",
++    "\n",
++    "class YoloV5Dataset(ptq_api_dataset.Dataset):\n",
++    "    def __init__(self, path, batch_size, shuffle):\n",
++    "        super().__init__(batch_size, shuffle)\n",
++    "        self.load_images = LoadImagesAndLabels(path)\n",
++    "\n",
++    "    def __getitem__(self, item):\n",
++    "        img, _, _, _ = self.load_images[item]\n",
++    "        # Input should be in [0,1].\n",
++    "        img = (1 / 255.) * img\n",
++    "        return img.numpy(), 1 # Add dummy label = 1\n",
++    "\n",
++    "    def __len__(self):\n",
++    "        return len(self.load_images)\n",
++    "\n",
++    "dataset = YoloV5Dataset(\"../datasets/coco/images/val2017\", 1, True)"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "### Run PTQ"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 10,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stdout",
++     "output_type": "stream",
++     "text": [
++      "INFO:nncf:Post-Training Quantization has just started!\n",
++      "INFO:nncf:Original opset = 12\n",
++      "INFO:nncf:Original ir_version = 6\n",
++      "INFO:nncf:Successfully converted the model to the opset = 13\n",
++      "ERROR:nncf:The tensor 344 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 345 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 346 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 347 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 348 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 349 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 351 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 353 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 355 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 357 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 359 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 361 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 362 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 369 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 388 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 389 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 390 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 391 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 392 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 393 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 395 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 397 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 399 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 401 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 403 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 405 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 406 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 413 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 432 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 433 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 434 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 435 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 436 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 437 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 439 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 441 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 443 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 445 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 447 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 449 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 450 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "ERROR:nncf:The tensor 457 does not have shape field\n",
++      "ERROR:nncf:The default tensor shape will be set.\n",
++      "INFO:nncf:Using Shuffled dataset\n"
++     ]
++    },
++    {
++     "name": "stderr",
++     "output_type": "stream",
++     "text": [
++      "2022-06-29 15:10:34.901450891 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.0.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901484941 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.0.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901493512 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901500309 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901506651 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901513214 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901519398 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901525486 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901531596 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901537606 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901544444 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901550545 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901563172 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901569931 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901576021 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901581906 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901587789 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901593875 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901599750 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901606750 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901612723 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901618912 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901625039 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901631187 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901637272 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901643291 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901649460 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901655635 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901662872 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901669747 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901675692 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.5.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901681597 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.5.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901687582 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901693802 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901699758 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901705652 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901711604 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901718207 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901724268 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901730181 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901736088 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901742309 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901748144 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901754014 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901759877 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901766606 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901772736 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901778672 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901784717 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901790567 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901796483 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.7.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901802650 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.7.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901808748 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901814897 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901821679 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901827711 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901833674 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901839579 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901846314 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901854087 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901860236 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901866204 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901872465 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901879387 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901885425 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901891373 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901897371 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.10.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901903412 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.10.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901909297 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901915281 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901921206 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901927055 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901933724 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901939822 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901945953 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901951903 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901957918 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901963891 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901969786 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.14.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901975671 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.14.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901981631 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901988547 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.901994463 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902000495 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902006428 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902012307 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902018192 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902024195 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902030135 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902036096 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902042901 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.18.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902048988 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.18.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902055099 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902060924 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902066910 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902072713 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902078568 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902084556 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902090719 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902097648 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902103641 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902109520 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902115357 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.21.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902157734 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.21.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902164070 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902170248 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902176300 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902182209 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902189132 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902195250 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902201564 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902207829 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902213823 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902219746 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902225716 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.0.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902231899 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.0.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902238521 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.1.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902245189 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.1.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902251240 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.2.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902257315 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.2.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902263466 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 459 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902269836 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 460 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902275662 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 461 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902281564 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 462 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902287282 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 463 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902293096 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 464 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902299582 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 465 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902308698 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 466 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902314787 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 467 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902320612 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 468 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902326392 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 469 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902332112 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 470 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902337782 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 471 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:10:34.902343414 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 472 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "  2%|▏         | 100/5000 [00:11<09:00,  9.06it/s]\n"
++     ]
++    },
++    {
++     "name": "stdout",
++     "output_type": "stream",
++     "text": [
++      "INFO:nncf:The quantized model is saved on yolov5s-quantized.onnx\n"
++     ]
++    }
++   ],
++   "source": [
++    "original_model = onnx.load(\"yolov5s.onnx\")\n",
++    "num_init_samples = 100\n",
++    "ignored_scopes = []\n",
++    "output_model_path = \"yolov5s-quantized.onnx\"\n",
++    "\n",
++    "# Step 1: Create a pipeline of compression algorithms.\n",
++    "builder = CompressionBuilder()\n",
++    "\n",
++    "# Step 2: Create the quantization algorithm and add to the builder.\n",
++    "quantization_parameters = PostTrainingQuantizationParameters(\n",
++    "    number_samples=num_init_samples,\n",
++    "    ignored_scopes=ignored_scopes\n",
++    ")\n",
++    "quantization = PostTrainingQuantization(quantization_parameters)\n",
++    "builder.add_algorithm(quantization)\n",
++    "\n",
++    "# Step 4: Execute the pipeline.\n",
++    "nncf_logger.info(\"Post-Training Quantization has just started!\")\n",
++    "quantized_model = builder.apply(original_model, dataset)\n",
++    "\n",
++    "# Step 5: Save the quantized model.\n",
++    "onnx.save(quantized_model, output_model_path)\n",
++    "nncf_logger.info(\n",
++    "    \"The quantized model is saved on {}\".format(output_model_path))\n",
++    "\n",
++    "onnx.checker.check_model(output_model_path)"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Benchmark"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "### Original (FP32) model"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": null,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stderr",
++     "output_type": "stream",
++     "text": [
++      "YOLOv5 🚀 v6.1-266-g34df503 Python-3.8.10 torch-1.9.1+cu102 CPU\n",
++      "\n",
++      "Loading yolov5s.onnx for ONNX Runtime inference...\n",
++      "Use ORT providers: ['OpenVINOExecutionProvider']\n",
++      "Forcing --batch-size 1 square inference (1,3,640,640) for non-PyTorch models\n",
++      "\u001b[34m\u001b[1mval: \u001b[0mScanning '/home/vinnamki/nncf/examples/experimental/onnx/datasets/coco/val2017.cache' images and labels... 4952 found, 48 missing, 0 empty, 0 corrupt: 100%|██████████| 5000/5000 [00:00<?, ?it/s]\n",
++      "               Class     Images     Labels          P          R     mAP@.5 mAP@.5:.95: 100%|██████████| 5000/5000 [03:06<00:00, 26.76it/s]\n",
++      "                 all       5000      36335      0.668      0.516      0.561      0.371\n",
++      "Speed: 0.2ms pre-process, 23.7ms inference, 5.3ms NMS per image at shape (1, 3, 640, 640)\n",
++      "Results saved to \u001b[1mruns/val/exp21\u001b[0m\n"
++     ]
++    }
++   ],
++   "source": [
++    "from val import run\n",
++    "\n",
++    "o_results = run(\n",
++    "    data=\"data/coco.yaml\",\n",
++    "    weights=\"yolov5s.onnx\",\n",
++    "    imgsz=640,\n",
++    "    iou_thres=0.65,\n",
++    "    device=\"cpu\"\n",
++    ")"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "### Quantized (INT8) model"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 4,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stderr",
++     "output_type": "stream",
++     "text": [
++      "YOLOv5 🚀 v6.1-266-g34df503 Python-3.8.10 torch-1.9.1+cu102 CPU\n",
++      "\n",
++      "Loading yolov5s-quantized.onnx for ONNX Runtime inference...\n",
++      "2022-06-29 15:23:22.359891570 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.0.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "Use ORT providers: ['OpenVINOExecutionProvider']\n",
++      "2022-06-29 15:23:22.359929114 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.0.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.359937938 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.359943566 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.1.conv.bias appearForcing --batch-size 1 square inference (1,3,640,640) for non-PyTorch models\n",
++      "s in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.359948922 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.359955100 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.359960257 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.359965770 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.359971627 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.359976931 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.359982182 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.359989194 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.359994492 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360000298 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.2.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360005903 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360012310 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360018491 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360023844 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360028792 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360033681 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360040305 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360045951 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360051175 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360056287 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360061538 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360066657 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360071855 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360076904 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360082332 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360089684 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.4.m.1.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360094908 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.5.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360099973 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.5.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360105149 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360110860 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360115951 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360120821 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360125925 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360131006 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360136920 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360142536 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360147914 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360152769 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360157527 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360163152 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360169004 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360174329 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.1.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360179993 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360185909 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360191497 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360198336 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.6.m.2.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360203392 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.7.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360208432 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.7.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360214053 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360219345 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360224999 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360231798 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360238085 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360243795 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360249118 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360254879 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360260148 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360265125 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.8.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360270604 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360275828 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360282389 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360287315 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.9.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360292203 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.10.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360297102 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.10.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360302293 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360307370 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360312667 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360317612 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360323344 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360329054 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360334794 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360339920 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360345534 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360351295 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.13.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360356522 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.14.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360362122 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.14.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360367565 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360373409 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360380333 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360387414 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360392736 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360398031 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360403623 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360408438 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360415641 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360420509 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.17.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360425982 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.18.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360431864 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.18.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360436766 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360441836 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360446732 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360451672 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360456766 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360461829 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360466777 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360471692 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360477582 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360482129 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.20.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360486973 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.21.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360491779 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.21.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360496886 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360501905 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360507039 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360511921 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360517210 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv3.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360522873 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.cv3.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360527500 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv1.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360532453 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv1.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360537354 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv2.conv.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360542816 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.23.m.0.cv2.conv.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360547672 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.0.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360552699 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.0.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360557779 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.1.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360562714 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.1.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360568423 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.2.weight appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360573217 [W:onnxruntime:, graph.cc:1271 Graph] Initializer model.24.m.2.bias appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360578294 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 459 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360583991 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 460 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360588718 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 461 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360593295 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 462 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360598009 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 463 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360602631 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 464 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360607496 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 465 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360621421 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 466 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360626979 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 467 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360632364 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 468 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360637039 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 469 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360641995 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 470 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360646701 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 471 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "2022-06-29 15:23:22.360651509 [W:onnxruntime:, graph.cc:1271 Graph] Initializer 472 appears in graph inputs and will not be treated as constant value/weight. This may prevent some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.\n",
++      "\u001b[34m\u001b[1mval: \u001b[0mScanning '/home/vinnamki/nncf/examples/experimental/onnx/datasets/coco/val2017.cache' images and labels... 4952 found, 48 missing, 0 empty, 0 corrupt: 100%|██████████| 5000/5000 [00:00<?, ?it/s]\n",
++      "               Class     Images     Labels          P          R     mAP@.5 mAP@.5:.95:  69%|██████▊   | 3436/5000 [01:58<01:08, 22.96it/s]WARNING: NMS time limit 0.330s exceeded\n",
++      "               Class     Images     Labels          P          R     mAP@.5 mAP@.5:.95:  75%|███████▍  | 3748/5000 [02:09<00:44, 27.90it/s]WARNING: NMS time limit 0.330s exceeded\n",
++      "               Class     Images     Labels          P          R     mAP@.5 mAP@.5:.95: 100%|██████████| 5000/5000 [02:51<00:00, 29.11it/s]\n",
++      "                 all       5000      36335      0.487      0.471       0.42      0.257\n",
++      "Speed: 0.2ms pre-process, 19.7ms inference, 6.2ms NMS per image at shape (1, 3, 640, 640)\n",
++      "Results saved to \u001b[1mruns/val/exp20\u001b[0m\n"
++     ]
++    }
++   ],
++   "source": [
++    "from val import run\n",
++    "\n",
++    "q_results = run(\n",
++    "    data=\"data/coco.yaml\",\n",
++    "    weights=\"yolov5s-quantized.onnx\",\n",
++    "    imgsz=640,\n",
++    "    iou_thres=0.65,\n",
++    "    device=\"cpu\"\n",
++    ")"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "### Model latency comparison"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 19,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stdout",
++     "output_type": "stream",
++     "text": [
++      "FP32 latency: 23.7ms, INT8 latency: 19.7ms, FP32/INT8: 1.21x\n"
++     ]
++    }
++   ],
++   "source": [
++    "o_latency = o_results[2][1]\n",
++    "q_latency = q_results[2][1]\n",
++    "\n",
++    "print(f\"FP32 latency: {o_latency:.1f}ms, INT8 latency: {q_latency:.1f}ms, FP32/INT8: {o_latency / q_latency:.2f}x\")"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "### Model accuracy comparison"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "execution_count": 21,
++   "metadata": {},
++   "outputs": [
++    {
++     "name": "stdout",
++     "output_type": "stream",
++     "text": [
++      "FP32 mAP: 37.1%, INT8 mAP: 25.7%, mAP difference: 11.5%\n"
++     ]
++    }
++   ],
++   "source": [
++    "o_map = o_results[0][3] * 100.0\n",
++    "q_map = q_results[0][3] * 100.0\n",
++    "\n",
++    "print(f\"FP32 mAP: {o_map:.1f}%, INT8 mAP: {q_map:.1f}%, mAP difference: {o_map - q_map:.1f}%\")"
++   ]
++  }
++ ],
++ "metadata": {
++  "kernelspec": {
++   "display_name": "Python 3.8.10 ('venv_nncf')",
++   "language": "python",
++   "name": "python3"
++  },
++  "language_info": {
++   "codemirror_mode": {
++    "name": "ipython",
++    "version": 3
++   },
++   "file_extension": ".py",
++   "mimetype": "text/x-python",
++   "name": "python",
++   "nbconvert_exporter": "python",
++   "pygments_lexer": "ipython3",
++   "version": "3.8.10"
++  },
++  "orig_nbformat": 4,
++  "vscode": {
++   "interpreter": {
++    "hash": "75220ca69b28c67a71fa579310ced1c62db7505e5120c61c1b6a8dc6ee480ac9"
++   }
++  }
++ },
++ "nbformat": 4,
++ "nbformat_minor": 2
++}
+-- 
+2.25.1
+


### PR DESCRIPTION
### Changes
- Added a Git patch file to support ONNXRuntime PTQ for Yolov5 third-party.
- Updated `README.md` to guide users on how to use it.

### Reason for changes
- To enable Yolov5s through ONNX Post-Training quantization POC

### Related tickets
72747

### Tests
This PR would be merged without test because there is no code change.