### PR TITLE
Add basic config examples

### DIFF
--- a/docs/ConfigFile.md
+++ b/docs/ConfigFile.md
@@ -3,8 +3,9 @@
 The Neural Network Compression Framework (NNCF) is designed to work with the configuration file where the parameters of compression that should be applied to the model are specified. 
 These parameters are organized as a dictionary and stored in a JSON file that is deserialized when the training starts. 
 The JSON file allows using comments that are supported by the [jstyleson](https://github.com/linjackson78/jstyleson) Python package.
+The NNCF config .json file is validated against a JSON schema - you can review the latest version of the schema at FIXME.
 
-Below is an example of the NNCF configuration file
+Below is an example of the NNCF configuration file:
 
 ```
 {
@@ -72,6 +73,8 @@ See [Algorithms.md](./Algorithms.md) for a list of supported algorithms and thei
 To specify multiple compression algorithm at once, the "compression" section should hold an array (list) of dictionaries each corresponding to a single compression algorithm.
 
 **IMPORTANT:** The `"ignored_scopes"` and `"target_scopes"` sections use a special string format (see "Operation addressing and scope" in [NNCFArchitecture.md](./NNCFArchitecture.md)) to specify the parts of the model that the compression should be applied to. For all such section, regular expression matching can be enabled by prefixing the string with `{re}`, which helps to specify the same compression pattern concisely for networks with multiple same-structured blocks such as ResNet or BERT.
+
+
 
 The [example scripts](../examples) use the same configuration file structure to specify compression, but extend it at the root level to specify the training pipeline hyperparameters as well.
 These extensions are training pipeline-specific rather than NNCF-specific and their format differs across the example scripts.

--- a/docs/ConfigFile.md
+++ b/docs/ConfigFile.md
@@ -3,7 +3,7 @@
 The Neural Network Compression Framework (NNCF) is designed to work with the configuration file where the parameters of compression that should be applied to the model are specified. 
 These parameters are organized as a dictionary and stored in a JSON file that is deserialized when the training starts. 
 The JSON file allows using comments that are supported by the [jstyleson](https://github.com/linjackson78/jstyleson) Python package.
-The NNCF config .json file is validated against a JSON schema - you can review the latest version of the schema at FIXME.
+The NNCF config .json file is validated against a JSON schema - you can review the latest version of the schema at https://openvinotoolkit.github.io/nncf/.
 
 Below is an example of the NNCF configuration file:
 

--- a/docs/ConfigFile.md
+++ b/docs/ConfigFile.md
@@ -22,10 +22,10 @@ Below is an example of the NNCF configuration file:
                         "type": "long",
                         "filler": "ones",
                         "keyword": "another_input"
-                    },
+                    }
 
                 },
-            ],
+            ]
         },
         "target_device": "VPU", // The target device, the specificity of which will be taken into account while compressing in order to obtain the best performance for this type of device. The default "ANY" means compatible quantization supported by any HW. The parameter takes values from the set ('CPU', 'GPU', 'VPU', 'ANY', 'TRIAL'). Set this value to 'TRIAL' if you are going to use a custom quantization schema.. Optional.
         "compression": [ // One or more definitions for the compression algorithms to be applied to the model; either a single JSON object or an array of JSON objects. See README for each compression algorithm for a description of the available config parameters.

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -270,34 +270,9 @@ from nncf.common.accuracy_aware_training import create_accuracy_aware_training_l
 training_loop = create_accuracy_aware_training_loop(nncf_config, compression_ctrl)
 ```
 
-In order to properly instantiate the accuracy-aware training loop, the user has to specify the 'accuracy_aware_training' section. This section fully depends on what Accuracy-Aware Training loop is being used. For more details about config of Adaptive Compression Level Training refer to [Adaptive Compression Level Training documentation](./accuracy_aware_model_training/AdaptiveCompressionTraining.md) and Early Exit Training refer to [Early Exit Training documentation](./accuracy_aware_model_training/EarlyExitTraining.md).
-
-```
-{
-    "accuracy_aware_training": {
-        "mode": "adaptive_compression_level",
-        "params": {
-            "maximal_relative_accuracy_degradation": 1.0,
-            "initial_training_phase_epochs": 100,
-            "patience_epochs": 30
-        }
-    },
-    "compression": [
-        {
-            "algorithm": "filter_pruning",
-    
-            "pruning_init": 0.05,
-            "params": {
-                "schedule": "exponential",
-                "pruning_target": 0.1,
-                "pruning_steps": 50,
-                "weight_importance": "geometric_median"
-            }
-        }
-    ]
-}
-
-```
+In order to properly instantiate the accuracy-aware training loop, the user has to specify the 'accuracy_aware_training' section. 
+This section fully depends on what Accuracy-Aware Training loop is being used. 
+For more details about config of Adaptive Compression Level Training refer to [Adaptive Compression Level Training documentation](./accuracy_aware_model_training/AdaptiveCompressionTraining.md) and Early Exit Training refer to [Early Exit Training documentation](./accuracy_aware_model_training/EarlyExitTraining.md).
 
 The training loop is launched by calling its `run` method. Before the start of the training loop, the user is expected to define several functions related to the training of the model and pass them as arguments to the `run` method of the training loop instance:
 

--- a/docs/accuracy_aware_model_training/AdaptiveCompressionLevelTraining.md
+++ b/docs/accuracy_aware_model_training/AdaptiveCompressionLevelTraining.md
@@ -14,9 +14,13 @@ The exact compression algorithm for which the compression level search will be a
 7) `maximal_total_epochs` (Optional; default=1e4) - The number of training epochs, if the fine-tuning epoch reaches this number, the loop finishes the fine-tuning and return the model with thi highest compression rate and the least accuracy drop.
 
 
