### PR TITLE
Add output_port_id, input_port_id to the NNCFGraph visualization

### DIFF
--- a/nncf/common/graph/graph.py
+++ b/nncf/common/graph/graph.py
@@ -568,7 +568,9 @@ class NNCFGraph:
                 style = 'dashed'
             else:
                 style = 'solid'
-            out_graph.add_edge(u, v, label=edge[NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR], style=style)
+            edge_label = f"{edge[NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR]} \\n" \
+                         f"{edge[NNCFGraph.OUTPUT_PORT_ID_EDGE_ATTR]} -> {edge[NNCFGraph.INPUT_PORT_ID_EDGE_ATTR]}"
+            out_graph.add_edge(u, v, label=edge_label, style=style)
 
         mapping = {k: v['label'] for k, v in out_graph.nodes.items()}
         out_graph = nx.relabel_nodes(out_graph, mapping)


### PR DESCRIPTION
### Changes

Add output_port_id, input_port_id to the NNCFGraph visualization.


![image](https://user-images.githubusercontent.com/32935044/190202443-65054197-c0a6-439e-861a-1bad23d51d7c.png)



### Reason for changes

To be able to see the ports connection between nodes in the graph visualization. To speed up graph debugging.

### Related tickets

The request from the comments in PR #1263 

### Tests

No tests
