### PR TITLE
BNAS: Allow disabling BN Adaptation

### DIFF
--- a/nncf/experimental/torch/nas/bootstrapNAS/search/search.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/search.py
@@ -185,7 +185,6 @@ class SearchAlgorithm(BaseSearchAlgorithm):
         super().__init__()
         self._model = model
         self._elasticity_ctrl = elasticity_ctrl
-        self._elasticity_ctrl.multi_elasticity_handler.activate_maximum_subnet()
         search_config = nncf_config.get('bootstrapNAS', {}).get('search', {})
         self.num_obj = None
         self.search_params = SearchParams.from_dict(search_config)
@@ -217,7 +216,8 @@ class SearchAlgorithm(BaseSearchAlgorithm):
         self._result = None
         bn_adapt_params = search_config.get('batchnorm_adaptation', {})
         bn_adapt_algo_kwargs = get_bn_adapt_algo_kwargs(nncf_config, bn_adapt_params)
-        self.bn_adaptation = BatchnormAdaptationAlgorithm(**bn_adapt_algo_kwargs)
+        self.bn_adaptation = BatchnormAdaptationAlgorithm(**bn_adapt_algo_kwargs) if bn_adapt_algo_kwargs else None
+
         self._problem = None
         self.checkpoint_save_dir = None
         self.type_var = np.int
@@ -308,6 +308,7 @@ class SearchAlgorithm(BaseSearchAlgorithm):
         :return: Elasticity controller with discovered sub-network, sub-network configuration and
                 its performance metrics.
         """
+        self._elasticity_ctrl.multi_elasticity_handler.activate_maximum_subnet()
         nncf_logger.info("Searching for optimal subnet.")
         if ref_acc != 100:
             self.search_params.ref_acc = ref_acc

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/search.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/search.py
@@ -331,6 +331,8 @@ class SearchAlgorithm(BaseSearchAlgorithm):
                                                                             self._elasticity_ctrl)
         self._evaluator_handlers.append(self._efficiency_evaluator_handler)
         self._evaluator_handlers.append(self._accuracy_evaluator_handler)
+        self.maximal_vals = [evaluator_handler.current_value for evaluator_handler
+                                  in self._evaluator_handlers]
 
         self._problem = SearchProblem(self)
         self._result = minimize(self._problem, self._algorithm,
@@ -341,15 +343,19 @@ class SearchAlgorithm(BaseSearchAlgorithm):
 
         if self.best_config is not None:
             self._elasticity_ctrl.multi_elasticity_handler.activate_subnet_for_config(self.best_config)
-            self.bn_adaptation.run(self._model)
+            if self.bn_adaptation is not None:
+                self.bn_adaptation.run(self._model)
+            ret_vals = self.best_vals
         else:
             nncf_logger.warning("Couldn't find a subnet that satisfies the requirements. Returning maximum subnet.")
             self._elasticity_ctrl.multi_elasticity_handler.activate_maximum_subnet()
-            self.bn_adaptation.run(self._model)
+            if self.bn_adaptation is not None:
+                self.bn_adaptation.run(self._model)
             self.best_config = self._elasticity_ctrl.multi_elasticity_handler.get_active_config()
             self.best_vals = [None, None]
+            ret_vals = self.maximal_vals
 
-        return self._elasticity_ctrl, self.best_config, [abs(elem) for elem in self.best_vals if elem is not None]
+        return self._elasticity_ctrl, self.best_config, [abs(elem) for elem in ret_vals if elem is not None]
 
     def visualize_search_progression(self, filename='search_progression') -> NoReturn:
         """
@@ -464,7 +470,7 @@ class SearchProblem(Problem):
             for evaluator_handler in self._evaluator_handlers:
                 in_cache, value = evaluator_handler.retrieve_from_cache(tuple(x_i))
                 if not in_cache:
-                    if not bn_adaption_executed:
+                    if not bn_adaption_executed and self._search.bn_adaptation is not None:
                         self._search.bn_adaptation.run(self._model)
                         bn_adaption_executed = True
                     value = evaluator_handler.evaluate_and_add_to_cache_from_pymoo(tuple(x_i))

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/lr_scheduler.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/lr_scheduler.py
@@ -15,6 +15,7 @@ from abc import abstractmethod
 import math
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
 from typing import TypeVar
 
