### PR TITLE
Fixed typo in the docstring of the get_keras_layer_metatype function

### DIFF
--- a/nncf/tensorflow/graph/metatypes/matcher.py
+++ b/nncf/tensorflow/graph/metatypes/matcher.py
@@ -41,9 +41,9 @@ def get_keras_layer_metatype(
     y = layer(x)
 
     metatype = get_keras_layer_metatype(layer, determine_subtype = False)
-    assert metatype == TFDepthwiseConv2DSubLayerMetatype
-    metatype = get_keras_layer_metatype(layer, determine_subtype = True)
     assert metatype == TFConv2DLayerMetatype
+    metatype = get_keras_layer_metatype(layer, determine_subtype = True)
+    assert metatype == TFDepthwiseConv2DSubLayerMetatype
     ```
 
     :param layer: The Keras layer.


### PR DESCRIPTION
### Changes

Fixed typo in the docstring of the get_keras_layer_metatype function

### Reason for changes

Incorrect docstring

### Related tickets

N/A

### Tests

N/A
