### PR TITLE
Make test quantizers FP32 instead of FP64/ fix refs

### DIFF
--- a/tests/torch/quantization/test_functions.py
+++ b/tests/torch/quantization/test_functions.py
@@ -195,6 +195,17 @@ def skip_if_half_on_cpu(is_fp16, use_cuda):
 
 
 def check_quant_moved(test_val, ref_val, quant_len, rtol, atol = 1e-10):
+    """
+    Checks values in `test_val` and `ref_val` elementwise eather equal with given rtol/atol or
+    values differ by correspondent `quant_len` +- rtol.
+    
+    :param test_val: Given test value.
+    :param ref_val: Given reference value.
+    :param quant_len: Lenghts of quants in quantizers
+        (for each channel in case per channel quantization).
+    :param atol: Absolute tollerance.
+    :param rtol: Relative tollerance.
+    """
     if not isinstance(test_val, list):
         test_val, ref_val = [test_val], [ref_val]
     for t, r in zip(test_val, ref_val):


### PR DESCRIPTION
### Changes

Test for quantization functions (CPU/GPU) was moved to FP32/FP16 precisions.
Reference quantization functions were fixed

### Related tickets

91663

