### PR TITLE
Fix PyTorch examples

### DIFF
--- a/examples/torch/classification/main.py
+++ b/examples/torch/classification/main.py
@@ -568,11 +568,11 @@ def train_epoch(train_loader, model, criterion, criterion_fn, optimizer, compres
         if is_main_process() and log_training_info:
             global_step = train_iters * epoch
             config.tb.add_scalar("train/learning_rate", get_lr(optimizer), i + global_step)
-            config.tb.add_scalar("train/criterion_loss", criterion_losses.avg, i + global_step)
-            config.tb.add_scalar("train/compression_loss", compression_losses.avg, i + global_step)
-            config.tb.add_scalar("train/loss", losses.avg, i + global_step)
-            config.tb.add_scalar("train/top1", top1.avg, i + global_step)
-            config.tb.add_scalar("train/top5", top5.avg, i + global_step)
+            config.tb.add_scalar("train/criterion_loss", criterion_losses.val, i + global_step)
+            config.tb.add_scalar("train/compression_loss", compression_losses.val, i + global_step)
+            config.tb.add_scalar("train/loss", losses.val, i + global_step)
+            config.tb.add_scalar("train/top1", top1.val, i + global_step)
+            config.tb.add_scalar("train/top5", top5.val, i + global_step)
 
             statistics = compression_ctrl.statistics(quickly_collected_only=True)
             for stat_name, stat_value in prepare_for_tensorboard(statistics).items():

--- a/examples/torch/requirements.txt
+++ b/examples/torch/requirements.txt
@@ -7,3 +7,8 @@ mlflow>=1.12.1
 returns==0.14
 opencv-python>=4.4.0.46
 torchvision==0.10.1  # should always match the torch version that is installed via NNCF's setup.py
+efficientnet_pytorch
+
+# Please see
+# https://stackoverflow.com/questions/70520120/attributeerror-module-setuptools-distutils-has-no-attribute-version
+setuptools==59.5.0

--- a/examples/torch/requirements.txt
+++ b/examples/torch/requirements.txt
@@ -8,7 +8,3 @@ returns==0.14
 opencv-python>=4.4.0.46
 torchvision==0.10.1  # should always match the torch version that is installed via NNCF's setup.py
 efficientnet_pytorch
-
-# Please see
-# https://stackoverflow.com/questions/70520120/attributeerror-module-setuptools-distutils-has-no-attribute-version
-setuptools==59.5.0

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,9 @@ EXTRAS_REQUIRE = {
     "torch": [
         "torch>=1.5.0, <=1.9.1, !=1.8.0",
         "numpy~=1.19.2",
+        # Please see
+        # https://stackoverflow.com/questions/70520120/attributeerror-module-setuptools-distutils-has-no-attribute-version
+        "setuptools==59.5.0"
     ],
     "onnx": [
         "torch==1.9.1",

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -9,5 +9,3 @@ pytest-dependency>=0.5.1
 
 # Ticket 69520
 pyparsing<3.0
-
-efficientnet_pytorch


### PR DESCRIPTION
### Changes

 - Fix PyTorch examples' pip dependency.
 - Fix PyTorch classification examples' Tensorboard logging.

### Reason for changes

While I have been working on https://github.com/openvinotoolkit/nncf/pull/1238, I found some buggy things.

 - It failed when I made a new virtual environment for PyTorch examples and ran example code as follows.
    1. Install NNCF
    2. Install `pip install examples/torch/requirements.txt`
    3. Run `examples/torch/classification/main.py`
 - This is because `efficientnet_pytorch` dependency exists in `tests/torch/requirements.txt`, but not in `examples/torch/requirements.txt`.
 - We log average statistics, not online statistics to Tensorboard. This is not a common practice when using Tensorboard. It makes this strange cascading pattern for losses which should be continuously smooth across epochs. ![image](https://user-images.githubusercontent.com/26541465/181723914-76e953f5-e573-4ec4-ac2c-bc3ed4d98593.png)

### Related tickets

### Tests
