### PR TITLE
HWConfigType was renamed to TargetDevice

### DIFF
--- a/examples/torch/common/argparser.py
+++ b/examples/torch/common/argparser.py
@@ -12,7 +12,7 @@
 """
 
 from examples.torch.common.sample_config import CustomArgumentParser
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 
 
 def get_common_argument_parser():
@@ -27,7 +27,7 @@ def get_common_argument_parser():
     parser.add_argument('--target-device', help='Type of the hardware configuration for compression algorithms',
                         type=str,
                         dest="target_device",
-                        choices=[t.value for t in HWConfigType])
+                        choices=[t.value for t in TargetDevice])
 
     parser.add_argument(
         "--mode",

--- a/nncf/common/hardware/config.py
+++ b/nncf/common/hardware/config.py
@@ -35,27 +35,27 @@ from nncf.definitions import HW_CONFIG_RELATIVE_DIR
 from nncf.definitions import NNCF_PACKAGE_ROOT_DIR
 from nncf.common.utils.logger import logger as nncf_logger
 
-class HWConfigType(Enum):
+class TargetDevice(Enum):
     CPU = 'CPU'
     GPU = 'GPU'
     VPU = 'VPU'
 
     @staticmethod
-    def from_str(config_value: str) -> 'HWConfigType':
-        if config_value == HWConfigType.CPU.value:
-            return HWConfigType.CPU
-        if config_value == HWConfigType.GPU.value:
-            return HWConfigType.GPU
-        if config_value == HWConfigType.VPU.value:
-            return HWConfigType.VPU
+    def from_str(config_value: str) -> 'TargetDevice':
+        if config_value == TargetDevice.CPU.value:
+            return TargetDevice.CPU
+        if config_value == TargetDevice.GPU.value:
+            return TargetDevice.GPU
+        if config_value == TargetDevice.VPU.value:
+            return TargetDevice.VPU
         raise RuntimeError('Unknown HW config type string')
 
 
 HW_CONFIG_TYPE_TARGET_DEVICE_MAP = {
-    'ANY': HWConfigType.CPU.value,
-    'CPU': HWConfigType.CPU.value,
-    'VPU': HWConfigType.VPU.value,
-    'GPU': HWConfigType.GPU.value,
+    'ANY': TargetDevice.CPU.value,
+    'CPU': TargetDevice.CPU.value,
+    'VPU': TargetDevice.VPU.value,
+    'GPU': TargetDevice.GPU.value,
     'TRIAL': None
 }
 
@@ -71,9 +71,9 @@ class HWConfig(list, ABC):
     ADJUST_PADDING_ATTRIBUTE_NAME = 'adjust_padding'
 
     TYPE_TO_CONF_NAME_DICT = {
-        HWConfigType.CPU: 'cpu.json',
-        HWConfigType.VPU: 'vpu.json',
-        HWConfigType.GPU: 'gpu.json'
+        TargetDevice.CPU: 'cpu.json',
+        TargetDevice.VPU: 'vpu.json',
+        TargetDevice.GPU: 'gpu.json'
     }
 
     def __init__(self):
@@ -86,7 +86,7 @@ class HWConfig(list, ABC):
         pass
 
     @staticmethod
-    def get_path_to_hw_config(hw_config_type: HWConfigType):
+    def get_path_to_hw_config(hw_config_type: TargetDevice):
         return '/'.join([NNCF_PACKAGE_ROOT_DIR, HW_CONFIG_RELATIVE_DIR,
                          HWConfig.TYPE_TO_CONF_NAME_DICT[hw_config_type]])
 

--- a/nncf/experimental/post_training/algorithms/quantization/algorithm.py
+++ b/nncf/experimental/post_training/algorithms/quantization/algorithm.py
@@ -19,7 +19,7 @@ from typing import TypeVar
 
 from nncf.common.quantization.structs import QuantizerConfig
 from nncf.common.quantization.structs import QuantizationMode
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 
 from nncf.common.utils.backend import BackendType
 from nncf.experimental.post_training.api.engine import Engine
@@ -48,7 +48,7 @@ class PostTrainingQuantizationParameters(AlgorithmParameters):
                  activation_granularity: Granularity = Granularity.PERTENSOR,
                  range_type: RangeType = RangeType.MEAN_MINMAX,
                  number_samples: int = 300,
-                 target_device: HWConfigType = HWConfigType.CPU,
+                 target_device: TargetDevice = TargetDevice.CPU,
                  ignored_scopes: Optional[List[str]] = None
                  ):
         weight_mode, activation_mode = self._determine_weight_activation_modes(preset)

--- a/nncf/experimental/post_training/algorithms/quantization/min_max_quantization.py
+++ b/nncf/experimental/post_training/algorithms/quantization/min_max_quantization.py
@@ -22,7 +22,7 @@ from copy import deepcopy
 from nncf.common.utils.ordered_enum import OrderedEnum
 from nncf.common.quantization.structs import QuantizerConfig
 from nncf.common.quantization.structs import QuantizationMode
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 
 from nncf.experimental.post_training.algorithms import Algorithm
 from nncf.experimental.post_training.algorithms import AlgorithmParameters
@@ -55,7 +55,7 @@ class MinMaxQuantizationParameters(AlgorithmParameters):
                  weight_quantizer_config: QuantizerConfig = None,
                  activation_quantizer_config: QuantizerConfig = None,
                  number_samples: int = 100,
-                 target_device: HWConfigType = HWConfigType.CPU,
+                 target_device: TargetDevice = TargetDevice.CPU,
                  range_type: RangeType = RangeType.MEAN_MINMAX,
                  quatize_outputs: bool = False,
                  ignored_scopes: List[str] = None,

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -30,7 +30,7 @@ from nncf.common.graph import OUTPUT_NOOP_METATYPES
 from nncf.common.graph.transformations.commands import TargetPoint
 from nncf.common.graph.transformations.commands import TransformationPriority
 from nncf.common.graph.utils import get_first_nodes_of_type
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 from nncf.common.hardware.config import HW_CONFIG_TYPE_TARGET_DEVICE_MAP
 from nncf.common.initialization.batchnorm_adaptation import BatchnormAdaptationAlgorithm
 from nncf.common.insertion_point_graph import InsertionPointGraph
@@ -268,7 +268,7 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
 
         self.hw_config = None
         if self._target_device != "TRIAL":
-            hw_config_type = HWConfigType.from_str(HW_CONFIG_TYPE_TARGET_DEVICE_MAP[self._target_device])
+            hw_config_type = TargetDevice.from_str(HW_CONFIG_TYPE_TARGET_DEVICE_MAP[self._target_device])
             hw_config_path = TFHWConfig.get_path_to_hw_config(hw_config_type)
             self.hw_config = TFHWConfig.from_json(hw_config_path)
 

--- a/nncf/torch/automl/environment/quantization_env.py
+++ b/nncf/torch/automl/environment/quantization_env.py
@@ -40,7 +40,7 @@ from nncf.common.initialization.batchnorm_adaptation import BatchnormAdaptationA
 from nncf.common.quantization.structs import QuantizerConfig
 from nncf.config.extractors import extract_bn_adaptation_init_params
 from nncf.common.utils.logger import logger
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 from nncf.common.utils.debug import DEBUG_LOG_DIR
 from nncf.common.utils.debug import is_debug
 from nncf.torch.initialization import PartialDataLoader
@@ -132,7 +132,7 @@ class QuantizationEnv:
                  hw_precision_constraints: HardwareQuantizationConstraints,
                  eval_loader: torch.utils.data.DataLoader,
                  eval_fn: Callable[[nn.Module, torch.utils.data.DataLoader], float],
-                 hw_config_type: HWConfigType,
+                 hw_config_type: TargetDevice,
                  params: QuantizationEnvParams
                  ):
 
@@ -148,7 +148,7 @@ class QuantizationEnv:
 
         # Check and only proceed if target device is supported by Q.Env
         self.hw_cfg_type = hw_config_type
-        assert self.hw_cfg_type in [None, HWConfigType.VPU]
+        assert self.hw_cfg_type in [None, TargetDevice.VPU]
 
         # Set target compression ratio
         self.compression_ratio = params.compression_ratio
@@ -170,7 +170,7 @@ class QuantizationEnv:
         # Configure search space for precision according to target device
         if self.hw_cfg_type is None:
             self.model_bitwidth_space = params.bits
-        elif self.hw_cfg_type is HWConfigType.VPU:
+        elif self.hw_cfg_type is TargetDevice.VPU:
             self.model_bitwidth_space = self._hw_precision_constraints.get_all_unique_bitwidths()
         self.model_bitwidth_space = sorted(list(self.model_bitwidth_space))
 

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -41,7 +41,7 @@ from nncf.common.graph.transformations.commands import TargetPoint
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.utils import get_first_nodes_of_type
 from nncf.common.hardware.config import HWConfig
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 from nncf.common.hardware.config import HW_CONFIG_TYPE_TARGET_DEVICE_MAP
 from nncf.common.initialization.batchnorm_adaptation import BatchnormAdaptationAlgorithm
 from nncf.common.insertion_point_graph import InsertionPointGraph
@@ -467,7 +467,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
         hw_config_type = None
         target_device = self.config.get('target_device', 'ANY')
         if target_device != 'TRIAL':
-            hw_config_type = HWConfigType.from_str(HW_CONFIG_TYPE_TARGET_DEVICE_MAP[target_device])
+            hw_config_type = TargetDevice.from_str(HW_CONFIG_TYPE_TARGET_DEVICE_MAP[target_device])
         if hw_config_type is not None:
             hw_config_path = PTHWConfig.get_path_to_hw_config(hw_config_type)
             self.hw_config = PTHWConfig.from_json(hw_config_path)
@@ -558,7 +558,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
                 precision_init_args
             )
         elif precision_init_type == "autoq":
-            if self.hw_config is not None and self.hw_config.target_device != HWConfigType.VPU.value:
+            if self.hw_config is not None and self.hw_config.target_device != TargetDevice.VPU.value:
                 raise ValueError("Unsupported device ({}). Automatic Precision Initialization only supports for "
                                  "target_device NONE or VPU".format(self.hw_config.target_device))
             try:
@@ -571,7 +571,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
 
             hw_config_type = None
             if self.hw_config is not None:
-                hw_config_type = HWConfigType.from_str(self.hw_config.target_device)
+                hw_config_type = TargetDevice.from_str(self.hw_config.target_device)
             precision_init_params = AutoQPrecisionInitParams.from_config(init_precision_config,
                                                                          precision_init_args,
                                                                          hw_config_type)

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -49,7 +49,7 @@ class QuantizerExportMode(Enum):
     ONNX_QUANTIZE_DEQUANTIZE_PAIRS = "quantize_dequantize"
 
     @staticmethod
-    def from_str(config_value: str) -> 'HWConfigType':
+    def from_str(config_value: str) -> 'QuantizerExportMode':
         if config_value == QuantizerExportMode.FAKE_QUANTIZE.value:
             return QuantizerExportMode.FAKE_QUANTIZE
         if config_value == QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS.value:

--- a/nncf/torch/quantization/precision_init/autoq_init.py
+++ b/nncf/torch/quantization/precision_init/autoq_init.py
@@ -17,7 +17,7 @@ from typing import Dict, Tuple, List, Optional
 import os
 
 from nncf.common.utils.debug import is_debug
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 from nncf.common.utils.logger import logger
 from nncf.common.utils.os import safe_open
 from nncf.config.schemata.defaults import AUTOQ_EVAL_SUBSET_RATIO
@@ -48,7 +48,7 @@ class AutoQPrecisionInitParams(BasePrecisionInitParams):
                  compression_ratio: float = None,
                  eval_subset_ratio: float = None,
                  ddpg_hparams_dict: Dict = None,
-                 hw_cfg_type: HWConfigType = None,
+                 hw_cfg_type: TargetDevice = None,
                  skip_constraint: bool = False,
                  finetune: bool = False,
                  bits: List[int] = None):
@@ -70,7 +70,7 @@ class AutoQPrecisionInitParams(BasePrecisionInitParams):
     @classmethod
     def from_config(cls, autoq_init_config_dict: Dict,
                     user_init_args: AutoQPrecisionInitArgs,
-                    target_hw_config_type: Optional[HWConfigType]) -> 'AutoQPrecisionInitParams':
+                    target_hw_config_type: Optional[TargetDevice]) -> 'AutoQPrecisionInitParams':
         dict_copy = autoq_init_config_dict.copy()
         dump_autoq_data = dict_copy.pop('dump_init_precision_data', False)
         iter_number = dict_copy.pop('iter_number', AUTOQ_ITER_NUMBER)

--- a/tests/tensorflow/quantization/test_unified_scales.py
+++ b/tests/tensorflow/quantization/test_unified_scales.py
@@ -17,7 +17,7 @@ import pytest
 import tensorflow as tf
 from tensorflow.keras import layers
 
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 from nncf.tensorflow.quantization.utils import collect_fake_quantize_layers
 from tests.tensorflow.helpers import create_compressed_model_and_algo_for_test
 from tests.tensorflow.quantization.utils import get_basic_quantization_config
@@ -88,7 +88,7 @@ def get_total_quantizations(model: tf.keras.Model) -> int:
 
 @pytest.mark.parametrize("target_device, model_creator, ref_aq_module_count, ref_quantizations",
                          [(t_dev, ) + rest for t_dev, rest in
-                             itertools.product([x.value for x in HWConfigType],
+                             itertools.product([x.value for x in TargetDevice],
                                                CAT_UNIFIED_SCALE_TEST_STRUCTS)])
 def test_unified_scales_with_concat(target_device, model_creator, ref_aq_module_count, ref_quantizations):
     nncf_config = get_basic_quantization_config()
@@ -151,7 +151,7 @@ def get_shared_conv_test_model():
     return tf.keras.Model(inputs=inputs, outputs=out)
 
 
-@pytest.mark.parametrize("target_device", [t_dev.value for t_dev in HWConfigType])
+@pytest.mark.parametrize("target_device", [t_dev.value for t_dev in TargetDevice])
 def test_shared_op_unified_scales(target_device):
     nncf_config = get_basic_quantization_config()
     nncf_config["target_device"] = target_device

--- a/tests/tensorflow/test_compressed_graph.py
+++ b/tests/tensorflow/test_compressed_graph.py
@@ -22,7 +22,7 @@ import tensorflow as tf
 import networkx as nx
 
 from nncf import NNCFConfig
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 from tests.tensorflow import test_models
 from tests.tensorflow.helpers import get_empty_config, create_compressed_model_and_algo_for_test
 from tests.tensorflow.helpers import operational_node
@@ -461,7 +461,7 @@ def test_quantize_outputs(desc: ModelDesc, _quantization_case_config):
                       desc.rename_resource_nodes)
 
 
-TYPE_HW = [(HWConfigType.CPU), (HWConfigType.GPU), (HWConfigType.VPU)]
+TYPE_HW = [(TargetDevice.CPU), (TargetDevice.GPU), (TargetDevice.VPU)]
 
 TEST_HW_MODELS_DESC = [
     ModelDesc('resnet50.pb', test_models.ResNet50, [1, 32, 32, 3]),

--- a/tests/torch/automl/test_quantization_env.py
+++ b/tests/torch/automl/test_quantization_env.py
@@ -17,7 +17,7 @@ import pytest
 from nncf import NNCFConfig
 from nncf.torch.automl.environment.quantization_env import QuantizationEnv, ModelSizeCalculator, QuantizationEnvParams
 from nncf.torch.dynamic_graph.graph_tracer import create_input_infos
-from nncf.common.hardware.config import HWConfigType, HWConfig
+from nncf.common.hardware.config import TargetDevice, HWConfig
 from nncf.torch.hardware.config import PTHWConfig
 from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.quantization.algo import ExperimentalQuantizationBuilder, PropagationBasedQuantizerSetupGenerator
@@ -36,7 +36,7 @@ def create_test_quantization_env(model_creator=BasicConvTestModel, input_info_cf
 
     model = model_creator()
     nncf_network = NNCFNetwork(model, input_infos=create_input_infos(input_info_cfg))
-    hw_config_type = HWConfigType.VPU
+    hw_config_type = TargetDevice.VPU
     hw_config_path = HWConfig.get_path_to_hw_config(hw_config_type)
     hw_config = PTHWConfig.from_json(hw_config_path)
     setup = PropagationBasedQuantizerSetupGenerator(NNCFConfig(),
@@ -70,7 +70,7 @@ def create_test_quantization_env(model_creator=BasicConvTestModel, input_info_cf
                            constraints,
                            data_loader,
                            lambda *x: 0,
-                           hw_config_type=HWConfigType.VPU,
+                           hw_config_type=TargetDevice.VPU,
                            params=QuantizationEnvParams(compression_ratio=0.15,
                                                         eval_subset_ratio=1.0,
                                                         skip_constraint=False,

--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -26,7 +26,7 @@ from torchvision.models import squeezenet1_1
 
 from nncf import NNCFConfig
 from nncf.api.compression import CompressionScheduler
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 from nncf.common.quantization.structs import NonWeightQuantizerId
 from nncf.common.quantization.structs import QuantizationMode
 from nncf.common.quantization.structs import QuantizerConfig
@@ -291,7 +291,7 @@ def test_quantizers_have_proper_narrow_range_set():
         assert aq.narrow_range is False
 
 
-@pytest.fixture(name="hw_config_type", params=HWConfigType)
+@pytest.fixture(name="hw_config_type", params=TargetDevice)
 def hw_config_type_(request):
     return request.param
 

--- a/tests/torch/quantization/test_hawq_precision_init.py
+++ b/tests/torch/quantization/test_hawq_precision_init.py
@@ -38,7 +38,7 @@ from examples.torch.object_detection.models.ssd_vgg import SSD_VGG
 from nncf.torch import register_default_init_args
 from nncf.torch.checkpoint_loading import load_state
 from nncf.common.graph import NNCFNodeName
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 from nncf.common.quantization.structs import QuantizerGroup
 from nncf.common.utils.debug import set_debug_log_dir
 from nncf.torch.utils import get_model_device
@@ -151,10 +151,10 @@ class BaseConfigBuilder:
         return self
 
     def for_vpu(self):
-        return self._set_target_device(HWConfigType.VPU.value)
+        return self._set_target_device(TargetDevice.VPU.value)
 
     def for_cpu(self):
-        return self._set_target_device(HWConfigType.CPU.value)
+        return self._set_target_device(TargetDevice.CPU.value)
 
     def for_trial(self):
         return self._set_target_device('TRIAL')

--- a/tests/torch/quantization/test_unified_scales.py
+++ b/tests/torch/quantization/test_unified_scales.py
@@ -23,7 +23,7 @@ import torch.nn
 from nncf.common.graph import NNCFNodeName
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.torch.dynamic_graph.operation_address import OperationAddress
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 from nncf.torch.graph.transformations.commands import PTTargetPoint
 from nncf.torch.quantization.layers import AsymmetricQuantizer
 from nncf.common.quantization.structs import NonWeightQuantizerId
@@ -563,7 +563,7 @@ CAT_UNIFIED_SCALE_TEST_STRUCTS = [(SingleCatModel, 3, 4),
 
 @pytest.mark.parametrize("target_device, model_creator, ref_aq_module_count, ref_quantizations",
                          [(t_dev,) + rest for t_dev, rest in
-                          itertools.product([x.value for x in HWConfigType],
+                          itertools.product([x.value for x in TargetDevice],
                                             CAT_UNIFIED_SCALE_TEST_STRUCTS)])
 def test_unified_scales_with_concat(target_device, model_creator, ref_aq_module_count, ref_quantizations):
     nncf_config = get_quantization_config_without_range_init(model_size=1)

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -33,7 +33,7 @@ from torch import nn
 import torch.nn.functional as F
 import torchvision
 
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 from nncf.common.quantization.quantizer_setup import ActivationQuantizationInsertionPoint
 from nncf.common.quantization.quantizer_setup import SingleConfigQuantizerSetup
 from nncf.torch import nncf_model_input
@@ -744,7 +744,7 @@ TEST_HW_MODELS_DESC = [
     ModelDesc("mobilenet_v2", torchvision.models.MobileNetV2, [2, 3, 32, 32])
 ]
 
-TYPE_HW = [(HWConfigType.CPU), (HWConfigType.GPU), (HWConfigType.VPU)]
+TYPE_HW = [(TargetDevice.CPU), (TargetDevice.GPU), (TargetDevice.VPU)]
 
 
 @pytest.fixture(scope='function', params=TYPE_HW)

--- a/tests/torch/test_sanity_sample.py
+++ b/tests/torch/test_sanity_sample.py
@@ -28,7 +28,7 @@ from examples.torch.common.utils import is_staged_quantization
 from nncf.api.compression import CompressionStage
 from nncf.common.compression import BaseCompressionAlgorithmController as BaseController
 from nncf.common.compression import BaseControllerStateNames
-from nncf.common.hardware.config import HWConfigType
+from nncf.common.hardware.config import TargetDevice
 from nncf.config import NNCFConfig
 from tests.common.config_factory import ConfigFactory
 from tests.common.helpers import TEST_ROOT
@@ -460,7 +460,7 @@ def test_cpu_only_mode_produces_cpu_only_model(config, tmp_path, mocker):
         assert not p.is_cuda
 
 
-@pytest.mark.parametrize('target_device', [x.value for x in HWConfigType])
+@pytest.mark.parametrize('target_device', [x.value for x in TargetDevice])
 def test_sample_propagates_target_device_cl_param_to_nncf_config(mocker, tmp_path, target_device):
     config_dict = {
         "input_info":


### PR DESCRIPTION
### Changes

The `HWConfigType` class was renamed to the `TargetDevice` class.

### Reason for changes

There are a lot of places where we should pass the `target_device` parameter. One of them is the new `nncf.quantize()` method that was introduced in PR #1295. It would be great to have the understandable type alias to the `target_device` parameter.

### Related tickets

N/A

### Tests

N/A

Only renaming. No new features.
