### PR TITLE
Fixed degradation in block search tests with LayerNorm

### DIFF
--- a/tests/torch/data/search_building_block/BERT
+++ b/tests/torch/data/search_building_block/BERT
@@ -41,7 +41,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[0]/BertAttention[attention]/BertSelfOutput[output]/LayerNorm[LayerNorm]/layer_norm_0",
+            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[0]/BertAttention[attention]/BertSelfOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[0]/BertIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[0]/BertIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[0]/BertOutput[output]/Dropout[dropout]/dropout_0",
@@ -56,7 +56,7 @@
     {
         "basic_block": {
             "end_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[1]/BertAttention[attention]/BertSelfOutput[output]/__add___0",
-            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[0]/BertOutput[output]/LayerNorm[LayerNorm]/layer_norm_0"
+            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[0]/BertOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -95,7 +95,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[1]/BertAttention[attention]/BertSelfOutput[output]/LayerNorm[LayerNorm]/layer_norm_0",
+            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[1]/BertAttention[attention]/BertSelfOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[1]/BertIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[1]/BertIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[1]/BertOutput[output]/Dropout[dropout]/dropout_0",
@@ -110,7 +110,7 @@
     {
         "basic_block": {
             "end_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[2]/BertAttention[attention]/BertSelfOutput[output]/__add___0",
-            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[1]/BertOutput[output]/LayerNorm[LayerNorm]/layer_norm_0"
+            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[1]/BertOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -149,7 +149,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[2]/BertAttention[attention]/BertSelfOutput[output]/LayerNorm[LayerNorm]/layer_norm_0",
+            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[2]/BertAttention[attention]/BertSelfOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[2]/BertIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[2]/BertIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[2]/BertOutput[output]/Dropout[dropout]/dropout_0",
@@ -164,7 +164,7 @@
     {
         "basic_block": {
             "end_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[3]/BertAttention[attention]/BertSelfOutput[output]/__add___0",
-            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[2]/BertOutput[output]/LayerNorm[LayerNorm]/layer_norm_0"
+            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[2]/BertOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -203,7 +203,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[3]/BertAttention[attention]/BertSelfOutput[output]/LayerNorm[LayerNorm]/layer_norm_0",
+            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[3]/BertAttention[attention]/BertSelfOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[3]/BertIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[3]/BertIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[3]/BertOutput[output]/Dropout[dropout]/dropout_0",
@@ -218,7 +218,7 @@
     {
         "basic_block": {
             "end_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[4]/BertAttention[attention]/BertSelfOutput[output]/__add___0",
-            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[3]/BertOutput[output]/LayerNorm[LayerNorm]/layer_norm_0"
+            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[3]/BertOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -257,7 +257,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[4]/BertAttention[attention]/BertSelfOutput[output]/LayerNorm[LayerNorm]/layer_norm_0",
+            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[4]/BertAttention[attention]/BertSelfOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[4]/BertIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[4]/BertIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[4]/BertOutput[output]/Dropout[dropout]/dropout_0",
@@ -272,7 +272,7 @@
     {
         "basic_block": {
             "end_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[5]/BertAttention[attention]/BertSelfOutput[output]/__add___0",
-            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[4]/BertOutput[output]/LayerNorm[LayerNorm]/layer_norm_0"
+            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[4]/BertOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -311,7 +311,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[5]/BertAttention[attention]/BertSelfOutput[output]/LayerNorm[LayerNorm]/layer_norm_0",
+            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[5]/BertAttention[attention]/BertSelfOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[5]/BertIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[5]/BertIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[5]/BertOutput[output]/Dropout[dropout]/dropout_0",
@@ -326,7 +326,7 @@
     {
         "basic_block": {
             "end_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[6]/BertAttention[attention]/BertSelfOutput[output]/__add___0",
-            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[5]/BertOutput[output]/LayerNorm[LayerNorm]/layer_norm_0"
+            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[5]/BertOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -365,7 +365,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[6]/BertAttention[attention]/BertSelfOutput[output]/LayerNorm[LayerNorm]/layer_norm_0",
+            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[6]/BertAttention[attention]/BertSelfOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[6]/BertIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[6]/BertIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[6]/BertOutput[output]/Dropout[dropout]/dropout_0",
@@ -380,7 +380,7 @@
     {
         "basic_block": {
             "end_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[7]/BertAttention[attention]/BertSelfOutput[output]/__add___0",
-            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[6]/BertOutput[output]/LayerNorm[LayerNorm]/layer_norm_0"
+            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[6]/BertOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -419,7 +419,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[7]/BertAttention[attention]/BertSelfOutput[output]/LayerNorm[LayerNorm]/layer_norm_0",
+            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[7]/BertAttention[attention]/BertSelfOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[7]/BertIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[7]/BertIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[7]/BertOutput[output]/Dropout[dropout]/dropout_0",
@@ -434,7 +434,7 @@
     {
         "basic_block": {
             "end_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[8]/BertAttention[attention]/BertSelfOutput[output]/__add___0",
-            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[7]/BertOutput[output]/LayerNorm[LayerNorm]/layer_norm_0"
+            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[7]/BertOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -473,7 +473,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[8]/BertAttention[attention]/BertSelfOutput[output]/LayerNorm[LayerNorm]/layer_norm_0",
+            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[8]/BertAttention[attention]/BertSelfOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[8]/BertIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[8]/BertIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[8]/BertOutput[output]/Dropout[dropout]/dropout_0",
@@ -488,7 +488,7 @@
     {
         "basic_block": {
             "end_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[9]/BertAttention[attention]/BertSelfOutput[output]/__add___0",
-            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[8]/BertOutput[output]/LayerNorm[LayerNorm]/layer_norm_0"
+            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[8]/BertOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -527,7 +527,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[9]/BertAttention[attention]/BertSelfOutput[output]/LayerNorm[LayerNorm]/layer_norm_0",
+            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[9]/BertAttention[attention]/BertSelfOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[9]/BertIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[9]/BertIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[9]/BertOutput[output]/Dropout[dropout]/dropout_0",
@@ -542,7 +542,7 @@
     {
         "basic_block": {
             "end_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[10]/BertAttention[attention]/BertSelfOutput[output]/__add___0",
-            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[9]/BertOutput[output]/LayerNorm[LayerNorm]/layer_norm_0"
+            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[9]/BertOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -581,7 +581,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[10]/BertAttention[attention]/BertSelfOutput[output]/LayerNorm[LayerNorm]/layer_norm_0",
+            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[10]/BertAttention[attention]/BertSelfOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[10]/BertIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[10]/BertIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[10]/BertOutput[output]/Dropout[dropout]/dropout_0",
@@ -596,7 +596,7 @@
     {
         "basic_block": {
             "end_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[11]/BertAttention[attention]/BertSelfOutput[output]/__add___0",
-            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[10]/BertOutput[output]/LayerNorm[LayerNorm]/layer_norm_0"
+            "start_node_name": "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[10]/BertOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -635,7 +635,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[11]/BertAttention[attention]/BertSelfOutput[output]/LayerNorm[LayerNorm]/layer_norm_0",
+            "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[11]/BertAttention[attention]/BertSelfOutput[output]/NNCFLayerNorm[LayerNorm]/layer_norm_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[11]/BertIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[11]/BertIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[11]/BertOutput[output]/Dropout[dropout]/dropout_0",

--- a/tests/torch/data/search_building_block/ViT
+++ b/tests/torch/data/search_building_block/ViT
@@ -2,7 +2,7 @@
     {
         "basic_block": {
             "end_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[0]/ViTAttention[attention]/ViTSelfOutput[output]/NNCFLinear[dense]/linear_0",
-            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[0]/LayerNorm[layernorm_before]/layer_norm_0"
+            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[0]/NNCFLayerNorm[layernorm_before]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -38,7 +38,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[0]/LayerNorm[layernorm_after]/layer_norm_0",
+            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[0]/NNCFLayerNorm[layernorm_after]/layer_norm_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[0]/ViTIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[0]/ViTIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[0]/ViTOutput[output]/Dropout[dropout]/dropout_0",
@@ -53,7 +53,7 @@
     {
         "basic_block": {
             "end_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[1]/ViTAttention[attention]/ViTSelfOutput[output]/NNCFLinear[dense]/linear_0",
-            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[1]/LayerNorm[layernorm_before]/layer_norm_0"
+            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[1]/NNCFLayerNorm[layernorm_before]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -89,7 +89,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[1]/LayerNorm[layernorm_after]/layer_norm_0",
+            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[1]/NNCFLayerNorm[layernorm_after]/layer_norm_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[1]/ViTIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[1]/ViTIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[1]/ViTOutput[output]/Dropout[dropout]/dropout_0",
@@ -104,7 +104,7 @@
     {
         "basic_block": {
             "end_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[2]/ViTAttention[attention]/ViTSelfOutput[output]/NNCFLinear[dense]/linear_0",
-            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[2]/LayerNorm[layernorm_before]/layer_norm_0"
+            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[2]/NNCFLayerNorm[layernorm_before]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -140,7 +140,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[2]/LayerNorm[layernorm_after]/layer_norm_0",
+            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[2]/NNCFLayerNorm[layernorm_after]/layer_norm_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[2]/ViTIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[2]/ViTIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[2]/ViTOutput[output]/Dropout[dropout]/dropout_0",
@@ -155,7 +155,7 @@
     {
         "basic_block": {
             "end_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[3]/ViTAttention[attention]/ViTSelfOutput[output]/NNCFLinear[dense]/linear_0",
-            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[3]/LayerNorm[layernorm_before]/layer_norm_0"
+            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[3]/NNCFLayerNorm[layernorm_before]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -191,7 +191,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[3]/LayerNorm[layernorm_after]/layer_norm_0",
+            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[3]/NNCFLayerNorm[layernorm_after]/layer_norm_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[3]/ViTIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[3]/ViTIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[3]/ViTOutput[output]/Dropout[dropout]/dropout_0",
@@ -206,7 +206,7 @@
     {
         "basic_block": {
             "end_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[4]/ViTAttention[attention]/ViTSelfOutput[output]/NNCFLinear[dense]/linear_0",
-            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[4]/LayerNorm[layernorm_before]/layer_norm_0"
+            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[4]/NNCFLayerNorm[layernorm_before]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -242,7 +242,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[4]/LayerNorm[layernorm_after]/layer_norm_0",
+            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[4]/NNCFLayerNorm[layernorm_after]/layer_norm_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[4]/ViTIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[4]/ViTIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[4]/ViTOutput[output]/Dropout[dropout]/dropout_0",
@@ -257,7 +257,7 @@
     {
         "basic_block": {
             "end_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[5]/ViTAttention[attention]/ViTSelfOutput[output]/NNCFLinear[dense]/linear_0",
-            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[5]/LayerNorm[layernorm_before]/layer_norm_0"
+            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[5]/NNCFLayerNorm[layernorm_before]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -293,7 +293,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[5]/LayerNorm[layernorm_after]/layer_norm_0",
+            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[5]/NNCFLayerNorm[layernorm_after]/layer_norm_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[5]/ViTIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[5]/ViTIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[5]/ViTOutput[output]/Dropout[dropout]/dropout_0",
@@ -308,7 +308,7 @@
     {
         "basic_block": {
             "end_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[6]/ViTAttention[attention]/ViTSelfOutput[output]/NNCFLinear[dense]/linear_0",
-            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[6]/LayerNorm[layernorm_before]/layer_norm_0"
+            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[6]/NNCFLayerNorm[layernorm_before]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -344,7 +344,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[6]/LayerNorm[layernorm_after]/layer_norm_0",
+            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[6]/NNCFLayerNorm[layernorm_after]/layer_norm_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[6]/ViTIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[6]/ViTIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[6]/ViTOutput[output]/Dropout[dropout]/dropout_0",
@@ -359,7 +359,7 @@
     {
         "basic_block": {
             "end_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[7]/ViTAttention[attention]/ViTSelfOutput[output]/NNCFLinear[dense]/linear_0",
-            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[7]/LayerNorm[layernorm_before]/layer_norm_0"
+            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[7]/NNCFLayerNorm[layernorm_before]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -395,7 +395,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[7]/LayerNorm[layernorm_after]/layer_norm_0",
+            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[7]/NNCFLayerNorm[layernorm_after]/layer_norm_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[7]/ViTIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[7]/ViTIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[7]/ViTOutput[output]/Dropout[dropout]/dropout_0",
@@ -410,7 +410,7 @@
     {
         "basic_block": {
             "end_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[8]/ViTAttention[attention]/ViTSelfOutput[output]/NNCFLinear[dense]/linear_0",
-            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[8]/LayerNorm[layernorm_before]/layer_norm_0"
+            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[8]/NNCFLayerNorm[layernorm_before]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -446,7 +446,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[8]/LayerNorm[layernorm_after]/layer_norm_0",
+            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[8]/NNCFLayerNorm[layernorm_after]/layer_norm_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[8]/ViTIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[8]/ViTIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[8]/ViTOutput[output]/Dropout[dropout]/dropout_0",
@@ -461,7 +461,7 @@
     {
         "basic_block": {
             "end_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[9]/ViTAttention[attention]/ViTSelfOutput[output]/NNCFLinear[dense]/linear_0",
-            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[9]/LayerNorm[layernorm_before]/layer_norm_0"
+            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[9]/NNCFLayerNorm[layernorm_before]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -497,7 +497,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[9]/LayerNorm[layernorm_after]/layer_norm_0",
+            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[9]/NNCFLayerNorm[layernorm_after]/layer_norm_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[9]/ViTIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[9]/ViTIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[9]/ViTOutput[output]/Dropout[dropout]/dropout_0",
@@ -512,7 +512,7 @@
     {
         "basic_block": {
             "end_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[10]/ViTAttention[attention]/ViTSelfOutput[output]/NNCFLinear[dense]/linear_0",
-            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[10]/LayerNorm[layernorm_before]/layer_norm_0"
+            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[10]/NNCFLayerNorm[layernorm_before]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -548,7 +548,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[10]/LayerNorm[layernorm_after]/layer_norm_0",
+            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[10]/NNCFLayerNorm[layernorm_after]/layer_norm_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[10]/ViTIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[10]/ViTIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[10]/ViTOutput[output]/Dropout[dropout]/dropout_0",
@@ -563,7 +563,7 @@
     {
         "basic_block": {
             "end_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[11]/ViTAttention[attention]/ViTSelfOutput[output]/NNCFLinear[dense]/linear_0",
-            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[11]/LayerNorm[layernorm_before]/layer_norm_0"
+            "start_node_name": "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[11]/NNCFLayerNorm[layernorm_before]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -599,7 +599,7 @@
         },
         "block_type": "FF",
         "op_addresses": [
-            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[11]/LayerNorm[layernorm_after]/layer_norm_0",
+            "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[11]/NNCFLayerNorm[layernorm_after]/layer_norm_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[11]/ViTIntermediate[intermediate]/GELUActivation[intermediate_act_fn]/gelu_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[11]/ViTIntermediate[intermediate]/NNCFLinear[dense]/linear_0",
             "ViTForImageClassification/ViTModel[vit]/ViTEncoder[encoder]/ModuleList[layer]/ViTLayer[11]/ViTOutput[output]/Dropout[dropout]/dropout_0",

--- a/tests/torch/data/search_building_block/wave2vec 2.0
+++ b/tests/torch/data/search_building_block/wave2vec 2.0
@@ -42,7 +42,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[0]/__add___1",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[0]/LayerNorm[layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[0]/NNCFLayerNorm[layer_norm]/layer_norm_0"
         },
         "block_type": "FF",
         "op_addresses": [
@@ -61,7 +61,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[1]/__add___0",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[0]/LayerNorm[final_layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[0]/NNCFLayerNorm[final_layer_norm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -101,7 +101,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[1]/__add___1",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[1]/LayerNorm[layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[1]/NNCFLayerNorm[layer_norm]/layer_norm_0"
         },
         "block_type": "FF",
         "op_addresses": [
@@ -120,7 +120,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[2]/__add___0",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[1]/LayerNorm[final_layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[1]/NNCFLayerNorm[final_layer_norm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -160,7 +160,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[2]/__add___1",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[2]/LayerNorm[layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[2]/NNCFLayerNorm[layer_norm]/layer_norm_0"
         },
         "block_type": "FF",
         "op_addresses": [
@@ -179,7 +179,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[3]/__add___0",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[2]/LayerNorm[final_layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[2]/NNCFLayerNorm[final_layer_norm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -219,7 +219,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[3]/__add___1",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[3]/LayerNorm[layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[3]/NNCFLayerNorm[layer_norm]/layer_norm_0"
         },
         "block_type": "FF",
         "op_addresses": [
@@ -238,7 +238,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[4]/__add___0",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[3]/LayerNorm[final_layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[3]/NNCFLayerNorm[final_layer_norm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -278,7 +278,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[4]/__add___1",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[4]/LayerNorm[layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[4]/NNCFLayerNorm[layer_norm]/layer_norm_0"
         },
         "block_type": "FF",
         "op_addresses": [
@@ -297,7 +297,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[5]/__add___0",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[4]/LayerNorm[final_layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[4]/NNCFLayerNorm[final_layer_norm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -337,7 +337,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[5]/__add___1",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[5]/LayerNorm[layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[5]/NNCFLayerNorm[layer_norm]/layer_norm_0"
         },
         "block_type": "FF",
         "op_addresses": [
@@ -356,7 +356,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[6]/__add___0",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[5]/LayerNorm[final_layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[5]/NNCFLayerNorm[final_layer_norm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -396,7 +396,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[6]/__add___1",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[6]/LayerNorm[layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[6]/NNCFLayerNorm[layer_norm]/layer_norm_0"
         },
         "block_type": "FF",
         "op_addresses": [
@@ -415,7 +415,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[7]/__add___0",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[6]/LayerNorm[final_layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[6]/NNCFLayerNorm[final_layer_norm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -455,7 +455,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[7]/__add___1",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[7]/LayerNorm[layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[7]/NNCFLayerNorm[layer_norm]/layer_norm_0"
         },
         "block_type": "FF",
         "op_addresses": [
@@ -474,7 +474,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[8]/__add___0",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[7]/LayerNorm[final_layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[7]/NNCFLayerNorm[final_layer_norm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -514,7 +514,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[8]/__add___1",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[8]/LayerNorm[layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[8]/NNCFLayerNorm[layer_norm]/layer_norm_0"
         },
         "block_type": "FF",
         "op_addresses": [
@@ -533,7 +533,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[9]/__add___0",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[8]/LayerNorm[final_layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[8]/NNCFLayerNorm[final_layer_norm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -573,7 +573,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[9]/__add___1",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[9]/LayerNorm[layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[9]/NNCFLayerNorm[layer_norm]/layer_norm_0"
         },
         "block_type": "FF",
         "op_addresses": [
@@ -592,7 +592,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[10]/__add___0",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[9]/LayerNorm[final_layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[9]/NNCFLayerNorm[final_layer_norm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -632,7 +632,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[10]/__add___1",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[10]/LayerNorm[layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[10]/NNCFLayerNorm[layer_norm]/layer_norm_0"
         },
         "block_type": "FF",
         "op_addresses": [
@@ -651,7 +651,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[11]/__add___0",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[10]/LayerNorm[final_layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[10]/NNCFLayerNorm[final_layer_norm]/layer_norm_0"
         },
         "block_type": "MSHA",
         "op_addresses": [
@@ -691,7 +691,7 @@
     {
         "basic_block": {
             "end_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[11]/__add___1",
-            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[11]/LayerNorm[layer_norm]/layer_norm_0"
+            "start_node_name": "Wav2Vec2ForSequenceClassification/Wav2Vec2Model[wav2vec2]/Wav2Vec2Encoder[encoder]/ModuleList[layers]/Wav2Vec2EncoderLayer[11]/NNCFLayerNorm[layer_norm]/layer_norm_0"
         },
         "block_type": "FF",
         "op_addresses": [


### PR DESCRIPTION
### Changes

Updated reference graph for block search tests

### Reason for changes

https://github.com/openvinotoolkit/nncf/pull/1273 introduced new layer - NNCFLayerNorm, but block search tests weren't updated correspondingly

### Related tickets

n/a

### Tests

test_transformer_building_blocks
