### PR TITLE
Add sample rate for subnet sampling in BootstrapNAS and fix search example

### DIFF
--- a/examples/experimental/torch/classification/bootstrap_nas_search.py
+++ b/examples/experimental/torch/classification/bootstrap_nas_search.py
@@ -39,7 +39,7 @@ from examples.torch.common.utils import create_code_snapshot
 from examples.torch.common.utils import is_pretrained_model_requested
 from examples.torch.common.utils import print_args
 from nncf.config.structures import BNAdaptationInitArgs
-from nncf.experimental.torch.nas.bootstrapNAS.search import SearchAlgorithm
+from nncf.experimental.torch.nas.bootstrapNAS import SearchAlgorithm
 from nncf.experimental.torch.nas.bootstrapNAS.training.model_creator_helpers import resume_compression_from_state
 from nncf.torch.initialization import wrap_dataloader_for_init
 from nncf.torch.model_creation import create_nncf_network
@@ -158,6 +158,7 @@ def main_worker(current_gpu, config: SampleConfig):
         logger.info(f"Best config: {best_config}")
         logger.info(f"Performance metrics: {performance_metrics}")
 
+        search_algo.visualize_search_progression()
         search_algo.search_progression_to_csv()
         search_algo.evaluators_to_csv()
 

--- a/nncf/config/experimental_schema.py
+++ b/nncf/config/experimental_schema.py
@@ -191,7 +191,10 @@ STAGE_DESCRIPTOR_SCHEMA = {
                                                " descriptor, it will trigger a reset of the learning rate at "
                                                "the beginning of the stage."),
         "epochs_lr": with_attributes(NUMBER,
-                                     description="Number of epochs to compute the adjustment of the learning rate.")
+                                     description="Number of epochs to compute the adjustment of the learning rate."),
+        "sample_rate": with_attributes(NUMBER,
+                                       description="Number of iterations to activate the random subnet."
+                                                   "Default value is 1.")
     },
     "description": "Defines a supernet training stage: how many epochs it takes, which elasticities with which "
                    "settings are enabled, whether some operation should happen in the beginning",

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -148,9 +148,9 @@ class ElasticWidthParams(BaseElasticityParams):
                  width_step: int,
                  width_multipliers: List[float],
                  filter_importance: str,
