### PR TITLE
Revise ONNX PTQ pipeline

### DIFF
--- a/examples/experimental/onnx/classification/onnx_ptq_classification.py
+++ b/examples/experimental/onnx/classification/onnx_ptq_classification.py
@@ -43,9 +43,15 @@ def run(onnx_model_path: str, output_model_path: str,
             "input_shape is None. Infer input_shape from the model.")
         input_shape = infer_input_shape(original_model)
 
+    input_keys = [node.name for node in original_model.graph.input]
+    if len(input_keys) != 1:
+        raise RuntimeError(
+            f"The number of inputs should be 1(!={len(input_keys)}).")
+
     # Step 1: Initialize the data loader and metric (if it is needed).
-    dataset = create_imagenet_torch_dataset(dataset_path, input_shape,
-                                            batch_size=batch_size, shuffle=shuffle)
+    dataset = create_imagenet_torch_dataset(
+        dataset_path, input_key=input_keys[0],
+        input_shape=input_shape, batch_size=batch_size, shuffle=shuffle)
     metric = Accuracy(top_k=1)
 
     # Step 2: Create a pipeline of compression algorithms.
@@ -84,13 +90,13 @@ def run(onnx_model_path: str, output_model_path: str,
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--onnx_model_path", "-m",
-                        help="Path to ONNX model", type=str)
+                        help="Path to ONNX model", type=str, required=True)
     parser.add_argument("--output_model_path", "-o",
-                        help="Path to output quantized ONNX model", type=str)
+                        help="Path to output quantized ONNX model", type=str, required=True)
     parser.add_argument("--data",
                         help="Path to ImageNet validation data in the ImageFolder torchvision format "
                              "(Please, take a look at torchvision.datasets.ImageFolder)",
-                        type=str)
+                        type=str, required=True)
     parser.add_argument(
         "--batch_size", help="Batch size for initialization", type=int, default=1)
     parser.add_argument(

--- a/examples/experimental/onnx/run_ptq.py
+++ b/examples/experimental/onnx/run_ptq.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 import numpy as np
 import onnx
+from nncf.experimental.onnx.tensor import ONNXNNCFTensor
 
 from nncf.experimental.post_training.compression_builder import CompressionBuilder
 from nncf.experimental.post_training.algorithms.quantization import PostTrainingQuantization
@@ -42,13 +43,10 @@ class OpenVINOAccuracyCheckerDataset(ptq_api_dataset.Dataset):
         filled_inputs, _, _ = self.model_evaluator._get_batch_input(
             batch_annotation, batch_input)
 
-        assert len(filled_inputs) == 1
-        dummy_target = 0
+        if len(filled_inputs) == 1:
+            return {k: ONNXNNCFTensor(np.squeeze(v, axis=0)) for k, v in filled_inputs[0].items()}
 
-        for _, v in filled_inputs[0].items():
-            return np.squeeze(v, axis=0), dummy_target
-
-        raise RuntimeError("filled_inputs has no value.")
+        raise Exception("len(filled_inputs) should be one.")
 
     def __len__(self):
         return len(self.model_evaluator.dataset)

--- a/examples/experimental/onnx/semantic_segmentation/onnx_ptq_segmentation.py
+++ b/examples/experimental/onnx/semantic_segmentation/onnx_ptq_segmentation.py
@@ -33,9 +33,14 @@ def run(onnx_model_path: str, output_model_path: str, dataset_name: str,
     original_model = onnx.load(onnx_model_path)
     print(f"The model is loaded from {onnx_model_path}")
 
+    input_keys = [node.name for node in original_model.graph.input]
+    if len(input_keys) != 1:
+        raise RuntimeError(
+            f"The number of inputs should be 1(!={len(input_keys)}).")
+
     # Step 1: Initialize the data loader.
     dataloader = create_dataset_from_segmentation_torch_dataset(
-        dataset_name, dataset_path, input_shape)
+        dataset_name, dataset_path, input_keys[0], input_shape)
 
     # Step 2: Create a pipeline of compression algorithms.
     builder = CompressionBuilder()

--- a/nncf/common/tensor.py
+++ b/nncf/common/tensor.py
@@ -27,7 +27,7 @@ class NNCFTensor:
     def __init__(self, tensor: Optional[TensorType]):
         self._tensor = tensor
 
-    def __eq__(self, other: 'NNCFTensor') -> bool:
+    def __eq__(self, other: "NNCFTensor") -> bool:
         return self._tensor == other.tensor
 
     @property

--- a/nncf/experimental/onnx/datasets/imagenet_dataset.py
+++ b/nncf/experimental/onnx/datasets/imagenet_dataset.py
@@ -18,8 +18,9 @@ import os
 import torch
 
 from nncf.common.utils.logger import logger as nncf_logger
+from nncf.experimental.onnx.tensor import ONNXNNCFTensor
 
-from nncf.experimental.post_training.api.dataset import Dataset
+from nncf.experimental.post_training.api.dataset import Dataset, NNCFData
 
 from onnx import ModelProto
 from google.protobuf.json_format import MessageToDict
@@ -28,18 +29,21 @@ from torchvision.datasets import ImageFolder
 
 
 class ImageNetDataset(Dataset):
-    def __init__(self, dataset, batch_size, shuffle):
+    def __init__(self, dataset, batch_size, shuffle, input_key):
         super().__init__(batch_size, shuffle)
         self.dataset = dataset
+        self.input_key = input_key
         nncf_logger.info(
-            'The dataset is built with the data located on  {}'.format(dataset.root))
+            f"The dataset is built with the data located on {dataset.root}. "
+            f"Model input key is {input_key}."
+        )
 