-To launch the adaptive compression training loop, the user should define several functions related to model training, validation and optimizer creation (see [the usage documentation](../Usage.md#accuracy-aware-model-training) for more details) and pass them to the run method of an `AdaptiveCompressionTrainingLoop` instance. The training loop logic inside of the `AdaptiveCompressionTrainingLoop` is framework-agnostic, while all of the framework specifics are encapsulated inside of corresponding `Runner` objects, which are created and called inside the training loop. The adaptive compression training loop is generally aimed at automatically searching for the optimal compression rate in the model, with the parameters of the search algorithm specified in the configuration file. Below is an example of a filter pruning configuration with added `"accuracy_aware_training"` parameters.
-```
+To launch the adaptive compression training loop, the user should define several functions related to model training, validation and optimizer creation (see [the usage documentation](../Usage.md#accuracy-aware-model-training) for more details) and pass them to the run method of an `AdaptiveCompressionTrainingLoop` instance.
+The training loop logic inside of the `AdaptiveCompressionTrainingLoop` is framework-agnostic, while all of the framework specifics are encapsulated inside of corresponding `Runner` objects, which are created and called inside the training loop.
+The adaptive compression training loop is generally aimed at automatically searching for the optimal compression rate in the model, with the parameters of the search algorithm specified in the configuration file.
+Below is an example of a filter pruning configuration with added `"accuracy_aware_training"` parameters.
+```json5
 {
+    "input_infos": {"sample_size": [1, 2, 224, 224]},
     "accuracy_aware_training": {
         "mode": "adaptive_compression_level",
         "params": {

--- a/docs/accuracy_aware_model_training/EarlyExitTraining.md
+++ b/docs/accuracy_aware_model_training/EarlyExitTraining.md
@@ -9,10 +9,11 @@ This training loop supports any combination of NNCF compression algorithms.
 
 There are only two main parameters of Early-Exit training loop: `maximal_relative_accuracy_degradation` or `maximal_absolute_accuracy_degradation` - relative/absolute accuracy drop in percentage/in original metric with original, uncompressed model less than that is user tolerant. And `maximal_total_epochs` - number of training epochs, if the fine-tuning epoch reaches this number, the loop finishes the fine-tuning and returns the model with the least accuracy drop.
 
-There is an example of config file needed to be provided to create_accuracy_aware_training_loop (see [the usage documentation](../Usage.md#accuracy-aware-model-training) for more details).
+Example of config file needed to be provided to create_accuracy_aware_training_loop (see [the usage documentation](../Usage.md#accuracy-aware-model-training) for more details).
 
-```
+```json5
 {
+    "input_infos": {"sample_size": [1, 2, 224, 224]},
     "accuracy_aware_training": {
         "mode": "early_exit",
         "params": {

--- a/docs/accuracy_aware_model_training/EarlyExitTraining.md
+++ b/docs/accuracy_aware_model_training/EarlyExitTraining.md
@@ -18,7 +18,7 @@ Example of config file needed to be provided to create_accuracy_aware_training_l
         "mode": "early_exit",
         "params": {
             "maximal_relative_accuracy_degradation": 1.0,
-            "maximal_total_expochs": 100,
+            "maximal_total_expochs": 100
         }
     },
     "compression": [

--- a/docs/compression_algorithms/BatchnormAdaptation.md
+++ b/docs/compression_algorithms/BatchnormAdaptation.md
@@ -3,7 +3,7 @@
 After the compression-related changes in the model have been committed, the statistics of the batchnorm layers (per-channel rolling means and variances of activation tensors) can be updated by passing several batches of data through the model before the fine-tuning starts. 
 This allows to correct the compression-induced bias in the model and reduce the corresponding accuracy drop even before model training. 
 This option is common for quantization, magnitude sparsity and filter pruning algorithms. 
-It can be enabled by setting a non-zero value of `num_bn_adaptation_samples` in the `batchnorm_adaptation` section of the `initializer` configuration - see [NNCF config schema](FIXME) for reference.
+It can be enabled by setting a non-zero value of `num_bn_adaptation_samples` in the `batchnorm_adaptation` section of the `initializer` configuration - see [NNCF config schema](https://openvinotoolkit.github.io/nncf/) for reference.
 
 Note that in order to use batchnorm adaptation for your model, you must supply to NNCF a data loader using a `register_default_init_args` helper function or by registering a `nncf.config.structures.BNAdaptationInitArgs` structure within the `NNCFConfig` object in your integration code.
 

--- a/docs/compression_algorithms/BatchnormAdaptation.md
+++ b/docs/compression_algorithms/BatchnormAdaptation.md
@@ -21,7 +21,7 @@ Note that in order to use batchnorm adaptation for your model, you must supply t
             "batchnorm_adaptation": {
                 "num_bn_adaptation_samples": 2048
             }
-        },
+        }
     }
 }
 ```

--- a/docs/compression_algorithms/BatchnormAdaptation.md
+++ b/docs/compression_algorithms/BatchnormAdaptation.md
@@ -1,4 +1,4 @@
-#### Batch-norm statistics adaptation
+### Batch-norm statistics adaptation
 
 After the compression-related changes in the model have been committed, the statistics of the batchnorm layers (per-channel rolling means and variances of activation tensors) can be updated by passing several batches of data through the model before the fine-tuning starts. 
 This allows to correct the compression-induced bias in the model and reduce the corresponding accuracy drop even before model training. 
@@ -7,3 +7,40 @@ It can be enabled by setting a non-zero value of `num_bn_adaptation_samples` in 
 
 Note that in order to use batchnorm adaptation for your model, you must supply to NNCF a data loader using a `register_default_init_args` helper function or by registering a `nncf.config.structures.BNAdaptationInitArgs` structure within the `NNCFConfig` object in your integration code.
 
+### Example configuration files
+
+>_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](https://openvinotoolkit.github.io/nncf/)_.
+
+- Apply batchnorm adaptation for 2048 samples (rounded to nearest batch size multiple) during model quantization:
+```json5
+{
+    "input_info": {"sample_size" :  [1, 3, 224, 224]},  // the input shape of your model may vary
+   "compression": {
+        "algorithm": "quantization",
+        "initializer": {
+            "batchnorm_adaptation": {
+                "num_bn_adaptation_samples": 2048
+            }
+        },
+    }
+}
+```
+
+- Apply batchnorm adaptation for 32 samples (rounded to nearest batch size multiple) during model magnitude-based sparsification:
+```json5
+{
+    "input_info": {"sample_size" :  [1, 3, 224, 224]},  // the input shape of your model may vary
+   "compression": {
+        "algorithm": "magnitude_sparsity",
+        "initializer": {
+            "batchnorm_adaptation": {
+                "num_bn_adaptation_samples": 32
+            }
+        },
+       "params": {
+           "sparsity_target": 0.5,
+           "sparsity_target_epoch": 10
+       }
+    }
+}
+```

--- a/docs/compression_algorithms/BatchnormAdaptation.md
+++ b/docs/compression_algorithms/BatchnormAdaptation.md
@@ -1,0 +1,9 @@
+#### Batch-norm statistics adaptation
+
+After the compression-related changes in the model have been committed, the statistics of the batchnorm layers (per-channel rolling means and variances of activation tensors) can be updated by passing several batches of data through the model before the fine-tuning starts. 
+This allows to correct the compression-induced bias in the model and reduce the corresponding accuracy drop even before model training. 
+This option is common for quantization, magnitude sparsity and filter pruning algorithms. 
+It can be enabled by setting a non-zero value of `num_bn_adaptation_samples` in the `batchnorm_adaptation` section of the `initializer` configuration - see [NNCF config schema](FIXME) for reference.
+
+Note that in order to use batchnorm adaptation for your model, you must supply to NNCF a data loader using a `register_default_init_args` helper function or by registering a `nncf.config.structures.BNAdaptationInitArgs` structure within the `NNCFConfig` object in your integration code.
+

--- a/docs/compression_algorithms/Binarization.md
+++ b/docs/compression_algorithms/Binarization.md
@@ -17,7 +17,7 @@ In the formula above,
 Training binarized networks requires special scheduling of the training process. For instance, binarizing a pretrained ResNet18 model on ImageNet is a four-stage process, with each stage taking a certain number of epochs. During the stage 1, the network is trained without any binarization. During the stage 2, the training continues with binarization enabled for activations only. During the stage 3, binarization is enabled both for activations and weights. Finally, during the stage 4 the optimizer learning rate, which was kept constant at previous stages, is decreased according to a polynomial law, while weight decay parameter of the optimizer is set to 0. The configuration files for the NNCF binarization algorithm allow to control certain parameters of this training schedule.
 
 
-**Example configuration files**:
+### Example configuration files:
 
 >_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](https://openvinotoolkit.github.io/nncf/)_.
 

--- a/docs/compression_algorithms/Binarization.md
+++ b/docs/compression_algorithms/Binarization.md
@@ -19,7 +19,7 @@ Training binarized networks requires special scheduling of the training process.
 
 **Example configuration files**:
 
->_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](FIXME)_.
+>_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](https://openvinotoolkit.github.io/nncf/)_.
 
 - Binarize a ResNet using XNOR algorithm, ignoring several portions of the model, with finetuning on the scope of 60 epochs and staged binarization schedule (activations first, then weights)
 ```json5

--- a/docs/compression_algorithms/Binarization.md
+++ b/docs/compression_algorithms/Binarization.md
@@ -41,7 +41,7 @@ Training binarized networks requires special scheduling of the training process.
                            "ResNet/Conv2d[conv1]",
                            "ResNet/Sequential[layer2]/BasicBlock[0]/Sequential[downsample]",
                            "ResNet/Sequential[layer3]/BasicBlock[0]/Sequential[downsample]",
-                           "ResNet/Sequential[layer4]/BasicBlock[0]/Sequential[downsample]"],
+                           "ResNet/Sequential[layer4]/BasicBlock[0]/Sequential[downsample]"]
     }
 }
 ```

--- a/docs/compression_algorithms/Binarization.md
+++ b/docs/compression_algorithms/Binarization.md
@@ -1,3 +1,4 @@
+>_Scroll down for the examples of the JSON configuration files that can be used to apply this algorithm_.
 ### Binarization
 NNCF supports binarizing weights and activations for 2D convolutional PyTorch\* layers (Conv2D) *only*.
 
@@ -16,30 +17,31 @@ In the formula above,
 Training binarized networks requires special scheduling of the training process. For instance, binarizing a pretrained ResNet18 model on ImageNet is a four-stage process, with each stage taking a certain number of epochs. During the stage 1, the network is trained without any binarization. During the stage 2, the training continues with binarization enabled for activations only. During the stage 3, binarization is enabled both for activations and weights. Finally, during the stage 4 the optimizer learning rate, which was kept constant at previous stages, is decreased according to a polynomial law, while weight decay parameter of the optimizer is set to 0. The configuration files for the NNCF binarization algorithm allow to control certain parameters of this training schedule.
 
 
-**Algorithm configuration file parameters**:
+**Example configuration files**:
 
-```
+>_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](FIXME)_.
+
+- Binarize a ResNet using XNOR algorithm, ignoring several portions of the model, with finetuning on the scope of 60 epochs and staged binarization schedule (activations first, then weights)
+```json5
 {
-    "algorithm": "binarization",
-    "mode": "xnor", // Selects the mode of binarization - either 'xnor' for XNOR binarization, or 'dorefa' for DoReFa binarization
-    "params": {
-        "batch_multiplier": 1,  // Gradients will be accumulated for this number of batches before doing a 'backward' call
-        "activations_quant_start_epoch": 10,  // Epoch to start binarizing activations
-        "weights_quant_start_epoch": 30,  // Epoch to start binarizing weights
-        "lr_poly_drop_start_epoch": 60,  // Epoch to start dropping the learning rate
-        "lr_poly_drop_duration_epochs": 30,  // Duration, in epochs, of the learning rate dropping process.
-        "disable_wd_start_epoch": 60  // Epoch to disable weight decay in the optimizer
-    },
-
-    //A list of model control flow graph node scopes to be ignored for this operation - functions as a 'denylist'. Optional.
-    "ignored_scopes": ["ResNet/Linear[fc]",
-                       "ResNet/Conv2d[conv1]",
-                       "ResNet/Sequential[layer2]/BasicBlock[0]/Sequential[downsample]",
-                       "ResNet/Sequential[layer3]/BasicBlock[0]/Sequential[downsample]",
-                       "ResNet/Sequential[layer4]/BasicBlock[0]/Sequential[downsample]"],
-
-    // A list of model control flow graph node scopes to be considered for this operation - functions as a 'allowlist'. Optional.
-    // "target_scopes": [],
+    "input_info": { "sample_size": [1, 3, 224, 224] },
+    "compression":
+    {
+        "algorithm": "binarization",
+        "mode": "xnor",
+        "params": {
+            "activations_quant_start_epoch": 10,  // Epoch to start binarizing activations
+            "weights_quant_start_epoch": 30,  // Epoch to start binarizing weights
+            "lr_poly_drop_start_epoch": 60,  // Epoch to start dropping the learning rate
+            "lr_poly_drop_duration_epochs": 30,  // Duration, in epochs, of the learning rate dropping process.
+            "disable_wd_start_epoch": 60  // Epoch to disable weight decay in the optimizer
+        },
+    
+        "ignored_scopes": ["ResNet/Linear[fc]",
+                           "ResNet/Conv2d[conv1]",
+                           "ResNet/Sequential[layer2]/BasicBlock[0]/Sequential[downsample]",
+                           "ResNet/Sequential[layer3]/BasicBlock[0]/Sequential[downsample]",
+                           "ResNet/Sequential[layer4]/BasicBlock[0]/Sequential[downsample]"],
+    }
 }
-
 ```

--- a/docs/compression_algorithms/KnowledgeDistillation.md
+++ b/docs/compression_algorithms/KnowledgeDistillation.md
@@ -52,7 +52,7 @@ specify `knowledge_distillation` algorithm and its type in the config:
     ]
 }
 ```
-See this [config file](../../examples/torch/classification/configs/pruning/resnet34_pruning_geometric_median_kd.json) for an example, and [NNCF config schema](FIXME) for reference to the available configuration parameters for the algorithm.
+See this [config file](../../examples/torch/classification/configs/pruning/resnet34_pruning_geometric_median_kd.json) for an example, and [NNCF config schema](https://openvinotoolkit.github.io/nncf/) for reference to the available configuration parameters for the algorithm.
 
 ##### Limitations
 

--- a/docs/compression_algorithms/KnowledgeDistillation.md
+++ b/docs/compression_algorithms/KnowledgeDistillation.md
@@ -52,15 +52,14 @@ specify `knowledge_distillation` algorithm and its type in the config:
     ]
 }
 ```
-Example of a config: [example](../../examples/torch/classification/configs/pruning/resnet34_pruning_geometric_median_kd.json)
+See this [config file](../../examples/torch/classification/configs/pruning/resnet34_pruning_geometric_median_kd.json) for an example, and [NNCF config schema](FIXME) for reference to the available configuration parameters for the algorithm.
 
 ##### Limitations
 
 - The algorithm is supported for PyTorch only.
-
 - Training the same configuration with Knowledge Distillation requires more time and GPU memory than without it. 
-  On average, memory (for all GPU execution modes) and time overhead is below 20% each.
-
+On average, memory (for all GPU execution modes) and time overhead is below 20% each.
 - Outputs of model that shouldn't be differentiated must have `requires_grad=False`.
-
 - Model should output predictions, not calculate the losses.
+
+

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -1,6 +1,5 @@
-### Pruning
-
-#### Filter pruning
+>_Scroll down for the examples of the JSON configuration files that can be used to apply this algorithm_.
+### Filter pruning
 
 Filter pruning algorithm zeros output filters in Convolutional layers based on some filter importance criterion  (filters with smaller importance are pruned).
 The framework contains three filter importance criteria: `L1`, `L2` norm, and `Geometric Median`. Also, different schemes of pruning application are presented by different schedulers.
@@ -77,45 +76,6 @@ Interlayer ranking type can be one of `unweighted_ranking` or `learned_ranking`.
 The $(a_i, b_i)$ pair of scalars will be learned for each ( $i$ layer and used to transform norms of $i$-th layer filters before sorting all filter norms together as $a_i * N_i + b_i$ , where $N_i$ - is vector of filter norma of $i$-th layer, $(a_i, b_i)$ is ranking coefficients for $i$-th layer.
 This approach allows pruning the model taking into account layer-specific sensitivity to weight perturbations and get pruned models with higher accuracy.
 
-#### Filter pruning configuration file parameters
-```
-{
-    "algorithm": "filter_pruning",
-    "initializer": {
-        "batchnorm_adaptation": {
-            "num_bn_adaptation_samples": 2048, // Number of samples from the training dataset to pass through the model at initialization in order to update batchnorm statistics of the original model. The actual number of samples will be a closest multiple of the batch size.
-        }
-    },
-    "pruning_init": 0.1, // Initial value of the pruning level applied to the convolutions that can be pruned in 'create_compressed_model' function. 0.0 by default.
-    "params": {
-        "schedule": "exponential", // The type of scheduling to use for adjusting the target pruning level. Either `exponential`, `exponential_with_bias`,  or `baseline`, by default it is `exponential`"
-        "pruning_target": 0.4, // Target value of the pruning level for the convolutions that can be pruned. These convolutions are determined by the model architecture. 0.5 by default.
-        "pruning_flops_target": 0.4, // Target value of the pruning level by FLOPs in the whole model. Only one parameter from `pruning_target` and `pruning_flops_target` can be set. If none of them is specified, `pruning_target` = 0.5 is used as the default value. 
-        "num_init_steps": 3, // Number of epochs for model pretraining before starting filter pruning. 0 by default.
-        "pruning_steps": 10, // Number of epochs during which the pruning level is increased from `pruning_init` to `pruning_target` value.
-        "filter_importance": "L2", // The type of filter importance metric. Can be one of `L1`, `L2`, `geometric_median`. `L2` by default.
-        "interlayer_ranking_type": "unweighted_ranking", // The type of filter ranking across the layers. Can be one of `unweighted_ranking`, `learned_ranking`. `unweighted_ranking` by default.
-        "all_weights": false, // Whether to prune layers independently (choose filters with the smallest importance in each layer separately) or not. `False` by default.
-        "prune_first_conv": false, // Whether to prune first Convolutional layers or not. First means that it is a convolutional layer such that there is a path from model input to this layer such that there are no other convolution operations on it. `False` by default (`True` by default in case of 'learned_ranking' interlayer_ranking_type).
-        "prune_downsample_convs": false, // Whether to prune downsample Convolutional layers (with stride > 1) or not. `False` by default (`True` by default in case of 'learned_ranking' interlayer_ranking_type).
-        "prune_batch_norms": true, // Whether to nullifies parameters of Batch Norm layer corresponds to zeroed filters of convolution corresponding to this Batch Norm. `True` by default.
-        "save_ranking_coeffs_path": "path/coeffs.json", // Path to save .json file with interlayer ranking coefficients.
-        "load_ranking_coeffs_path": "PATH/learned_coeffs.json", // Path to loading interlayer ranking coefficients .json file, pretrained earlier.
-        "legr_params": { // Set of parameters, that can be set for 'learned_ranking' interlayer_ranking_type case
-            "generations": 200, //  Number of generations for evolution algorithm optimizing. 400 by default
-            "train_steps": 150, // Number of training steps to estimate pruned model accuracy. 200 by default 
-            "max_pruning": 0.6, // Pruning level for the model to train LeGR algorithm on it. If learned ranking will be used for multiple pruning levels, the highest should be used as `max_pruning`. If model will be pruned with one pruning level, target pruning level should be used.
-            "random_seed": 42, // Random seed for ranking coefficients generation during optimization 
-        },
-    },
-
-    // A list of model control flow graph node scopes to be ignored for this operation - functions as a 'denylist'. Optional.
-    "ignored_scopes": []
-
-    // A list of model control flow graph node scopes to be considered for this operation - functions as a 'allowlist'. Optional.
-    // "target_scopes": []
-}
-```
 
 > **NOTE:**  In all our pruning experiments we used SGD optimizer.
 
@@ -203,3 +163,71 @@ it does not take into account the number of filters in layers that cannot be pru
 It is important to note that pruning levels mentioned in the `statistics of the filter pruning algorithm` are the goals the algorithm aims to achieve.
 It is not always possible to achieve these levels of pruning due to cross-layer and inference constraints. 
 Therefore, it is expected that these numbers may differ from the calculated statistics in the `statistics of the pruned model` section.
+
+**Example configuration files**
+
+>_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](FIXME)_.
+
+- Prune a model with default parameters (from 0 to 0.5 pruning level across 100 epochs with exponential schedule)
+```json5
+{
+    "input_info": { "sample_size": [1, 3, 224, 224] },
+    "compression":
+    {
+        "algorithm": "filter_pruning",
+    }
+}
+```
+
+- Prune a model, immediately setting pruning level to 10%, applying [batchnorm adaptation](./BatchnormAdaptation.md) and reaching 60% within 20 epochs using exponential schedule, enabling pruning of first convolutional layers and downsampling convolutional layers:
+```json5
+{
+    "input_info": { "sample_size": [1, 3, 224, 224] },
+    "compression":
+    {
+        "algorithm": "filter_pruning",
+        "pruning_init": 0.1,
+        "params": {
+            "pruning_target": 0.6,
+            "pruning_steps": 20,
+            "schedule": "exponential",
+            "prune_first_conv": true,
+            "prune_downsample_convs": true,
+        }
+    }
+}
+```
+
+- Prune a model using geometric median filter importance and reaching 30% within 10 epochs using exponential schedule, postponing application of pruning for 10 epochs:
+```json5
+{
+    "input_info": { "sample_size": [1, 3, 224, 224] },
+    "compression":
+    {
+        "algorithm": "filter_pruning",
+        "params": {
+            "filter_importance": "geometric_median",
+            "pruning_target": 0.3,
+            "pruning_steps": 10,
+            "schedule": "exponential",
+            "num_init_steps": 10
+        }
+    }
+}
+```
+
+- Prune and quantize a model at the same time using default parameters:
+```json5
+{
+    "input_info": { "sample_size": [1, 3, 224, 224] },
+    "compression":
+    [
+        {
+            "algorithm": "filter_pruning",
+        },
+        {
+            "algorithm": "quantization",
+        }
+    ]
+}
+```

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -204,7 +204,7 @@ Therefore, it is expected that these numbers may differ from the calculated stat
             "pruning_steps": 20,
             "schedule": "exponential",
             "prune_first_conv": true,
-            "prune_downsample_convs": true,
+            "prune_downsample_convs": true
         }
     }
 }
