### PR TITLE
[Pruning] Input shapes param removal

### DIFF
--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/multi_elasticity_handler.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/multi_elasticity_handler.py
@@ -41,7 +41,6 @@ from nncf.torch.graph.operator_metatypes import PTDepthwiseConv2dSubtype
 from nncf.torch.graph.operator_metatypes import PTDepthwiseConv3dSubtype
 from nncf.torch.graph.operator_metatypes import PTLinearMetatype
 from nncf.torch.nncf_network import NNCFNetwork
-from nncf.torch.pruning.utils import collect_input_shapes
 from nncf.torch.pruning.utils import collect_output_shapes
 
 SubnetConfig = OrderedDictType[ElasticityDim, ElasticityConfig]
@@ -238,7 +237,6 @@ class MultiElasticityHandler(ElasticityHandler):
 
         graph = self._target_model.get_graph()
         modules_out_shapes = collect_output_shapes(graph)
-        modules_in_shapes = collect_input_shapes(graph)
 
         kernel_sizes = None
         if self.kernel_handler is not None:
@@ -254,7 +252,6 @@ class MultiElasticityHandler(ElasticityHandler):
 
         flops_pers_node, num_weights_per_node = count_flops_and_weights_per_node(
             graph=graph,
-            input_shapes=modules_in_shapes,
             output_shapes=modules_out_shapes,
             input_channels=input_width_values,
             output_channels=output_width_values,

--- a/nncf/tensorflow/pruning/filter_pruning/algorithm.py
+++ b/nncf/tensorflow/pruning/filter_pruning/algorithm.py
@@ -124,7 +124,6 @@ class FilterPruningController(BasePruningAlgoController):
         self._nodes_params_num = {}  # type: Dict[NNCFNodeName, int]
         self._layers_in_channels = {}
         self._layers_out_channels = {}
-        self._layers_in_shapes = {}
         self._layers_out_shapes = {}
         self._pruning_quotas = {}
         self._next_nodes = {}
@@ -260,7 +259,6 @@ class FilterPruningController(BasePruningAlgoController):
             if not is_valid_shape(in_shape) or not is_valid_shape(out_shape):
                 raise RuntimeError(f'Input/output shape is not defined for layer `{layer.name}` ')
 
-            self._layers_in_shapes[node.node_name] = in_shape
             self._layers_out_shapes[node.node_name] = out_shape
 
         for node in self._original_graph.get_nodes_by_metatypes(LINEAR_LAYER_METATYPES):
@@ -273,12 +271,10 @@ class FilterPruningController(BasePruningAlgoController):
             if not is_valid_shape(in_shape) or not is_valid_shape(out_shape):
                 raise RuntimeError(f'Input/output shape is not defined for layer `{layer.name}` ')
 
-            self._layers_in_shapes[node.node_name] = in_shape
             self._layers_out_shapes[node.node_name] = out_shape
 
         self._nodes_flops, self._nodes_params_num = \
             count_flops_and_weights_per_node(self._original_graph,
-                                             self._layers_in_shapes,
                                              self._layers_out_shapes,
                                              conv_op_metatypes=GENERAL_CONV_LAYER_METATYPES,
                                              linear_op_metatypes=LINEAR_LAYER_METATYPES)
@@ -423,7 +419,6 @@ class FilterPruningController(BasePruningAlgoController):
                 tmp_in_channels[node_name] -= 1
 
             flops, params_num = count_flops_and_weights(self._original_graph,
-                                                        self._layers_in_shapes,
                                                         self._layers_out_shapes,
                                                         input_channels=tmp_in_channels,
                                                         output_channels=tmp_out_channels,
@@ -492,7 +487,6 @@ class FilterPruningController(BasePruningAlgoController):
                 pruning_groups_next_nodes=self._next_nodes)
 
         return count_flops_and_weights(self._original_graph,
-                                       self._layers_in_shapes,
                                        self._layers_out_shapes,
                                        input_channels=tmp_in_channels,
                                        output_channels=tmp_out_channels,
@@ -540,7 +534,6 @@ class FilterPruningController(BasePruningAlgoController):
 
         self.current_flops, self.current_params_num = \
             count_flops_and_weights(self._original_graph,
-                                    self._layers_in_shapes,
                                     self._layers_out_shapes,
                                     input_channels=tmp_in_channels,
                                     output_channels=tmp_out_channels,

--- a/nncf/torch/pruning/utils.py
+++ b/nncf/torch/pruning/utils.py
@@ -122,21 +122,3 @@ def collect_output_shapes(graph: NNCFGraph) -> Dict[NNCFNodeName, List[int]]:
             nncf_logger.error("Node %s have no output edge in NNCFGraph", node.node_name)
             modules_out_shapes[node.node_name] = node.layer_attributes.out_features
     return modules_out_shapes
-
-
-def collect_input_shapes(graph: NNCFGraph) -> Dict[NNCFNodeName, List[int]]:
-    """
-    Collects input dimension shapes for fully connected layers from the connected edges in the NNCFGraph.
-
-    :param graph: NNCFGraph.
-    :return: Dictionary of input dimension shapes. E.g {node_name: (height, width)}
-    """
-    modules_in_shapes = {}
-    for node in graph.get_nodes_by_types([v.op_func_name for v in NNCF_LINEAR_MODULES_DICT]):
-        in_edge = graph.get_input_edges(node)[0]
-        in_shape = in_edge.tensor_shape
-        if len(in_shape) == 1:
-            modules_in_shapes[node.node_name] = in_shape[0]
-        else:
-            modules_in_shapes[node.node_name] = in_shape[1:]
-    return modules_in_shapes

--- a/tests/tensorflow/pruning/test_flops_pruning.py
+++ b/tests/tensorflow/pruning/test_flops_pruning.py
@@ -62,7 +62,6 @@ def test_flops_calulation_for_spec_layers(model_fn, all_weights, pruning_flops_t
 
     cur_flops, cur_params_num = \
         count_flops_and_weights(compression_ctrl._original_graph,
-                                compression_ctrl._layers_in_shapes,
                                 compression_ctrl._layers_out_shapes,
                                 input_channels=tmp_in_channels,
                                 output_channels=tmp_out_channels,

--- a/tests/torch/pruning/filter_pruning/test_algo.py
+++ b/tests/torch/pruning/filter_pruning/test_algo.py
@@ -435,7 +435,6 @@ def test_calculation_of_flops(all_weights, pruning_flops_target, ref_flops, ref_
 
     cur_flops, cur_params_num = count_flops_and_weights(
         pruning_algo._model.get_original_graph(),
-        pruning_algo._modules_in_shapes,
         pruning_algo._modules_out_shapes,
         input_channels=tmp_in_channels,
         output_channels=tmp_out_channels,


### PR DESCRIPTION
### Changes

Redundant input shape param was removed from `count_flops_and_weights_per_node` function.
`count_filters_num` now always takes into account pruned linear layers.

### Reason for changes

<!--- Why should the change be applied -->

`collect_input_shapes` function isn't protected from case when input edges don't exist (unlike `collect_output_shapes`, which process nodes without output edges correctly). Turns out that output of `collect_input_shaped` used only in `count_flops_and_weights_per_node` function and could be easily replaced by linear layers `in_features` and `out_features` attributes

86889

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
No need