@@ -106,6 +107,8 @@ class BaseLRScheduler(BaseCompressionScheduler):
     def from_state(cls, state: Dict[str, Any], optimizer: OptimizerType):
         return cls(optimizer, **state)
 
+    def get_last_lr(self) -> List[Any]:
+        return [group['lr'] for group in self._optimizer.param_groups]
 
 class GlobalLRScheduler(BaseLRScheduler):
     """

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_builder.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_builder.py
@@ -123,5 +123,5 @@ class ProgressiveShrinkingBuilder(PTCompressionAlgorithmBuilder):
         self._progressivity_of_elasticity = [ElasticityDim.from_str(dim) for dim in progressivity_of_elasticity]
         self._bn_adapt_params = state_without_name[self._state_names.BN_ADAPTATION_PARAMS]
         bn_adapt_algo_kwargs = get_bn_adapt_algo_kwargs(self.config,
-                                                        state_without_name[self._bn_adapt_params])
+                                                        self._bn_adapt_params)
         self._bn_adaptation = BatchnormAdaptationAlgorithm(**bn_adapt_algo_kwargs) if bn_adapt_algo_kwargs else None

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_builder.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_builder.py
@@ -47,8 +47,8 @@ class ProgressiveShrinkingBuilder(PTCompressionAlgorithmBuilder):
 
     def __init__(self, nncf_config: NNCFConfig, should_init: bool = True):
         super().__init__(nncf_config, should_init)
-        bn_adapt_params = self._algo_config.get('batchnorm_adaptation', {})
-        bn_adapt_algo_kwargs = get_bn_adapt_algo_kwargs(nncf_config, bn_adapt_params)
+        self._bn_adapt_params = self._algo_config.get('batchnorm_adaptation', {})
+        bn_adapt_algo_kwargs = get_bn_adapt_algo_kwargs(nncf_config, self._bn_adapt_params)
         self._bn_adaptation = BatchnormAdaptationAlgorithm(**bn_adapt_algo_kwargs) if bn_adapt_algo_kwargs else None
 
         default_progressivity = map(lambda x: x.value, self.DEFAULT_PROGRESSIVITY)
@@ -107,7 +107,7 @@ class ProgressiveShrinkingBuilder(PTCompressionAlgorithmBuilder):
         return {
             self._state_names.ELASTICITY_BUILDER_STATE: self._elasticity_builder.get_state(),
             self._state_names.PROGRESSIVITY_OF_ELASTICITY: [d.value for d in self._progressivity_of_elasticity],
-            self._state_names.BN_ADAPTATION_PARAMS: self._algo_config.get('batchnorm_adaptation', {})
+            self._state_names.BN_ADAPTATION_PARAMS: self._bn_adapt_params
         }
 
     def _load_state_without_name(self, state_without_name: Dict[str, Any]):
@@ -121,6 +121,7 @@ class ProgressiveShrinkingBuilder(PTCompressionAlgorithmBuilder):
         progressivity_of_elasticity = state_without_name[self._state_names.PROGRESSIVITY_OF_ELASTICITY]
         # No conflict resolving with the related config options, parameters are overridden by compression state
         self._progressivity_of_elasticity = [ElasticityDim.from_str(dim) for dim in progressivity_of_elasticity]
+        self._bn_adapt_params = state_without_name[self._state_names.BN_ADAPTATION_PARAMS]
         bn_adapt_algo_kwargs = get_bn_adapt_algo_kwargs(self.config,
-                                                        state_without_name[self._state_names.BN_ADAPTATION_PARAMS])
+                                                        state_without_name[self._bn_adapt_params])
         self._bn_adaptation = BatchnormAdaptationAlgorithm(**bn_adapt_algo_kwargs) if bn_adapt_algo_kwargs else None

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_builder.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_builder.py
@@ -48,7 +48,7 @@ class ProgressiveShrinkingBuilder(PTCompressionAlgorithmBuilder):
         super().__init__(nncf_config, should_init)
         bn_adapt_params = self._algo_config.get('batchnorm_adaptation', {})
         bn_adapt_algo_kwargs = get_bn_adapt_algo_kwargs(nncf_config, bn_adapt_params)
-        self._bn_adaptation = BatchnormAdaptationAlgorithm(**bn_adapt_algo_kwargs)
+        self._bn_adaptation = BatchnormAdaptationAlgorithm(**bn_adapt_algo_kwargs) if bn_adapt_algo_kwargs else None
 
         default_progressivity = map(lambda x: x.value, self.DEFAULT_PROGRESSIVITY)
         progressivity_of_elasticity = self._algo_config.get('progressivity_of_elasticity', default_progressivity)

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_controller.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_controller.py
@@ -144,7 +144,8 @@ class ProgressiveShrinkingController(BNASTrainingController):
         Performs some action on active subnet or supernet before validation. For instance, it can be the batchnorm
         adaptation to achieve the best accuracy on validation.
         """