@@ -237,7 +237,7 @@ Therefore, it is expected that these numbers may differ from the calculated stat
         {
             "algorithm": "filter_pruning",
             "params": {
-                "pruning_flops_target": 0.6,
+                "pruning_flops_target": 0.6
             }
         },
         {

--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -166,7 +166,7 @@ Therefore, it is expected that these numbers may differ from the calculated stat
 
 **Example configuration files**
 
->_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](FIXME)_.
+>_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](https://openvinotoolkit.github.io/nncf/)_.
 
 - Prune a model with default parameters (from 0 to 0.5 pruning level across 100 epochs with exponential schedule)
 ```json5

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -235,7 +235,7 @@ For automatic mixed-precision selection it's recommended to use the following te
             "precision": {
                 "type": "hawq",
                 "bits": [4,8]
-                "compression_ratio": 1.5,
+                "compression_ratio": 1.5
             }
         }
     }
@@ -320,7 +320,7 @@ Following is an example of wrapping ImageNet validation loop as a callback. Top5
 {
     "input_info": { "sample_size": [1, 3, 224, 224] }, // the input shape of your model may vary
     "compression": {
-       "algorithm": "quantization",
+       "algorithm": "quantization"
     }
 }
 ```
@@ -332,7 +332,7 @@ Following is an example of wrapping ImageNet validation loop as a callback. Top5
     "compression": {
        "algorithm": "quantization",
        "weights": {"mode": "symmetric"},
-       "activations": {"mode": "asymmetric"},
+       "activations": {"mode": "asymmetric"}
     },
    "target_device": "CPU"
 }
@@ -359,7 +359,7 @@ Following is an example of wrapping ImageNet validation loop as a callback. Top5
     "compression": {
        "algorithm": "quantization",
        "bits": 4,
-       "per_channel": true,
+       "per_channel": true
     },
     "target_device": "TRIAL"
 }
@@ -397,7 +397,7 @@ Following is an example of wrapping ImageNet validation loop as a callback. Top5
        "ignored_scopes": ["{re}BertSelfAttention\\[self\\]/__add___0",
             "RobertaForSequenceClassification/RobertaClassificationHead[classifier]/Linear[out_proj]",
             "RobertaForSequenceClassification/RobertaClassificationHead[classifier]/Linear[dense]"
-        ],
+        ]
     },
     "target_device": "TRIAL"
 }
@@ -413,9 +413,9 @@ Following is an example of wrapping ImageNet validation loop as a callback. Top5
                "type": "autoq", // or "type": "hawq"
                "bits": [2, 4, 8],
                "compression_ratio": 0.15,
-               "iter_number": 300,
-           },
-       },
+               "iter_number": 300
+           }
+       }
     },
     "target_device": "TRIAL"
 }

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -1,6 +1,6 @@
+>_Scroll down for the examples of the JSON configuration files that can be used to apply this algorithm_.
 
 ### Uniform Quantization with Fine-Tuning
-
 A uniform "fake" quantization method supports an arbitrary number of bits (>=2) which is used to represent weights and activations.
 The method performs differentiable sampling of the continuous signal (for example, activations or weights) during forward pass, simulating inference with integer arithmetic.
 
@@ -269,7 +269,7 @@ When the agent enters a state/quantizer, it receives the state features and forw
 
 To evaluate the goodness of a policy, NNCF backend quantizes the workload accordingly and performs evaluation with the user-registered function. The evaluated score, together with the state embedding, predicted action are appended to an experience vault to serve for DDPG learning. The learning is carried out by sampling the data point from the experience vault for supervised training of the DDPG network. This process typically happens at a fixed interval. In the current implementation, it is performed after each episode evaluation. For bootstrapping, exploration and diversity of experience, noise is added to action output. As the episodic iterations progress, the noise magnitude is gradually reduced to zero, a deterministic mixed-precision policy is converged at the end of the episodes. NNCF currently keeps track of the best policy and uses it for fine tuning.
 
