### PR TITLE
test_install was fixed for TF, PT backends

### DIFF
--- a/tests/tensorflow/requirements.txt
+++ b/tests/tensorflow/requirements.txt
@@ -7,6 +7,7 @@ yattag>=1.14.0
 prettytable>=2.0.0
 pydot
 tensorflow_hub
+virtualenv
 
 # Ticket 69520
 pyparsing<3.0

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -6,6 +6,6 @@ onnx>=1.8.0
 onnxruntime==1.6.0
 pytest-mock>=3.3.1
 pytest-dependency>=0.5.1
-
+virtualenv
 # Ticket 69520
 pyparsing<3.0


### PR DESCRIPTION
### Changes

The `virtualenv` was added to the `tests/tensorflow/requirements.txt` file.

### Reason for changes

The `install_tf` job from the nightly jobs has not been passed.

### Related tickets

Ref: 89150

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