-        self._run_batchnorm_adaptation(self._target_model)
+        if self._bn_adaptation:
+            self._run_batchnorm_adaptation(self._target_model)
 
     def get_total_num_epochs(self) -> int:
         """
@@ -232,5 +233,5 @@ class ProgressiveShrinkingController(BNASTrainingController):
 
     def _run_batchnorm_adaptation(self, model):
         if self._bn_adaptation is None:
-            raise RuntimeError("Missing initialization of Batchnorm Adaptation algorithm")
+            nncf_logger.warning("Batchnorm adaptation requested but it hasn't been enabled for training.")
         self._bn_adaptation.run(model)

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_controller.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_controller.py
@@ -82,7 +82,7 @@ class ProgressiveShrinkingController(BNASTrainingController):
         else:
             nncf_logger.info("Stage LR scheduler in use")
             lr_scheduler = StageLRScheduler(optimizer, train_iters)
-        self._scheduler.set_lr_scheduler(lr_scheduler)
+        self._scheduler.lr_scheduler = lr_scheduler
 
     @property
     def lr_schedule_config(self) -> str:

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/scheduler.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/scheduler.py
@@ -123,7 +123,12 @@ class BootstrapNASScheduler(BaseCompressionScheduler):
         self._is_elasticity_dims_validated = False
         self._lr_scheduler = None
 
-    def set_lr_scheduler(self, lr_scheduler: BaseLRScheduler):
+    @property
+    def lr_scheduler(self):
+        return self._lr_scheduler
+
+    @lr_scheduler.setter
+    def lr_scheduler(self, lr_scheduler: BaseLRScheduler) -> None:
         self._lr_scheduler = lr_scheduler
 
     @property

--- a/tests/torch/nas/creators.py
+++ b/tests/torch/nas/creators.py
@@ -51,10 +51,13 @@ from tests.torch.nas.models.vgg_k7 import VGG11_K7
 
 # TODO(nlyalyus) reduce number of creators and descriptors. create wrapper of TrainingAlgorithm  (ticket 81015)
 def create_bootstrap_training_model_and_ctrl(model,
-                                             nncf_config: NNCFConfig) -> Tuple[NNCFNetwork, BNASTrainingController]:
+                                             nncf_config: NNCFConfig,
+                                             register_bn_adapt: bool = True) \
+                                             -> Tuple[NNCFNetwork, BNASTrainingController]:
     algo_name = nncf_config.get('bootstrapNAS', {}).get('training', {}).get('algorithm', 'progressive_shrinking')
     nncf_network = create_nncf_network(model, nncf_config)
-    register_bn_adaptation_init_args(nncf_config)
+    if register_bn_adapt:
+        register_bn_adaptation_init_args(nncf_config)
     ctrl, model = create_compressed_model_from_algo_names(nncf_network, nncf_config, [algo_name], False)
 
     # Default optimizer

--- a/tests/torch/nas/test_all_elasticity.py
+++ b/tests/torch/nas/test_all_elasticity.py
@@ -10,7 +10,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from copy import deepcopy
 
 import pytest
 import torch

--- a/tests/torch/nas/test_all_elasticity.py
+++ b/tests/torch/nas/test_all_elasticity.py
@@ -401,10 +401,7 @@ def test_can_restore_from_state():
     _, training_ctrl = resume_compression_from_state(nncf_network, old_state, empty_nncf_config)
 
     new_state = training_ctrl.get_compression_state()
-    assert old_state == REF_COMPRESSION_STATE_FOR_TWO_CONV
-    REF_NEW_STATE = deepcopy(REF_COMPRESSION_STATE_FOR_TWO_CONV)
-    REF_NEW_STATE['builder_state']['progressive_shrinking'].update({'bn_adaptation_params': {}})
-    assert new_state == REF_NEW_STATE
+    assert new_state == old_state
 
 
 def test_can_restore_and_get_the_same_output():

--- a/tests/torch/nas/test_all_elasticity.py
+++ b/tests/torch/nas/test_all_elasticity.py
@@ -10,6 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from copy import deepcopy
 
 import pytest
 import torch
@@ -284,6 +285,7 @@ REF_COMPRESSION_STATE_FOR_TWO_CONV = {
                 }
             },
             'progressivity_of_elasticity': ['kernel', 'width', 'depth'],
+            'bn_adaptation_params': {'num_bn_adaptation_samples': 2},
         }
     },
     'ctrl_state': {
@@ -399,7 +401,10 @@ def test_can_restore_from_state():
     _, training_ctrl = resume_compression_from_state(nncf_network, old_state, empty_nncf_config)
 
     new_state = training_ctrl.get_compression_state()
-    assert new_state == old_state
+    assert old_state == REF_COMPRESSION_STATE_FOR_TWO_CONV
+    REF_NEW_STATE = deepcopy(REF_COMPRESSION_STATE_FOR_TWO_CONV)
+    REF_NEW_STATE['builder_state']['progressive_shrinking'].update({'bn_adaptation_params': {}})
+    assert new_state == REF_NEW_STATE
 
 
 def test_can_restore_and_get_the_same_output():

--- a/tests/torch/nas/test_ps_controller.py
+++ b/tests/torch/nas/test_ps_controller.py
@@ -10,9 +10,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from copy import deepcopy
-from pathlib import Path
-
 from typing import Any
 from typing import Dict
 from typing import List
@@ -24,10 +21,8 @@ import torch
 from nncf import NNCFConfig
 from nncf.config.structures import BNAdaptationInitArgs
 from nncf.experimental.torch.nas.bootstrapNAS import EpochBasedTrainingAlgorithm
-from nncf.experimental.torch.nas.bootstrapNAS.training.training_algorithm import EBTrainAlgoStateNames
 from nncf.torch.model_creation import create_nncf_network
 from tests.torch.helpers import create_ones_mock_dataloader
-from tests.torch.nas.creators import create_bootstrap_training_model_and_ctrl
 from tests.torch.nas.helpers import move_model_to_cuda_if_available
 from tests.torch.nas.models.synthetic import ThreeConvModel
 from tests.torch.nas.test_scheduler import fixture_schedule_params  # pylint: disable=unused-import
@@ -86,7 +81,7 @@ class TestProgressiveTrainingController:
                                          )
         bn_adapt_run_patch = mocker.patch(
             "nncf.common.initialization.batchnorm_adaptation.BatchnormAdaptationAlgorithm.run")
-        model, bn_adapt_args, nncf_config = prepare_test_model(test_desc, bn_adapt_section_is_called)
+        model, _, nncf_config = prepare_test_model(test_desc, bn_adapt_section_is_called)
         model = create_nncf_network(model, nncf_config)
 
         training_algorithm = EpochBasedTrainingAlgorithm.from_config(model, nncf_config)

--- a/tests/torch/nas/test_ps_controller.py
+++ b/tests/torch/nas/test_ps_controller.py
@@ -1,0 +1,130 @@
+"""
+ Copyright (c) 2022 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+from collections import OrderedDict
+
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import NamedTuple
+
+import pytest
+
+from nncf import NNCFConfig
+from nncf.common.initialization.batchnorm_adaptation import BatchnormAdaptationAlgorithm
+from nncf.config.extractors import get_bn_adapt_algo_kwargs
+from nncf.config.structures import BNAdaptationInitArgs
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.base_handler import SingleElasticityHandler
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elastic_depth import ElasticDepthHandler
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elastic_width import ElasticWidthHandler
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_dim import ElasticityDim
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.multi_elasticity_handler import MultiElasticityHandler
+from nncf.experimental.torch.nas.bootstrapNAS.training.progressive_shrinking_builder import ProgressiveShrinkingBuilder
+from nncf.experimental.torch.nas.bootstrapNAS.training.progressive_shrinking_controller import \
+    ProgressiveShrinkingController
+from nncf.experimental.torch.nas.bootstrapNAS.training.stage_descriptor import StageDescriptor
+from nncf.torch.nncf_network import NNCFNetwork
+from tests.torch.helpers import create_ones_mock_dataloader, MockModel
+from tests.torch.nas.creators import create_bnas_model_and_ctrl_by_test_desc
+from tests.torch.nas.models.synthetic import ThreeConvModel
+from tests.torch.nas.test_scheduler import fixture_schedule_params
+
+
+class PSControllerTestDesc(NamedTuple):
+    model_creator: Any
+    blocks_to_skip: List[List[str]] = None
+    input_sizes: List[int] = [1, 3, 32, 32]
+    algo_params: Dict = {}
+    name: str = None
+    mode: str = "auto"
+
+    def __str__(self):
+        if hasattr(self.model_creator, '__name__'):
+            name = self.model_creator.__name__
+        elif self.name is not None:
+            name = self.name
+        else:
+            name = 'NOT_DEFINED'
+        return name
+
+
+def prepare_test_model(ps_ctrl_desc):
+    model, ctrl = create_bnas_model_and_ctrl_by_test_desc(ps_ctrl_desc)
+    elasticity_ctrl = ctrl.elasticity_controller
+    config = {
+        "input_info": {"sample_size": ps_ctrl_desc.input_sizes},
+        "bootstrapNAS": {
+            "training": {
+                "batchnorm_adaptation": {
+                    "num_bn_adaptation_samples": 2
+                },
+                "elasticity": {
+                    "available_elasticity_dims": ["depth", "width"]
+                }
+            },
+        }
+    }
+    nncf_config = NNCFConfig.from_dict(config)
+    bn_adapt_args = BNAdaptationInitArgs(data_loader=create_ones_mock_dataloader(nncf_config))
+    nncf_config.register_extra_structs([bn_adapt_args])
+    return model, elasticity_ctrl, nncf_config
+
+
+def update_train_bn_adapt_section(nncf_config, bn_adapt_section_is_called):
+    if not bn_adapt_section_is_called:
+        nncf_config['bootstrapNAS']['training']['batchnorm_adaptation']['num_bn_adaptation_samples'] = 0
+
+
+# pylint: disable=protected-access
+class TestProgressiveTrainingController:
+    @pytest.mark.parametrize(('bn_adapt_section', 'is_called'), (("section_with_zero_num_samples", False),
+                                                                 ("section_with_non_zero_num_samples", True)))
+    def test_bn_adapt(self, mocker, bn_adapt_section, is_called, tmp_path, schedule_params):
+        test_desc = PSControllerTestDesc(model_creator=ThreeConvModel,
+                                     algo_params={'width': {'min_width': 1, 'width_step': 1}},
+                                     input_sizes=ThreeConvModel.INPUT_SIZE,
+                                     )
+        nncf_network, ctrl, nncf_config = prepare_test_model(test_desc)
+        update_train_bn_adapt_section(nncf_config, is_called)
+        bn_adapt_run_patch = mocker.patch(
+            "nncf.common.initialization.batchnorm_adaptation.BatchnormAdaptationAlgorithm.run")
+        mock_model = MockModel()
+        mock_nncf_network = mocker.MagicMock(spec=NNCFNetwork)
+        mock_width_handler = mocker.MagicMock(spec=ElasticWidthHandler)
+        mock_depth_handler = mocker.MagicMock(spec=ElasticDepthHandler)
+        mock_kernel_handler = mocker.MagicMock(spec=SingleElasticityHandler)
+        handlers = OrderedDict({
+            ElasticityDim.WIDTH: mock_width_handler,
+            ElasticityDim.KERNEL: mock_kernel_handler,
+            ElasticityDim.DEPTH: mock_depth_handler,
+        })
+        mock_handler = MultiElasticityHandler(handlers, mock_nncf_network)
+        # pylint:disable=protected-access
+        mock_elasticity_ctrl = mocker.stub()
+        mock_elasticity_ctrl.multi_elasticity_handler = mock_handler
+        lr_schedule_config = {}
+        training_config = nncf_config.get('bootstrapNAS', {}).get('training', {})
+        bn_adapt_params = training_config.get('batchnorm_adaptation', {})
+        bn_adapt_algo_kwargs = get_bn_adapt_algo_kwargs(nncf_config, bn_adapt_params)
+        bn_adaptation = BatchnormAdaptationAlgorithm(**bn_adapt_algo_kwargs) if bn_adapt_algo_kwargs else None
+        training_algo = ProgressiveShrinkingController(mock_model, mock_elasticity_ctrl, bn_adaptation,
+                                                       ProgressiveShrinkingBuilder.DEFAULT_PROGRESSIVITY,
+                                                       schedule_params, lr_schedule_config)
+        # Check prepare for validation
+        training_algo.prepare_for_validation()
+        # Check when setting stage
+        desc = StageDescriptor([ElasticityDim.DEPTH, ElasticityDim.WIDTH], bn_adapt=is_called)
+        training_algo.set_stage(desc)
+        if is_called:
+            bn_adapt_run_patch.assert_called()
+        else:
+            bn_adapt_run_patch.assert_not_called()