-```
+```json5
     "target_device": "VPU",
     "compression": {
         "algorithm": "quantization",
@@ -310,116 +310,114 @@ Following is an example of wrapping ImageNet validation loop as a callback. Top5
             autoq_eval_fn, val_loader, config.device)
 ```
 
-#### Batch-norm statistics adaptation
 
-After the compression-related changes in the model have been committed, the statistics of the batchnorm layers
-(per-channel rolling means and variances of activation tensors) can be updated by passing several batches of data
-through the model before the fine-tuning starts. This allows to correct the compression-induced bias in the model
-and reduce the corresponding accuracy drop even before model training. This option is common for quantization, magnitude
-sparsity and filter pruning algorithms. It can be enabled by setting a non-zero value of `num_bn_adaptation_samples` in the
-`batchnorm_adaptation` section of the `initializer` configuration (see example below).
+**Example configuration files**:
 
+>_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](FIXME)_.
 
-**Quantization configuration file parameters**:
-```
+- Quantize a model using default algorithm settings (8-bit, quantizers configuration chosen to be compatible with all Intel target HW types):
+```json5
 {
-    "algorithm": "quantization",
-    "preset": "performance", // The preset defines the quantization schema for weights and activations. The parameter takes values 'performance' or 'mixed'. The mode 'performance' defines symmetric weights and activations. The mode 'mixed' defines symmetric 'weights' and asymmetric 'activations'. Any preset parameters can be overridden by sections 'weights' and 'activations'. Preset "performance" set by default for all target devices except "TRIAL".
-    "initializer": {
-        "range": {
-            "num_init_samples": 256, // Number of samples from the training dataset to consume as sample model inputs for purposes of setting initial minimum and maximum quantization ranges
-            "type": "min_max" // Type of the initializer - determines which statistics gathered during initialization will be used to initialize the quantization ranges. "mean_min_max" is used by default
-        },
-        "precision": {
-            "type": "hawq", // Type of precision initialization - either "manual" or "hawq". With "manual", precisions are defined explicitly via "bitwidth_per_scope". With "hawq", these are determined automatically using the HAWQ algorithm.
-            "bits": [4, 8], // A list of bitwidth to choose from when performing precision initialization. Overrides bitwidth constraints specified in `weight` and `activation` sections",
-            "num_data_points": 100, // Number of data points to iteratively estimate Hessian trace, 100 by default.
-            "iter_number": 200, // Maximum number of iterations of Hutchinson algorithm to estimate Hessian trace, 200 by default
-            "tolerance": 1e-4, //  Minimum relative tolerance for stopping the Hutchinson algorithm. It's calculated between mean average trace from previous iteration and current one. 1e-4 by default
-            "compression_ratio": 1.5, // The desired ratio between bits complexity of fully INT8 model and mixed-precision lower-bit one.
-            "bitwidth_per_scope": [ // Manual settings for the quantizer bitwidths. Scopes are used to identify the weight quantizers. The same number of bits is assigned to adjacent activation quantizers. By default bitwidth is taken from global quantization parameters from `weights` and `activations` sections above
-                [
-                    4,
-                    "InsertionType.NNCF_MODULE_PRE_OP MobileNetV2/Sequential[features]/InvertedResidual[16]/Sequential[conv]/NNCFConv2d[2]"
-                ], // A tuple of a bitwidth and a scope
-                [
-                    4,
-                    "TargetType.OPERATOR_POST_HOOK MobileNetV2/Sequential[features]/ConvBNReLU[0]/ReLU6[2]/hardtanh_0",
-                ]
-            ]
-        }
-        "batchnorm_adaptation": {
-            "num_bn_adaptation_samples": 2048, // Number of samples from the training dataset to pass through the model at initialization in order to update batchnorm statistics of the original model. The actual number of samples will be a closest multiple of the batch size.
-        }
+    "input_info": { "sample_size": [1, 3, 224, 224] }, // the input shape of your model may vary
+    "compression": {
+       "algorithm": "quantization",
     }
-    "weights": { // Constraints to be applied to model weights quantization only.
-        "mode": "symmetric", // Mode of quantization
-        "bits": 8, // Bitwidth to quantize to. It is intended to manually specify bitwidth for all weights. Can be overridden by the `bits` parameter from the `precision` initializer section. An error happens if it doesn't match a bitwidth constraints for module weight specified in the hardware configuration.
-        "signed": true, // Whether to use signed or unsigned input/output values for quantization. If specified as unsigned and the input values during initialization have differing signs, will reset to performing signed quantization instead.
-        "per_channel": false, // Whether to quantize inputs per channel (i.e. per 0-th dimension for weight quantization,and per 1-st dimension for activation quantization)
-
-        // A list of model control flow graph node scopes to be ignored for this operation - functions as a 'denylist'. Optional.
-        "ignored_scopes": []
-
-        // A list of model control flow graph node scopes to be considered for this operation - functions as a 'allowlist'. Optional.
-        // "target_scopes": []
-    },
-    "activations": { // Constraints to be applied to model activations quantization only.
-        "mode": "symmetric", // Mode of quantization
-        "bits": 4, // Bitwidth to quantize to. It is intended to manually specify bitwidth for all activations. Can be overridden by the `bits` parameter from the `precision` initializer section. An error happens if it doesn't match a bitwidth constraints for module inputs specified in the hardware configuration.
-        "signed": true, // Whether to use signed or unsigned input/output values for quantization. If specified as unsigned and the input values during initialization have differing signs, will reset to performing signed quantization instead.
-        "per_channel": false, // Whether to quantize inputs per channel (i.e. per 0-th dimension for weight quantization,and per 1-st dimension for activation quantization)
-
-        // A list of model control flow graph node scopes to be ignored for this operation - functions as a 'denylist'. Optional.
-        "ignored_scopes": []
-
-        // A list of model control flow graph node scopes to be considered for this operation - functions as a 'allowlist'. Optional.
-        // "target_scopes": []
-
-        // Specifies points in the model which will share the same quantizer module for activations. This is helpful in case one and the same quantizer scale is required for inputs to the same operation. Each sub-array will define a group of activation quantizer insertion points that have to share a single actual quantization module, each entry in this subarray should correspond to exactly one node in the NNCF graph and the groups should not overlap. The finalquantizer for each sub-array will be associated with the first element of this sub-array.
-        "linked_quantizer_scopes": []
-    },
-    "quantize_inputs": true, // Whether the model inputs should be immediately quantized prior to any other model operations."
-    "scope_overrides": { // This option is used to specify overriding quantization constraints for specific scope, e.g. in case you need to quantize a single operation differently than the rest of the model.
-    	"activations": {
-		"{re}.*InvertedResidual.*": {
-		    "mode": "symmetric", // Mode of quantization
-		    "bits": 4, // Bitwidth to quantize to.
-		    "signed": true, // Whether to use signed or unsigned input/output values for quantization. If specified as unsigned and the input values during initialization have differing signs, will reset to performing signed quantization instead.
-		    "per_channel": false // Whether to quantize inputs per channel (i.e. per 0-th dimension for weight quantization,and per 1-st dimension for activation quantization)
-		}
-	}
-    },
-
-    // A list of model control flow graph node scopes to be ignored for this operation - functions as a 'denylist'. Optional.
-    "ignored_scopes": [],
-
-    // A list of model control flow graph node scopes to be considered for this operation - functions as a 'allowlist'. Optional.
-    // "target_scopes": [],
-
-    // Determines how should the additional quantization operations be exported into the ONNX format. Set this to false for export to OpenVINO-supported FakeQuantize ONNX, or to true for export to ONNX standard QuantizeLinear-DequantizeLinear node pairs (8-bit quantization only in the latter case). Default: false
-    "export_to_onnx_standard_ops": false,
 }
 ```
 
-***Per layer ranges initializations parameters***:
-Per layer ranges initiaization can be enabled by specifying  in `"initializer"` section `"range"` as list of dictionaries in the following format:
-
-```
+- Quantize a model to 8-bit precision targeted for Intel CPUs, with additional constraints of symmetric weight quantization and asymmetric activation quantization:
+```json5
 {
-    "range": [
-        {
-            "type": "min_max", // Type of the initializer - determines which statistics gathered during initialization will be used to initialize the quantization ranges for all modules specified by `"target_scopes"` or `"ignored_scopes"`.
-
-            "num_init_samples": 256, // Number of samples from the training dataset to consume as sample model inputs for purposes of setting initial minimum and maximum quantization ranges
-
-            "target_scopes": [], // A list of model control flow graph node scopes to be considered for this operation - functions as a 'allowlist'. Optional.
-            "ignored_scopes": [], // A list of model control flow graph node scopes to be ignored for this operation - functions as a 'denylist'. Optional.
-            "target_quantizer_group": "weights" // Type of quantizer group to which this initialization of ranges will be applied. Optional. (By default this initialization of ranges will be applied to weights and activations quantizers)
-        },
-        ...
-    ]
+    "input_info": { "sample_size": [1, 3, 32, 32] }, // the input shape of your model may vary
+    "compression": {
+       "algorithm": "quantization",
+       "weights": {"mode": "symmetric"},
+       "activations": {"mode": "asymmetric"},
+    },
+   "target_device": "CPU"
 }
