### PR TITLE
Add reorder weights for Linear layer

### DIFF
--- a/nncf/torch/pruning/operations.py
+++ b/nncf/torch/pruning/operations.py
@@ -288,7 +288,6 @@ class PTLinearPruningOp(LinearPruningOp, PTPruner):
         if reorder_indexes is None:
             return
         reorder_indexes = reorder_indexes.tensor
-        reorder_indexes = reorder_indexes.int()
         fc = model.get_containing_module(node.node_name)
         fc.weight.data = torch.index_select(fc.weight.data, 1, reorder_indexes)
         nncf_logger.debug(

--- a/tests/torch/nas/test_elastic_width.py
+++ b/tests/torch/nas/test_elastic_width.py
@@ -29,6 +29,7 @@ from tests.torch.nas.helpers import compare_tensors_ignoring_the_order
 from tests.torch.nas.helpers import move_model_to_cuda_if_available
 from tests.torch.nas.models.synthetic import TwoConvAddConvTestModel
 from tests.torch.nas.models.synthetic import TwoSequentialConvBNTestModel
+from tests.torch.nas.models.synthetic import ConvTwoFcTestModel
 from tests.torch.nas.test_all_elasticity import NAS_MODELS_SCOPE
 from tests.torch.nas.test_elastic_kernel import do_conv2d
 ###########################
@@ -44,7 +45,7 @@ def _seed():
     manual_seed(0)
 
 
-@pytest.fixture(name='basic_model', params=(TwoConvAddConvTestModel, TwoSequentialConvBNTestModel))
+@pytest.fixture(name='basic_model', params=(ConvTwoFcTestModel, TwoConvAddConvTestModel, TwoSequentialConvBNTestModel))
 def fixture_basic_model(request):
     model_cls = request.param
     model = model_cls()


### PR DESCRIPTION
Co-authored-by: Zheng, Yi <yi.zheng@intel.com>

### Changes

Add input_reorder and output_reorder for linear layer

### Reason for changes

Enable weights reordering for linear layer. Please see how other layers already have enabled weight reordering. This is used by BootstrapNAS for its [filter reordering algorithm](https://github.com/openvinotoolkit/nncf/blob/d5e9edf8f335fc6d97825ddc07cfbd03594defd2/nncf/experimental/torch/nas/bootstrapNAS/elasticity/filter_reorder.py#L50): 

### Tests

Added test in BootstrapNAS tests 
