### PR TITLE
Introduced --torch-with-cuda11 option for 3rd party sanity tests

### DIFF
--- a/tests/torch/conftest.py
+++ b/tests/torch/conftest.py
@@ -78,6 +78,11 @@ def pytest_addoption(parser):
         "--third-party-sanity", action="store_true", default=False, help="To run third party sanity test cases"
     )
     parser.addoption(
+        "--torch-with-cuda11", action="store_true", default=False, help="To trigger installation of pytorch with "
+                                                                        "CUDA11. It's required for 3rd sanity tests "
+                                                                        "on RTX3090 cards"
+    )
+    parser.addoption(
         "--run-openvino-eval", action="store_true", default=False, help="To run eval models via OpenVino"
     )
     parser.addoption(
@@ -157,6 +162,11 @@ def torch_home_dir(request, monkeypatch):
 @pytest.fixture(scope="session")
 def third_party(request):
     return request.config.getoption("--third-party-sanity")
+
+
+@pytest.fixture(scope="session")
+def torch_with_cuda11(request):
+    return request.config.getoption("--torch-with-cuda11")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
### Changes

Introduced --torch-with-cuda11 option for 3rd party sanity tests to install torch compatible with GTX3090.

### Reason for changes

There's issue with torch installation inside a 3rd party test.

The 3rd party sanity test creates a virtual python environment by itself. Particularly, it installs default pytorch 1.9.1 with CUDA 10 support.
```python
BKC_TORCH_VERSION=1.9.1
pip_runner.run_pip("install torch=={}".format(BKC_TORCH_VERSION))
```

The target hardware might have RTX-3090 cards, which requires torch with CUDA 11 support.
It can be installed as follows:
```bash
pip install torch==1.9.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html 
```
Currently, the corresponding CI job has RTX3090 card now. As results, test fails with the following error:
```
NVIDIA GeForce RTX 3090 with CUDA capability sm_86 is not compatible with the current PyTorch installation
```
The test is not hardware-agnostic. It doesn't know how to install pytorch properly. That's why some option is required.

### Related tickets

89154

### Tests

- [ ] need to make sure that 3rd sanity test passes with the option
- [ ] modify scripts in Jenkins to pass the option