-
 ```
-Initialization of ranges defined in this way must specify an unambiguous initialization rule for each module.
+
+- Quantize a model with fully symmetric INT8 quantization and increased number of quantizer range initialization samples (make sure to supply a corresponding data loader in code via `nncf.config.structures.QuantizationRangeInitArgs` or the `register_default_init_args` helper function):
+```json5
+{
+    "input_info": { "sample_size": [1, 3, 224, 224] }, // the input shape of your model may vary
+    "compression": {
+       "algorithm": "quantization",
+       "mode": "symmetric",
+       "initializer": {
+         "range": { "num_init_samples": 5000 }
+       }
+    }
+}
+```
+
+- Quantize a model using 4-bit per-channel quantization for experimentation/trial purposes (end-to-end performance and/or compatibility with OpenVINO Inference Engine not guaranteed)
+```json5
+{
+    "input_info": { "sample_size": [1, 3, 32, 32] }, // the input shape of your model may vary
+    "compression": {
+       "algorithm": "quantization",
+       "bits": 4,
+       "per_channel": true,
+    },
+    "target_device": "TRIAL"
+}
+```
+
+- Quantize a multi-input model to 8-bit precision targeted for Intel CPUs, with a range initialization performed using percentile statistics (empirically known to be better for NLP models, for example) and excluding some parts of the model from quantization:
+```json5
+{
+    "input_info": [
+       {
+            "keyword": "input_ids",
+            "sample_size": [1, 128],
+            "type": "long",
+            "filler": "ones"
+        },
+        {
+            "keyword": "attention_mask",
+            "sample_size": [1, 128],
+            "type": "long",
+            "filler": "ones"
+        }
+    ], // the input shape of your model may vary
+    "compression": {
+       "algorithm": "quantization",
+       "initializer": {
+          "range": {
+             "num_init_samples": 64,
+             "type": "percentile",
+             "params": {
+                "min_percentile": 0.01,
+                "max_percentile": 99.99
+             }
+          }
+       },
+       "ignored_scopes": ["{re}BertSelfAttention\\[self\\]/__add___0",
+            "RobertaForSequenceClassification/RobertaClassificationHead[classifier]/Linear[out_proj]",
+            "RobertaForSequenceClassification/RobertaClassificationHead[classifier]/Linear[dense]"
+        ],
+    },
+    "target_device": "TRIAL"
+}
+```
+- Quantize a model to variable bit width using 300 iterations of the AutoQ algorithm, with a target model size (w.r.t the effective parameter storage size) set to 15% of the FP32 model and possible quantizer bitwidths limited to INT2, INT4 or INT8.
+```json5
+{
+    "input_info": { "sample_size": [1, 3, 224, 224] }, // the input shape of your model may vary
+    "compression": {
+       "algorithm": "quantization",
+       "initializer": {
+           "precision": {
+               "type": "autoq", // or "type": "hawq"
+               "bits": [2, 4, 8],
+               "compression_ratio": 0.15,
+               "iter_number": 300,
+           },
+       },
+    },
+    "target_device": "TRIAL"
+}
+```
+

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -313,7 +313,7 @@ Following is an example of wrapping ImageNet validation loop as a callback. Top5
 
 **Example configuration files**:
 
->_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](FIXME)_.
+>_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](https://openvinotoolkit.github.io/nncf/)_.
 
 - Quantize a model using default algorithm settings (8-bit, quantizers configuration chosen to be compatible with all Intel target HW types):
 ```json5

--- a/docs/compression_algorithms/Quantization.md
+++ b/docs/compression_algorithms/Quantization.md
@@ -311,7 +311,7 @@ Following is an example of wrapping ImageNet validation loop as a callback. Top5
 ```
 
 
-**Example configuration files**:
+### Example configuration files:
 
 >_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](https://openvinotoolkit.github.io/nncf/)_.
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -56,7 +56,7 @@ This special algorithm takes no additional parameters and is used when you want 
 
 **Example configuration files**
 
->_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](FIXME)_.
+>_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](https://openvinotoolkit.github.io/nncf/)_.
 
 - Apply magnitude sparsity with default parameters (0 to 90% sparsity over 90 epochs of training, sparsity increased polynomially with each epoch):
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -54,7 +54,7 @@ The magnitude sparsity method implements a naive approach that is based on the a
 #### Constant Sparsity
 This special algorithm takes no additional parameters and is used when you want to load a checkpoint already trained with another sparsity algorithm and do other compression without changing the sparsity mask.
 
-**Example configuration files**
+### Example configuration files
 
 >_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](https://openvinotoolkit.github.io/nncf/)_.
 

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -1,3 +1,6 @@
+
+>_Scroll down for the examples of the JSON configuration files that can be used to apply this algorithm_.
+
 ### Non-Structured Sparsity
 Sparsity algorithm zeros weights in Convolutional and Fully-Connected layers in a non-structured way,
 so that zero values are randomly distributed inside the tensor. Most of the sparsity algorithms set the less important weights to zero but the criteria of how they do it is different. The framework contains several implementations of sparsity methods.
@@ -39,30 +42,6 @@ and reduce the corresponding accuracy drop even before model training. This opti
 sparsity and filter pruning algorithms. It can be enabled by setting a non-zero value of `num_bn_adaptation_samples` in the
 `batchnorm_adaptation` section of the `initializer` configuration (see example below).
 
-**RB sparsity configuration file parameters**:
-
-```
-{
-    "algorithm": "rb_sparsity",
-    "sparsity_init": 0.05,// "Initial value of the sparsity level applied to the model in 'create_compressed_model' function
-    "params": {
-            "schedule": "multistep",  // The type of scheduling to use for adjusting the target sparsity level
-            "patience": 3, // A regular patience parameter for the scheduler, as for any other standard scheduler. Specified in units of scheduler steps.
-            "sparsity_target": 0.7, // Target value of the sparsity level for the model
-            "sparsity_target_epoch": 3, // Index of the epoch from which the sparsity level of the model will be equal to spatsity_target value
-            "sparsity_freeze_epoch": 50, // Index of the epoch from which the sparsity mask will be frozen and no longer trained
-            "multistep_steps": [10, 20], // A list of scheduler steps at which to transition to the next scheduled sparsity level (multistep scheduler only).
-            "multistep_sparsity_levels": [0.2, 0.5, 0.7] // Levels of sparsity to use at each step of the scheduler as specified in the 'multistep_steps' attribute. The first sparsity level will be applied immediately, so the length of this list should be larger than the length of the 'steps' by one. The last sparsity level will function as the ultimate sparsity target, overriding the "sparsity_target" setting if it is present.
-    },
-
-    // A list of model control flow graph node scopes to be ignored for this operation - functions as a 'denylist'. Optional.
-    "ignored_scopes": []
-
-    // A list of model control flow graph node scopes to be considered for this operation - functions as a 'allowlist'. Optional.
-    // "target_scopes": []
-}
-```
-
 > **NOTE**: In all our sparsity experiments, we used the Adam optimizer and initial learning rate `0.001` for model weights and sparsity mask.
 
 #### Magnitude Sparsity
@@ -71,45 +50,80 @@ The magnitude sparsity method implements a naive approach that is based on the a
 - Weights are used as is during the threshold calculation procedure.
 - Weights are normalized before the threshold calculation.
 
-**Magnitude sparsity configuration file parameters**:
-```
-{
-    "algorithm": "magnitude_sparsity",
-    "initializer": {
-        "batchnorm_adaptation": {
-            "num_bn_adaptation_samples": 2048, // Number of samples from the training dataset to pass through the model at initialization in order to update batchnorm statistics of the original model. The actual number of samples will be a closest multiple of the batch size.
-        }
-    }
-    "sparsity_init": 0.05,// "Initial value of the sparsity level applied to the model in 'create_compressed_model' function
-    "params": {
-            "schedule": "multistep",  // The type of scheduling to use for adjusting the target sparsity level
-            "patience": 3, // A regular patience parameter for the scheduler, as for any other standard scheduler. Specified in units of scheduler steps.
-            "sparsity_target": 0.7, // Target value of the sparsity level for the model
-            "sparsity_target_epoch": 3, // Index of the epoch from which the sparsity level of the model will be equal to spatsity_target value
-            "sparsity_freeze_epoch": 50, // Index of the epoch from which the sparsity mask will be frozen and no longer trained
-            "multistep_steps": [10, 20], // A list of scheduler steps at which to transition to the next scheduled sparsity level (multistep scheduler only).
-            "multistep_sparsity_levels": [0.2, 0.5, 0.7] // Levels of sparsity to use at each step of the scheduler as specified in the 'multistep_steps' attribute. The first sparsity level will be applied immediately, so the length of this list should be larger than the length of the 'steps' by one. The last sparsity level will function as the ultimate sparsity target, overriding the "sparsity_target" setting if it is present.
-    },
-
-    // A list of model control flow graph node scopes to be ignored for this operation - functions as a 'denylist'. Optional.
-    "ignored_scopes": []
-
-    // A list of model control flow graph node scopes to be considered for this operation - functions as a 'allowlist'. Optional.
-    // "target_scopes": []
-}
-```
 
 #### Constant Sparsity
 This special algorithm takes no additional parameters and is used when you want to load a checkpoint already trained with another sparsity algorithm and do other compression without changing the sparsity mask.
 
-**Constant sparsity configuration file parameters**:
-```
-{
-    "algorithm": "const_sparsity",
-    // A list of model control flow graph node scopes to be ignored for this operation - functions as a 'denylist'. Optional.
-    "ignored_scopes": []
+**Example configuration files**
 
-    // A list of model control flow graph node scopes to be considered for this operation - functions as a 'allowlist'. Optional.
-    // "target_scopes": []
-}).
+>_For the full list of the algorithm configuration parameters via config file, see the corresponding section in the [NNCF config schema](FIXME)_.
+
+- Apply magnitude sparsity with default parameters (0 to 90% sparsity over 90 epochs of training, sparsity increased polynomially with each epoch):
+
+```json5
+{
+    "input_info": { "sample_size": [1, 3, 224, 224] }, // the input shape of your model may vary
+    "compression": {
+      "algorithm": "magnitude_sparsity",
+    }
+}
+```
+
+- Apply magnitude sparsity, increasing sparsity level step-wise from 0 to 70% in 3 steps at given training epoch indices:
+```json5
+{
+    "input_info": { "sample_size": [1, 3, 224, 224] }, // the input shape of your model may vary
+    "compression": {
+      "algorithm": "magnitude_sparsity",
+      "params": {
+        "schedule": "multistep",
+        "multistep_steps": [10, 20],
+        "multistep_sparsity_levels": [0, 0.35, 0.7], // first level applied immediately (epoch 0), 0.35 - at epoch 10, 0.7 - at epoch 20
+        "sparsity_target": 0.5,
+        "sparsity_target_epoch": 20 // "sparsity_target" fully reached at the beginning of epoch 20
+      },
+    }
+}
+```
+
+- Apply magnitude sparsity, immediately setting sparsity level to 10%, performing [batch-norm adaptation](./BatchnormAdaptation.md) to potentially recover accuracy, and exponentially increasing sparsity to 50% over 30 epochs of training:
+```json5
+{
+    "input_info": { "sample_size": [1, 3, 224, 224] }, // the input shape of your model may vary
+    "compression": {
+      "algorithm": "magnitude_sparsity",
+      "sparsity_init": 0.1,  // set already before the beginning of epoch 0 of training
+      "params": {
+        "schedule": "exponential",
+        "sparsity_target": 0.5,
+        "sparsity_target_epoch": 30 // "sparsity_target" fully reached at the beginning of epoch 20
+      },
+      "initializer": {
+        "batchnorm_adaptation": {
+          "num_bn_adaptation_samples": 100,
+        }
+      }
+    }
+}
+```
+
+- Apply RB-sparsity to UNet, increasing sparsity level exponentially from 1% to 60% over 100 epochs, keeping the sparsity mask trainable until epoch 110 (after which the mask is frozen and the model is allowed to fine-tune with a fixed sparsity level), and excluding parts of the model from sparsification:
+```json5
+{
+    "input_info": { "sample_size": [1, 3, 224, 224] }, // the input shape of your model may vary
+    "compression": {
+        "algorithm": "rb_sparsity",
+        "sparsity_init": 0.01,
+        "params": {
+            "sparsity_target": 0.60,
+            "sparsity_target_epoch": 100,
+            "sparsity_freeze_epoch": 110
+        },
+        "ignored_scopes": [
+          // assuming PyTorch model
+           "{re}UNet/ModuleList\\[up_path\\].*", // do not sparsify decoder
+           "UNet/NNCFConv2d[last]/conv2d_0" // do not sparsify final convolution
+        ]
+    }
+}
 ```

