### PR TITLE
Search BN Adapt

### DIFF
--- a/nncf/config/experimental_schema.py
+++ b/nncf/config/experimental_schema.py
@@ -261,6 +261,7 @@ BOOTSTRAP_NAS_SEARCH_SCHEMA = {
         "algorithm":
         with_attributes(SEARCH_ALGORITHMS_SCHEMA,
                         description="Defines the search algorithm. Default algorithm is NSGA-II."),
+        "batchnorm_adaptation": BATCHNORM_ADAPTATION_SCHEMA,
         "num_evals":
         with_attributes(NUMBER,
                         description="Defines the number of evaluations that will be used by the search algorithm."),

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/search.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/search.py
@@ -215,7 +215,7 @@ class SearchAlgorithm(BaseSearchAlgorithm):
             raise RuntimeError("Search space is empty")
 
         self._result = None
-        bn_adapt_params = nncf_config.get('compression', {}).get('initializer', {}).get('batchnorm_adaptation', {})
+        bn_adapt_params = search_config.get('batchnorm_adaptation', {})
         bn_adapt_algo_kwargs = get_bn_adapt_algo_kwargs(nncf_config, bn_adapt_params)
         self.bn_adaptation = BatchnormAdaptationAlgorithm(**bn_adapt_algo_kwargs)
         self._problem = None
@@ -373,6 +373,8 @@ class SearchAlgorithm(BaseSearchAlgorithm):
             plt.scatter(*tuple(abs(val) for val in self.best_vals),
                         marker='o', s=120,color='yellow', label='BootstrapNAS A',
                         edgecolors='black', linewidth=2.5)
+        plt.legend()
+        plt.title('Search Progression')
         plt.xlabel(self.efficiency_evaluator_handler.name)
         plt.ylabel(self.accuracy_evaluator_handler.name)
         plt.savefig(f'{self._log_dir}/{filename}.png')

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/stage_descriptor.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/stage_descriptor.py
@@ -57,7 +57,7 @@ class StageDescriptor:
         self.sample_rate = sample_rate
         if sample_rate <= 0:
             nncf_logger.warning(f"Only positive integers are allowed for sample rate, but sample_rate={sample_rate}.")
-            nncf_logger.warning(f"Setting sample rate to default 1")
+            nncf_logger.warning("Setting sample rate to default 1")
             self.sample_rate = 1
 
     def __eq__(self, other: 'StageDescriptor'):


### PR DESCRIPTION
### Changes

Enable BootstrapNAS search component to use its own parameters for BN adaptation 

### Reason for changes

User might want to use a different BN adaptation parameters for training the super-network and searching for sub-networks. 

### Related tickets

N/A