--- a/tests/torch/nas/test_ps_controller.py
+++ b/tests/torch/nas/test_ps_controller.py
@@ -36,7 +36,7 @@ from nncf.torch.nncf_network import NNCFNetwork
 from tests.torch.helpers import create_ones_mock_dataloader, MockModel
 from tests.torch.nas.creators import create_bnas_model_and_ctrl_by_test_desc
 from tests.torch.nas.models.synthetic import ThreeConvModel
-from tests.torch.nas.test_scheduler import fixture_schedule_params
+from tests.torch.nas.test_scheduler import fixture_schedule_params # pylint: disable=unused-import
 
 
 class PSControllerTestDesc(NamedTuple):
@@ -93,7 +93,7 @@ class TestProgressiveTrainingController:
                                      algo_params={'width': {'min_width': 1, 'width_step': 1}},
                                      input_sizes=ThreeConvModel.INPUT_SIZE,
                                      )
-        nncf_network, ctrl, nncf_config = prepare_test_model(test_desc)
+        _, _, nncf_config = prepare_test_model(test_desc)
         update_train_bn_adapt_section(nncf_config, is_called)
         bn_adapt_run_patch = mocker.patch(
             "nncf.common.initialization.batchnorm_adaptation.BatchnormAdaptationAlgorithm.run")