--- a/docs/compression_algorithms/Sparsity.md
+++ b/docs/compression_algorithms/Sparsity.md
@@ -64,7 +64,7 @@ This special algorithm takes no additional parameters and is used when you want 
 {
     "input_info": { "sample_size": [1, 3, 224, 224] }, // the input shape of your model may vary
     "compression": {
-      "algorithm": "magnitude_sparsity",
+      "algorithm": "magnitude_sparsity"
     }
 }
 ```
@@ -81,7 +81,7 @@ This special algorithm takes no additional parameters and is used when you want 
         "multistep_sparsity_levels": [0, 0.35, 0.7], // first level applied immediately (epoch 0), 0.35 - at epoch 10, 0.7 - at epoch 20
         "sparsity_target": 0.5,
         "sparsity_target_epoch": 20 // "sparsity_target" fully reached at the beginning of epoch 20
-      },
+      }
     }
 }
 ```
@@ -100,7 +100,7 @@ This special algorithm takes no additional parameters and is used when you want 
       },
       "initializer": {
         "batchnorm_adaptation": {
-          "num_bn_adaptation_samples": 100,
+          "num_bn_adaptation_samples": 100
         }
       }
     }

--- a/docs/styleguide/PyGuide.md
+++ b/docs/styleguide/PyGuide.md
@@ -494,7 +494,7 @@ long_name = 2  # comment that should not be aligned
 
 dictionary = {
     'foo': 1,
-    'long_name': 2,
+    'long_name': 2
 }
 ```
 
@@ -505,7 +505,7 @@ long_name = 2     # comment that should not be aligned
 
 dictionary = {
     'foo'      : 1,
-    'long_name': 2,
+    'long_name': 2
 }
 ```
 

--- a/examples/experimental/torch/classification/bootstrapnas_examples/config.json
+++ b/examples/experimental/torch/classification/bootstrapnas_examples/config.json
@@ -15,7 +15,7 @@
         "weight_decay": 3e-7,
         "base_lr": 3.5e-3,
         "label_smoothing": 0.1,
-        "no_decay_keys": "bn#bias",
+        "no_decay_keys": "bn#bias"
     },
     "bootstrapNAS": {
         "training": {
@@ -49,15 +49,15 @@
                         ["ResNet/Sequential[layer3]/Bottleneck[3]/ReLU[relu]/relu__2", "ResNet/Sequential[layer3]/Bottleneck[4]/ReLU[relu]/relu__2"],
                         ["ResNet/Sequential[layer3]/Bottleneck[4]/ReLU[relu]/relu__2", "ResNet/Sequential[layer3]/Bottleneck[5]/ReLU[relu]/relu__2"],
                         ["ResNet/Sequential[layer4]/Bottleneck[1]/ReLU[relu]/relu__2", "ResNet/Sequential[layer4]/Bottleneck[2]/ReLU[relu]/relu__2"]
-                    ],
+                    ]
                 }
-            },
+            }
         },
         "search": {
             "algorithm": "NSGA2",
             "num_evals": 3000,
             "population": 50,
-            "ref_acc": 93.65,
+            "ref_acc": 93.65
         }
     }
 }

--- a/examples/torch/classification/configs/mixed_precision/mobilenet_v2_imagenet_mixed_int_autoq_staged.json
+++ b/examples/torch/classification/configs/mixed_precision/mobilenet_v2_imagenet_mixed_int_autoq_staged.json
@@ -37,7 +37,7 @@
             "activations_quant_start_epoch": 0,
             "weights_quant_start_epoch": 0,
             "lr_poly_drop_start_epoch": 0,
-            "lr_poly_drop_duration_epochs": 10,
+            "lr_poly_drop_duration_epochs": 10
         }
     }
 }

--- a/examples/torch/classification/configs/mixed_precision/resnet50_imagenet_mixed_int_autoq_staged.json
+++ b/examples/torch/classification/configs/mixed_precision/resnet50_imagenet_mixed_int_autoq_staged.json
@@ -42,7 +42,7 @@
             "activations_quant_start_epoch": 0,
             "weights_quant_start_epoch": 0,
             "lr_poly_drop_start_epoch": 0,
-            "lr_poly_drop_duration_epochs": 10,
+            "lr_poly_drop_duration_epochs": 10
         }
     }
 }

--- a/examples/torch/classification/configs/pruning/googlenet_pruning_geometric_median.json
+++ b/examples/torch/classification/configs/pruning/googlenet_pruning_geometric_median.json
@@ -35,7 +35,7 @@
             "params": {
                 "schedule": "exponential",
                 "pruning_target": 0.4,
-                 "pruning_steps": 15,
+                "pruning_steps": 15,
                 "filter_importance": "geometric_median"
             }
        }

--- a/examples/torch/object_detection/configs/ssd300_mobilenet_voc.json
+++ b/examples/torch/object_detection/configs/ssd300_mobilenet_voc.json
@@ -34,7 +34,7 @@
     "aspect_ratios": [[2], [2, 3], [2, 3], [2, 3], [2], [2]],
     "clip": false,
     "flip": true,
-    "top_k": 200,
+    "top_k": 200
   }
 }
 

--- a/nncf/config/config.py
+++ b/nncf/config/config.py
@@ -22,6 +22,7 @@ import jstyleson as json
 
 from nncf.common.utils.logger import logger
 from nncf.common.utils.os import safe_open
+from nncf.config.definitions import SCHEMA_VISUALIZATION_URL
 from nncf.config.schema import REF_VS_ALGO_SCHEMA
 from nncf.config.schema import NNCF_CONFIG_SCHEMA
 from nncf.config.schema import validate_single_compression_algo_schema
@@ -108,8 +109,9 @@ class NNCFConfig(dict):
             logger.error('Invalid NNCF config supplied!')
             absolute_path_parts = [str(x) for x in e.absolute_path]
             if not NNCFConfig._is_path_to_algorithm_name(absolute_path_parts):
-                e.message += "\nRefer to the NNCF config schema documentation at FILLME"
-                e.schema = "*schema too long for stdout display, see full schema documentation at FILLME*"
+                e.message += f"\nRefer to the NNCF config schema documentation at " \
+                             f"{SCHEMA_VISUALIZATION_URL}"
+                e.schema = "*schema too long for stdout display*"
                 raise e
 
             # Need to make the error more algo-specific in case the config was so bad that no

--- a/nncf/config/definitions.py
+++ b/nncf/config/definitions.py
@@ -35,4 +35,3 @@ ALGO_NAME_VS_README_URL = {
     KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG: 'docs/compression_algorithms/KnowledgeDistillation.md',
     BINARIZATION_ALGO_NAME_IN_CONFIG: 'docs/compression_algorithms/Binarization.md'
 }
-