-    def __getitem__(self, item):
+    def __getitem__(self, item) -> NNCFData:
         tensor, target = self.dataset[item]
         tensor = tensor.cpu().detach().numpy()
-        return tensor, target
+        return {self.input_key: ONNXNNCFTensor(tensor), "targets": ONNXNNCFTensor(target)}
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.dataset)
 
 
@@ -81,6 +85,7 @@ def get_transform(image_size: Tuple[int, int],
 
 
 def create_imagenet_torch_dataset(dataset_dir: str,
+                                  input_key: str,
                                   input_shape: Optional[Tuple[int, int, int, int]],
                                   mean=(0.485, 0.456, 0.406),
                                   std=(0.229, 0.224, 0.225),
@@ -97,4 +102,4 @@ def create_imagenet_torch_dataset(dataset_dir: str,
     transform = get_transform(image_size, crop_ratio, mean, std, channel_last)
     # The best practise is to use validation part of dataset for calibration (aligning with POT)
     initialization_dataset = ImageFolder(os.path.join(dataset_dir), transform)
-    return ImageNetDataset(initialization_dataset, batch_size, shuffle)
+    return ImageNetDataset(initialization_dataset, batch_size, shuffle, input_key)

--- a/nncf/experimental/onnx/datasets/segmentation_dataset.py
+++ b/nncf/experimental/onnx/datasets/segmentation_dataset.py
@@ -14,6 +14,7 @@
 from typing import List
 
 from nncf.common.utils.logger import logger as nncf_logger
+from nncf.experimental.onnx.tensor import ONNXNNCFTensor
 
 from nncf.experimental.post_training.api.dataset import Dataset
 from examples.torch.semantic_segmentation.datasets.camvid import CamVid
@@ -21,16 +22,17 @@ from examples.torch.semantic_segmentation.datasets.mapillary import Mapillary
 
 
 class SegmentationDataLoader(Dataset):
-    def __init__(self, dataset, batch_size, shuffle):
+    def __init__(self, dataset, batch_size, shuffle, input_key):
         super().__init__(batch_size, shuffle)
         self.dataset = dataset
+        self.input_key = input_key
         nncf_logger.info(
             'The dataset is built with the data located on  {}'.format(dataset.root_dir))
 
     def __getitem__(self, item):
         tensor, target = self.dataset[item]
         tensor = tensor.cpu().detach().numpy()
-        return tensor, target
+        return {self.input_key: ONNXNNCFTensor(tensor), "targets": ONNXNNCFTensor(target)}
 
     def __len__(self):
         return len(self.dataset)
@@ -38,6 +40,7 @@ class SegmentationDataLoader(Dataset):
 
 def create_dataset_from_segmentation_torch_dataset(dataset_name: str,
                                                    dataset_dir: str,
+                                                   input_key: str,
                                                    input_shape: List[int]):
     from examples.torch.semantic_segmentation.utils.transforms import Resize
     from examples.torch.semantic_segmentation.utils.transforms import Normalize
@@ -63,4 +66,4 @@ def create_dataset_from_segmentation_torch_dataset(dataset_name: str,
     ])
     initialization_dataset = dataset_class(
         dataset_dir, 'val', transforms=transform)
-    return SegmentationDataLoader(initialization_dataset, 1, True)
+    return SegmentationDataLoader(initialization_dataset, 1, True, input_key)

--- a/nncf/experimental/onnx/statistics/collectors.py
+++ b/nncf/experimental/onnx/statistics/collectors.py
@@ -72,8 +72,8 @@ class ONNXMinMaxStatisticCollector(MinMaxStatisticCollector):
     def _get_processor() -> NNCFCollectorTensorProcessor:
         return ONNXNNCFCollectorTensorProcessor()
 
-    def _register_input(self, x: np.ndarray):
-        self._register_input_common(ONNXNNCFTensor(x))
+    def _register_input(self, x: ONNXNNCFTensor):
+        self._register_input_common(x)
 
     def _get_statistics(self) -> ONNXMinMaxTensorStatistic:
         return ONNXMinMaxTensorStatistic(self._min_values.tensor, self._max_values.tensor)
@@ -84,8 +84,8 @@ class ONNXMeanMinMaxStatisticCollector(MeanMinMaxStatisticCollector):
     def _get_processor() -> NNCFCollectorTensorProcessor:
         return ONNXNNCFCollectorTensorProcessor()
 
-    def _register_input(self, x: np.ndarray):
-        self._register_input_common(ONNXNNCFTensor(x))
+    def _register_input(self, x: ONNXNNCFTensor):
+        self._register_input_common(x)
 
     def _get_statistics(self) -> ONNXMinMaxTensorStatistic:
         return ONNXMinMaxTensorStatistic(self._min_aggregate().tensor, self._max_aggregate().tensor)

--- a/nncf/experimental/post_training/api/dataset.py
+++ b/nncf/experimental/post_training/api/dataset.py
@@ -11,16 +11,15 @@
  limitations under the License.
 """
 
-from typing import Tuple
-from typing import TypeVar
+from typing import Dict
 
 from abc import ABC
 from abc import abstractmethod
 
 from nncf.common.utils.logger import logger as nncf_logger
+from nncf.common.tensor import NNCFTensor
 
-ModelInput = TypeVar('ModelInput')
-Target = TypeVar('Target')
+NNCFData = Dict[str, NNCFTensor]
 
 
 class Dataset(ABC):
@@ -37,7 +36,7 @@ class Dataset(ABC):
         self.shuffle = shuffle
 
     @abstractmethod
-    def __getitem__(self, i: int) -> Tuple[ModelInput, Target]:
+    def __getitem__(self, i: int) -> NNCFData:
         """
         Returns the i-th element of the dataset with the target value.
         """

--- a/nncf/experimental/post_training/api/sampler.py
+++ b/nncf/experimental/post_training/api/sampler.py
@@ -12,9 +12,10 @@
 """
 from abc import ABC
 from abc import abstractmethod
+from typing import Iterator
 
 
-from nncf.experimental.post_training.api.dataset import Dataset
+from nncf.experimental.post_training.api.dataset import Dataset, NNCFData
 
 
 class Sampler(ABC):
@@ -30,9 +31,9 @@ class Sampler(ABC):
         self.batch_indices = list(range(0, max_samples_len + 1, self.batch_size))
 
     @abstractmethod
-    def __iter__(self):
+    def __iter__(self) -> Iterator[NNCFData]:
         pass
 
     @abstractmethod
-    def __len__(self):
+    def __len__(self) -> int:
         pass

--- a/nncf/experimental/post_training/samplers.py
+++ b/nncf/experimental/post_training/samplers.py
@@ -11,45 +11,40 @@
  limitations under the License.
 """
 
-from typing import List, Tuple, Union
+from typing import Iterator, List, Union
 import torch
 import numpy as np
 
 from abc import abstractmethod
+
 from nncf.experimental.post_training.api.sampler import Sampler
-from nncf.experimental.post_training.api.dataset import Dataset
+from nncf.experimental.post_training.api.dataset import Dataset, NNCFData
 
 import random
 
 SAMPLER_OUTPUT_TYPE = Union[torch.Tensor, np.ndarray]
 
 # TODO (Nikita Malinin): Replace or rename this file
+
+
 class BatchSampler(Sampler):
     """
     Base class for dataset sampler forms a batch from samples
     with batch_size determined in dataset instance.
     """
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[NNCFData]:
         for i in range(len(self.batch_indices) - 1):
             batch = self.form_batch(
                 self.batch_indices[i], self.batch_indices[i + 1])
             yield batch
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.dataset)
 
     @abstractmethod
-    def form_batch(self, start_i: int, end_i: int):
+    def form_batch(self, start_i: int, end_i: int) -> NNCFData:
         pass
-
-    def _post_process(self, tensors: List, targets: List) -> Tuple[SAMPLER_OUTPUT_TYPE, SAMPLER_OUTPUT_TYPE]:
-        if isinstance(tensors[0], torch.Tensor):
-            return torch.stack(tensors), torch.LongTensor(targets)
-        if isinstance(tensors[0], np.ndarray):
-            return np.stack(tensors), np.array(targets)
-        raise RuntimeError(
-            'Unexpected input data type {tensors[0]}. Should be one of torch.Tensor or np.ndarray')
 
 
 class RandomBatchSampler(BatchSampler):

--- a/tests/onnx/test_statistics_aggregator.py
+++ b/tests/onnx/test_statistics_aggregator.py
@@ -26,9 +26,9 @@ from tests.onnx.test_samplers import TestDataset
 
 INPUT_SHAPE = [3, 10, 10]
 
-DATASET_SAMPLES = [(np.zeros(INPUT_SHAPE), 0),
-                   (np.zeros(INPUT_SHAPE), 1),
-                   (np.zeros(INPUT_SHAPE), 2)]
+DATASET_SAMPLES = [(np.zeros(INPUT_SHAPE, dtype=np.float32), 0),
+                   (np.zeros(INPUT_SHAPE, dtype=np.float32), 1),
+                   (np.zeros(INPUT_SHAPE, dtype=np.float32), 2)]
 
 DATASET_SAMPLES[0][0][0, 0, 0] = 128  # max
 DATASET_SAMPLES[0][0][0, 0, 1] = -128  # min
@@ -59,7 +59,7 @@ class TestParameters:
 def test_statistics_aggregator(range_type, test_parameters):
     model = OneConvolutionalModel().onnx_model
 
-    dataset = TestDataset(DATASET_SAMPLES)
+    dataset = TestDataset(DATASET_SAMPLES, input_key="X")
     compression_builder = CompressionBuilder()
 
     quantization = ONNXMinMaxQuantization(MinMaxQuantizationParameters(


### PR DESCRIPTION
### Changes

 - Add `NNCFData` data type which is a dictionary with string key and tensor values.
 - Revise ONNX PTQ pipeline to handle `NNCFData` as inputs and outputs.

### Reason for changes

 - ONNX PTQAPI fails for `yolov3-12` and `tiny-yolov3-11` models. This is because those models require to put `input_shape` tensor as their inputs. However, the current input pipeline cannot handle this case.

### Related tickets

86465

### Tests
