### PR TITLE
Use reference quantization on CPU if compiled extensions are unavailable

### DIFF
--- a/examples/torch/object_detection/layers/extensions/__init__.py
+++ b/examples/torch/object_detection/layers/extensions/__init__.py
@@ -2,14 +2,13 @@ import os.path
 
 import torch
 
-from torch.utils.cpp_extension import load
 
 from nncf.torch.extensions import CudaNotAvailableStub
 from nncf.torch.extensions import get_build_directory_for_extension
 
 ext_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 if torch.cuda.is_available():
-    EXTENSIONS = load(
+    EXTENSIONS = torch.utils.cpp_extension.load(
         'extensions', [
             os.path.join(ext_dir, 'extensions.cpp'),
             os.path.join(ext_dir, 'nms/nms.cpp'),

--- a/nncf/common/logging/logger.py
+++ b/nncf/common/logging/logger.py
@@ -70,8 +70,9 @@ def warning_deprecated(msg):
 
 @contextmanager
 def extension_is_loading_info_log(extension_name: str):
-    nncf_logger.info(f"Compiling and loading extensions for {extension_name}...")
+    nncf_logger.info(f"Compiling and loading torch extension: {extension_name}...")
     yield
+    nncf_logger.info(f"Finished loading torch extension: {extension_name}")
 
 
 def warn_bkc_version_mismatch(backend: str, bkc_version: str, current_version: str):

--- a/nncf/torch/binarization/reference.py
+++ b/nncf/torch/binarization/reference.py
@@ -1,0 +1,102 @@
+"""
+ Copyright (c) 2022 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+from enum import Enum
+from typing import TypeVar
+
+import numpy as np
+import torch
+
+GeneralizedTensor = TypeVar('GeneralizedTensor', torch.Tensor, np.ndarray)
+
+
+class ReferenceBackendType(Enum):
+    NUMPY = 'numpy'
+    TORCH = 'torch'
+
+
+class ReferenceBase:
+    def __init__(self, backend_type: ReferenceBackendType):
+        if backend_type is ReferenceBackendType.NUMPY:
+            self.backend = np
+        elif backend_type is ReferenceBackendType.TORCH:
+            self.backend = torch
+        else:
+            raise RuntimeError("Unknown backend for ReferenceQuantize")
+
+
+class ReferenceXNORBinarize(ReferenceBase):
+    def forward(self, x: GeneralizedTensor) -> GeneralizedTensor:
+        norm = self.backend.abs(x).mean((1, 2, 3), keepdims=True)
+        sign = ((x > 0).astype(x.dtype) * 2 - 1)
+        output = sign * norm
+        return output
+
+    @staticmethod
+    def backward(grad_output: GeneralizedTensor) -> GeneralizedTensor:
+        return grad_output
+
+
+class ReferenceDOREFABinarize(ReferenceBase):
+    def forward(self, x: GeneralizedTensor) -> GeneralizedTensor:
+        norm = self.backend.abs(x).mean()
+        sign = ((x > 0).astype(x.dtype) * 2 - 1)
+        return sign * norm
+
+    @staticmethod
+    def backward(grad_output: GeneralizedTensor) -> GeneralizedTensor:
+        return grad_output
+
+
+class ReferenceActivationBinarize(ReferenceBase):
+    @staticmethod
+    def forward(x: GeneralizedTensor, scale: GeneralizedTensor, threshold: GeneralizedTensor) -> GeneralizedTensor:
+        shape = [1 for s in x.shape]
+        shape[1] = x.shape[1]
+        t = threshold * scale
+        output = (x > t).astype(x.dtype) * scale
+        return output
+
+    @staticmethod
+    def backward(grad_output, x, scale, output):
+
+        # calc gradient for input
+        mask_lower = (x <= scale).astype(x.dtype)
+        grad_input = grad_output * (x >= 0).astype(x.dtype) * mask_lower
+
+        # calc gradient for scale
+        err = (output - x) / scale
+        grad_scale = grad_output * (mask_lower * err + (1 - mask_lower))
+        grad_scale = grad_scale.sum()
+
+        # calc gradient for threshold
+        grad_threshold = -grad_output * (x > 0).astype(x.dtype) * (x < scale).astype(x.dtype)
+
+        for idx, _ in enumerate(x.shape):
+            if idx != 1:  # activation channel dimension
+                grad_threshold = grad_threshold.sum(idx, keepdims=True)
+
+        return [grad_input, grad_scale, grad_threshold]
+
+
+class ReferenceBinarizedFunctions:
+    _xnor = ReferenceXNORBinarize(backend_type=ReferenceBackendType.TORCH)
+    _dorefa = ReferenceDOREFABinarize(backend_type=ReferenceBackendType.TORCH)
+    _act = ReferenceActivationBinarize(backend_type=ReferenceBackendType.TORCH)
+
+    @staticmethod
+    def WeightBinarize_forward(x: torch.Tensor, is_xnor: bool) -> torch.Tensor:
+        if is_xnor:
+            return ReferenceBinarizedFunctions._xnor.forward(x)
+        return ReferenceBinarizedFunctions._dorefa.forward(x)
+
+    ActivationBinarize_forward = _act.forward

--- a/nncf/torch/extensions/__init__.py
+++ b/nncf/torch/extensions/__init__.py
@@ -1,5 +1,6 @@
 import enum
 from pathlib import Path
+from typing import Callable
 
 import torch
 
@@ -7,6 +8,7 @@ from abc import ABC, abstractmethod
 
 from torch.utils.cpp_extension import _get_build_directory
 
+from nncf.common.logging.logger import extension_is_loading_info_log
 from nncf.common.utils.registry import Registry
 from nncf.common.logging import nncf_logger
 
@@ -46,6 +48,31 @@ class ExtensionLoader(ABC):
         return str(get_build_directory_for_extension(cls.name()))
 
 
+class ExtensionNamespace:
+    """
+    Provides lazy loading of the underlying extension, i.e. on the first request of a function from the extension.
+    """
+    def __init__(self, loader: ExtensionLoader):
+        """
+        :param loader: The extension loader.
+        """
+        self._loaded_namespace = None
+        self._loader = loader
+
+    def get(self, fn_name: str) -> Callable:
+        """
+        Returns the callable object corresponding to a function from the extension, loading the extension first if
+        necessary.
+        :param fn_name: A function name as normally accessible from the object return by torch extension's native
+          .load() method.
+        :return: A callable object corresponding to the requested function.
+        """
+        if self._loaded_namespace is None:
+            with extension_is_loading_info_log(self._loader.name()):
+                self._loaded_namespace = self._loader.load()
+        return getattr(self._loaded_namespace, fn_name)
+
+
 def _force_build_extensions(ext_type: ExtensionsType):
     for class_type in EXTENSIONS.registry_dict.values():
         if class_type.extension_type() != ext_type:
@@ -63,5 +90,5 @@ def force_build_cuda_extensions():
 
 class CudaNotAvailableStub:
     def __getattr__(self, item):
-        raise RuntimeError(f"CUDA is not available on this machine. Check that the machine has a GPU and a proper"
-                           f"driver supporting CUDA {torch.version.cuda} is installed")
+        raise RuntimeError(f"CUDA is not available on this machine. Check that the machine has a GPU and a proper "
+                           f"driver supporting CUDA {torch.version.cuda} is installed.")

--- a/nncf/torch/quantization/quantize_functions.py
+++ b/nncf/torch/quantization/quantize_functions.py
@@ -39,9 +39,9 @@ class QuantizeSymmetric(torch.autograd.Function):
             if input_.dtype == torch.float16:
                 input_low = input_low.type(torch.float16)
                 input_range = input_range.type(torch.float16)
-            output = QuantizedFunctionsCUDA.Quantize_forward(input_, input_low, input_range, levels)
+            output = QuantizedFunctionsCUDA.get("Quantize_forward")(input_, input_low, input_range, levels)
         else:
-            output = QuantizedFunctionsCPU.Quantize_forward(input_, input_low, input_range, levels)
+            output = QuantizedFunctionsCPU.get("Quantize_forward")(input_, input_low, input_range, levels)
 
         ctx.save_for_backward(input_, input_low, input_range)
         ctx.levels = levels
@@ -63,11 +63,11 @@ class QuantizeSymmetric(torch.autograd.Function):
                 nncf_logger.debug("grad_output is not contiguous!")
                 grad_output = grad_output.contiguous()
 
-            grad_input, _, grad_scale = QuantizedFunctionsCUDA.Quantize_backward(
+            grad_input, _, grad_scale = QuantizedFunctionsCUDA.get("Quantize_backward")(
                 grad_output, input_, input_low, input_range, levels, level_low, level_high
             )
         else:
-            grad_input, _, grad_scale = QuantizedFunctionsCPU.Quantize_backward(
+            grad_input, _, grad_scale = QuantizedFunctionsCPU.get("Quantize_backward")(
                 grad_output, input_, input_low, input_range, levels, level_low, level_high, False
             )
 
@@ -88,9 +88,9 @@ class QuantizeAsymmetric(torch.autograd.Function):
             if input_.dtype == torch.float16:
                 input_low = input_low.type(torch.float16)
                 input_range = input_range.type(torch.float16)
-            output = QuantizedFunctionsCUDA.Quantize_forward(input_, input_low, input_range, levels)
+            output = QuantizedFunctionsCUDA.get("Quantize_forward")(input_, input_low, input_range, levels)
         else:
-            output = QuantizedFunctionsCPU.Quantize_forward(input_, input_low, input_range, levels)
+            output = QuantizedFunctionsCPU.get("Quantize_forward")(input_, input_low, input_range, levels)
 
         ctx.save_for_backward(input_, input_low, input_range)
         ctx.levels = levels
@@ -112,11 +112,11 @@ class QuantizeAsymmetric(torch.autograd.Function):
                 nncf_logger.debug("grad_output is not contiguous!")
                 grad_output = grad_output.contiguous()
 
-            grad_input, grad_input_low, grad_input_range = QuantizedFunctionsCUDA.Quantize_backward(
+            grad_input, grad_input_low, grad_input_range = QuantizedFunctionsCUDA.get("Quantize_backward")(
                 grad_output, input_, input_low, input_range, levels, level_low, level_high
             )
         else:
-            grad_input, grad_input_low, grad_input_range = QuantizedFunctionsCPU.Quantize_backward(
+            grad_input, grad_input_low, grad_input_range = QuantizedFunctionsCPU.get("Quantize_backward")(
                 grad_output, input_, input_low, input_range, levels, level_low, level_high, True
             )
 

--- a/nncf/torch/quantization/reference.py
+++ b/nncf/torch/quantization/reference.py
@@ -1,0 +1,94 @@
+from enum import Enum
+from typing import List
+from typing import Tuple
+from typing import TypeVar
+
+import numpy as np
+import torch
+
+from nncf.torch.utils import sum_like
+
+GeneralizedTensor = TypeVar('GeneralizedTensor', torch.Tensor, np.ndarray)
+
+
+class ReferenceBackendType(Enum):
+    NUMPY = 'numpy'
+    TORCH = 'torch'
+
+
+class ReferenceQuantize:
+    def __init__(self, backend_type: ReferenceBackendType):
+        if backend_type is ReferenceBackendType.NUMPY:
+            self.backend = np
+        elif backend_type is ReferenceBackendType.TORCH:
+            self.backend = torch
+        else:
+            raise RuntimeError("Unknown backend for ReferenceQuantize")
+
+    def forward(self,
+                input_: GeneralizedTensor,
+                input_low: GeneralizedTensor,
+                input_range: GeneralizedTensor,
+                levels: int) -> GeneralizedTensor:
+        scale = (levels - 1) / input_range
+        output = input_.clip(min=input_low, max=input_low + input_range)
+        zero_point = (- input_low * scale).round()
+        output -= input_low
+        output *= scale
+        output -= zero_point
+        output = output.round()
+        output = output / scale
+        return output
+
+    def backward(self,
+                 grad_output: GeneralizedTensor,
+                 input_: GeneralizedTensor,
+                 input_low: GeneralizedTensor,
+                 input_range: GeneralizedTensor,
+                 output: GeneralizedTensor,
+                 level_low: int,
+                 level_high: int,
+                 range_sign: int) -> List[GeneralizedTensor]:
+        mask_hi = (input_ > (input_low + input_range)).astype(input_.dtype)
+        mask_lo = (input_ < input_low).astype(input_.dtype)
+
+        mask_in = 1 - mask_hi - mask_lo
+        err = (output - input_) * np.reciprocal(input_range * range_sign)
+        grad_range = grad_output * (err * mask_in + range_sign * (level_low / level_high) * mask_lo + mask_hi)
+        grad_range = sum_like(grad_range, input_range)
+
+        grad_input = grad_output * mask_in
+
+        grad_low = grad_output * (mask_hi + mask_lo)
+        grad_low = sum_like(grad_low, input_low)
+        return [grad_input, grad_low, grad_range]
+
+    def tune_range(self, input_low: GeneralizedTensor, input_range: GeneralizedTensor, levels: int) \
+            -> Tuple[GeneralizedTensor, GeneralizedTensor]:
+        input_high = input_range + input_low
+        input_low[input_low > 0] = 0
+        input_high[input_high < 0] = 0
+        n = levels - 1
+        scale = levels / (input_high - input_low)
+        scale = scale.astype(dtype=input_high.dtype)
+        zp = self.backend.round(-input_low * scale)
+
+        new_input_low = self.backend.where(zp < n, zp / (zp - n) * input_high, input_low)
+        new_input_high = self.backend.where(zp > 0., (zp - n) / zp * input_low, input_high)
+
+        range_1 = input_high - new_input_low
+        range_2 = new_input_high - input_low
+
+        mask = (range_1 > range_2).astype(input_high.dtype)
+        inv_mask = abs(1 - mask)
+
+        new_input_low = mask * new_input_low + inv_mask * input_low
+        new_input_range = inv_mask * new_input_high + mask * input_high - new_input_low
+
+        return new_input_low, new_input_range
+
+
+class ReferenceQuantizedFunctions:
+    _executor = ReferenceQuantize(backend_type=ReferenceBackendType.TORCH)
+    Quantize_forward = _executor.forward
+    Quantize_backward = _executor.backward

--- a/tests/cross_fw/install/install_checks_torch.py
+++ b/tests/cross_fw/install/install_checks_torch.py
@@ -50,9 +50,9 @@ if execution_type == "cpu":
     else:
         from nncf.torch.binarization.extensions import BinarizedFunctionsCPU
         from nncf.torch.quantization.extensions import QuantizedFunctionsCPU
-    output_tensor = QuantizedFunctionsCPU.Quantize_forward(input_tensor, input_low_tensor, input_high_tensor, levels)
-    output_tensor = BinarizedFunctionsCPU.ActivationBinarize_forward(output_tensor, scale_tensor, threshold_tensor)
-    output_tensor = BinarizedFunctionsCPU.WeightBinarize_forward(output_tensor, True)
+    output_tensor = QuantizedFunctionsCPU.get("Quantize_forward")(input_tensor, input_low_tensor, input_high_tensor, levels)
+    output_tensor = BinarizedFunctionsCPU.get("ActivationBinarize_forward")(output_tensor, scale_tensor, threshold_tensor)
+    output_tensor = BinarizedFunctionsCPU.get("WeightBinarize_forward")(output_tensor, True)
 elif execution_type == "gpu":
     input_tensor = input_tensor.cuda()
     input_low_tensor = input_low_tensor.cuda()
@@ -69,8 +69,8 @@ elif execution_type == "gpu":
     else:
         from nncf.torch.binarization.extensions import BinarizedFunctionsCUDA
         from nncf.torch.quantization.extensions import QuantizedFunctionsCUDA
-    output_tensor = QuantizedFunctionsCUDA.Quantize_forward(input_tensor, input_low_tensor, input_high_tensor, levels)
-    output_tensor = BinarizedFunctionsCUDA.ActivationBinarize_forward(output_tensor, scale_tensor, threshold_tensor)
-    output_tensor = BinarizedFunctionsCUDA.WeightBinarize_forward(output_tensor, True)
+    output_tensor = QuantizedFunctionsCUDA.get("Quantize_forward")(input_tensor, input_low_tensor, input_high_tensor, levels)
+    output_tensor = BinarizedFunctionsCUDA.get("ActivationBinarize_forward")(output_tensor, scale_tensor, threshold_tensor)
+    output_tensor = BinarizedFunctionsCUDA.get("WeightBinarize_forward")(output_tensor, True)
 else:
     raise RuntimeError("Invalid execution type!")

--- a/tests/shared/isolation_runner.py
+++ b/tests/shared/isolation_runner.py
@@ -1,0 +1,39 @@
+import inspect
+import os
+import subprocess
+from typing import Callable
+from typing import Tuple
+
+import pytest
+
+ISOLATION_RUN_ENV_VAR = "ISOLATION_RUN"
+def run_pytest_case_function_in_separate_process(fn: Callable) -> Tuple[int, str, str]:
+    """
+    Use this function for launching test cases that rely on global object behaviour such as module import
+    order that cannot be reliably reset and/or isolated using regular pytest functionality. This will
+    launch a separate pytest process that will run only the test function passed as the parameter. If the
+    pytest run failed, this function will trigger pytest.fail().
+    :param fn - The function object corresponding to a pytest test function defined elsewhere.
+    :returns A tuple of return code for the pytest invocation, and string representations of the stdout and stderr
+    pipe outputs of the pytest invoсation.
+    """
+    filename = inspect.getfile(fn)
+    func_name = fn.__name__
+    env = os.environ.copy()
+    env[ISOLATION_RUN_ENV_VAR] = "1"
+    with subprocess.Popen(f'pytest -s {filename} -k {func_name}',
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT, shell=True,
+                          bufsize=1,
+                          env=env) as p:
+        stdout, stderr = p.communicate()
+
+    stdout = stdout.decode("utf-8") if stdout is not None else ''
+    stderr = stderr.decode("utf-8") if stderr is not None else ''
+    if p.returncode != 0:
+        pytest.fail(f"pytest invocation failed with exit code {p.returncode}\n"
+                    f"STDOUT:\n"
+                    f"{stdout}\n"
+                    f"STDERR:\n"
+                    f"{stderr}\n")
+    return p.returncode, stdout, stderr

--- a/tests/torch/quantization/extensions/__init__.py
+++ b/tests/torch/quantization/extensions/__init__.py
@@ -1,0 +1,12 @@
+"""
+ Copyright (c) 2022 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""

--- a/tests/torch/quantization/extensions/isolated_cases.py
+++ b/tests/torch/quantization/extensions/isolated_cases.py
@@ -1,0 +1,94 @@
+"""
+ Copyright (c) 2022 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+
+import os
+# This file deliberately does not follow naming convention for pytest-discoverable test case files
+# because the cases in this file are not to be called directly within the general pytest invocation;
+# these are rather executed via proxy test cases that make sure that these test cases are launched in
+# separate processes each.
+import subprocess
+
+import numpy as np
+import pytest
+import torch
+
+from tests.shared.isolation_runner import ISOLATION_RUN_ENV_VAR
+
+@pytest.mark.skipif(ISOLATION_RUN_ENV_VAR not in os.environ, reason="Should be run via isolation proxy")
+def test_reference_quantization_on_cpu_isolated(mocker):
+    load_stub = mocker.patch('torch.utils.cpp_extension.load')
+    def side_effect_fn(name, *args, **kwargs):
+        # simulating failure to find a compiler during extension load
+        if name in ["quantized_functions_cpu", "binarized_functions_cpu"]:
+            raise subprocess.CalledProcessError(returncode=-1, cmd='where cl.exe')
+    load_stub.side_effect = side_effect_fn
+
+    from tests.torch.quantization.test_functions import check_outputs_for_quantization_functions
+    from tests.torch.quantization.test_functions import generate_input
+    from nncf.torch.quantization.quantize_functions import asymmetric_quantize
+    from nncf.torch.quantization.reference import ReferenceBackendType
+    from nncf.torch.quantization.reference import ReferenceQuantize
+    shape = [2, 3, 32, 32]
+    scale_shape = [1, 3, 1, 1]
+    ref_input_low = -np.ones(scale_shape).astype(np.float32)
+    ref_input_range = 2 * np.ones_like(ref_input_low).astype(np.float32)
+    ref_input = generate_input(shape,
+                               ref_input_low,
+                               ref_input_range,
+                               8, "per_channel_scale", is_weights=False,
+                               middle_points=False).astype(np.float32)
+
+    level_low = -128
+    level_high = 127
+    levels = 256
+    test_input = torch.from_numpy(ref_input).float()
+    test_input_low = torch.from_numpy(ref_input_low).float()
+    test_input_range = torch.from_numpy(ref_input_range).float()
+
+    RQ = ReferenceQuantize(backend_type=ReferenceBackendType.NUMPY)
+    ref_input_low, ref_input_range = RQ.tune_range(ref_input_low, ref_input_range, levels)
+    ref_value = RQ.forward(ref_input, ref_input_low, ref_input_range, levels)
+    test_value = asymmetric_quantize(test_input, levels, level_low, level_high, test_input_low, test_input_range,
+                                     eps=0)
+    check_outputs_for_quantization_functions(test_value, ref_value, rtol=1e-3)
+
+
+def _parametrized_missing_cuda_test_body(mocker, exception):
+    load_stub = mocker.patch('torch.utils.cpp_extension.load')
+
+    def side_effect_fn(name, *args, **kwargs):
+        # simulating failure to find a compiler during extension load
+        if name == "quantized_functions_cuda":
+            raise exception
+
+    load_stub.side_effect = side_effect_fn
+
+    patched_fn = mocker.patch("torch.cuda.is_available")
+    patched_fn.return_value = True
+    # loading should trigger an exception and a message to the user
+    with pytest.raises(RuntimeError) as exc_info:
+        from nncf.torch.quantization.extensions import QuantizedFunctionsCUDALoader
+        QuantizedFunctionsCUDALoader.load()
+    print(str(exc_info.getrepr()))
+
+
+@pytest.mark.skipif(ISOLATION_RUN_ENV_VAR not in os.environ, reason="Should be run via isolation proxy")
+def test_missing_cuda_compiler_fails_with_message_isolated_calledprocesserror(mocker):
+    # simulates compiler not found
+    _parametrized_missing_cuda_test_body(mocker, subprocess.CalledProcessError(returncode=-1, cmd='which nvcc'))
+
+@pytest.mark.skipif(ISOLATION_RUN_ENV_VAR not in os.environ, reason="Should be run via isolation proxy")
+def test_missing_cuda_compiler_fails_with_message_isolated_oserror(mocker):
+    # simulates CUDA_HOME not set
+    _parametrized_missing_cuda_test_body(mocker, OSError)

--- a/tests/torch/quantization/extensions/test_extension_unavailable.py
+++ b/tests/torch/quantization/extensions/test_extension_unavailable.py
@@ -1,0 +1,38 @@
+"""
+ Copyright (c) 2022 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+import pytest
+
+from tests.shared.isolation_runner import run_pytest_case_function_in_separate_process
+from tests.torch.quantization.extensions.isolated_cases import \
+    test_missing_cuda_compiler_fails_with_message_isolated_calledprocesserror
+from tests.torch.quantization.extensions.isolated_cases import \
+    test_missing_cuda_compiler_fails_with_message_isolated_oserror
+from tests.torch.quantization.extensions.isolated_cases import test_reference_quantization_on_cpu_isolated
+
+
+def test_reference_quantization_on_cpu():
+    _, stdout, _ = \
+        run_pytest_case_function_in_separate_process(test_reference_quantization_on_cpu_isolated)
+    print(stdout)
+    assert "Could not compile CPU quantization extensions." in stdout
+
+
+@pytest.mark.parametrize("case", [
+    test_missing_cuda_compiler_fails_with_message_isolated_calledprocesserror,
+    test_missing_cuda_compiler_fails_with_message_isolated_oserror
+])
+def test_missing_cuda_compiler_fails_with_message(case):
+    _, stdout, _ = \
+        run_pytest_case_function_in_separate_process(case)
+    print(stdout)
+    assert "https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html" in stdout

--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -776,8 +776,8 @@ class TestHalfPrecisionModels:
         compressed_model(inputs)
 
     @pytest.mark.parametrize('device',
-        [pytest.param("cuda"), pytest.param("cpu", marks=pytest.mark.xfail(reason="CVS-86697"))])
-    def test_manual_partial_half_precision_model(self, initializing_config: NNCFConfig, device):
+        [pytest.param("cuda"), pytest.param("cpu", marks=pytest.mark.skip(reason="CVS-86697"))])
+    def test_manual_partial_half_precision_model(self, initializing_config: NNCFConfig, device: str):
         model = TestHalfPrecisionModels.ModelWithManualPartialHalfPrecision()
         inputs = torch.ones([1, 1, 1, 1])
 


### PR DESCRIPTION
### Changes
As stated in the title. Also changed the way of loading extensions to the lazy approach, so that the extensions are only loaded if associated quantization or binarization functionality is invoked, meaning that non-INT8 workflows will have less points of failure for the user.

### Reason for changes
UX improvement due to not failing where we may keep working functionally.

### Related tickets
94348

### Tests
test_extension_unavailable
