### PR TITLE
Handle KerasLayer in the experimental_quantization algorithm

### DIFF
--- a/nncf/tensorflow/graph/utils.py
+++ b/nncf/tensorflow/graph/utils.py
@@ -44,6 +44,20 @@ def is_functional_model(model):
            and getattr(model, '_is_graph_network', False)
 
 
+def is_keras_layer_model(model: tf.keras.Model) -> bool:
+    """
+    Checks if there is `tensorflow_hub.KerasLayer` layer in the model or not.
+
+    :param model: Keras model to check.
+    :return: `True` if there is `hub.KerasLayer` in the model and
+        `False` otherwise.
+    """
+    for layer in model.submodules:
+        if layer.__class__.__name__ == 'KerasLayer':
+            return True
+    return False
+
+
 def get_keras_layers_class_names():
     keras_layers = [class_name for class_name, _ in
                     inspect.getmembers(sys.modules[tf.keras.layers.__name__], inspect.isclass)]

--- a/nncf/tensorflow/helpers/model_creation.py
+++ b/nncf/tensorflow/helpers/model_creation.py
@@ -29,6 +29,7 @@ from nncf.tensorflow.algorithm_selector import NoCompressionAlgorithmBuilder
 from nncf.tensorflow.algorithm_selector import get_compression_algorithm_builder
 from nncf.tensorflow.api.composite_compression import TFCompositeCompressionAlgorithmBuilder
 from nncf.tensorflow.helpers.utils import get_built_model
+from nncf.tensorflow.graph.utils import is_keras_layer_model
 
 
 def create_compression_algorithm_builder(config: NNCFConfig,
@@ -75,6 +76,10 @@ def create_compressed_model(model: tf.keras.Model,
             necessary to enable algorithm-specific compression during fine-tuning.
     """
     if is_experimental_quantization(config):
+        if is_keras_layer_model(model):
+            raise ValueError('Experimental quantization algorithm has not supported models with '
+                             '`tensorflow_hub.KerasLayer` layer yet.')
+
         from nncf.experimental.tensorflow.nncf_network import NNCFNetwork #pylint: disable=cyclic-import
         input_signature = get_input_signature(config)
         model = NNCFNetwork(model, input_signature)

--- a/tests/experimental/tensorflow/test_keras_layer_model.py
+++ b/tests/experimental/tensorflow/test_keras_layer_model.py
@@ -1,0 +1,41 @@
+"""
+ Copyright (c) 2022 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import pytest
+import tensorflow as tf
+import tensorflow_hub as hub
+
+from nncf import NNCFConfig
+from nncf.experimental.tensorflow.patch_tf import patch_tf_operations
+
+from tests.tensorflow.helpers import create_compressed_model_and_algo_for_test
+
+
+patch_tf_operations()
+
+
+def test_keras_layer_model():
+    nncf_config = NNCFConfig({
+        'model': 'Model',
+        'input_info': [{'sample_size': [1, 224, 224, 3]}],
+        'compression': {
+            'algorithm': 'experimental_quantization'
+        }
+    })
+
+    model = tf.keras.Sequential([
+        hub.KerasLayer('https://tfhub.dev/google/imagenet/mobilenet_v3_small_100_224/classification/5')
+    ])
+
+    with pytest.raises(ValueError):
+        create_compressed_model_and_algo_for_test(model, nncf_config, force_no_init=True)

--- a/tests/tensorflow/requirements.txt
+++ b/tests/tensorflow/requirements.txt
@@ -6,6 +6,7 @@ pytest-dependency
 yattag>=1.14.0
 prettytable>=2.0.0
 pydot
+tensorflow_hub
 
 # Ticket 69520
 pyparsing<3.0


### PR DESCRIPTION
### Changes

We get an exception if we try to run tensorflow experimental quantization algorithm with model that contains `tensorflow_hub.KerasLayer`.

### Reason for changes

The tensorflow experimental quantization has not supported models with `tensorflow_hub.KerasLayer` layer yet. This layer contains already compiled subgraphs so we cannot wrap operations inside them. When we try to run the algorithm on such model we get strange error. Please look at this GitHub [issue](https://github.com/openvinotoolkit/nncf/issues/1161). Current changes resolves this problem. Now we get the message which explains the reason.

### Related tickets

Ref: 88614

### Tests

N/A