--- a/nncf/config/definitions.py
+++ b/nncf/config/definitions.py
@@ -12,3 +12,27 @@
 """
 
 ONLINE_DOCS_ROOT = 'https://github.com/openvinotoolkit/nncf/tree/develop/'
+SCHEMA_VISUALIZATION_URL = 'https://openvinotoolkit.github.io/nncf/'
+
+ADAPTIVE_COMPRESSION_LEVEL_TRAINING_MODE_NAME_IN_CONFIG = "adaptive_compression_level"
+EARLY_EXIT_TRAINING_MODE_NAME_IN_CONFIG = "early_exit"
+EXPERIMENTAL_QUANTIZATION_ALGO_NAME_IN_CONFIG = 'experimental_quantization'
+BOOTSTRAP_NAS_ALGO_NAME_IN_CONFIG = 'bootstrapNAS'
+BINARIZATION_ALGO_NAME_IN_CONFIG = "binarization"
+CONST_SPARSITY_ALGO_NAME_IN_CONFIG = "const_sparsity"
+FILTER_PRUNING_ALGO_NAME_IN_CONFIG = 'filter_pruning'
+KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG = 'knowledge_distillation'
+MAGNITUDE_SPARSITY_ALGO_NAME_IN_CONFIG = "magnitude_sparsity"
+QUANTIZATION_ALGO_NAME_IN_CONFIG = "quantization"
+RB_SPARSITY_ALGO_NAME_IN_CONFIG = "rb_sparsity"
+
+ALGO_NAME_VS_README_URL = {
+    QUANTIZATION_ALGO_NAME_IN_CONFIG: 'docs/compression_algorithms/Quantization.md',
+    FILTER_PRUNING_ALGO_NAME_IN_CONFIG: 'docs/compression_algorithms/Pruning.md',
+    MAGNITUDE_SPARSITY_ALGO_NAME_IN_CONFIG: 'docs/compression_algorithms/Sparsity.md',
+    RB_SPARSITY_ALGO_NAME_IN_CONFIG: 'docs/compression_algorithms/Sparsity.md',
+    CONST_SPARSITY_ALGO_NAME_IN_CONFIG: 'docs/compression_algorithms/Sparsity.md',
+    KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG: 'docs/compression_algorithms/KnowledgeDistillation.md',
+    BINARIZATION_ALGO_NAME_IN_CONFIG: 'docs/compression_algorithms/Binarization.md'
+}
+

--- a/nncf/config/schema.py
+++ b/nncf/config/schema.py
@@ -16,22 +16,24 @@ from typing import Dict
 
 import jsonschema
 
+from nncf.config.definitions import ALGO_NAME_VS_README_URL
+from nncf.config.definitions import SCHEMA_VISUALIZATION_URL
 from nncf.config.schemata.experimental_schema import EXPERIMENTAL_REF_VS_ALGO_SCHEMA
 from nncf.config.schemata.accuracy_aware import ACCURACY_AWARE_MODES_VS_SCHEMA
 from nncf.config.schemata.accuracy_aware import ACCURACY_AWARE_TRAINING_SCHEMA
-from nncf.config.schemata.algo.binarization import BINARIZATION_ALGO_NAME_IN_CONFIG
+from nncf.config.definitions import BINARIZATION_ALGO_NAME_IN_CONFIG
 from nncf.config.schemata.algo.binarization import BINARIZATION_SCHEMA
-from nncf.config.schemata.algo.const_sparsity import CONST_SPARSITY_ALGO_NAME_IN_CONFIG
+from nncf.config.definitions import CONST_SPARSITY_ALGO_NAME_IN_CONFIG
 from nncf.config.schemata.algo.const_sparsity import CONST_SPARSITY_SCHEMA
-from nncf.config.schemata.algo.filter_pruning import FILTER_PRUNING_ALGO_NAME_IN_CONFIG
+from nncf.config.definitions import FILTER_PRUNING_ALGO_NAME_IN_CONFIG
 from nncf.config.schemata.algo.filter_pruning import FILTER_PRUNING_SCHEMA
-from nncf.config.schemata.algo.knowledge_distillation import KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG
+from nncf.config.definitions import KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG
 from nncf.config.schemata.algo.knowledge_distillation import KNOWLEDGE_DISTILLATION_SCHEMA
-from nncf.config.schemata.algo.magnitude_sparsity import MAGNITUDE_SPARSITY_ALGO_NAME_IN_CONFIG
+from nncf.config.definitions import MAGNITUDE_SPARSITY_ALGO_NAME_IN_CONFIG
 from nncf.config.schemata.algo.magnitude_sparsity import MAGNITUDE_SPARSITY_SCHEMA
-from nncf.config.schemata.algo.quantization import QUANTIZATION_ALGO_NAME_IN_CONFIG
+from nncf.config.definitions import QUANTIZATION_ALGO_NAME_IN_CONFIG
 from nncf.config.schemata.algo.quantization import QUANTIZATION_SCHEMA
-from nncf.config.schemata.algo.rb_sparsity import RB_SPARSITY_ALGO_NAME_IN_CONFIG
+from nncf.config.definitions import RB_SPARSITY_ALGO_NAME_IN_CONFIG
 from nncf.config.schemata.algo.rb_sparsity import RB_SPARSITY_SCHEMA
 from nncf.config.schemata.basic import ARRAY_OF_NUMBERS
 from nncf.config.schemata.basic import BOOLEAN
@@ -43,14 +45,15 @@ from nncf.config.schemata.common.compression import COMPRESSION_LR_MULTIPLIER_PR
 logger = logging.getLogger('nncf')
 
 REF_VS_ALGO_SCHEMA = {
-                      QUANTIZATION_ALGO_NAME_IN_CONFIG: QUANTIZATION_SCHEMA,
-                      FILTER_PRUNING_ALGO_NAME_IN_CONFIG: FILTER_PRUNING_SCHEMA,
-                      MAGNITUDE_SPARSITY_ALGO_NAME_IN_CONFIG: MAGNITUDE_SPARSITY_SCHEMA,
-                      RB_SPARSITY_ALGO_NAME_IN_CONFIG: RB_SPARSITY_SCHEMA,
-                      KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG: KNOWLEDGE_DISTILLATION_SCHEMA,
-                      CONST_SPARSITY_ALGO_NAME_IN_CONFIG: CONST_SPARSITY_SCHEMA,
-                      BINARIZATION_ALGO_NAME_IN_CONFIG: BINARIZATION_SCHEMA,
-                      **EXPERIMENTAL_REF_VS_ALGO_SCHEMA}
+    QUANTIZATION_ALGO_NAME_IN_CONFIG: QUANTIZATION_SCHEMA,
+    FILTER_PRUNING_ALGO_NAME_IN_CONFIG: FILTER_PRUNING_SCHEMA,
+    MAGNITUDE_SPARSITY_ALGO_NAME_IN_CONFIG: MAGNITUDE_SPARSITY_SCHEMA,
+    RB_SPARSITY_ALGO_NAME_IN_CONFIG: RB_SPARSITY_SCHEMA,
+    KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG: KNOWLEDGE_DISTILLATION_SCHEMA,
+    CONST_SPARSITY_ALGO_NAME_IN_CONFIG: CONST_SPARSITY_SCHEMA,
+    BINARIZATION_ALGO_NAME_IN_CONFIG: BINARIZATION_SCHEMA,
+    **EXPERIMENTAL_REF_VS_ALGO_SCHEMA
+}
 
 
 SINGLE_INPUT_INFO_SCHEMA = {
@@ -159,7 +162,10 @@ def validate_single_compression_algo_schema(single_compression_algo_dict: Dict, 
         jsonschema.validate(single_compression_algo_dict, schema=ref_vs_algo_schema[algo_name])
     except jsonschema.ValidationError as e:
         e.message = f"While validating the config for algorithm '{algo_name}' , got:\n" + e.message + \
-                    "\nRefer to the algorithm subschema definition at FIXME"
+                    f"\nRefer to the algorithm subschema definition at {SCHEMA_VISUALIZATION_URL}\n"
+        if algo_name in ALGO_NAME_VS_README_URL:
+            e.message += f"or to the algorithm documentation for examples of the configs: " \
+                         f"{ALGO_NAME_VS_README_URL[algo_name]}"
         raise e
 
 

--- a/nncf/config/schemata/accuracy_aware.py
+++ b/nncf/config/schemata/accuracy_aware.py
@@ -10,6 +10,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from nncf.config.definitions import ADAPTIVE_COMPRESSION_LEVEL_TRAINING_MODE_NAME_IN_CONFIG
+from nncf.config.definitions import EARLY_EXIT_TRAINING_MODE_NAME_IN_CONFIG
 from nncf.config.definitions import ONLINE_DOCS_ROOT
 from nncf.config.schemata.basic import NUMBER
 from nncf.config.schemata.basic import with_attributes
@@ -31,7 +33,6 @@ COMMON_AA_PROPERTIES = {
                                     "in units of absolute metric of the original model."),
 }
 
-ADAPTIVE_COMPRESSION_LEVEL_TRAINING_MODE_NAME_IN_CONFIG = "adaptive_compression_level"
 ADAPTIVE_COMPRESSION_LEVEL_TRAINING_SCHEMA = {
     "type": "object",
     "title": ADAPTIVE_COMPRESSION_LEVEL_TRAINING_MODE_NAME_IN_CONFIG,
@@ -89,7 +90,6 @@ ADAPTIVE_COMPRESSION_LEVEL_TRAINING_SCHEMA = {
     "required": ["mode", "params"],
     "additionalProperties": False
 }
-EARLY_EXIT_TRAINING_MODE_NAME_IN_CONFIG = "early_exit"
 EARLY_EXIT_TRAINING_SCHEMA = {
     "type": "object",
     "title": EARLY_EXIT_TRAINING_MODE_NAME_IN_CONFIG,

--- a/nncf/config/schemata/algo/binarization.py
+++ b/nncf/config/schemata/algo/binarization.py
@@ -10,6 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from nncf.config.definitions import BINARIZATION_ALGO_NAME_IN_CONFIG
 from nncf.config.definitions import ONLINE_DOCS_ROOT
 from nncf.config.schemata.common.compression import BASIC_COMPRESSION_ALGO_SCHEMA
 from nncf.config.schemata.common.compression import COMPRESSION_LR_MULTIPLIER_PROPERTY
@@ -20,7 +21,6 @@ from nncf.config.schemata.basic import with_attributes
 from nncf.config.schemata.common.targeting import SCOPING_PROPERTIES
 from nncf.config.schemata.defaults import BINARIZATION_MODE
 
-BINARIZATION_ALGO_NAME_IN_CONFIG = "binarization"
 BINARIZATION_MODE_OPTIONS = ['xnor', 'dorefa']
 BINARIZATION_SCHEMA = {
     **BASIC_COMPRESSION_ALGO_SCHEMA,

--- a/nncf/config/schemata/algo/const_sparsity.py
+++ b/nncf/config/schemata/algo/const_sparsity.py
@@ -10,10 +10,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from nncf.config.definitions import CONST_SPARSITY_ALGO_NAME_IN_CONFIG
 from nncf.config.schemata.common.compression import BASIC_COMPRESSION_ALGO_SCHEMA
 from nncf.config.schemata.common.targeting import SCOPING_PROPERTIES
 
-CONST_SPARSITY_ALGO_NAME_IN_CONFIG = "const_sparsity"
 CONST_SPARSITY_SCHEMA = {
     **BASIC_COMPRESSION_ALGO_SCHEMA,
     "properties": {

--- a/nncf/config/schemata/algo/filter_pruning.py
+++ b/nncf/config/schemata/algo/filter_pruning.py
@@ -82,7 +82,7 @@ FILTER_PRUNING_SCHEMA = {
                                                                         "FLOPs."),
                     "schedule": with_attributes(STRING,
                                                 description="The type of scheduling to use for adjusting the target "
-                                                            "pruning level. ",
+                                                            "pruning level.",
                                                 enum=FILTER_PRUNING_SCHEDULE_OPTIONS,
                                                 default=PRUNING_SCHEDULE),
 
@@ -111,7 +111,7 @@ FILTER_PRUNING_SCHEMA = {
                     "prune_downsample_convs": with_attributes(BOOLEAN,
                                                               description="Whether to prune downsampling "
                                                                           "convolutional layers (with stride > 1) "
-                                                                          "or not. ",
+                                                                          "or not.",
                                                               default=PRUNE_DOWNSAMPLE_CONVS),
                     "prune_batch_norms": with_attributes(BOOLEAN,
                                                          description="Whether to prune parameters of the Batch Norm "

--- a/nncf/config/schemata/algo/filter_pruning.py
+++ b/nncf/config/schemata/algo/filter_pruning.py
@@ -10,6 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from nncf.config.definitions import FILTER_PRUNING_ALGO_NAME_IN_CONFIG
 from nncf.config.definitions import ONLINE_DOCS_ROOT
 from nncf.config.schemata.common.compression import BASIC_COMPRESSION_ALGO_SCHEMA
 from nncf.config.schemata.basic import BOOLEAN
@@ -34,7 +35,6 @@ from nncf.config.schemata.defaults import PRUNING_SCHEDULE
 from nncf.config.schemata.defaults import PRUNING_STEPS
 from nncf.config.schemata.defaults import PRUNING_TARGET
 
-FILTER_PRUNING_ALGO_NAME_IN_CONFIG = 'filter_pruning'
 FILTER_PRUNING_SCHEDULE_OPTIONS = ['exponential', 'exponential_with_bias', 'baseline']
 FILTER_IMPORTANCE_OPTIONS = ['L2', 'L1', 'geometric_median']
 INTERLAYER_RANKING_TYPE_OPTIONS = ['unweighted_ranking', 'learned_ranking']

--- a/nncf/config/schemata/algo/knowledge_distillation.py
+++ b/nncf/config/schemata/algo/knowledge_distillation.py
@@ -10,6 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from nncf.config.definitions import KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG
 from nncf.config.definitions import ONLINE_DOCS_ROOT
 from nncf.config.schemata.basic import STRING
 from nncf.config.schemata.common.compression import BASIC_COMPRESSION_ALGO_SCHEMA
@@ -19,7 +20,6 @@ from nncf.config.schemata.defaults import KNOWLEDGE_DISTILLATION_SCALE
 from nncf.config.schemata.defaults import KNOWLEDGE_DISTILLATION_TEMPERATURE
 
 KNOWLEDGE_DISTILLATION_TYPE_OPTIONS = ["mse", "softmax"]
-KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG = 'knowledge_distillation'
 
 KNOWLEDGE_DISTILLATION_SCHEMA = {
     **BASIC_COMPRESSION_ALGO_SCHEMA,

--- a/nncf/config/schemata/algo/magnitude_sparsity.py
+++ b/nncf/config/schemata/algo/magnitude_sparsity.py
@@ -10,6 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from nncf.config.definitions import MAGNITUDE_SPARSITY_ALGO_NAME_IN_CONFIG
 from nncf.config.definitions import ONLINE_DOCS_ROOT
 from nncf.config.schemata.common.compression import BASIC_COMPRESSION_ALGO_SCHEMA
 from nncf.config.schemata.basic import NUMBER
@@ -19,8 +20,6 @@ from nncf.config.schemata.common.sparsity import COMMON_SPARSITY_PARAM_PROPERTIE
 from nncf.config.schemata.common.targeting import GENERIC_INITIALIZER_SCHEMA
 from nncf.config.schemata.common.targeting import SCOPING_PROPERTIES
 from nncf.config.schemata.defaults import SPARSITY_INIT
-
-MAGNITUDE_SPARSITY_ALGO_NAME_IN_CONFIG = "magnitude_sparsity"
 
 WEIGHT_IMPORTANCE_OPTIONS = ['abs', 'normed_abs']
 

--- a/nncf/config/schemata/algo/quantization.py
+++ b/nncf/config/schemata/algo/quantization.py
@@ -199,10 +199,10 @@ BITWIDTH_ASSIGNMENT_MODE_SCHEMA = {
 PRECISION_INIT_TYPES_VS_DESCRIPTION = {
     "hawq": f"Applies HAWQ algorithm to determine best bitwidths for each quantizer using a Hessian"
             f"calculation approach. For more details see "
-            f"[Quantization.md]{ONLINE_DOCS_ROOT}/docs/compression_algorithms/Quantization.md#hawq",
+            f"[Quantization.md]({ONLINE_DOCS_ROOT}/docs/compression_algorithms/Quantization.md#hawq)",
     "autoq": f"Applies AutoQ algorithm to determine best bitwidths for each quantizer using reinforcement learning. "
              f"For more details see "
-             f"[Quantization.md]{ONLINE_DOCS_ROOT}/docs/compression_algorithms/Quantization.md#autoq",
+             f"[Quantization.md]({ONLINE_DOCS_ROOT}/docs/compression_algorithms/Quantization.md#autoq)",
     "manual": "Allows to manually specify via following config options the exact bitwidth "
               "for each quantizer location. "
 }
@@ -237,7 +237,8 @@ PRECISION_INITIALIZER_SCHEMA = {
                                                  "from the previous iteration and the current one.",
                                      default=HAWQ_TOLERANCE),
         "compression_ratio": with_attributes(NUMBER,
-                                             description="The desired ratio between bits complexity of "
+                                             description="For the `hawq` mode:\n"
+                                                         "The desired ratio between bit complexity of "
                                                          "a fully INT8 model and a mixed-precision lower-bit "
                                                          "one. On precision initialization stage the HAWQ "
                                                          "algorithm chooses the most accurate "
@@ -246,8 +247,13 @@ PRECISION_INITIALIZER_SCHEMA = {
                                                          "is a sum of bit complexities for each quantized "
                                                          "layer, which are a multiplication of FLOPS for "
                                                          "the layer by the number of bits for its "
-                                                         "quantization.",
-                                             default=HAWQ_COMPRESSION_RATIO),
+                                                         "quantization.\n"
+                                                         "For the `autoq` mode:\n"
+                                                         "The target model size after quantization, relative to total "
+                                                         "parameters size in FP32. E.g. a uniform INT8-quantized model "
+                                                         "would have a `compression_ratio` equal to 0.25,"
+                                                         "and a uniform INT4-quantized model would have "
+                                                         "`compression_ratio` equal to 0.125."),
         "eval_subset_ratio": with_attributes(NUMBER,
                                              description="The desired ratio of dataloader to be iterated "
                                                          "during each search iteration of AutoQ precision "

--- a/nncf/config/schemata/algo/quantization.py
+++ b/nncf/config/schemata/algo/quantization.py
@@ -11,6 +11,7 @@
  limitations under the License.
 """
 from nncf.config.definitions import ONLINE_DOCS_ROOT