--- a/tests/torch/nas/test_ps_controller.py
+++ b/tests/torch/nas/test_ps_controller.py
@@ -16,7 +16,6 @@ from typing import List
 from typing import NamedTuple
 
 import pytest
-import torch
 
 from nncf import NNCFConfig
 from nncf.config.structures import BNAdaptationInitArgs

--- a/tests/torch/nas/test_scheduler.py
+++ b/tests/torch/nas/test_scheduler.py
@@ -76,7 +76,7 @@ class TestScheduler:
         scheduler = BootstrapNASScheduler(training_ctrl_mock, schedule_params, LIST_DIMS__KDW, LIST_DIMS__KDW)
         optimizer_mock = mocker.stub()
         optimizer_mock.param_groups = [{'lr': 1}]
-        scheduler.set_lr_scheduler(StageLRScheduler(optimizer_mock, 10))
+        scheduler.lr_scheduler = StageLRScheduler(optimizer_mock, 10)
         scheduler.epoch_step()
         ref_desc = StageDescriptor(train_dims=[ElasticityDim.KERNEL],
                                    epochs=1, init_lr=DEFAULT_STAGE_LR_RATE, epochs_lr=1)
@@ -127,7 +127,7 @@ class TestScheduler:
                                                        schedule_params, lr_schedule_config)
         scheduler = training_algo.scheduler
         lr_scheduler = GlobalLRScheduler(mocker.stub(), mocker.stub(), base_lr=None, num_epochs=None)
