### PR TITLE
Fix ONNX PTQ API for yolov3-12 and tiny-yolov3-11 models

### DIFF
--- a/examples/experimental/onnx/README.md
+++ b/examples/experimental/onnx/README.md
@@ -305,10 +305,10 @@ After benchmark is done, outputs are located in `/output` which is a mounted dir
 | fcn-resnet50-12      | 250.28            | 400.34            | 0.63                      | 38.31             | 38.14             | 0.17               |
 | retinanet-9          | 110.18            | NaN               | NaN                       | 18.45             | NaN               | NaN                |
 | ssd-12               | 205.84            | NaN               | NaN                       | 22.91             | NaN               | NaN                |
-| tiny-yolov3-11       | NaN               | NaN               | NaN                       | 8.68              | NaN               | NaN                |
+| tiny-yolov3-11       | 9.87              | NaN               | NaN                       | 8.68              | 7.97              | NaN                |
 | tinyyolov2-8         | 10.48             | 6.06              | 1.73                      | 32.34             | 31.78             | 0.56               |
 | yolov2-coco-9        | 24.06             | 14.8              | 1.63                      | 21.7              | 22.17             | \-0.47             |
-| yolov3-12            | NaN               | NaN               | NaN                       | 31.08             | NaN               | NaN                |
+| yolov3-12            | 40.09             | NaN               | NaN                       | 31.08             | 29.01             | NaN                |
 | yolov4               | 41.08             | NaN               | NaN                       | 14.28             | NaN               | NaN                |
 
 <details>
@@ -403,6 +403,7 @@ After benchmark is done, outputs are located in `/output` which is a mounted dir
 
 * `nan` means that NNCF PTQ API failed to generate proper quantized onnx model. We are working on these defects.
 * `MaskRCNN-12` can be used two task types detection (`det`) and instance segmentation (`inst-seg`).
+* `tiny-yolov3-11` and `yolov3-12` models can be quantized by PTQ API, but the quantized models cannot be run on `OpenVINOExecutionProvider(onnxruntime-openvino==1.11.0)`. Therefore, we obtain the model accuracy by running those models on `CPUExecutionProvider`.
 
 # Support ONNXRuntime PTQ for Yolov5 models
 

--- a/examples/experimental/onnx/det_and_seg/onnx_models_configs/tiny-yolov3-11.yml
+++ b/examples/experimental/onnx/det_and_seg/onnx_models_configs/tiny-yolov3-11.yml
@@ -31,3 +31,8 @@ models:
           - type: coco_precision
             max_detections: 100
             threshold: .5:.05:.95
+
+    ignored_scopes: [
+      "{re}TFNodes/yolo_evaluation_layer_*",
+      "Add__375"
+    ]

--- a/examples/experimental/onnx/det_and_seg/onnx_models_configs/yolov3-12.yml
+++ b/examples/experimental/onnx/det_and_seg/onnx_models_configs/yolov3-12.yml
@@ -29,3 +29,7 @@ models:
         metrics:
           - type: coco_precision
             threshold: .5:.05:.95
+    ignored_scopes: [
+      "{re}TFNodes/yolo_evaluation_layer_*",
+      "Add__375"
+    ]

--- a/examples/experimental/onnx/run_ptq.py
+++ b/examples/experimental/onnx/run_ptq.py
@@ -115,7 +115,10 @@ if __name__ == '__main__':
             args.output_model_dir, fname + "-quantized.onnx")
 
         onnx_model_path = str(onnx_model_path)
+
+        ignored_scopes = config_entry.get("ignored_scopes", None)
+
         run(onnx_model_path,
             output_model_path,
-            dataset
-            )
+            dataset,
+            ignored_scopes)

--- a/nncf/experimental/onnx/graph/nncf_graph_builder.py
+++ b/nncf/experimental/onnx/graph/nncf_graph_builder.py
@@ -89,7 +89,12 @@ class GraphConverter:
                     )
         # Add Input Nodes
         for i, _input in enumerate(onnx_graph.get_model_inputs()):
-            input_shape = onnx_graph.get_tensor_shape(_input)
+            try:
+                input_shape = onnx_graph.get_tensor_shape(_input)
+            except RuntimeError as err:
+                nncf_logger.error(err)
+                nncf_logger.error('The default tensor shape will be set.')
+                input_shape = GraphConverter.DEFAULT_TENSOR_SHAPE
             input_node = nncf_graph.add_nncf_node(node_name=MODEL_INPUT_OP_NAME + '_' + str(i),
                                                   node_type=NNCFGraphNodeType.INPUT_NODE,
                                                   node_metatype=InputNoopMetatype,
@@ -113,7 +118,12 @@ class GraphConverter:
                 )
         # Add Output Nodes
         for i, _output in enumerate(onnx_graph.get_model_outputs()):
-            output_shape = onnx_graph.get_tensor_shape(_output)
+            try:
+                output_shape = onnx_graph.get_tensor_shape(_output)
+            except RuntimeError as err:
+                nncf_logger.error(err)
+                nncf_logger.error('The default tensor shape will be set.')
+                output_shape = GraphConverter.DEFAULT_TENSOR_SHAPE
             output_node = nncf_graph.add_nncf_node(node_name=MODEL_OUTPUT_OP_NAME + '_' + str(i),
                                                    node_type=NNCFGraphNodeType.OUTPUT_NODE,
                                                    node_metatype=OutputNoopMetatype,


### PR DESCRIPTION
Please merge this after https://github.com/openvinotoolkit/nncf/pull/1214.

### Changes

 - Give `GraphConverter.DEFAULT_TENSOR_SHAPE` to input and output nodes when it cannot infer shape as same as https://github.com/openvinotoolkit/nncf/blob/d5e9edf8f335fc6d97825ddc07cfbd03594defd2/nncf/experimental/onnx/graph/nncf_graph_builder.py#L66-L75
 - Fix `run_ptq.py` to accept `ignored_scopes` parameter from the config file.
 - Update model accuracy and performance in `README.md`

### Reason for changes
 - To support ONNX PTQ API for `yolov3-12` and `tiny-yolov3-11` models

### Related tickets
86465

### Tests