+from nncf.config.definitions import QUANTIZATION_ALGO_NAME_IN_CONFIG
 from nncf.config.schemata.basic import ARRAY_OF_NUMBERS
 from nncf.config.schemata.basic import ARRAY_OF_STRINGS
 from nncf.config.schemata.basic import BOOLEAN
@@ -25,7 +26,6 @@ from nncf.config.schemata.common.targeting import SCOPING_PROPERTIES
 from nncf.config.schemata.defaults import ACTIVATIONS_QUANT_START_EPOCH
 from nncf.config.schemata.defaults import AUTOQ_EVAL_SUBSET_RATIO
 from nncf.config.schemata.defaults import AUTOQ_WARMUP_ITER_NUMBER
-from nncf.config.schemata.defaults import HAWQ_COMPRESSION_RATIO
 from nncf.config.schemata.defaults import HAWQ_DUMP_INIT_PRECISION_DATA
 from nncf.config.schemata.defaults import HAWQ_ITER_NUMBER
 from nncf.config.schemata.defaults import HAWQ_NUM_DATA_POINTS
@@ -363,7 +363,6 @@ STAGED_QUANTIZATION_PARAMS = {
     }
 }
 
-QUANTIZATION_ALGO_NAME_IN_CONFIG = "quantization"
 QUANTIZATION_PRESETS_SCHEMA = {
     "type": "string",
     "enum": ["performance", "mixed"]

--- a/nncf/config/schemata/algo/rb_sparsity.py
+++ b/nncf/config/schemata/algo/rb_sparsity.py
@@ -11,6 +11,7 @@
  limitations under the License.
 """
 from nncf.config.definitions import ONLINE_DOCS_ROOT
+from nncf.config.definitions import RB_SPARSITY_ALGO_NAME_IN_CONFIG
 from nncf.config.schemata.common.compression import BASIC_COMPRESSION_ALGO_SCHEMA
 from nncf.config.schemata.common.compression import COMPRESSION_LR_MULTIPLIER_PROPERTY
 from nncf.config.schemata.basic import NUMBER
@@ -19,7 +20,6 @@ from nncf.config.schemata.common.sparsity import COMMON_SPARSITY_PARAM_PROPERTIE
 from nncf.config.schemata.common.targeting import SCOPING_PROPERTIES
 from nncf.config.schemata.defaults import SPARSITY_INIT
 
-RB_SPARSITY_ALGO_NAME_IN_CONFIG = "rb_sparsity"
 RB_SPARSITY_SCHEMA = {
     **BASIC_COMPRESSION_ALGO_SCHEMA,
     "description": f"Applies sparsity on top of the current model. Each weight tensor value will be either kept as-is, "

--- a/nncf/config/schemata/experimental_schema.py
+++ b/nncf/config/schemata/experimental_schema.py
@@ -13,6 +13,9 @@
 
 import copy
 
+from nncf.config.definitions import BOOTSTRAP_NAS_ALGO_NAME_IN_CONFIG
+from nncf.config.definitions import EXPERIMENTAL_QUANTIZATION_ALGO_NAME_IN_CONFIG
+
 from nncf.config.schemata.basic import ARRAY_OF_NUMBERS
 from nncf.config.schemata.basic import ARRAY_OF_STRINGS
 from nncf.config.schemata.common.initialization import BATCHNORM_ADAPTATION_SCHEMA
@@ -28,14 +31,12 @@ from nncf.config.schemata.basic import with_attributes
 ########################################################################################################################
 # Experimental Quantization
 ########################################################################################################################
-EXPERIMENTAL_QUANTIZATION_ALGO_NAME_IN_CONFIG = 'experimental_quantization'
 EXPERIMENTAL_QUANTIZATION_SCHEMA = copy.deepcopy(QUANTIZATION_SCHEMA)
 EXPERIMENTAL_QUANTIZATION_SCHEMA['properties']['algorithm']['const'] = EXPERIMENTAL_QUANTIZATION_ALGO_NAME_IN_CONFIG
 
 ########################################################################################################################
 # BootstrapNAS
 ########################################################################################################################
-BOOTSTRAP_NAS_ALGO_NAME_IN_CONFIG = 'bootstrapNAS'
 
 TRAINING_ALGORITHMS_SCHEMA = {
     "type": "string",

--- a/nncf/experimental/torch/nas/bootstrapNAS/BootstrapNAS.md
+++ b/nncf/experimental/torch/nas/bootstrapNAS/BootstrapNAS.md
@@ -55,7 +55,7 @@ In the search section, you specify the search algorithm, e.g., `NSGA-II` and its
     "algorithm": "NSGA2",
             "num_evals": 3000,
             "population": 50,
-            "ref_acc": 93.65,
+            "ref_acc": 93.65
 }
 ```
 

--- a/tests/torch/data/configs/weekly/classification/cifar10/resnet50_nas_SMALL.json
+++ b/tests/torch/data/configs/weekly/classification/cifar10/resnet50_nas_SMALL.json
@@ -43,7 +43,7 @@
         "search": {
             "algorithm": "NSGA2",
             "num_evals": 4,
-            "population": 1,
+            "population": 1
         }
     }
 }

--- a/tests/torch/data/schema_validation_bad_configs/params_mismatch.json
+++ b/tests/torch/data/schema_validation_bad_configs/params_mismatch.json
@@ -21,7 +21,7 @@
                 "sparsity_init": 0.01,
                 "sparsity_target": 0.61,
                 "sparsity_target_epoch": 5,
-                "sparsity_freeze_epoch": 10,
+                "sparsity_freeze_epoch": 10
             }
         }
     ]


### PR DESCRIPTION
### Changes

Examples in docs/**/*.md files were replaced so as not to list every possible parameter in a corresponding config section, but instead to list common, simple use cases and corresponding configs.

### Reason for changes
Increased readability of the doc files.

### Related tickets
N/A

### Tests
N/A