### PR TITLE
Do not ignore the entire fused pattern if non-primary nodes are in the ignored scopes

### DIFF
--- a/nncf/common/insertion_point_graph.py
+++ b/nncf/common/insertion_point_graph.py
@@ -290,6 +290,8 @@ class InsertionPointGraph(nx.DiGraph):
                 merged_ip_graph.remove_node(node_key)
                 merged_node_key += node_key + '\n'
 
+            # The first node in the merged node list will be considered a "primary" node for purposes
+            # of further ignored/target scope application.
             merged_node_attrs[InsertionPointGraph.MERGED_NNCF_NODE_LIST_NODE_ATTR] = merged_nncf_nodes
             merged_ip_graph.add_node(merged_node_key, **merged_node_attrs)
             for in_edge_key, in_edge_attrs in in_edge_copies_dict.items():

--- a/nncf/common/quantization/quantizer_propagation/graph.py
+++ b/nncf/common/quantization/quantizer_propagation/graph.py
@@ -128,9 +128,12 @@ class QuantizerPropagationStateGraph(nx.DiGraph):
                 self.op_node_keys_to_underlying_nodes_mapping[node_key] = underlying_nncf_nodes
 
                 ignored = False
-                for nncf_node in underlying_nncf_nodes:
-                    if not should_consider_scope(nncf_node.node_name, self._ignored_scopes, self._target_scopes):
-                        ignored = True
+                # For the fused-pattern nodes, will only ignore the entire pattern if the primary node in the
+                # merged pattern is in the ignored scopes. The primary node is the first one in the
+                # underlying_nncf_nodes list.
+                primary_node = underlying_nncf_nodes[0]
+                if not should_consider_scope(primary_node.node_name, self._ignored_scopes, self._target_scopes):
+                    ignored = True
 
                 if ignored:
                     qpg_node[self.IS_IN_IGNORED_SCOPES] = True


### PR DESCRIPTION
### Changes
Adjusted quantizer propagation common algo to only ignore the entire fused pattern if the primary node from the pattern ends up matching to an ignored scope.

### Reason for changes
Improves logical consistency of the "ignored_scopes" and its effect on the algo result.

### Related tickets

92302

### Tests
TBA
