### PR TITLE
[ONNX PTQ API] Fix ssd-12

### DIFF
--- a/examples/experimental/onnx/README.md
+++ b/examples/experimental/onnx/README.md
@@ -304,7 +304,7 @@ After benchmark is done, outputs are located in `/output` which is a mounted dir
 | ResNet101-DUC-12              | 904.88            | 435.51            | 2.08                      | 71.2              | 70.36             | 0.84               |
 | fcn-resnet50-12               | 250.28            | 400.34            | 0.63                      | 38.31             | 38.14             | 0.17               |
 | retinanet-9                   | 110.18            | 38.05             | 2.90                      | 18.45             | 18.39             | 0.06               |
-| ssd-12 :zap:                  | 205.84            | NaN               | NaN                       | 22.91             | NaN               | NaN                |
+| ssd-12                        | 204.44            | 76.08             | 2.69                      | 22.91             | 22.54             | 0.37               |
 | tiny-yolov3-11 :cloud:        | 9.87              | NaN               | NaN                       | 8.68              | 7.97              | 0.71               |
 | tinyyolov2-8                  | 10.48             | 6.06              | 1.73                      | 32.34             | 31.78             | 0.56               |
 | yolov2-coco-9                 | 24.06             | 14.8              | 1.63                      | 21.7              | 22.17             | \-0.47             |

--- a/examples/experimental/onnx/run_ptq.py
+++ b/examples/experimental/onnx/run_ptq.py
@@ -53,7 +53,8 @@ class OpenVINOAccuracyCheckerDataset(ptq_api_dataset.Dataset):
 
 
 def run(onnx_model_path: str, output_model_path: str, dataset: Dataset,
-        ignored_scopes: Optional[List[str]] = None, evaluate: Optional[bool] = False):
+        ignored_scopes: Optional[List[str]] = None,
+        convert_opset_version: bool = True):
 
     num_init_samples = len(dataset)
 
@@ -65,7 +66,7 @@ def run(onnx_model_path: str, output_model_path: str, dataset: Dataset,
     nncf_logger.info(f"The model is loaded from {onnx_model_path}")
 
     # Step 1: Create a pipeline of compression algorithms.
-    builder = CompressionBuilder()
+    builder = CompressionBuilder(convert_opset_version)
 
     # Step 2: Create the quantization algorithm and add to the builder.
     quantization_parameters = PostTrainingQuantizationParameters(

--- a/nncf/experimental/onnx/model_normalizer.py
+++ b/nncf/experimental/onnx/model_normalizer.py
@@ -11,7 +11,7 @@
  limitations under the License.
 """
 
-from collections import Counter, defaultdict
+from collections import Counter
 from copy import deepcopy
 import onnx
 from onnx.version_converter import convert_version, ConvertError  # pylint: disable=no-name-in-module

--- a/nncf/experimental/onnx/model_normalizer.py
+++ b/nncf/experimental/onnx/model_normalizer.py
@@ -11,15 +11,16 @@
  limitations under the License.
 """
 
+from collections import defaultdict
 from copy import deepcopy
 import onnx
 from onnx.version_converter import convert_version, ConvertError  # pylint: disable=no-name-in-module
 from nncf.common.utils.logger import logger as nncf_logger
 
 
-class ONNNXModelNormalizer:
+class ONNXModelNormalizer:
     @staticmethod
-    def modify_onnx_model_for_quantization(model: onnx.ModelProto) -> onnx.ModelProto:
+    def convert_opset_version(model: onnx.ModelProto) -> onnx.ModelProto:
         # pylint: disable=no-member
         def add_input_from_initializer(model: onnx.ModelProto) -> None:
             """
@@ -101,13 +102,33 @@ class ONNNXModelNormalizer:
 
             nncf_logger.info(
                 'Successfully converted the model to the opset = {}'.format(modified_model.opset_import[0].version))
-        except (RuntimeError, ConvertError) as e:
+        except (RuntimeError, ConvertError):
             modified_model = model
-            nncf_logger.error("Couldn't convert target model to opset13. "
-                              "Models with opset < 13 is not supported by PTQ yet.")
-            raise ConvertError from e
+            nncf_logger.error(
+                "Couldn't convert target model to opset13. Use original model")
 
-        for i, node in enumerate(modified_model.graph.node):
+        return modified_model
+
+    @staticmethod
+    def replace_empty_node_name(model: onnx.ModelProto):
+        """
+        NNCFGraph.get_node_by_name() does not allow empty node names.
+        NNCF expects every node to have a unique name.
+        """
+        for i, node in enumerate(model.graph.node):
             if node.name == '':
                 node.name = node.op_type + '_nncf_' + str(i)
-        return modified_model
+
+        name_counter = defaultdict(int)
+
+        for i, node in enumerate(model.graph.node):
+            name_counter[node.name] += 1
+
+        for name, cnt in name_counter.items():
+            if cnt > 1:
+                raise RuntimeError(
+                    f"Node {name} occurs more than once ({cnt} times). "
+                    "NNCF expects every node to have a unique name."
+                )
+
+        return model

--- a/tests/onnx/quantization/common.py
+++ b/tests/onnx/quantization/common.py
@@ -63,17 +63,20 @@ def _get_input_key(original_model: onnx.ModelProto) -> str:
 
     return input_keys[0]
 
-def min_max_quantize_model(input_shape: List[int], original_model: onnx.ModelProto) -> onnx.ModelProto:
+
+def min_max_quantize_model(
+    input_shape: List[int], original_model: onnx.ModelProto, convert_opset_version: bool = True) -> onnx.ModelProto:
     dataset = DatasetForTest(_get_input_key(original_model), input_shape)
-    builder = CompressionBuilder()
+    builder = CompressionBuilder(convert_opset_version)
     builder.add_algorithm(ONNXMinMaxQuantization(MinMaxQuantizationParameters(number_samples=1)))
     quantized_model = builder.apply(original_model, dataset)
     return quantized_model
 
 
-def ptq_quantize_model(input_shape: List[int], original_model: onnx.ModelProto) -> onnx.ModelProto:
+def ptq_quantize_model(
+    input_shape: List[int], original_model: onnx.ModelProto, convert_opset_version: bool = True) -> onnx.ModelProto:
     dataset = DatasetForTest(_get_input_key(original_model), input_shape)
-    builder = CompressionBuilder()
+    builder = CompressionBuilder(convert_opset_version)
     builder.add_algorithm(PostTrainingQuantization(PostTrainingQuantizationParameters(number_samples=1)))
     quantized_model = builder.apply(original_model, dataset)
     return quantized_model


### PR DESCRIPTION
### Changes
- Support `opset` version < 13
   - Block per channel quantization for `opset` version < 13 models
   - Add `convert_opset_version` flag to `CompressionBuilder`
   - Add test cases for `opset` version < 13
- Update ssd-12 benchmark results

### Reason for changes
Support PTQ API for ssd-12 model which cannot be converted to `opset_version=13`

### Related tickets
87359

### Tests
