### PR TITLE
Add pruning stats docs

### DIFF
--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -27,6 +27,32 @@ Where ![L_j](https://latex.codecogs.com/png.latex?L_j) is j-th convolutional lay
 
 Then during pruning filters with smaller ![G(F_i)](https://latex.codecogs.com/png.latex?G%28F_i%29) importance function will be pruned first.
 
+#### Algorithm statistics
+A model compression can be measured by two main metrics: filter pruning rate and FLOPs pruning rate. While 
+filter pruning rate shows the ratio of removed filters to the total number of filters in the model, FLOPs pruning rate 
+indicates how the removed filters affect the number of floating point operations required to run a model. 
+
+During the algorithm execution several compression statistics are available:
+
+`Target pruning level for the current epoch` - a pruning level calculated by the algorithm scheduler at each training epoch for 
+all layers previously defined as prunable. Note that this metric does not indicate the whole model filter pruning rate, as 
+it does not take into account the number of filters in layers that cannot be pruned.
+
+`FLOPs pruning level` - estimated reduction in the number of floating point operations of the model.
+The number of FLOPs for a single convolutional layer can be computed as:
+
+![FLOPs](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20FLOPs&space;=&space;2&space;%5Ctimes&space;input%5C;channels&space;%5Ctimes&space;kernel%5C;size%5E%7B2%7D%5Ctimes&space;W%5Ctimes&space;H%5Ctimes&space;filters)
+
+Each removed filter contributes to FLOPs reduction in two convolutional layers as it affects the number 
+of filters in one and the number of input channels of the next layer. Thus it is expected that this number may differ 
+significantly from the filter pruning rate.
+
+`MParams` - the number of parameters in the model in millions. Typically convolutional layer weights have shape 
+![shape](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20%5Cinline%20(kernel%5C;size,&space;kernel%5C;size,&space;input%5C;channels,&space;filters%5C;&space;num)).
+Thus each removed filter affects the number of parameters in two convolutional layers as it affects the number 
+of filters in one and the number of input channels of the next layer. It is expected that this number may differ 
+significantly from the filter pruning rate.
+
 #### Schedulers
 
 **Baseline Scheduler**

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -33,22 +33,44 @@ filter pruning level shows the ratio of removed filters to the total number of f
 indicates how the removed filters affect the number of floating point operations required to run a model. 
 
 During the algorithm execution several compression statistics are available:
+```
+Statistics of the pruned model:
++---------+-------+---------+---------------+
+|    #    | Full  | Current | Pruning level |
++=========+=======+=========+===============+
+| GFLOPS  | 0.602 | 0.241   | 0.599         |
++---------+-------+---------+---------------+
+| MParams | 3.470 | 1.997   | 0.424         |
++---------+-------+---------+---------------+
+| Filters | 17056 | 10216   | 0.401         |
++---------+-------+---------+---------------+
+Prompt: statistic pruning level = 1 - statistic current / statistic full.
+Statistics of the filter pruning algorithm:
++---------------------------------------+-------+
+|           Statistic's name            | Value |
++=======================================+=======+
+| Filter pruning level in current epoch | 0.500 |
++---------------------------------------+-------+
+| Target filter pruning level           | 0.800 |
++---------------------------------------+-------+
+```
 
+##### Model statistics
 `Filter pruning level` - percentage of filters removed from the model. Calculated as: 
 
-![Filter pruning level](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20%5Cinline%20%5Ctextit%7Bfilter%20pruning%20rate%20%7D=%201%20-%20(%5Ctextit%7Bcurrent%20number%20of%20filters%20in%20the%20model%20%7D/%5Ctextit%7B%20total%20number%20of%20filters%20in%20the%20model%7D))
+![Filter pruning level](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20%5Cinline%20%5Ctextit%7Bfilter%20pruning%20level%7D%20=%201%20-%20(%5Ctextit%7Bcurrent%20number%20of%20filters%20in%20the%20model%20%7D%20/%20%5Ctextit%7B%20total%20number%20of%20filters%20in%20the%20model%7D))
 
 > **NOTE**: All other pruning levels are calculated in a similar way.
 
 `GFLOPs pruning level` - an estimated reduction in the number of floating point operations of the model. 
-The number of FLOPs for a single convolutional layer can be computed as:
+The number of FLOPs for a single convolutional layer can be calculated as:
 
 ![FLOPs](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20FLOPs&space;=&space;2&space;%5Ctimes&space;input%5C;channels&space;%5Ctimes&space;kernel%5C;size%5E%7B2%7D%5Ctimes&space;W%5Ctimes&space;H%5Ctimes&space;filters)
 
 > **NOTE**: One GFLOP is one billion (1e9) FLOPs.
 
 Each removed filter contributes to FLOPs reduction in two convolutional layers as it affects the number 
-of filters in one and the number of input channels of the next layer. Thus it is expected that this number may differ 
+of filters in one and the number of input channels of the next layer. Thus, it is expected that this number may differ 
 significantly from the filter pruning level.
 
 In addition, the decrease in GFLOPs is estimated by calculating the number of FLOPs of convolutional and fully connected layers. 
@@ -56,16 +78,22 @@ As a result, these estimates may differ slightly from the actual number of FLOPs
 
 `MParams  pruning level` - calculated reduction in the number of parameters in the model in millions. Typically convolutional layer weights have shape 
 ![shape](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20%5Cinline%20(kernel%5C;size,&space;kernel%5C;size,&space;input%5C;channels,&space;filters%5C;&space;num)).
-Thus each removed filter affects the number of parameters in two convolutional layers as it affects the number 
+Thus, each removed filter affects the number of parameters in two convolutional layers as it affects the number 
 of filters in one and the number of input channels of the next layer. It is expected that this number may differ 
 significantly from the filter pruning level.
 
-`Filter (or FLOPs) pruning level in current epoch` - a pruning level calculated by the algorithm scheduler at each training epoch for 
-all layers previously defined as prunable. 
+##### Algorithm statistics
+
+`Filter (or FLOPs) pruning level in current epoch` - a pruning level calculated by the algorithm scheduler to be applied in the current training epoch. 
 > **NOTE**: In case of `Filter pruning level in current epoch` this metric does not indicate the whole model filter pruning level, as 
 it does not take into account the number of filters in layers that cannot be pruned.
 
 `Target filter (or FLOPs) pruning level` - a pruning level that is expected to be achieved at the end of the algorithm execution.
+> **NOTE**: In case of `Target filter pruning level` this number indicates what percentage of filters will be removed from only those layers that can be pruned.
+
+It is important to note that pruning levels mentioned in the `statistics of the filter pruning algorithm` are the goals the algorithm aims to achieve.
+It is not always possible to achieve these levels of pruning due to cross-layer and inference constraints. 
+Therefore, it is expected that these numbers may differ from the calculated statistics in the `statistics of the pruned model` section.
 
 #### Schedulers
 

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -34,24 +34,38 @@ indicates how the removed filters affect the number of floating point operations
 
 During the algorithm execution several compression statistics are available:
 
-`Target pruning level for the current epoch` - a pruning level calculated by the algorithm scheduler at each training epoch for 
-all layers previously defined as prunable. Note that this metric does not indicate the whole model filter pruning level, as 
-it does not take into account the number of filters in layers that cannot be pruned.
+`Filter pruning level` - percentage of filters removed from the model. Calculated as: 
 
-`FLOPs pruning level` - estimated reduction in the number of floating point operations of the model.
+![Filter pruning level](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20%5Cinline%20%5Ctextit%7Bfilter%20pruning%20rate%20%7D=%201%20-%20(%5Ctextit%7Bcurrent%20number%20of%20filters%20in%20the%20model%20%7D/%5Ctextit%7B%20total%20number%20of%20filters%20in%20the%20model%7D))
+
+> **NOTE**: All other pruning levels are calculated in a similar way.
+
+`GFLOPs pruning level` - an estimated reduction in the number of floating point operations of the model. 
 The number of FLOPs for a single convolutional layer can be computed as:
 
 ![FLOPs](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20FLOPs&space;=&space;2&space;%5Ctimes&space;input%5C;channels&space;%5Ctimes&space;kernel%5C;size%5E%7B2%7D%5Ctimes&space;W%5Ctimes&space;H%5Ctimes&space;filters)
+
+> **NOTE**: One GFLOP is one billion (1e9) FLOPs.
 
 Each removed filter contributes to FLOPs reduction in two convolutional layers as it affects the number 
 of filters in one and the number of input channels of the next layer. Thus it is expected that this number may differ 
 significantly from the filter pruning level.
 
-`MParams` - the number of parameters in the model in millions. Typically convolutional layer weights have shape 
+In addition, the decrease in GFLOPs is estimated by calculating the number of FLOPs of convolutional and fully connected layers. 
+As a result, these estimates may differ slightly from the actual number of FLOPs in the compressed model.
+
+`MParams  pruning level` - calculated reduction in the number of parameters in the model in millions. Typically convolutional layer weights have shape 
 ![shape](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20%5Cinline%20(kernel%5C;size,&space;kernel%5C;size,&space;input%5C;channels,&space;filters%5C;&space;num)).
 Thus each removed filter affects the number of parameters in two convolutional layers as it affects the number 
 of filters in one and the number of input channels of the next layer. It is expected that this number may differ 
 significantly from the filter pruning level.
+
+`Filter (or FLOPs) pruning level in current epoch` - a pruning level calculated by the algorithm scheduler at each training epoch for 
+all layers previously defined as prunable. 
+> **NOTE**: In case of `Filter pruning level in current epoch` this metric does not indicate the whole model filter pruning level, as 
+it does not take into account the number of filters in layers that cannot be pruned.
+
+`Target filter (or FLOPs) pruning level` - a pruning level that is expected to be achieved at the end of the algorithm execution.
 
 #### Schedulers
 

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -135,7 +135,8 @@ Statistics by pruned layers:
 | FConv2d[conv]        |                  |              |                     |
 +----------------------+------------------+--------------+---------------------+
 | ConvBlock[conv2]/NNC | [384, 64, 1, 1]  | [384]        | 0.500               |
-
+| FConv2d[conv]        |                  |              |                     |
++----------------------+------------------+--------------+---------------------+
 Statistics of the pruned model:
 +---------+-------+---------+---------------+
 |    #    | Full  | Current | Pruning level |
@@ -161,15 +162,13 @@ Statistics of the filter pruning algorithm:
 shapes of pruning masks applied to respective weights and percentage of zeros in those masks. 
 
 ##### Model statistics
-The columns `Full` and `Current` represent the values of the corresponding statistics in the original model and compressed one in the current state, respectively. 
+The columns `Full` and `Current` represent the values of the corresponding statistics in the original model and compressed one in the current state, respectively.  
+The `Pruning level` column lists a ratio between values of full and current statistics in the correspondent rows defined by the formula:  
+![Statistic pruning level](https://latex.codecogs.com/png.image?\dpi{110}\text{statistic%20pruning%20level}%20=%201%20-%20\text{statistic%20current}%20/%20\text{statistic%20full})
+  
+`Filter pruning level` - percentage of filters removed from the model.  
 
-`Filter pruning level` - percentage of filters removed from the model. Calculated as: 
-
-![Filter pruning level](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20%5Cinline%20%5Ctextit%7Bfilter%20pruning%20level%7D%20=%201%20-%20(%5Ctextit%7Bcurrent%20number%20of%20filters%20in%20the%20model%20%7D%20/%20%5Ctextit%7B%20total%20number%20of%20filters%20in%20the%20model%7D))
-
-> **NOTE**: All other pruning levels are calculated in a similar way.
-
-`GFLOPs pruning level` - an estimated reduction in the number of floating point operations of the model. 
+`GFLOPs pruning level` - an estimated reduction in the number of floating point operations of the model.   
 The number of FLOPs for a single convolutional layer can be calculated as:
 
 ![FLOPs](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20FLOPs&space;=&space;2&space;%5Ctimes&space;input%5C;channels&space;%5Ctimes&space;kernel%5C;size%5E%7B2%7D%5Ctimes&space;W%5Ctimes&space;H%5Ctimes&space;filters)

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -27,74 +27,6 @@ Where ![L_j](https://latex.codecogs.com/png.latex?L_j) is j-th convolutional lay
 
 Then during pruning filters with smaller ![G(F_i)](https://latex.codecogs.com/png.latex?G%28F_i%29) importance function will be pruned first.
 
-#### Algorithm statistics
-A model compression can be measured by two main metrics: filter pruning level and FLOPs pruning level. While 
-filter pruning level shows the ratio of removed filters to the total number of filters in the model, FLOPs pruning level 
-indicates how the removed filters affect the number of floating point operations required to run a model. 
-
-During the algorithm execution several compression statistics are available:
-```
-Statistics of the pruned model:
-+---------+-------+---------+---------------+
-|    #    | Full  | Current | Pruning level |
-+=========+=======+=========+===============+
-| GFLOPS  | 0.602 | 0.241   | 0.599         |
-+---------+-------+---------+---------------+
-| MParams | 3.470 | 1.997   | 0.424         |
-+---------+-------+---------+---------------+
-| Filters | 17056 | 10216   | 0.401         |
-+---------+-------+---------+---------------+
-Prompt: statistic pruning level = 1 - statistic current / statistic full.
-Statistics of the filter pruning algorithm:
-+---------------------------------------+-------+
-|           Statistic's name            | Value |
-+=======================================+=======+
-| Filter pruning level in current epoch | 0.500 |
-+---------------------------------------+-------+
-| Target filter pruning level           | 0.800 |
-+---------------------------------------+-------+
-```
-
-##### Model statistics
-`Filter pruning level` - percentage of filters removed from the model. Calculated as: 
-
-![Filter pruning level](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20%5Cinline%20%5Ctextit%7Bfilter%20pruning%20level%7D%20=%201%20-%20(%5Ctextit%7Bcurrent%20number%20of%20filters%20in%20the%20model%20%7D%20/%20%5Ctextit%7B%20total%20number%20of%20filters%20in%20the%20model%7D))
-
-> **NOTE**: All other pruning levels are calculated in a similar way.
-
-`GFLOPs pruning level` - an estimated reduction in the number of floating point operations of the model. 
-The number of FLOPs for a single convolutional layer can be calculated as:
-
-![FLOPs](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20FLOPs&space;=&space;2&space;%5Ctimes&space;input%5C;channels&space;%5Ctimes&space;kernel%5C;size%5E%7B2%7D%5Ctimes&space;W%5Ctimes&space;H%5Ctimes&space;filters)
-
-> **NOTE**: One GFLOP is one billion (1e9) FLOPs.
-
-Each removed filter contributes to FLOPs reduction in two convolutional layers as it affects the number 
-of filters in one and the number of input channels of the next layer. Thus, it is expected that this number may differ 
-significantly from the filter pruning level.
-
-In addition, the decrease in GFLOPs is estimated by calculating the number of FLOPs of convolutional and fully connected layers. 
-As a result, these estimates may differ slightly from the actual number of FLOPs in the compressed model.
-
-`MParams  pruning level` - calculated reduction in the number of parameters in the model in millions. Typically convolutional layer weights have shape 
-![shape](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20%5Cinline%20(kernel%5C;size,&space;kernel%5C;size,&space;input%5C;channels,&space;filters%5C;&space;num)).
-Thus, each removed filter affects the number of parameters in two convolutional layers as it affects the number 
-of filters in one and the number of input channels of the next layer. It is expected that this number may differ 
-significantly from the filter pruning level.
-
-##### Algorithm statistics
-
-`Filter (or FLOPs) pruning level in current epoch` - a pruning level calculated by the algorithm scheduler to be applied in the current training epoch. 
-> **NOTE**: In case of `Filter pruning level in current epoch` this metric does not indicate the whole model filter pruning level, as 
-it does not take into account the number of filters in layers that cannot be pruned.
-
-`Target filter (or FLOPs) pruning level` - a pruning level that is expected to be achieved at the end of the algorithm execution.
-> **NOTE**: In case of `Target filter pruning level` this number indicates what percentage of filters will be removed from only those layers that can be pruned.
-
-It is important to note that pruning levels mentioned in the `statistics of the filter pruning algorithm` are the goals the algorithm aims to achieve.
-It is not always possible to achieve these levels of pruning due to cross-layer and inference constraints. 
-Therefore, it is expected that these numbers may differ from the calculated statistics in the `statistics of the pruned model` section.
-
 #### Schedulers
 
 **Baseline Scheduler**
@@ -145,7 +77,7 @@ Interlayer ranking type can be one of `unweighted_ranking` or `learned_ranking`.
 The ![(a_i, b_i)](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20(a_i,%20b_i)) pair of scalars will be learned for each (![i](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20i)-th) layer and used to transform norms of ![i](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20i)-th layer filters before sorting all filter norms together as ![a_i * N_i + b_i](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20a_i%20*%20N_i%20&plus;%20b_i) , where ![N_i](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20N_i) - is vector of filter norma of ![i](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20i)-th layer, ![(a_i, b_i)](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20(a_i,%20b_i)) is ranking coefficients for ![i](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20i)-th layer.
 This approach allows pruning the model taking into account layer-specific sensitivity to weight perturbations and get pruned models with higher accuracy.
 
-**Filter pruning configuration file parameters**:
+#### Filter pruning configuration file parameters
 ```
 {
     "algorithm": "filter_pruning",
@@ -186,3 +118,86 @@ This approach allows pruning the model taking into account layer-specific sensit
 ```
 
 > **NOTE:**  In all our pruning experiments we used SGD optimizer.
+
+#### Filter pruning statistics
+A model compression can be measured by two main metrics: filter pruning level and FLOPs pruning level. While 
+filter pruning level shows the ratio of removed filters to the total number of filters in the model, FLOPs pruning level 
+indicates how the removed filters affect the number of floating point operations required to run a model. 
+
+During the algorithm execution several compression statistics are available. See the example below.
+```
+Statistics by pruned layers:
++----------------------+------------------+--------------+---------------------+
+|     Layer's name     |  Weight's shape  | Mask's shape |   Filter pruning    |
+|                      |                  |              |        level        |
++======================+==================+==============+=====================+
+| ConvBlock[conv1]/NNC | [192, 32, 1, 1]  | [192]        | 0.500               |
+| FConv2d[conv]        |                  |              |                     |
++----------------------+------------------+--------------+---------------------+
+| ConvBlock[conv2]/NNC | [384, 64, 1, 1]  | [384]        | 0.500               |
+
+Statistics of the pruned model:
++---------+-------+---------+---------------+
+|    #    | Full  | Current | Pruning level |
++=========+=======+=========+===============+
+| GFLOPS  | 0.602 | 0.241   | 0.599         |
++---------+-------+---------+---------------+
+| MParams | 3.470 | 1.997   | 0.424         |
++---------+-------+---------+---------------+
+| Filters | 17056 | 10216   | 0.401         |
++---------+-------+---------+---------------+
+Prompt: statistic pruning level = 1 - statistic current / statistic full.
+Statistics of the filter pruning algorithm:
++---------------------------------------+-------+
+|           Statistic's name            | Value |
++=======================================+=======+
+| Filter pruning level in current epoch | 0.500 |
++---------------------------------------+-------+
+| Target filter pruning level           | 0.800 |
++---------------------------------------+-------+
+```
+##### Layer statistics
+`Statistics by pruned layers` section lists names of all layers that will be pruned, shapes of their weight tensors, 
+shapes of pruning masks applied to respective weights and percentage of zeros in those masks. 
+
+##### Model statistics
+The columns `Full` and `Current` represent the values of the corresponding statistics in the original model and compressed one in the current state, respectively. 
+
+`Filter pruning level` - percentage of filters removed from the model. Calculated as: 
+
+![Filter pruning level](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20%5Cinline%20%5Ctextit%7Bfilter%20pruning%20level%7D%20=%201%20-%20(%5Ctextit%7Bcurrent%20number%20of%20filters%20in%20the%20model%20%7D%20/%20%5Ctextit%7B%20total%20number%20of%20filters%20in%20the%20model%7D))
+
+> **NOTE**: All other pruning levels are calculated in a similar way.
+
+`GFLOPs pruning level` - an estimated reduction in the number of floating point operations of the model. 
+The number of FLOPs for a single convolutional layer can be calculated as:
+
+![FLOPs](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20FLOPs&space;=&space;2&space;%5Ctimes&space;input%5C;channels&space;%5Ctimes&space;kernel%5C;size%5E%7B2%7D%5Ctimes&space;W%5Ctimes&space;H%5Ctimes&space;filters)
+
+> **NOTE**: One GFLOP is one billion (1e9) FLOPs.
+
+Each removed filter contributes to FLOPs reduction in two convolutional layers as it affects the number 
+of filters in one and the number of input channels of the next layer. Thus, it is expected that this number may differ 
+significantly from the filter pruning level.
+
+In addition, the decrease in GFLOPs is estimated by calculating the number of FLOPs of convolutional and fully connected layers. 
+As a result, these estimates may differ slightly from the actual number of FLOPs in the compressed model.
+
+`MParams  pruning level` - calculated reduction in the number of parameters in the model in millions. Typically convolutional layer weights have shape 
+![shape](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20%5Cinline%20(kernel%5C;size,&space;kernel%5C;size,&space;input%5C;channels,&space;filters%5C;&space;num)).
+Thus, each removed filter affects the number of parameters in two convolutional layers as it affects the number 
+of filters in one and the number of input channels of the next layer. It is expected that this number may differ 
+significantly from the filter pruning level.
+
+##### Algorithm statistics
+
+`Filter (or FLOPs) pruning level in current epoch` - a pruning level calculated by the algorithm scheduler to be applied in the current training epoch. 
+> **NOTE**: In case of `Filter pruning level in current epoch` this metric does not indicate the whole model filter pruning level, as 
+it does not take into account the number of filters in layers that cannot be pruned.
+
+`Target filter (or FLOPs) pruning level` - a pruning level that is expected to be achieved at the end of the algorithm execution.
+> **NOTE**: In case of `Target filter pruning level` this number indicates what percentage of filters will be removed from only those layers that can be pruned.
+
+It is important to note that pruning levels mentioned in the `statistics of the filter pruning algorithm` are the goals the algorithm aims to achieve.
+It is not always possible to achieve these levels of pruning due to cross-layer and inference constraints. 
+Therefore, it is expected that these numbers may differ from the calculated statistics in the `statistics of the pruned model` section.

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -157,14 +157,17 @@ Statistics of the filter pruning algorithm:
 | Target filter pruning level           | 0.800 |
 +---------------------------------------+-------+
 ```
+
 ##### Layer statistics
 `Statistics by pruned layers` section lists names of all layers that will be pruned, shapes of their weight tensors, 
 shapes of pruning masks applied to respective weights and percentage of zeros in those masks. 
 
 ##### Model statistics
 The columns `Full` and `Current` represent the values of the corresponding statistics in the original model and compressed one in the current state, respectively.  
-The `Pruning level` column lists a ratio between values of full and current statistics in the correspondent rows defined by the formula:  
-![Statistic pruning level](https://latex.codecogs.com/png.image?\dpi{110}\text{statistic%20pruning%20level}%20=%201%20-%20\text{statistic%20current}%20/%20\text{statistic%20full})
+
+The `Pruning level` column indicates the ratio between the values of the full and current statistics in the corresponding rows, defined by the formula:
+
+![Statistic pruning level](https://latex.codecogs.com/png.image?\dpi{110}\textit{statistic&space;pruning&space;level}&space;=&space;1&space;-&space;\textit{statistic&space;current}&space;/&space;\textit{statistic&space;full})
   
 `Filter pruning level` - percentage of filters removed from the model.  
 

--- a/nncf/common/pruning/schedulers.py
+++ b/nncf/common/pruning/schedulers.py
@@ -158,7 +158,7 @@ class ExponentialPruningScheduler(PruningScheduler):
 @PRUNING_SCHEDULERS.register('exponential_with_bias')
 class ExponentialWithBiasPruningScheduler(PruningScheduler):
     """
-    Pruning scheduler which calculates pruning rate for the current epoch
+    Pruning scheduler which calculates pruning level for the current epoch
     according to the formula:
 
         current_level = a * exp(-k * epoch_idx) + b,

--- a/nncf/common/pruning/statistics.py
+++ b/nncf/common/pruning/statistics.py
@@ -168,14 +168,10 @@ class PrunedModelTheoreticalBorderline(Statistics):
         """
         Initializes statistics of the filter pruning theoretical borderline.
 
-        :param num_pruned_layers: Number of layers which was actually
-            pruned.
-        :param num_prunable_layers: Number of layers which have
-            prunable type.
-        :param max_prunable_flops: Number of flops for pruned
-            model with pruning rate = 1.
-        :param max_prunable_params: Number of weights for pruned
-            model with pruning rate = 1.
+        :param num_pruned_layers: Number of layers which was actually pruned.
+        :param num_prunable_layers: Number of layers which have prunable type.
+        :param max_prunable_flops: Number of flops for pruned model with pruning level = 1.
+        :param max_prunable_params: Number of weights for pruned model with pruning level = 1.
         :param total_flops: The total amount of FLOPS in the model.
         :param total_params: The total amount of weights in the model.
         """

--- a/nncf/common/pruning/statistics.py
+++ b/nncf/common/pruning/statistics.py
@@ -57,8 +57,8 @@ class PrunedModelStatistics(Statistics):
         """
         Initializes statistics of the pruned model.
 
-        :param full_flops: The total amount of FLOPS in the model.
-        :param current_flops: Current amount of FLOPS in the model.
+        :param full_flops: The total amount of FLOPs in the model.
+        :param current_flops: Current amount of FLOPs in the model.
         :param full_params_num: The total amount of weights in the model.
         :param current_params_num: Current amount of weights in the model.
         :param full_filters_num: The total amount of filters in the model.
@@ -83,7 +83,7 @@ class PrunedModelStatistics(Statistics):
         model_string = create_table(
             header=['#', 'Full', 'Current', 'Pruning level'],
             rows=[
-                ['GFLOPS', f'{self.full_flops / self._giga:.3f}',
+                ['GFLOPs', f'{self.full_flops / self._giga:.3f}',
                            f'{self.current_flops / self._giga:.3f}',
                            self.flops_pruning_level],
                 ['MParams', f'{self.full_params_num / self._mega:.3f}',
@@ -137,7 +137,7 @@ class FilterPruningStatistics(Statistics):
         self.prune_flops = prune_flops
 
     def to_str(self) -> str:
-        pruning_mode = 'FLOPS' if self.prune_flops else 'filter'
+        pruning_mode = 'FLOPs' if self.prune_flops else 'filter'
         algorithm_string = create_table(
             header=['Statistic\'s name', 'Value'],
             rows=[
@@ -194,7 +194,7 @@ class PrunedModelTheoreticalBorderline(Statistics):
             rows=[
                 ['Pruned layers count / prunable layers count', f'{self.pruned_layers_num} /'
                                                                 f' {self.prunable_layers_num}'],
-                ['GFLOPS minimum possible after pruning / total', f'{self.minimum_possible_flops / self._giga:.3f} /'
+                ['GFLOPs minimum possible after pruning / total', f'{self.minimum_possible_flops / self._giga:.3f} /'
                                                                   f' {self.total_flops / self._giga:.3f}'],
                 ['MParams minimum possible after pruning / total', f'{self.minimum_possible_params / self._mega:.3f} /'
                                                                    f' {self.total_params / self._mega:.3f}'],

--- a/nncf/common/pruning/utils.py
+++ b/nncf/common/pruning/utils.py
@@ -392,7 +392,7 @@ def calculate_in_out_channels_in_uniformly_pruned_model(pruning_groups: List[Clu
     and updating corresponding input channels number in `pruning_groups_next_nodes` nodes.
 
     :param pruning_groups: A list of pruning groups.
-    :param pruning_level: Target pruning rate.
+    :param pruning_level: Target pruning level.
     :param full_input_channels:  A dictionary of input channels number in original model.
     :param full_output_channels: A dictionary of output channels number in original model.
     :param pruning_groups_next_nodes: A dictionary of next nodes of each pruning group.

--- a/nncf/config/schema.py
+++ b/nncf/config/schema.py
@@ -748,7 +748,7 @@ FILTER_PRUNING_SCHEMA = {
                                                       description="Number of epochs for model pretraining before"
                                                                   " starting filter pruning. 0 by default."),
                     "pruning_steps": with_attributes(NUMBER,
-                                                     description="Number of epochs during which the pruning rate is"
+                                                     description="Number of epochs during which the pruning level is"
                                                                  " increased from `pruning_init` to `pruning_target`"
                                                                  " value."),
                     "filter_importance": with_attributes(STRING,
@@ -803,7 +803,7 @@ FILTER_PRUNING_SCHEMA = {
                                                                            " will be used for multiple pruning"
                                                                            " rates, the highest should be used as"
                                                                            "`max_pruning`. If model will be pruned"
-                                                                           " with one pruning rate, this target should"
+                                                                           " with one pruning level, this target should"
                                                                            "be used."),
                                 "random_seed": with_attributes(NUMBER,
                                                                description="Random seed for LeGR coefficients"

--- a/nncf/tensorflow/pruning/filter_pruning/algorithm.py
+++ b/nncf/tensorflow/pruning/filter_pruning/algorithm.py
@@ -205,7 +205,7 @@ class FilterPruningController(BasePruningAlgoController):
     def set_pruning_level(self, pruning_level: float,
                           run_batchnorm_adaptation: bool = False):
         """
-        Setup pruning masks in accordance to provided pruning rate
+        Setup pruning masks in accordance to provided pruning level
         :param pruning_level: pruning ration
         :return:
         """


### PR DESCRIPTION
### Changes
Rebase of #1028 
Added new section to documentation that describes filter pruning algorithm statistics

### Reason for changes
To provide a better understanding of algorithm logs.

### Related tickets
https://github.com/openvinotoolkit/nncf/issues/1011
73888
### Tests