-        scheduler.set_lr_scheduler(lr_scheduler)
+        scheduler.lr_scheduler = lr_scheduler
         scheduler.epoch_step()
         assert is_handler_enabled_map == {
             ElasticityDim.WIDTH: False,

--- a/tests/torch/nas/test_search.py
+++ b/tests/torch/nas/test_search.py
@@ -19,10 +19,7 @@ from typing import NamedTuple
 import pytest
 
 from nncf import NNCFConfig
-from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_controller import ElasticityController
-from nncf.experimental.torch.nas.bootstrapNAS.search.search import ValFnType, DataLoaderType
-from nncf.torch.nncf_network import NNCFNetwork
-from tests.torch.nas.test_all_elasticity import fixture_nas_model_name  # pylint: disable=unused-import
+from nncf.experimental.torch.nas.bootstrapNAS.search.search import DataLoaderType
 from nncf.config.structures import BNAdaptationInitArgs
 from nncf.experimental.torch.nas.bootstrapNAS import SearchAlgorithm
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_dim import ElasticityDim
@@ -32,6 +29,7 @@ from tests.torch.nas.creators import NAS_MODEL_DESCS
 from tests.torch.nas.creators import create_bnas_model_and_ctrl_by_test_desc
 from tests.torch.nas.creators import create_bootstrap_training_model_and_ctrl
 from tests.torch.nas.models.synthetic import ThreeConvModel
+from tests.torch.nas.test_all_elasticity import fixture_nas_model_name  # pylint: disable=unused-import
 
 
 class SearchTestDesc(NamedTuple):

--- a/tests/torch/nas/test_search.py
+++ b/tests/torch/nas/test_search.py
@@ -19,7 +19,10 @@ from typing import NamedTuple
 import pytest
 
 from nncf import NNCFConfig
-from tests.torch.nas.test_all_elasticity import fixture_nas_model_name #pylint: disable=unused-import
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_controller import ElasticityController
+from nncf.experimental.torch.nas.bootstrapNAS.search.search import ValFnType, DataLoaderType
+from nncf.torch.nncf_network import NNCFNetwork
+from tests.torch.nas.test_all_elasticity import fixture_nas_model_name  # pylint: disable=unused-import
 from nncf.config.structures import BNAdaptationInitArgs
 from nncf.experimental.torch.nas.bootstrapNAS import SearchAlgorithm
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_dim import ElasticityDim
@@ -56,14 +59,17 @@ def prepare_test_model(search_desc):
         "input_info": {"sample_size": search_desc.input_sizes},
         "bootstrapNAS": {
             "training": {
-                "batchnorm_adaptation": {
-                    "num_bn_adaptation_samples": 2
-                },
+                "elasticity": {
+                    "available_elasticity_dims": ["depth", "width"]
+                }
             },
             "search": {
                 "algorithm": "NSGA2",
                 "num_evals": 2,
-                "population": 1
+                "population": 1,
+                "batchnorm_adaptation": {
+                    "num_bn_adaptation_samples": 2
+                },
             }
         }
     }
