### PR TITLE
Fix third-party sanity tests

### DIFF
--- a/tests/torch/test_sanity_third_party.py
+++ b/tests/torch/test_sanity_third_party.py
@@ -99,9 +99,9 @@ class TestTransformers:
             pip_runner.run_pip(f"install -r examples/pytorch/{sample_folder}/requirements.txt",
                                cwd=self.TRANSFORMERS_REPO_PATH)
         pip_runner.run_pip("install boto3", cwd=self.TRANSFORMERS_REPO_PATH)
-        subprocess.run(
-            "{} && {} setup.py develop".format(self.VENV_ACTIVATE, self.PYTHON_EXECUTABLE), check=True,
-            shell=True, cwd=PROJECT_ROOT)
+        # WA for deleted CONLL2003 in datasets==1.11.0 (https://github.com/huggingface/datasets/issues/3582)
+        pip_runner.run_pip("install -U datasets", cwd=self.TRANSFORMERS_REPO_PATH)
+        pip_runner.run_pip("install -e .", cwd=PROJECT_ROOT)
 
     @pytest.mark.dependency(depends=['install_trans'], name='xnli_train')
     def test_xnli_train(self, temp_folder):


### PR DESCRIPTION
### Changes

Updated datasets dependency to solve some bugs in transformers' code.
Also use `pip install -e .` to install editable nncf. 

### Reason for changes

CI uses python3.7 that is fine with invoking setup.py for installing nncf. But for python3.8 it pulls some incompatible package versions (numpy, scipy) and tests fail.
A recommendation from [spec](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#working-in-development-mode)
 `pip install -e .`  solves the issue.

Also, there were 3 tests failing:
`test_ner_train` failed with
```python
FileNotFoundError: Couldn't find file at https://github.com/davidsbatista/NER-datasets/raw/master/CONLL2003/train.txt
```
The link to the file was corrected in the new version of datasets: 
https://github.com/davidsbatista/NER-datasets/issues/8

`test_convert_to_onnx` and `test_squad_eval` failed with 
```
E             File "/tmp/pytest-of-sys_icvadas/pytest-0/repo/transformers/src/transformers/trainer_pt_utils.py", line 61, in torch_pad_and_concatenate
E               if len(tensor1.shape) == 1 or tensor1.shape[1] == tensor2.shape[1]:
E           IndexError: tuple index out of range
```
The issue disappear with new version of datasets.

### Related tickets

89154

### Tests

run torch/test_third_party_sanity.py locally