### PR TITLE
Math png to text

### DIFF
--- a/docs/compression_algorithms/Binarization.md
+++ b/docs/compression_algorithms/Binarization.md
@@ -5,13 +5,13 @@ Weight binarization may be done in two ways, depending on the configuration file
 
 Binarization of activations is implemented via binarizing inputs to the convolutional layers in the following way:
 
-![\text{out} = s * H(\text{in} - s*t)](https://latex.codecogs.com/png.latex?%5Ctext%7Bout%7D%20%3D%20s%20*%20H%28%5Ctext%7Bin%7D%20-%20s*t%29)
+$\text{out} = s * H(\text{in} - s*t)$
 
 In the formula above,
- - ![\text{in}](https://latex.codecogs.com/png.latex?%5Ctext%7Bin%7D) - non-binarized activation values
- - ![\text{out}](https://latex.codecogs.com/png.latex?%5Ctext%7Bout%7D) - binarized activation values
- -  ![H(x)](https://latex.codecogs.com/png.latex?H%28x%29) is the Heaviside step function
- - ![s](https://latex.codecogs.com/png.latex?s) and ![t](https://latex.codecogs.com/png.latex?t) are trainable parameters corresponding to binarization scale and threshold respectively
+ - $\text{in}$ - non-binarized activation values
+ - $\text{out}$ - binarized activation values
+ - $H(x)$ is the Heaviside step function
+ - $s$ and $t$ are trainable parameters corresponding to binarization scale and threshold respectively
 
 Training binarized networks requires special scheduling of the training process. For instance, binarizing a pretrained ResNet18 model on ImageNet is a four-stage process, with each stage taking a certain number of epochs. During the stage 1, the network is trained without any binarization. During the stage 2, the training continues with binarization enabled for activations only. During the stage 3, binarization is enabled both for activations and weights. Finally, during the stage 4 the optimizer learning rate, which was kept constant at previous stages, is decreased according to a polynomial law, while weight decay parameter of the optimizer is set to 0. The configuration files for the NNCF binarization algorithm allow to control certain parameters of this training schedule.
 

--- a/docs/compression_algorithms/KnowledgeDistillation.md
+++ b/docs/compression_algorithms/KnowledgeDistillation.md
@@ -15,19 +15,19 @@ One of them should be explicitly specified in the config.
  
  MSE distillation loss:
  
-{L}_{MSE}(z^{s}, z^{t}) = || z^s - z^t ||_2^2 
+${L}_{MSE}(z^{s}, z^{t}) = || z^s - z^t ||_2^2$
  
  
  Cross-Entropy distillation loss:
  
- {p}_{i}=\frac{\exp({z}_{i})}{\sum_{j}(\exp({z}_{j}))}
+ ${p}_{i}=\frac{\exp({z}_{i})}{\sum_{j}(\exp({z}_{j}))}$
  
- {L}_{CE}({p}^{s}, {p}^{t}) = -\sum_{i}{p}^{t}_{i}*\log({p}^{s}_{i})
+ ${L}_{CE}({p}^{s}, {p}^{t}) = -\sum_{i}{p}^{t}_{i}*\log({p}^{s}_{i})$
  
  The Knowledge Distillation loss function is combined with a regular loss function, so overall loss function will be
   computed as:
   
- L = {L}_{reg}({z}^{s}, y) + {L}_{distill}({z}^{s}, {z}^{t})
+ $L = {L}_{reg}({z}^{s}, y) + {L}_{distill}({z}^{s}, {z}^{t})$
   
  ![kd_pic](../pics/knowledge_distillation.png)
   

--- a/docs/compression_algorithms/KnowledgeDistillation.md
+++ b/docs/compression_algorithms/KnowledgeDistillation.md
@@ -15,18 +15,19 @@ One of them should be explicitly specified in the config.
  
  MSE distillation loss:
  
- ![{L}_{MSE}(z^{s}, z^{t}) = || z^s - z^t ||_2^2](https://latex.codecogs.com/png.latex?{L}_{MSE}(z^{s},%20z^{t})%20=%20||%20z^s%20-%20z^t%20||_2^2)
+{L}_{MSE}(z^{s}, z^{t}) = || z^s - z^t ||_2^2 
+ 
  
  Cross-Entropy distillation loss:
  
- ![{p}_{i}=\frac{\exp({z}_{i})}{\sum_{j}(\exp({z}_{j}))}](https://latex.codecogs.com/png.latex?{p}_{i}=%20\frac{\exp({z}_{i})}{\sum_{j}(\exp({z}_{j}))})
+ {p}_{i}=\frac{\exp({z}_{i})}{\sum_{j}(\exp({z}_{j}))}
  
- ![{L}_{CE}({p}^{s}, {p}^{t}) = -\sum_{i}{p}^{t}_{i}*\log({p}^{s}_{i})](https://latex.codecogs.com/png.latex?{L}_{CE}({p}^{s},%20{p}^{t})%20=%20-\sum_{i}{p}^{t}_{i}*\log({p}^{s}_{i}))
+ {L}_{CE}({p}^{s}, {p}^{t}) = -\sum_{i}{p}^{t}_{i}*\log({p}^{s}_{i})
  
  The Knowledge Distillation loss function is combined with a regular loss function, so overall loss function will be
   computed as:
   
- ![L = {L}_{reg}({z}^{s}, y) + {L}_{distill}({z}^{s}, {z}^{t})](https://latex.codecogs.com/png.latex?L%20=%20{L}_{reg}({z}^{s},%20y)%20+%20{L}_{distill}({z}^{s},%20{z}^{t}))
+ L = {L}_{reg}({z}^{s}, y) + {L}_{distill}({z}^{s}, {z}^{t})
   
  ![kd_pic](../pics/knowledge_distillation.png)
   

--- a/docs/compression_algorithms/KnowledgeDistillation.md
+++ b/docs/compression_algorithms/KnowledgeDistillation.md
@@ -19,18 +19,14 @@ ${L}_{MSE}(z^{s}, z^{t}) = || z^s - z^t ||_2^2$
  
 Cross-Entropy distillation loss:
  
-${p}_{i}=$
-
-$\frac{\exp({z}\_{i})}{\sum\_{j}(\exp({z}\_{j}))}$
+${p}_{i} = \frac{\exp({z}\_{i})}{\sum\_{j}(\exp({z}\_{j}))}$
  
- 
- 
-${L}_{CE}({p}^{s}, {p}^{t}) = -\sum_{i}{p}^{t}_{i}*\log({p}^{s}_{i})$
+${L}\_{CE}({p}^{s}, {p}^{t}) = -\sum_{i}{p}^{t}\_{i}*\log({p}^{s}\_{i})$
  
 The Knowledge Distillation loss function is combined with a regular loss function, so overall loss function will be
 computed as:
   
- $L = {L}_{reg}({z}^{s}, y) + {L}_{distill}({z}^{s}, {z}^{t})$
+ $L = {L}\_{reg}({z}^{s}, y) + {L}\_{distill}({z}^{s}, {z}^{t})$
   
  ![kd_pic](../pics/knowledge_distillation.png)
   

--- a/docs/compression_algorithms/KnowledgeDistillation.md
+++ b/docs/compression_algorithms/KnowledgeDistillation.md
@@ -13,19 +13,22 @@ Knowledge is transferred from the teacher model to the student one by minimizing
 based on predictions of the models. At the moment, two types of loss functions are available. 
 One of them should be explicitly specified in the config.
  
- MSE distillation loss:
+MSE distillation loss:
  
 ${L}_{MSE}(z^{s}, z^{t}) = || z^s - z^t ||_2^2$
  
+Cross-Entropy distillation loss:
  
- Cross-Entropy distillation loss:
+${p}_{i}=$
+
+$\frac{\exp({z}\_{i})}{\sum\_{j}(\exp({z}\_{j}))}$
  
- ${p}_{i}=\frac{\exp({z}_{i})}{\sum_{j}(\exp({z}_{j}))}$
  
- ${L}_{CE}({p}^{s}, {p}^{t}) = -\sum_{i}{p}^{t}_{i}*\log({p}^{s}_{i})$
  
- The Knowledge Distillation loss function is combined with a regular loss function, so overall loss function will be
-  computed as:
+${L}_{CE}({p}^{s}, {p}^{t}) = -\sum_{i}{p}^{t}_{i}*\log({p}^{s}_{i})$
+ 
+The Knowledge Distillation loss function is combined with a regular loss function, so overall loss function will be
+computed as:
   
  $L = {L}_{reg}({z}^{s}, y) + {L}_{distill}({z}^{s}, {z}^{t})$
   

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -12,7 +12,10 @@ Not all Convolution layers in the model can be pruned. Such layers are determine
 > Convolutional filters with small $l_p$ norms do not significantly contribute to output activation values, and thus have a small impact on the final predictions of CNN models.
 In the above, the $l_p$ norm for filter F is:
 
-$||F||_p = \sqrt[p]{\sum_{c, k_1, k_2 = 1}^{C, K, K}|F(c, k_1, k_2)|^p}$
+$||F||_p =$
+
+
+$\sqrt[p]{\sum_{c, k_1, k_2 = 1}^{C, K, K}|F(c, k_1, k_2)|^p}$
 
 During the pruning procedure filters with smaller  `L1` or `L2` norm will be pruned first.
 

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -74,7 +74,7 @@ sparsity and filter pruning algorithms. It can be enabled by setting a non-zero 
 Interlayer ranking type can be one of `unweighted_ranking` or `learned_ranking`.
 - In case of `unweighted_ranking` and with  `all_weights=True` all filter norms will be collected together and sorted to choose the least important ones. But this approach may not be optimal because filter norms are a good measure of filter importance inside a layer, but not across layers.
 - In the case of `learned_ranking` that uses re-implementation of [Learned Global Ranking method](https://arxiv.org/abs/1904.12368), a set of ranking coefficients will be learned for comparing filters across different layers.
-The $(a_i, b_i)$ pair of scalars will be learned for each ($i$ layer and used to transform norms of $i$-th layer filters before sorting all filter norms together as $a_i * N_i + b_i$ , where $N_i$ - is vector of filter norma of $i$-th layer, $(a_i, b_i)$ is ranking coefficients for $i$-th layer.
+The $(a_i, b_i)$ pair of scalars will be learned for each ( $i$ layer and used to transform norms of $i$-th layer filters before sorting all filter norms together as $a_i * N_i + b_i$ , where $N_i$ - is vector of filter norma of $i$-th layer, $(a_i, b_i)$ is ranking coefficients for $i$-th layer.
 This approach allows pruning the model taking into account layer-specific sensitivity to weight perturbations and get pruned models with higher accuracy.
 
 #### Filter pruning configuration file parameters

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -174,7 +174,7 @@ $Statistic\\:pruning\\:level = 1 - statistic\\:current / statistic\\:full$
 `GFLOPs pruning level` - an estimated reduction in the number of floating point operations of the model.   
 The number of FLOPs for a single convolutional layer can be calculated as:
 
-$FLOPs = 2 * input channels * kernel size ^2 * W * H * filters$
+$FLOPs = 2 * input\\:channels * kernel\\:size ^2 * W * H * filters$
 
 > **NOTE**: One GFLOP is one billion (1e9) FLOPs.
 

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -9,23 +9,23 @@ Not all Convolution layers in the model can be pruned. Such layers are determine
 #### Filter importance criteria **L1, L2**
 
  `L1`, `L2` filter importance criteria are based on the following assumption:
-> Convolutional filters with small ![l_p](https://latex.codecogs.com/png.latex?l_p) norms do not significantly contribute to output activation values, and thus have a small impact on the final predictions of CNN models.
-In the above, the ![l_p](https://latex.codecogs.com/png.latex?l_p) norm for filter F is:
+> Convolutional filters with small $l_p$ norms do not significantly contribute to output activation values, and thus have a small impact on the final predictions of CNN models.
+In the above, the $l_p$ norm for filter F is:
 
-![||F||_p = \sqrt[p]{\sum_{c, k_1, k_2 = 1}^{C, K, K}|F(c, k_1, k_2)|^p}](https://latex.codecogs.com/png.latex?%7C%7CF%7C%7C_p%20%3D%20%5Csqrt%5Bp%5D%7B%5Csum_%7Bc%2C%20k_1%2C%20k_2%20%3D%201%7D%5E%7BC%2C%20K%2C%20K%7D%7CF%28c%2C%20k_1%2C%20k_2%29%7C%5Ep%7D)
+$||F||_p = \sqrt[p]{\sum_{c, k_1, k_2 = 1}^{C, K, K}|F(c, k_1, k_2)|^p}$
 
 During the pruning procedure filters with smaller  `L1` or `L2` norm will be pruned first.
 
 **Geometric Median**
 
 Usage of the geometric median filter importance criterion is based on the following assumptions:
-> Let ![\{F_i, \dots , F_j\}](https://latex.codecogs.com/png.latex?%5C%7BF_i%2C%20..%20%2C%20F_j%5C%7D) be the set of N filters in a convolutional layer that are closest to the geometric median of all the filters in that layer.   As it was shown, each of those filters can be decomposed into a linear combination of the rest of the filters further from the geometric median with a small error. Hence, these filters can be pruned without much impact on network accuracy.  Since we have only fixed number of filters in each layer and the task of calculation of geometric median is a non-trivial problem in computational geometry, we can instead find which filters minimize the summation of the distance with other filters.
+> Let $\{F_i, \dots , F_j\}$ be the set of N filters in a convolutional layer that are closest to the geometric median of all the filters in that layer.   As it was shown, each of those filters can be decomposed into a linear combination of the rest of the filters further from the geometric median with a small error. Hence, these filters can be pruned without much impact on network accuracy.  Since we have only fixed number of filters in each layer and the task of calculation of geometric median is a non-trivial problem in computational geometry, we can instead find which filters minimize the summation of the distance with other filters.
 
-Then Geometric Median importance of ![F_i](https://latex.codecogs.com/png.latex?F_i) filter from ![L_j](https://latex.codecogs.com/png.latex?L_j) layer is:
-![G(F_i) = \sum_{F_j \in \{F_1, \dots F_m\}, j\neq i} ||F_i - F_j||_2](https://latex.codecogs.com/png.latex?G%28F_i%29%20%3D%20%5Csum_%7BF_j%20%5Cin%20%5C%7BF_1%2C%20%5Cdots%20F_m%5C%7D%2C%20j%5Cneq%20i%7D%20%7C%7CF_i%20-%20F_j%7C%7C_2)
-Where ![L_j](https://latex.codecogs.com/png.latex?L_j) is j-th convolutional layer in model. ![\{F_1, \dots F_m\} \in L_j](https://latex.codecogs.com/png.latex?%5C%7BF_1%2C%20%5Cdots%20F_m%5C%7D%20%5Cin%20L_j) - set of all  output filters in ![L_j](https://latex.codecogs.com/png.latex?L_j) layer.
+Then Geometric Median importance of $F_i$ filter from $L_j$ layer is:
+$G(F_i) = \sum_{F_j \in \{F_1, \dots F_m\}, j\neq i} ||F_i - F_j||_2$
+Where $L_j$ is j-th convolutional layer in model. $\{F_1, \dots F_m\} \in L_j$ - set of all  output filters in $L_j$ layer.
 
-Then during pruning filters with smaller ![G(F_i)](https://latex.codecogs.com/png.latex?G%28F_i%29) importance function will be pruned first.
+Then during pruning filters with smaller $G(F_i)$ importance function will be pruned first.
 
 #### Schedulers
 
@@ -43,9 +43,9 @@ The zeroed filters are frozen afterwards and the remaining model parameters are 
 Similar to the Baseline scheduler, during `num_init_steps` epochs model is pretrained without pruning.
 During the next `pruning steps` epochs `Exponential scheduler` gradually increasing pruning level from `pruning_init` to `pruning_target`. After each pruning training epoch pruning algorithm calculates filter importances for all convolutional filters and prune (setting to zero) `current_pruning_rate` part of filters with the smallest importance in each Convolution.  After `num_init_steps` + `pruning_steps` epochs algorithm with zeroed filters is frozen and remaining model parameters only fine-tunes.
 
-Current pruning level ![P_{i}](https://latex.codecogs.com/svg.latex?P_{i}) (on i-th epoch) during training calculates by equation:
-![P_i = a * e^{- k * i}](https://latex.codecogs.com/png.latex?P_i%20%3D%20a%20*%20e%5E%7B-%20k%20*%20i%7D)
-Where ![a, k](https://latex.codecogs.com/svg.latex?a,%20k) - parameters.
+Current pruning level $P_{i}$ (on i-th epoch) during training calculates by equation:
+$P_i = a * e^{- k * i}$
+Where $a, k$ - parameters.
 
 **Parameters of scheduler:**
 - `num_init_steps` - number of epochs for model pretraining before pruning.
@@ -54,9 +54,9 @@ Where ![a, k](https://latex.codecogs.com/svg.latex?a,%20k) - parameters.
 - `pruning_target` - pruning level target at the end of the schedule. For example, the value `0.5` means that at the epoch with the number of `num_init_steps + pruning_steps`, convolutions that can be pruned will have 50% of their filters set to zero.
 
 **Exponential with bias scheduler**
-Similar to the `Exponential scheduler`, but current pruning level ![P_{i}](https://latex.codecogs.com/svg.latex?P_{i}) (on i-th epoch) during training calculates by equation:
-![P_i = a * e^{- k * i} + b](https://latex.codecogs.com/png.latex?P_i%20%3D%20a%20*%20e%5E%7B-%20k%20*%20i%7D%20&plus;%20b)
-Where ![a, k, b](https://latex.codecogs.com/png.latex?a%2C%20k%2C%20b) - parameters.
+Similar to the `Exponential scheduler`, but current pruning level $P_{i}$ (on i-th epoch) during training calculates by equation:
+$P_i = a * e^{- k * i} + b$
+Where $a, k, b$ - parameters.
 
 > **NOTE**:  Baseline scheduler prunes filters only ONCE and after it just fine-tunes remaining parameters while exponential (and exponential with bias) schedulers choose and prune different filters subsets at each pruning epoch.
 
@@ -74,7 +74,7 @@ sparsity and filter pruning algorithms. It can be enabled by setting a non-zero 
 Interlayer ranking type can be one of `unweighted_ranking` or `learned_ranking`.
 - In case of `unweighted_ranking` and with  `all_weights=True` all filter norms will be collected together and sorted to choose the least important ones. But this approach may not be optimal because filter norms are a good measure of filter importance inside a layer, but not across layers.
 - In the case of `learned_ranking` that uses re-implementation of [Learned Global Ranking method](https://arxiv.org/abs/1904.12368), a set of ranking coefficients will be learned for comparing filters across different layers.
-The ![(a_i, b_i)](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20(a_i,%20b_i)) pair of scalars will be learned for each (![i](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20i)-th) layer and used to transform norms of ![i](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20i)-th layer filters before sorting all filter norms together as ![a_i * N_i + b_i](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20a_i%20*%20N_i%20&plus;%20b_i) , where ![N_i](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20N_i) - is vector of filter norma of ![i](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20i)-th layer, ![(a_i, b_i)](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20(a_i,%20b_i)) is ranking coefficients for ![i](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20i)-th layer.
+The $(a_i, b_i)$ pair of scalars will be learned for each ($i$ layer and used to transform norms of $i$-th layer filters before sorting all filter norms together as $a_i * N_i + b_i$ , where $N_i$ - is vector of filter norma of $i$-th layer, $(a_i, b_i)$ is ranking coefficients for $i$-th layer.
 This approach allows pruning the model taking into account layer-specific sensitivity to weight perturbations and get pruned models with higher accuracy.
 
 #### Filter pruning configuration file parameters
@@ -167,14 +167,14 @@ The columns `Full` and `Current` represent the values of the corresponding stati
 
 The `Pruning level` column indicates the ratio between the values of the full and current statistics in the corresponding rows, defined by the formula:
 
-![Statistic pruning level](https://latex.codecogs.com/png.image?\dpi{110}\textit{statistic&space;pruning&space;level}&space;=&space;1&space;-&space;\textit{statistic&space;current}&space;/&space;\textit{statistic&space;full})
+$Statistic pruning level = 1 - statistic current / statistic full$
   
 `Filter pruning level` - percentage of filters removed from the model.  
 
 `GFLOPs pruning level` - an estimated reduction in the number of floating point operations of the model.   
 The number of FLOPs for a single convolutional layer can be calculated as:
 
-![FLOPs](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20FLOPs&space;=&space;2&space;%5Ctimes&space;input%5C;channels&space;%5Ctimes&space;kernel%5C;size%5E%7B2%7D%5Ctimes&space;W%5Ctimes&space;H%5Ctimes&space;filters)
+$FLOPs = 2x input channels x kernel size ^2 x W x H x filters$
 
 > **NOTE**: One GFLOP is one billion (1e9) FLOPs.
 
@@ -185,8 +185,8 @@ significantly from the filter pruning level.
 In addition, the decrease in GFLOPs is estimated by calculating the number of FLOPs of convolutional and fully connected layers. 
 As a result, these estimates may differ slightly from the actual number of FLOPs in the compressed model.
 
-`MParams  pruning level` - calculated reduction in the number of parameters in the model in millions. Typically convolutional layer weights have shape 
-![shape](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20%5Cinline%20(kernel%5C;size,&space;kernel%5C;size,&space;input%5C;channels,&space;filters%5C;&space;num)).
+`MParams  pruning level` - calculated reduction in the number of parameters in the model in millions. Typically convolutional layer weights have the shape of $(kernel size, kernel size, input channels, filter num)$.
+
 Thus, each removed filter affects the number of parameters in two convolutional layers as it affects the number 
 of filters in one and the number of input channels of the next layer. It is expected that this number may differ 
 significantly from the filter pruning level.

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -12,9 +12,9 @@ Not all Convolution layers in the model can be pruned. Such layers are determine
 > Convolutional filters with small $l_p$ norms do not significantly contribute to output activation values, and thus have a small impact on the final predictions of CNN models.
 In the above, the $l_p$ norm for filter F is:
 
-$||F||_p = \sqrt[p]{ \sum\limits_{c, k_1, k_2 = 1}^{C, K, K}   |F(c, k_1, k_2)|^p}$
+$||F||_p = \sqrt[p]{\sum\limits_{c, k_1, k_2 = 1}^{C, K, K} }$
 
-
+  |F(c, k_1, k_2)|^p
 
 During the pruning procedure filters with smaller  `L1` or `L2` norm will be pruned first.
 

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -12,9 +12,7 @@ Not all Convolution layers in the model can be pruned. Such layers are determine
 > Convolutional filters with small $l_p$ norms do not significantly contribute to output activation values, and thus have a small impact on the final predictions of CNN models.
 In the above, the $l_p$ norm for filter F is:
 
-$||F||_p = \sqrt[p]{\sum\limits\_{1}^{K} |F(c, k_1, k_2)|^p}$
-
-$||F||_p = \sqrt[p]{\sum\limits_{c, k_1, k_2 = 1}^{C, K, K} |F(c, k_1, k_2)|^p}$  
+$||F||_p = \sqrt[p]{\sum\limits\_{c, k_1, k_2 = 1}^{C, K, K} |F(c, k_1, k_2)|^p}$
 
 During the pruning procedure filters with smaller  `L1` or `L2` norm will be pruned first.
 

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -12,10 +12,9 @@ Not all Convolution layers in the model can be pruned. Such layers are determine
 > Convolutional filters with small $l_p$ norms do not significantly contribute to output activation values, and thus have a small impact on the final predictions of CNN models.
 In the above, the $l_p$ norm for filter F is:
 
-$||F||_p = \sqrt[p]{ |F(c, k_1, k_2)|^p}$
+$||F||_p = \sqrt[p]{ \sum\limits_{c, k_1, k_2 = 1}^{C, K, K}   |F(c, k_1, k_2)|^p}$
 
 
-$\sum_{c, k_1, k_2 = 1}^{C, K, K}$
 
 During the pruning procedure filters with smaller  `L1` or `L2` norm will be pruned first.
 

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -167,7 +167,7 @@ The columns `Full` and `Current` represent the values of the corresponding stati
 
 The `Pruning level` column indicates the ratio between the values of the full and current statistics in the corresponding rows, defined by the formula:
 
-$Statistic pruning level = 1 - statistic current / statistic full$
+$Statistic\\:pruning\\:level = 1 - statistic\\:current / statistic\\:full$
   
 `Filter pruning level` - percentage of filters removed from the model.  
 

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -174,7 +174,7 @@ $Statistic pruning level = 1 - statistic current / statistic full$
 `GFLOPs pruning level` - an estimated reduction in the number of floating point operations of the model.   
 The number of FLOPs for a single convolutional layer can be calculated as:
 
-$FLOPs = 2x input channels x kernel size ^2 x W x H x filters$
+$FLOPs = 2 * input channels * kernel size ^2 * W * H * filters$
 
 > **NOTE**: One GFLOP is one billion (1e9) FLOPs.
 

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -12,7 +12,7 @@ Not all Convolution layers in the model can be pruned. Such layers are determine
 > Convolutional filters with small $l_p$ norms do not significantly contribute to output activation values, and thus have a small impact on the final predictions of CNN models.
 In the above, the $l_p$ norm for filter F is:
 
-$||F||_p = \sqrt[p]{\sum\limits_{1}^{K} |F(c, k_1, k_2)|^p}$
+$||F||_p = \sqrt[p]{\sum\limits\_{1}^{K} |F(c, k_1, k_2)|^p}$
 
 $||F||_p = \sqrt[p]{\sum\limits_{c, k_1, k_2 = 1}^{C, K, K} |F(c, k_1, k_2)|^p}$  
 

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -12,9 +12,9 @@ Not all Convolution layers in the model can be pruned. Such layers are determine
 > Convolutional filters with small $l_p$ norms do not significantly contribute to output activation values, and thus have a small impact on the final predictions of CNN models.
 In the above, the $l_p$ norm for filter F is:
 
-$||F||_p = \sqrt[p]{\sum\limits_{c, k_1, k_2 = 1}^{C, K, K} }$
+$||F||_p = \sqrt[p]{\sum\limits_{1}^{K} |F(c, k_1, k_2)|^p}$
 
-  |F(c, k_1, k_2)|^p
+$||F||_p = \sqrt[p]{\sum\limits_{c, k_1, k_2 = 1}^{C, K, K} |F(c, k_1, k_2)|^p}$  
 
 During the pruning procedure filters with smaller  `L1` or `L2` norm will be pruned first.
 

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -12,10 +12,10 @@ Not all Convolution layers in the model can be pruned. Such layers are determine
 > Convolutional filters with small $l_p$ norms do not significantly contribute to output activation values, and thus have a small impact on the final predictions of CNN models.
 In the above, the $l_p$ norm for filter F is:
 
-$||F||_p = \sqrt[p]{ p}$
+$||F||_p = \sqrt[p]{ |F(c, k_1, k_2)|^p}$
 
 
-$\sqrt[p]{\sum_{c, k_1, k_2 = 1}^{C, K, K}|F(c, k_1, k_2)|^p}$
+$\sum_{c, k_1, k_2 = 1}^{C, K, K}$
 
 During the pruning procedure filters with smaller  `L1` or `L2` norm will be pruned first.
 

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -12,7 +12,7 @@ Not all Convolution layers in the model can be pruned. Such layers are determine
 > Convolutional filters with small $l_p$ norms do not significantly contribute to output activation values, and thus have a small impact on the final predictions of CNN models.
 In the above, the $l_p$ norm for filter F is:
 
-$||F||_p =$
+$||F||_p = \sqrt[p]{ p}$
 
 
 $\sqrt[p]{\sum_{c, k_1, k_2 = 1}^{C, K, K}|F(c, k_1, k_2)|^p}$

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -185,7 +185,7 @@ significantly from the filter pruning level.
 In addition, the decrease in GFLOPs is estimated by calculating the number of FLOPs of convolutional and fully connected layers. 
 As a result, these estimates may differ slightly from the actual number of FLOPs in the compressed model.
 
-`MParams  pruning level` - calculated reduction in the number of parameters in the model in millions. Typically convolutional layer weights have the shape of $(kernel size, kernel size, input channels, filter num)$.
+`MParams  pruning level` - calculated reduction in the number of parameters in the model in millions. Typically convolutional layer weights have the shape of $(kernel\\:size,\\:kernel\\:size,\\:input\\:channels,\\:filter\\:num)$.
 
 Thus, each removed filter affects the number of parameters in two convolutional layers as it affects the number 
 of filters in one and the number of input channels of the next layer. It is expected that this number may differ 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -85,7 +85,7 @@ ${input\\_high}''=\frac{ZP-levels+1}{ZP}*{input\\_low}'$
 ${input\\_low}''=\frac{ZP}{ZP-levels+1}*{input\\_high}'$
 
 
-${input\\_low,input\\_high} = \begin{cases} {input\\_low}',{input\\_high}', \& ZP \in \$\{0,levels-1\}$ \\ {input\\_low}',{input\\_high}'', \& {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}'' \\ {input\\_low}'',{input\\_high}', \& {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}''\\ \end{cases}$
+${input\\_low,input\\_high} = \begin{cases} {input\\_low}',{input\\_high}', \\& ZP \in \\$\{0,levels-1\}\\$ \\ {input\\_low}',{input\\_high}'', \\& {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}'' \\ {input\\_low}'',{input\\_high}', \& {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}''\\ \end{cases}$
 
 
 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -138,6 +138,7 @@ $input\\_range^{*} = input\\_range$
 For symmetric:
 
 $input\\_low^{*} = 0$
+
 $input\\_range^{*} = scale$
 
 ---
@@ -169,7 +170,6 @@ calculated by multiplying the average Hessian trace with the L2 norm of quantiza
 
 $\overline{Tr}(H_{i}) * \left \| Q(W_{i}) - W_{i} \right \|^2_2$
 
-
 The sum of the sensitivities for each layer forms a metric which serves as a proxy to the accuracy of the compressed
 model: the lower the metric, the more accurate should be the corresponding mixed precision model on the validation
 dataset.
@@ -196,14 +196,14 @@ $Tr(H) = \mathbb{E}[v^T H v]$
 The randomized algorithm solves the expectation by Monte Carlo using sampling of v from its distribution, evaluating
 the quadratic term, and averaging:
 
-Tr(H) \approx \frac{1}{m}\sum_{i=1}^{m}[v_i^T H v_i]$
+$Tr(H) \approx \frac{1}{m}\sum_{i=1}^{m}[v_i^T H v_i]$
 
 Evaluation of the quadratic term happens by computing ![Hv](https://latex.codecogs.com/png.latex?Hv) - the result
 of multiplication of the Hessian matrix with a given random vector v, without the explicit formation of the Hessian operator.
 For gradient of the loss with respect to the i-th block ![g_i](https://latex.codecogs.com/png.latex?g_i) and for
 a random vector v, which is independent of ![W_i](https://latex.codecogs.com/png.latex?W_i), we have the equation:
 
-\frac{\partial(g_i^T v)}{\partial  W_i} = H_i v$
+$\frac{\partial(g_i^T v)}{\partial  W_i} = H_i v$
 
 where $H_i$ is the Hessian matrix of loss with respect to
 $W_i$. Hence $Hv$ can be

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -131,11 +131,14 @@ $ZP = \lfloor-input\\_low * s\rceil$
 
 For asymmetric:
 
-$input\\_low^{*} = input\\_low \\\\ input\\_range^{*} = input\\_range$
+$input\\_low^{*} = input\\_low$
+
+$input\\_range^{*} = input\\_range$
 
 For symmetric:
 
-$input\\_low^{*} = 0 \\\\ input\\_range^{*} = scale$
+$input\\_low^{*} = 0$
+$input\\_range^{*} = scale$
 
 ---
 **NOTE**

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -123,19 +123,19 @@ For all target HW types, parts of the model graph can be marked as non-quantizab
 
 In our implementation, we use a slightly transformed formula. It is equivalent by order of floating-point operations to simplified symmetric formula and the assymetric one. The small difference is addition of small positive number `eps` to prevent division by zero and taking absolute value of range, since it might become negative on backward:
 
-$output = \frac{clamp(\left\lfloor (input-input\_low^{*}) *s - ZP \right \rceil, level\_low, level\_high)}{s}$
+$output = \frac{clamp(\left\lfloor (input-input\\_low^{*}) *s - ZP \right \rceil, level\\_low, level\\_high)}{s}$
 
-$s = \frac{level\_high}{|input\_range^{*}| + eps}$
+$s = \frac{level\\_high}{|input\\_range^{*}| + eps}$
 
-$ZP = \lfloor-input\_low * s\rceil$
+$ZP = \lfloor-input\\_low * s\rceil$
 
 For asymmetric:
 
-$\\input\_low^{*} = input\_low \\ input\_range^{*} = input\_range$
+$input\\_low^{*} = input\\_low \\ input\\_range^{*} = input\\_range$
 
 For symmetric:
 
-$\\input\_low^{*} = 0 \\ input\_range^{*} = scale$
+$input\\_low^{*} = 0 \\ input\\_range^{*} = scale$
 
 ---
 **NOTE**

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -74,17 +74,17 @@ $level\\_high=2^{bits}-1$
 
 For better accuracy, floating-point zero should be within quantization range and strictly mapped into quant (without rounding). Therefore, the following scheme is applied to ranges of weights and activations before quantization:
 
-${input\_low}' = min(input\_low, 0)$
+${input\\_low}' = min(input\\_low, 0)$
 
-${input\_high}' = max(input\_high, 0)$
+${input\\_high}' = max(input\\_high, 0)$
 
-$ZP= \left\lfloor \frac{-{input\_low}'*(levels-1)}{{input\_high}'-{input\_low}'} \right \rceil$
+$ZP= \left\lfloor \frac{-{input\\_low}'*(levels-1)}{{input\\_high}'-{input\\_low}'} \right \rceil$
 
-${input\_high}''=\frac{ZP-levels+1}{ZP}*{input\_low}'$
+${input\\_high}''=\frac{ZP-levels+1}{ZP}*{input\\_low}'$
 
-${input\_low}''=\frac{ZP}{ZP-levels+1}*{input\_high}'$
+${input\\_low}''=\frac{ZP}{ZP-levels+1}*{input\\_high}'$
 
-${input\_low,input\_high} = \begin{cases} {input\_low}',{input\_high}', & ZP \in $\{0,levels-1\}$ \\ {input\_low}',{input\_high}'', & {input\_high}'' - {input\_low}' > {input\_high}' - {input\_low}'' \\ {input\_low}'',{input\_high}', & {input\_high}'' - {input\_low}' <= {input\_high}' - {input\_low}''\\ \end{cases}$
+${input\\_low,input\\_high} = \begin{cases} {input\\_low}',{input\\_high}', & ZP \in $\{0,levels-1\}$ \\ {input\\_low}',{input\\_high}'', & {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}'' \\ {input\\_low}'',{input\\_high}', & {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}''\\ \end{cases}$
 
 You can use the `num_init_samples` parameter from the `initializer` group to initialize the values of `input_low` and `input_range` from the collected statistics using given number of samples.
 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -85,12 +85,12 @@ ${input\\_high}''=\frac{ZP-levels+1}{ZP}*{input\\_low}'$
 ${input\\_low}''=\frac{ZP}{ZP-levels+1}*{input\\_high}'$
 
 
-${input\\_low,input\\_high} = \begin{cases}{ll} {input\\_low}',{input\\_high}', \& ZP \in {0,levels-1}                                  \end{cases}$
+${input\\_low,input\\_high} = \begin{cases}{ll} {input\\_low}',{input\\_high}', \& ZP \in {0,levels-1} \\\\ {input\\_low}',{input\\_high}'', \& {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}''                            \end{cases}$
 
 
 
 
-\\$ \\ {input\\_low}',{input\\_high}'', \\& {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}'' \\ {input\\_low}'',{input\\_high}', \& {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}''\\ 
+  \\ {input\\_low}'',{input\\_high}', \& {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}''\\ 
 
 
 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -85,7 +85,12 @@ ${input\\_high}''=\frac{ZP-levels+1}{ZP}*{input\\_low}'$
 ${input\\_low}''=\frac{ZP}{ZP-levels+1}*{input\\_high}'$
 
 
-${input\\_low,input\\_high} = \begin{cases} {input\\_low}',{input\\_high}', \\& ZP \in \\$\{0,levels-1\}\\$ \\ {input\\_low}',{input\\_high}'', \\& {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}'' \\ {input\\_low}'',{input\\_high}', \& {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}''\\ \end{cases}$
+${input\\_low,input\\_high} = \begin{cases}{ll} {input\\_low}',{input\\_high}', \& ZP \in {0,levels-1}                                  \end{cases}$
+
+
+
+
+\\$ \\ {input\\_low}',{input\\_high}'', \\& {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}'' \\ {input\\_low}'',{input\\_high}', \& {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}''\\ 
 
 
 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -131,11 +131,11 @@ $ZP = \lfloor-input\\_low * s\rceil$
 
 For asymmetric:
 
-$input\\_low^{*} = input\\_low \\ input\\_range^{*} = input\\_range$
+$input\\_low^{*} = input\\_low \\\\ input\\_range^{*} = input\\_range$
 
 For symmetric:
 
-$input\\_low^{*} = 0 \\ input\\_range^{*} = scale$
+$input\\_low^{*} = 0 \\\\ input\\_range^{*} = scale$
 
 ---
 **NOTE**

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -14,7 +14,7 @@ $output = \frac{\left\lfloor (clamp(input; input\\_low, input\\_high)-input\\_lo
 
 $clamp(input; input\\_low, input\\_high)$
 
-$s = \frac{levels-1}{input\\_high - input\\_low$
+
 
 
 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -196,7 +196,7 @@ $Tr(H) = \mathbb{E}[v^T H v]$
 The randomized algorithm solves the expectation by Monte Carlo using sampling of v from its distribution, evaluating
 the quadratic term, and averaging:
 
-$Tr(H) \approx \frac{1}{m}\sum_{i=1}^{m}[v_i^T H v_i]$
+$Tr(H) \approx \frac{1}{m}\sum\limits_{i=1}^{m}[v_i^T H v_i]$
 
 Evaluation of the quadratic term happens by computing ![Hv](https://latex.codecogs.com/png.latex?Hv) - the result
 of multiplication of the Hessian matrix with a given random vector v, without the explicit formation of the Hessian operator.

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -123,17 +123,19 @@ For all target HW types, parts of the model graph can be marked as non-quantizab
 
 In our implementation, we use a slightly transformed formula. It is equivalent by order of floating-point operations to simplified symmetric formula and the assymetric one. The small difference is addition of small positive number `eps` to prevent division by zero and taking absolute value of range, since it might become negative on backward:
 
-![output = \frac{clamp(\left\lfloor (input-input\_low^{*}) *s - ZP \right \rceil, level\_low, level\_high)}{s}](https://latex.codecogs.com/svg.image?output%20=%20%5Cfrac%7Bclamp(%5Cleft%5Clfloor%20(input-input%5C_low%5E%7B*%7D)%20*s%20-%20ZP%20%5Cright%20%5Crceil,%20level%5C_low,%20level%5C_high)%7D%7Bs%7D)
+$output = \frac{clamp(\left\lfloor (input-input\_low^{*}) *s - ZP \right \rceil, level\_low, level\_high)}{s}$
 
-![s = \frac{level\_high}{|input\_range^{*}| + eps}](https://latex.codecogs.com/png.latex?s%20%3D%20%5Cfrac%7Blevel%5C_high%7D%7B%7Cinput%5C_range%5E%7B*%7D%7C%20&plus;%20eps%7D)
+$s = \frac{level\_high}{|input\_range^{*}| + eps}$
 
-![ZP = \lfloor-input\_low * s\rceil](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20ZP%20=%20%5Clfloor-input%5C_low%5E%7B*%7D%20*%20s%5Crceil)
+$ZP = \lfloor-input\_low * s\rceil$
 
 For asymmetric:
-![\\input\_low^{*} = input\_low \\ input\_range^{*} = input\_range ](https://latex.codecogs.com/png.latex?%5C%5Cinput%5C_low%5E%7B*%7D%20%3D%20input%5C_low%20%5C%5C%20input%5C_range%5E%7B*%7D%20%3D%20input%5C_range)
+
+$\\input\_low^{*} = input\_low \\ input\_range^{*} = input\_range$
 
 For symmetric:
-![\\input\_low^{*} = 0 \\ input\_range^{*} = scale](https://latex.codecogs.com/png.latex?%5C%5Cinput%5C_low%5E%7B*%7D%20%3D%200%20%5C%5C%20input%5C_range%5E%7B*%7D%20%3D%20scale)
+
+$\\input\_low^{*} = 0 \\ input\_range^{*} = scale$
 
 ---
 **NOTE**
@@ -162,7 +164,8 @@ configuration by taking into account the sensitivity of each layer, i.e. how muc
 decreases the accuracy of model. The most sensitive layers are kept at higher precision. The sensitivity of the i-th layer is
 calculated by multiplying the average Hessian trace with the L2 norm of quantization perturbation:
 
-![\overline{Tr}(H_{i}) * \left \| Q(W_{i}) - W_{i} \right \|^2_2](https://latex.codecogs.com/png.latex?%5Coverline%7BTr%7D%28H_%7Bi%7D%29%20*%20%5Cleft%20%5C%7C%20Q%28W_%7Bi%7D%29%20-%20W_%7Bi%7D%20%5Cright%20%5C%7C%5E2_2)
+$\overline{Tr}(H_{i}) * \left \| Q(W_{i}) - W_{i} \right \|^2_2$
+
 
 The sum of the sensitivities for each layer forms a metric which serves as a proxy to the accuracy of the compressed
 model: the lower the metric, the more accurate should be the corresponding mixed precision model on the validation
@@ -185,22 +188,22 @@ trace value are quantized to lower bitwidth and vice versa.
 The Hessian trace is estimated with the randomized [Hutchinson algorithm](https://www.researchgate.net/publication/220432178_Randomized_Algorithms_for_Estimating_the_Trace_of_an_Implicit_Symmetric_Positive_Semi-Definite_Matrix).
 Given Rademacher distributed random vector v, the trace of symmetric matrix H is equal to the estimation of a quadratic form:
 
-![Tr(H) = \mathbb{E}[v^T H v]](https://latex.codecogs.com/png.latex?Tr%28H%29%20%3D%20%5Cmathbb%7BE%7D%5Bv%5ET%20H%20v%5D)
+$Tr(H) = \mathbb{E}[v^T H v]$
 
 The randomized algorithm solves the expectation by Monte Carlo using sampling of v from its distribution, evaluating
 the quadratic term, and averaging:
 
-![Tr(H) \approx \frac{1}{m}\sum_{i=1}^{m}[v_i^T H v_i]](https://latex.codecogs.com/png.latex?Tr%28H%29%20%5Capprox%20%5Cfrac%7B1%7D%7Bm%7D%5Csum_%7Bi%3D1%7D%5E%7Bm%7D%5Bv_i%5ET%20H%20v_i%5D)
+Tr(H) \approx \frac{1}{m}\sum_{i=1}^{m}[v_i^T H v_i]$
 
 Evaluation of the quadratic term happens by computing ![Hv](https://latex.codecogs.com/png.latex?Hv) - the result
 of multiplication of the Hessian matrix with a given random vector v, without the explicit formation of the Hessian operator.
 For gradient of the loss with respect to the i-th block ![g_i](https://latex.codecogs.com/png.latex?g_i) and for
 a random vector v, which is independent of ![W_i](https://latex.codecogs.com/png.latex?W_i), we have the equation:
 
-![\frac{\partial(g_i^T v)}{\partial  W_i} = H_i v](https://latex.codecogs.com/png.latex?%5Cfrac%7B%5Cpartial%28g_i%5ET%20v%29%7D%7B%5Cpartial%20W_i%7D%20%3D%20H_i%20v)
+\frac{\partial(g_i^T v)}{\partial  W_i} = H_i v$
 
-where ![H_i](https://latex.codecogs.com/png.latex?H_i) is the Hessian matrix of loss with respect to
-![W_i](https://latex.codecogs.com/png.latex?W_i). Hence ![Hv](https://latex.codecogs.com/png.latex?Hv) can be
+where $H_i$ is the Hessian matrix of loss with respect to
+$W_i$. Hence $Hv$ can be
 computed by 2 backpropagation passes: first  - with respect to the loss and second - with respect to the product of the
 gradients and a random vector.
 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -14,11 +14,11 @@ $output = \frac{\left\lfloor (clamp(input; input\\_low, input\\_high)-input\\_lo
 
 $clamp(input; input\\_low, input\\_high)$
 
+$s = \frac{levels - 1}{input\\_high - input\\_low}$
 
 
 
-
-$input_low$ and $input_high$ represent the quantization range and $\left\lfloor\cdot\right \rceil$ denotes rounding to the nearest integer.
+$input\\_low$ and $input\\_high$ represent the quantization range and $\left\lfloor \cdot \right\rceil$ denotes rounding to the nearest integer.
 
 
 ####  Symmetric Quantization

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -168,7 +168,7 @@ configuration by taking into account the sensitivity of each layer, i.e. how muc
 decreases the accuracy of model. The most sensitive layers are kept at higher precision. The sensitivity of the i-th layer is
 calculated by multiplying the average Hessian trace with the L2 norm of quantization perturbation:
 
-$\overline{Tr}(H_{i}) * \left \| Q(W_{i}) - W_{i} \right \|^2_2$
+$\overline{Tr}(H_{i}) * \left \|\| Q(W_{i}) - W_{i} \right \|\|^2_2$
 
 The sum of the sensitivities for each layer forms a metric which serves as a proxy to the accuracy of the compressed
 model: the lower the metric, the more accurate should be the corresponding mixed precision model on the validation

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -84,13 +84,8 @@ ${input\\_high}''=\frac{ZP-levels+1}{ZP}*{input\\_low}'$
 
 ${input\\_low}''=\frac{ZP}{ZP-levels+1}*{input\\_high}'$
 
+${input\\_low,input\\_high} = \begin{cases} {input\\_low}',{input\\_high}', \& ZP \in {0,levels-1} \\\\ {input\\_low}',{input\\_high}'', \& {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}'' \\\\ {input\\_low}'',{input\\_high}', \& {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}'' \end{cases}$
 
-${input\\_low,input\\_high} = \begin{cases}{ll} {input\\_low}',{input\\_high}', \& ZP \in {0,levels-1} \\\\ {input\\_low}',{input\\_high}'', \& {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}''                            \end{cases}$
-
-
-
-
-  \\ {input\\_low}'',{input\\_high}', \& {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}''\\ 
 
 
 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -54,9 +54,9 @@ In the formula above, $level_low$ and $level_high$ represent the range of the di
 
     $levels=256$
 
-For all the cases listed above, the common quantization formula is simplified after substitution of $input_low$, $input_high$ and $levels$:
+For all the cases listed above, the common quantization formula is simplified after substitution of $input\\_low$, $input\\_high$ and $levels$:
 
-$output = \left\lfloor clamp(input * \frac{level\_high}{scale}, level\_low, level\_high)\right \rceil * \frac{scale}{level\_high}$
+$output = \left\lfloor clamp(input * \frac{level\\_high}{scale}, level\\_low, level\\_high)\right \rceil * \frac{scale}{level\\_high}$
 
 Use the `num_init_samples` parameter from the `initializer` group to initialize the values of `scale` and determine which activation should be signed or unsigned from the collected statistics using given number of samples.
 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -85,9 +85,8 @@ ${input\\_high}''=\frac{ZP-levels+1}{ZP}*{input\\_low}'$
 ${input\\_low}''=\frac{ZP}{ZP-levels+1}*{input\\_high}'$
 
 
-${input\\_low,input\\_high} = \begin{cases} {input\\_low}',{input\\_high}', & ZP \in $\{0,levels-1\}$ \\ {input\\_low}',{input\\_high}'', & {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}'' \\ {input\\_low}'',{input\\_high}', & {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}''\\ \end{cases}$
+${input\\_low,input\\_high} = \begin{cases} {input\\_low}',{input\\_high}', \& ZP \in \$\{0,levels-1\}$ \\ {input\\_low}',{input\\_high}'', \& {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}'' \\ {input\\_low}'',{input\\_high}', \& {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}''\\ \end{cases}$
 
-${input\\_low,input\\_high} = \begin{cases} {input\\_low}',{input\\_high}', & ZP \in $\{0,levels-1\}$ \\ {input\\_low}',{input\\_high}'', & {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}'' \\ {input\\_low}'',{input\\_high}', & {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}''\\    \end{cases}$
 
 
 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -18,18 +18,8 @@ $s = \frac{levels-1}{input\\_high - input\\_low$
 
 
 
-![ZP = \lfloor-input\_low * s\rceil](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20ZP%20=%20%5Clfloor-input%5C_low%20*%20s%5Crceil)
-
-![output = \frac{\left\lfloor (clamp(input; input\_low, input\_high)-input\_low)  *s - ZP \right \rceil}{s}\\](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D%20output%20=%20%5Cfrac%7B%5Cleft%5Clfloor%20(clamp(input;%20input%5C_low,%20input%5C_high)-input%5C_low)%20%20*s%20-%20ZP%20%5Cright%20%5Crceil%7D%7Bs%7D)
-
-![clamp(input; input\_low, input\_high) = min(max(input, input\_low), input\_high)))](https://latex.codecogs.com/png.latex?clamp%28input%3B%20input%5C_low%2C%20input%5C_high%29%20%3D%20min%28max%28input%2C%20input%5C_low%29%2C%20input%5C_high%29%29%29)
-
-![s=\frac{levels-1}{input\_high - input\_low}](https://latex.codecogs.com/png.latex?s%3D%5Cfrac%7Blevels-1%7D%7Binput%5C_high%20-%20input%5C_low%7D)
-
-
 $input_low$ and $input_high$ represent the quantization range and $\left\lfloor\cdot\right \rceil$ denotes rounding to the nearest integer.
 
-`input_low` and `input_high` represent the quantization range and ![\left\lfloor\cdot\right \rceil](https://latex.codecogs.com/png.latex?%5Cleft%5Clfloor%5Ccdot%5Cright%20%5Crceil) denotes rounding to the nearest integer.
 
 ####  Symmetric Quantization
 

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -84,7 +84,12 @@ ${input\\_high}''=\frac{ZP-levels+1}{ZP}*{input\\_low}'$
 
 ${input\\_low}''=\frac{ZP}{ZP-levels+1}*{input\\_high}'$
 
+
 ${input\\_low,input\\_high} = \begin{cases} {input\\_low}',{input\\_high}', & ZP \in $\{0,levels-1\}$ \\ {input\\_low}',{input\\_high}'', & {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}'' \\ {input\\_low}'',{input\\_high}', & {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}''\\ \end{cases}$
+
+${input\\_low,input\\_high} = \begin{cases} {input\\_low}',{input\\_high}', & ZP \in $\{0,levels-1\}$ \\ {input\\_low}',{input\\_high}'', & {input\\_high}'' - {input\\_low}' > {input\\_high}' - {input\\_low}'' \\ {input\\_low}'',{input\\_high}', & {input\\_high}'' - {input\\_low}' <= {input\\_high}' - {input\\_low}''\\    \end{cases}$
+
+
 
 You can use the `num_init_samples` parameter from the `initializer` group to initialize the values of `input_low` and `input_range` from the collected statistics using given number of samples.
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -4,27 +4,27 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 #### RB-Sparsity
 
-This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on ![L_0](https://latex.codecogs.com/png.latex?%5Cinline%20%5Cdpi%7B120%7D%20L_0)-regularization, with which parameters of the model tend to zero:
+This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-![||\theta||_0 = \sum_{i=0}^{|\theta|} \lbrack \theta_i = 0 \rbrack](https://latex.codecogs.com/png.latex?%5Cdpi%7B130%7D%20%7C%7C%5Ctheta%7C%7C_0%20%3D%20%5Csum_%7Bi%3D0%7D%5E%7B%7C%5Ctheta%7C%7D%20%5Clbrack%20%5Ctheta_i%20%3D%200%20%5Crbrack)
+$||\theta||_0 = \sum_{i=0}^{|\theta|} \lbrack \theta_i = 0 \rbrack$
 
 We then reparametrize the network's weights as follows:
 
-![\theta_{sparse}^{(i)} = \theta_i \cdot \epsilon_i, \quad \epsilon_i \sim \mathcal{B}(p_i)](https://latex.codecogs.com/png.latex?%5Cdpi%7B130%7D%20%5Ctheta_%7Bsparse%7D%5E%7B%28i%29%7D%20%3D%20%5Ctheta_i%20%5Ccdot%20%5Cepsilon_i%2C%20%5Cquad%20%5Cepsilon_i%20%5Csim%20%5Cmathcal%7BB%7D%28p_i%29)
+$\theta_{sparse}^{(i)} = \theta_i \cdot \epsilon_i, \quad \epsilon_i \sim \mathcal{B}(p_i)$
 
-Here, ![\mathcal{B}(p_i)](https://latex.codecogs.com/png.latex?%5Cmathcal%7BB%7D%28p_i%29) is the Bernoulli distribution, ![\epsilon_i](https://latex.codecogs.com/png.latex?%5Cinline%20%5Cdpi%7B120%7D%20%5Cepsilon_i) may be interpreted as a binary mask that selects which weights should be zeroed. We then add the regularizing term to the objective function that encourages desired level of sparsity to our model:
+Here, $\mathcal{B}(p_i)$ is the Bernoulli distribution, $\epsilon_i$ may be interpreted as a binary mask that selects which weights should be zeroed. We then add the regularizing term to the objective function that encourages desired level of sparsity to our model:
 
-![L_{sparse} = \mathbb{E}_{\epsilon \sim P_{\epsilon}} \lbrack \frac{\sum_{i=0}^{|\theta|} \epsilon_i}{|\theta|} - level \rbrack ^2](https://latex.codecogs.com/png.latex?%5Cdpi%7B120%7D%20L_%7Bsparse%7D%20%3D%20%5Cmathbb%7BE%7D_%7B%5Cepsilon%20%5Csim%20P_%7B%5Cepsilon%7D%7D%20%5Clbrack%20%5Cfrac%7B%5Csum_%7Bi%3D0%7D%5E%7B%7C%5Ctheta%7C%7D%20%5Cepsilon_i%7D%7B%7C%5Ctheta%7C%7D%20-%20level%20%5Crbrack%20%5E2)
+$L_{sparse} = \mathbb{E}_{\epsilon \sim P_{\epsilon}} \lbrack \frac{\sum_{i=0}^{|\theta|} \epsilon_i}{|\theta|} - level \rbrack ^2$
 
-During training, we store and optimize ![p_i](https://latex.codecogs.com/png.latex?%5Cinline%20%5Cdpi%7B120%7D%20p_i)'s in the logit form:
+During training, we store and optimize $p_i$'s in the logit form:
 
-![s_i = \sigma^{-1}(p_i) = log (\frac{p_i}{1 - p_i})](https://latex.codecogs.com/png.latex?%5Cdpi%7B120%7D%20s_i%20%3D%20%5Csigma%5E%7B-1%7D%28p_i%29%20%3D%20log%20%28%5Cfrac%7Bp_i%7D%7B1%20-%20p_i%7D%29)
+$s_i = \sigma^{-1}(p_i) = log (\frac{p_i}{1 - p_i})$
 
-and reparametrize the sampling of ![\epsilon_i](https://latex.codecogs.com/png.latex?%5Cinline%20%5Cdpi%7B120%7D%20%5Cepsilon_i)'s as follows:
+and reparametrize the sampling of $\epsilon_i$'s as follows:
 
-![\epsilon = \lbrack \sigma(s + \sigma^{-1}(\xi)) > \frac{1}{2} \rbrack, \quad \xi \sim \mathcal{U}(0,1)](https://latex.codecogs.com/png.latex?%5Cdpi%7B120%7D%20%5Cepsilon%20%3D%20%5Clbrack%20%5Csigma%28s%20&plus;%20%5Csigma%5E%7B-1%7D%28%5Cxi%29%29%20%3E%20%5Cfrac%7B1%7D%7B2%7D%20%5Crbrack%2C%20%5Cquad%20%5Cxi%20%5Csim%20%5Cmathcal%7BU%7D%280%2C1%29)
+$\epsilon = \lbrack \sigma(s + \sigma^{-1}(\xi)) > \frac{1}{2} \rbrack, \quad \xi \sim \mathcal{U}(0,1)$
 
-With this reparametrization, the probability of keeping a particular weight during the forward pass equals exactly to ![\mathbb{P}( \epsilon_i = 1) = p_i](https://latex.codecogs.com/png.latex?%5Cdpi%7B100%7D%20%5Cmathbb%7BP%7D%28%20%5Cepsilon_i%20%3D%201%29%20%3D%20p_i). We only sample the binary mask once per each training iteration. At test time, we only use the weights with ![p_i > \frac{1}{2}](https://latex.codecogs.com/png.latex?%5Cinline%20p_i%20%3E%20%5Cfrac%7B1%7D%7B2%7D) as given by the trained importance scores ![s_i](https://latex.codecogs.com/png.latex?%5Cinline%20%5Cdpi%7B120%7D%20s_i). To make the objective function differentiable, we treat threshold function ![t(x) = x > c](https://latex.codecogs.com/png.latex?%5Cinline%20t%28x%29%20%3D%20x%20%3E%20c) as a straight through estimator i.e. ![\frac{d t}{dx} = 1](https://latex.codecogs.com/png.latex?%5Cinline%20%5Cfrac%7Bd%20t%7D%7Bdx%7D%20%3D%201)
+With this reparametrization, the probability of keeping a particular weight during the forward pass equals exactly to $\mathbb{P}( \epsilon_i = 1) = p_i$. We only sample the binary mask once per each training iteration. At test time, we only use the weights with $p_i > \frac{1}{2}$ as given by the trained importance scores $s_i$. To make the objective function differentiable, we treat threshold function $t(x) = x > c$ as a straight through estimator i.e. $\frac{d t}{dx} = 1$
 
 The method requires a long schedule of the training process in order to minimize the accuracy drop.
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -16,7 +16,7 @@ Here, $\mathcal{B}(p_i)$ is the Bernoulli distribution, $\epsilon_i$ may be inte
 
 
 
-$L_{sparse} = \mathbb{E}\_{\epsilon \sum P_{\epsilon}} $
+$L_{sparse} = \mathbb{E}\_{\epsilon \sim P_{\epsilon}} $
 
 $L_{sparse} = \mathbb{E}$
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,7 +6,9 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$||\theta||_0 = \sum_{i=0}^{|\theta|} \lbrack \theta_i = 0 \rbrack$
+$||\theta||_0 = $
+
+\sum_{i=0}^{|\theta|} \lbrack \theta_i = 0 \rbrack$
 
 We then reparametrize the network's weights as follows:
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -16,7 +16,11 @@ Here, $\mathcal{B}(p_i)$ is the Bernoulli distribution, $\epsilon_i$ may be inte
 
 $L_{sparse} = \mathbb{E}_{\epsilon \sim P_{\epsilon}} $
 
+$L_{sparse} =$
+
 $ \lbrack \frac{\sum_{i=0}^{|\theta|} \epsilon_i}{|\theta|} - level \rbrack ^2$
+
+
 
 
 During training, we store and optimize $p_i$'s in the logit form:

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,9 +6,9 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$||\theta||_0 = \sum\_{i=0}$
+$||\theta||_0 = \sum\_{i=0}^{|\theta|} \lbrack \theta\_i = 0 \rbrack$
 
-^{|\theta|} \lbrack \theta_i = 0 \rbrack$
+
 
 We then reparametrize the network's weights as follows:
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -14,9 +14,11 @@ $\theta_{sparse}^{(i)} = \theta_i \cdot \epsilon_i, \quad \epsilon_i \sim \mathc
 
 Here, $\mathcal{B}(p_i)$ is the Bernoulli distribution, $\epsilon_i$ may be interpreted as a binary mask that selects which weights should be zeroed. We then add the regularizing term to the objective function that encourages desired level of sparsity to our model:
 
+
+
 $L_{sparse} = \mathbb{E}_{\epsilon \sum P_{\epsilon}} $
 
-$L_{sparse} =$
+$L_{sparse} = \mathbb{E}$
 
 $ \lbrack \frac{\sum_{i=0}^{|\theta|} \epsilon_i}{|\theta|} - level \rbrack ^2$
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,11 +6,11 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$\sum\limits_{i=0}^{|\theta|}$
+$$
 
 
 
-$||\theta||\_0 =   \lbrack \theta\_i = 0 \rbrack$
+$||\theta||\_0 = \sum\limits_{i=0}^{|\theta|} \lbrack \theta\_i = 0 \rbrack$
 
 We then reparametrize the network's weights as follows:
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,7 +6,7 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$||\theta||_0 = \sum_{i=0}$
+$||\theta||_0 = \sum\_{i=0}$
 
 ^{|\theta|} \lbrack \theta_i = 0 \rbrack$
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,9 +6,9 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$||\theta||\_0 = \sum\_{i=0}^{|\theta|} \lbrack \theta\_i = 0 \rbrack$
+$||\theta||\_0 = \sum\_{i=0}^{|\theta|} $
 
-
+\lbrack \theta\_i = 0 \rbrack
 
 We then reparametrize the network's weights as follows:
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,7 +6,7 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$ \sum\_{i=0}^{|\theta|} $
+$ \sum\_{i=0}{|\theta|} $
 
 $\sum_{n=1}^{\infty}$
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -16,12 +16,7 @@ Here, $\mathcal{B}(p_i)$ is the Bernoulli distribution, $\epsilon_i$ may be inte
 
 
 
-$L_{sparse} = \mathbb{E}\_{\epsilon \sim P_{\epsilon}} $
-
-
-
-$\lbrack \frac{\sum\limits_{i=0}^{|\theta|} \epsilon_i}{|\theta|} - level \rbrack ^2$
-
+$L_{sparse} = \mathbb{E}\_{\epsilon \sim P_{\epsilon}} \lbrack \frac{\sum\limits_{i=0}^{|\theta|} \epsilon_i}{|\theta|} - level \rbrack ^2 $
 
 
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -20,7 +20,7 @@ $L_{sparse} = \mathbb{E}\_{\epsilon \sim P_{\epsilon}} $
 
 
 
-$\lbrack \frac{\sum_{i=0}^{|\theta|} \epsilon_i}{|\theta|} - level \rbrack ^2$
+$\lbrack \frac{\sum\limits_{i=0}^{|\theta|} \epsilon_i}{|\theta|} - level \rbrack ^2$
 
 
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,9 +6,12 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$||\theta||\_0 = \sum\_{i=0}^{|\theta|} $
+$ \sum\_{i=0}^{|\theta|} $
 
-\lbrack \theta\_i = 0 \rbrack
+$\sum_{n=1}^{\infty}$
+
+
+$||\theta||\_0   =   \lbrack \theta\_i = 0 \rbrack$
 
 We then reparametrize the network's weights as follows:
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,7 +6,10 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$ \sum\limits\_{i=0}^{x+1} $
+$\sum\limits_{i=0}^n f(x)$
+
+
+$\sum\limits_{i=0}^{x+1}$
 
 
 |\theta|

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -14,7 +14,7 @@ $\theta_{sparse}^{(i)} = \theta_i \cdot \epsilon_i, \quad \epsilon_i \sim \mathc
 
 Here, $\mathcal{B}(p_i)$ is the Bernoulli distribution, $\epsilon_i$ may be interpreted as a binary mask that selects which weights should be zeroed. We then add the regularizing term to the objective function that encourages desired level of sparsity to our model:
 
-$L_{sparse} = \mathbb{E}_{\epsilon \sim P_{\epsilon}} $
+$L_{sparse} = \mathbb{E}_{\epsilon \sum P_{\epsilon}} $
 
 $L_{sparse} =$
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -14,11 +14,7 @@ $\theta_{sparse}^{(i)} = \theta_i \cdot \epsilon_i, \quad \epsilon_i \sim \mathc
 
 Here, $\mathcal{B}(p_i)$ is the Bernoulli distribution, $\epsilon_i$ may be interpreted as a binary mask that selects which weights should be zeroed. We then add the regularizing term to the objective function that encourages desired level of sparsity to our model:
 
-
-
 $L_{sparse} = \mathbb{E}\_{\epsilon \sim P_{\epsilon}} \lbrack \frac{\sum\limits_{i=0}^{|\theta|} \epsilon_i}{|\theta|} - level \rbrack ^2 $
-
-
 
 During training, we store and optimize $p_i$'s in the logit form:
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,7 +6,7 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$ \sum\limits_{i=0}^{|\theta|} $
+$ \sum\limits\_{i=0}^{|\theta|} $
 
 
 $\sum\limits_{i=0}^n f(x)$

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,15 +6,8 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$\sum\limits_{i=0}^n f(x)$
+$\sum\limits_{i=0}^{|\theta|}$
 
-
-$\sum\limits_{i=0}^{x+1}$
-
-
-|\theta|
-
-$\sum\limits_{i=0}^n f(x)$
 
 
 $||\theta||\_0 =   \lbrack \theta\_i = 0 \rbrack$

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -8,16 +8,16 @@ This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm
 
 $||\theta||\_0 = \sum\limits_{i=0}^{|\theta|} \lbrack \theta\_i = 0 \rbrack$
 
-
-
-
 We then reparametrize the network's weights as follows:
 
 $\theta_{sparse}^{(i)} = \theta_i \cdot \epsilon_i, \quad \epsilon_i \sim \mathcal{B}(p_i)$
 
 Here, $\mathcal{B}(p_i)$ is the Bernoulli distribution, $\epsilon_i$ may be interpreted as a binary mask that selects which weights should be zeroed. We then add the regularizing term to the objective function that encourages desired level of sparsity to our model:
 
-$L_{sparse} = \mathbb{E}_{\epsilon \sim P_{\epsilon}} \lbrack \frac{\sum_{i=0}^{|\theta|} \epsilon_i}{|\theta|} - level \rbrack ^2$
+$L_{sparse} = \mathbb{E}_{\epsilon \sim P_{\epsilon}} $
+
+$ \lbrack \frac{\sum_{i=0}^{|\theta|} \epsilon_i}{|\theta|} - level \rbrack ^2$
+
 
 During training, we store and optimize $p_i$'s in the logit form:
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -16,7 +16,7 @@ Here, $\mathcal{B}(p_i)$ is the Bernoulli distribution, $\epsilon_i$ may be inte
 
 
 
-$L_{sparse} = \mathbb{E}_{\epsilon \sum P_{\epsilon}} $
+$L_{sparse} = \mathbb{E}\_{\epsilon \sum P_{\epsilon}} $
 
 $L_{sparse} = \mathbb{E}$
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -10,8 +10,10 @@ $ \sum\_{i=0}{|\theta|} $
 
 $\sum_{n=1}^{\infty}$
 
+$\sum\limits_{i=0}^n f(x)$
 
-$||\theta||\_0   =   \lbrack \theta\_i = 0 \rbrack$
+
+$||\theta||\_0 =   \lbrack \theta\_i = 0 \rbrack$
 
 We then reparametrize the network's weights as follows:
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,7 +6,7 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$||\theta||_0 = \sum\_{i=0}^{|\theta|} \lbrack \theta\_i = 0 \rbrack$
+$||\theta||\_0 = \sum\_{i=0}^{|\theta|} \lbrack \theta\_i = 0 \rbrack$
 
 
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -18,9 +18,9 @@ Here, $\mathcal{B}(p_i)$ is the Bernoulli distribution, $\epsilon_i$ may be inte
 
 $L_{sparse} = \mathbb{E}\_{\epsilon \sim P_{\epsilon}} $
 
-$L_{sparse} = \mathbb{E}$
 
-$ \lbrack \frac{\sum_{i=0}^{|\theta|} \epsilon_i}{|\theta|} - level \rbrack ^2$
+
+$\lbrack \frac{\sum_{i=0}^{|\theta|} \epsilon_i}{|\theta|} - level \rbrack ^2$
 
 
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,11 +6,10 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$$
-
-
-
 $||\theta||\_0 = \sum\limits_{i=0}^{|\theta|} \lbrack \theta\_i = 0 \rbrack$
+
+
+
 
 We then reparametrize the network's weights as follows:
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,9 +6,9 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$||\theta||_0 = $
+$||\theta||_0 = \sum_{i=0}$
 
-\sum_{i=0}^{|\theta|} \lbrack \theta_i = 0 \rbrack$
+^{|\theta|} \lbrack \theta_i = 0 \rbrack$
 
 We then reparametrize the network's weights as follows:
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,9 +6,8 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$ \sum\_{i=0}{|\theta|} $
+$ \sum\limits_{i=0}^{|\theta|} $
 
-$\sum_{n=1}^{\infty}$
 
 $\sum\limits_{i=0}^n f(x)$
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -6,8 +6,10 @@ so that zero values are randomly distributed inside the tensor. Most of the spar
 
 This section describes the Regularization-Based Sparsity (RB-Sparsity) algorithm implemented in this framework. The method is based on $L_0$-regularization, with which parameters of the model tend to zero:
 
-$ \sum\limits\_{i=0}^{|\theta|} $
+$ \sum\limits\_{i=0}^{x+1} $
 
+
+|\theta|
 
 $\sum\limits_{i=0}^n f(x)$
 


### PR DESCRIPTION
### Changes
mathematical equations in "compression_algorithms" have been changed from png to text, using LaTex formatting, which is rendered by GitHub natively and can be processed by Sphinx using Mathjax.

### Reason for changes
images are not visible in darkmode and are not searchable

### Related tickets
81822