-                 overwrite_groups: List[str],
-                 overwrite_groups_widths: List[str],
-                 add_dynamic_inputs: Optional[List[str]]):
+                 overwrite_groups: Optional[List[str]] = None,
+                 overwrite_groups_widths: Optional[List[str]] = None,
+                 add_dynamic_inputs: Optional[List[str]] = None):
         """
         Constructor
 
@@ -996,12 +996,12 @@ class ElasticWidthBuilder(SingleElasticityBuilder):
         self._params = params
         self._grouped_node_names_to_prune = state[self._state_names.GROUPED_NODE_NAMES_TO_PRUNE]
 
-        if params_from_state[self._state_names.OVERWRITE_GROUP_WIDTHS] is not None:
+        if params_from_state.get(self._state_names.OVERWRITE_GROUP_WIDTHS, None) is not None:
             self._overwrite_groups_widths = params_from_state[self._state_names.OVERWRITE_GROUP_WIDTHS]
             self._overwriting_pruning_groups = True
             if len(self._grouped_node_names_to_prune) != len(self._overwrite_groups_widths):
                 raise RuntimeError("Mismatch between number of groups for pruning and their corresponding widths")
-        if params_from_state[self._state_names.ADD_DYNAMIC_INPUTS] is not None:
+        if params_from_state.get(self._state_names.ADD_DYNAMIC_INPUTS, None) is not None:
             self._add_dynamic_inputs = params_from_state[self._state_names.ADD_DYNAMIC_INPUTS]
 
     def get_state(self) -> Dict[str, Any]:

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/stage_descriptor.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/stage_descriptor.py
@@ -27,6 +27,7 @@ class SDescriptorParamNames:
     BN_ADAPT = 'bn_adapt'
     INIT_LR = 'init_lr'
     EPOCHS_LR = 'epochs_lr'
+    SAMPLE_RATE = 'sample_rate'
 
 
 class StageDescriptor:
@@ -42,7 +43,8 @@ class StageDescriptor:
                  depth_indicator: int = 1,
                  width_indicator: int = 1,
                  init_lr = None,
-                 epochs_lr = None):
+                 epochs_lr = None,
+                 sample_rate: int = 1):
         self.train_dims = train_dims
         self.epochs = epochs
         self.depth_indicator = depth_indicator
@@ -51,6 +53,7 @@ class StageDescriptor:
         self.bn_adapt = bn_adapt
         self.init_lr = init_lr
         self.epochs_lr = epochs_lr
+        self.sample_rate = sample_rate
 
     def __eq__(self, other: 'StageDescriptor'):
         return self.__dict__ == other.__dict__
@@ -69,7 +72,8 @@ class StageDescriptor:
             cls._state_names.DEPTH_INDICATOR: config.get(cls._state_names.DEPTH_INDICATOR, 1),
             cls._state_names.BN_ADAPT: config.get(cls._state_names.BN_ADAPT, False),
             cls._state_names.INIT_LR: config.get(cls._state_names.INIT_LR, None),
-            cls._state_names.EPOCHS_LR: config.get(cls._state_names.EPOCHS_LR, None)
+            cls._state_names.EPOCHS_LR: config.get(cls._state_names.EPOCHS_LR, None),
+            cls._state_names.SAMPLE_RATE: config.get(cls._state_names.SAMPLE_RATE, 1)
         }
         return cls(**kwargs)
 
@@ -93,6 +97,7 @@ class StageDescriptor:
             self._state_names.WIDTH_INDICATOR: self.width_indicator,
             self._state_names.DEPTH_INDICATOR: self.depth_indicator,
             self._state_names.BN_ADAPT: self.bn_adapt,
+            self._state_names.SAMPLE_RATE: self.sample_rate
         }
         if self.init_lr is not None:
             state_dict['init_lr'] = self.init_lr

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/stage_descriptor.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/stage_descriptor.py
@@ -14,6 +14,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+from nncf.common.utils.logger import logger as nncf_logger
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_dim import ElasticityDim
 
 DEFAULT_STAGE_LR_RATE = 3.5e-06
@@ -42,8 +43,8 @@ class StageDescriptor:
                  bn_adapt: bool = False,
                  depth_indicator: int = 1,
                  width_indicator: int = 1,
-                 init_lr = None,
-                 epochs_lr = None,
+                 init_lr: float = None,
+                 epochs_lr: int = None,
                  sample_rate: int = 1):
         self.train_dims = train_dims
         self.epochs = epochs
@@ -54,6 +55,10 @@ class StageDescriptor:
         self.init_lr = init_lr
         self.epochs_lr = epochs_lr
         self.sample_rate = sample_rate
+        if sample_rate <= 0:
+            nncf_logger.warning(f"Only positive integers are allowed for sample rate, but sample_rate={sample_rate}.")
+            nncf_logger.warning(f"Setting sample rate to default 1")
+            self.sample_rate = 1
 
     def __eq__(self, other: 'StageDescriptor'):
         return self.__dict__ == other.__dict__

--- a/tests/torch/nas/test_all_elasticity.py
+++ b/tests/torch/nas/test_all_elasticity.py
@@ -313,11 +313,11 @@ REF_COMPRESSION_STATE_FOR_TWO_CONV = {
                 'list_stage_descriptions': [
                     {
                         'bn_adapt': True, 'depth_indicator': 1, 'epochs': 1, 'reorg_weights': False,
-                        'train_dims': ['width'], 'width_indicator': 2
+                        "sample_rate": 1, 'train_dims': ['width'], 'width_indicator': 2
                     },
                     {
                         'bn_adapt': False, 'depth_indicator': 2, 'epochs': 1, 'reorg_weights': True,
-                        'train_dims': ['depth', 'width'], 'width_indicator': 1
+                        "sample_rate": 1, 'train_dims': ['depth', 'width'], 'width_indicator': 1
                     }
                 ]
             }


### PR DESCRIPTION
Co-authored-by: Zheng, Yi <yi.zheng@intel.com>

### Changes

- Add sample rate for subnet sampling in BootstrapNAS.

- The PR also fixes an import in BootstrapNAS subnet search example and adds a call to the visualization of the search. 

### Reason for changes

This PR enables the adjustment of the subnet sampling rate to improve training efficiency significantly while maintaining the original accuracy. This improvement is motivated by the paper ***Does Interference Exist When Training a Once-For-All Network?*** by Jordan Shipard et al., 2022. 

### Related tickets
N/A

### Tests

Modified elasticity test to include sample rate.