@@ -94,6 +100,11 @@ def prepare_search_algorithm(nas_model_name: str):
     elasticity_ctrl = ctrl.elasticity_controller
     elasticity_ctrl.multi_elasticity_handler.enable_all()
     return SearchAlgorithm.from_config(model, elasticity_ctrl, nncf_config)
+
+
+def update_search_bn_adapt_section(nncf_config, bn_adapt_section_is_called):
+    if not bn_adapt_section_is_called:
+        nncf_config['bootstrapNAS']['search']['batchnorm_adaptation']['num_bn_adaptation_samples'] = 0
 
 
 NAS_MODELS_SEARCH_ENCODING = {
@@ -159,6 +170,29 @@ class TestSearchAlgorithm:
         search = prepare_search_algorithm(nas_model_name)
         assert search.vars_upper == NAS_MODELS_SEARCH_ENCODING[nas_model_name]
         assert search.num_vars == len(NAS_MODELS_SEARCH_ENCODING[nas_model_name])
+
+    @pytest.mark.parametrize(('bn_adapt_section', 'is_called'), (("section_with_zero_num_samples", False),
+                                                                 ("section_with_non_zero_num_samples", True)))
+    def test_bn_adapt(self, mocker, bn_adapt_section, is_called, tmp_path):
+        search_desc = SearchTestDesc(model_creator=ThreeConvModel,
+                                     algo_params={'width': {'min_width': 1, 'width_step': 1}},
+                                     input_sizes=ThreeConvModel.INPUT_SIZE,
+                                     )
+        nncf_network, ctrl, nncf_config = prepare_test_model(search_desc)
+        update_search_bn_adapt_section(nncf_config, is_called)
+        bn_adapt_run_patch = mocker.patch(
+            "nncf.common.initialization.batchnorm_adaptation.BatchnormAdaptationAlgorithm.run")
+        ctrl.multi_elasticity_handler.enable_all()
+        search_algo = SearchAlgorithm(nncf_network, ctrl, nncf_config)
+
+        def fake_acc_eval(*unused):
+            return 0
+
+        search_algo.run(fake_acc_eval, mocker.MagicMock(spec=DataLoaderType), tmp_path)
+        if is_called:
+            bn_adapt_run_patch.assert_called()
+        else:
+            bn_adapt_run_patch.assert_not_called()
 
 
 class TestSearchEvaluators:

--- a/tests/torch/nas/test_search.py
+++ b/tests/torch/nas/test_search.py
@@ -169,15 +169,15 @@ class TestSearchAlgorithm:
         assert search.vars_upper == NAS_MODELS_SEARCH_ENCODING[nas_model_name]
         assert search.num_vars == len(NAS_MODELS_SEARCH_ENCODING[nas_model_name])
 
-    @pytest.mark.parametrize(('bn_adapt_section', 'is_called'), (("section_with_zero_num_samples", False),
-                                                                 ("section_with_non_zero_num_samples", True)))
-    def test_bn_adapt(self, mocker, bn_adapt_section, is_called, tmp_path):
+    @pytest.mark.parametrize("bn_adapt_section_is_called", [False,True],
+                              ids=["section_with_zero_num_samples", "section_with_non_zero_num_samples"])
+    def test_bn_adapt(self, mocker, bn_adapt_section_is_called, tmp_path):
         search_desc = SearchTestDesc(model_creator=ThreeConvModel,
                                      algo_params={'width': {'min_width': 1, 'width_step': 1}},
                                      input_sizes=ThreeConvModel.INPUT_SIZE,
                                      )
         nncf_network, ctrl, nncf_config = prepare_test_model(search_desc)
-        update_search_bn_adapt_section(nncf_config, is_called)
+        update_search_bn_adapt_section(nncf_config, bn_adapt_section_is_called)
         bn_adapt_run_patch = mocker.patch(
             "nncf.common.initialization.batchnorm_adaptation.BatchnormAdaptationAlgorithm.run")
         ctrl.multi_elasticity_handler.enable_all()
@@ -187,7 +187,7 @@ class TestSearchAlgorithm:
             return 0
 
         search_algo.run(fake_acc_eval, mocker.MagicMock(spec=DataLoaderType), tmp_path)
-        if is_called:
+        if bn_adapt_section_is_called:
             bn_adapt_run_patch.assert_called()
         else:
             bn_adapt_run_patch.assert_not_called()


### PR DESCRIPTION
### Changes

(1) When num_bn_adaptation_samples = 0, batchnorm adaptation will be skipped
(2) Add function "get_last_lr". This function will be used in Hugging Face patch.
(3) Add property for lr_scheduler. This will be used in Hugging Face patch.

### Reason for changes

Substep to implement a patch for HF Transformers for BootstrapNAS

### Related tickets

N/A

### Tests

N/A