### PR TITLE
Added the ignored scope parameter to the quantize function signature

### DIFF
--- a/nncf/__init__.py
+++ b/nncf/__init__.py
@@ -11,13 +11,15 @@
  limitations under the License.
 """
 
-from nncf.config import NNCFConfig
 from nncf.version import __version__
 
-from nncf.quantization import quantize
-from nncf.quantization import TargetDevice
-from nncf.quantization import QuantizationPreset
+from nncf.config import NNCFConfig
 from nncf.data import Dataset
+from nncf.parameters import IgnoredScope
+from nncf.parameters import TargetDevice
+from nncf.quantization import QuantizationPreset
+from nncf.quantization import quantize
+
 
 try:
     import torch

--- a/nncf/__init__.py
+++ b/nncf/__init__.py
@@ -20,7 +20,6 @@ from nncf.parameters import TargetDevice
 from nncf.quantization import QuantizationPreset
 from nncf.quantization import quantize
 
-
 try:
     import torch
 except ImportError:

--- a/nncf/openvino/quantization/helpers.py
+++ b/nncf/openvino/quantization/helpers.py
@@ -11,21 +11,21 @@
  limitations under the License.
 """
 
+import logging
 import tempfile
 from pathlib import Path
-from typing import Optional
-import logging
+from typing import Dict, Optional
 
 import openvino.runtime as ov
 from openvino.tools import pot
 
-from nncf.data import Dataset
-from nncf.openvino.utils import POTDataLoader
-from nncf.openvino.engine import OVEngine
-from nncf.parameters import IgnoredScope
-from nncf.parameters import TargetDevice
 from nncf.common.quantization.structs import QuantizationPreset
 from nncf.common.utils.logger import logger as nncf_logger
+from nncf.data import Dataset
+from nncf.openvino.engine import OVEngine
+from nncf.openvino.utils import POTDataLoader
+from nncf.parameters import IgnoredScope
+from nncf.parameters import TargetDevice
 
 
 def _convert_openvino_model_to_compressed_model(model: ov.Model,
@@ -67,7 +67,7 @@ def _convert_compressed_model_to_openvino_model(model: pot.graph.nx_model.Compre
     return ov_model
 
 
-def _create_ignored_scope_config(ignored_scope: IgnoredScope) -> dict:
+def _create_ignored_scope_config(ignored_scope: IgnoredScope) -> Dict:
     """
     Creates POT ignored scope configuration from the ignored scope that is
     defined using `IgnoredScope` class.
@@ -84,7 +84,7 @@ def _create_ignored_scope_config(ignored_scope: IgnoredScope) -> dict:
         if isinstance(node_names, str):
             node_names = [node_names]
         ignored['scope'] = node_names
-    if ignored_scope.node_name_regexps is not None:
+    if ignored_scope.node_name_patterns is not None:
         raise RuntimeError('Quantization algorithm form the OpenVINO backend '
                            'does not support node name regular expressions '
                            'in the ignored scopes yet')

--- a/nncf/openvino/quantization/helpers.py
+++ b/nncf/openvino/quantization/helpers.py
@@ -78,20 +78,20 @@ def _create_ignored_scope_config(ignored_scope: IgnoredScope) -> Dict:
         return {}
 
     ignored = {}
-    if ignored_scope.node_names is not None:
-        node_names = ignored_scope.node_names
-        if isinstance(node_names, str):
-            node_names = [node_names]
-        ignored['scope'] = node_names
-    if ignored_scope.node_name_patterns is not None:
+    if ignored_scope.names is not None:
+        names = ignored_scope.names
+        if isinstance(names, str):
+            names = [names]
+        ignored['scope'] = names
+    if ignored_scope.patterns is not None:
         raise RuntimeError('Quantization algorithm form the OpenVINO backend '
-                           'does not support node name regular expressions '
-                           'in the ignored scopes yet')
-    if ignored_scope.node_types is not None:
-        node_types = ignored_scope.node_types
-        if isinstance(node_types, str):
-            node_types = [node_types]
-        ignored['operations'] = [{'type': node_type} for node_type in node_types]
+                           'does not support regular expressions in the ignored '
+                           'scopes yet')
+    if ignored_scope.types is not None:
+        types = ignored_scope.types
+        if isinstance(types, str):
+            types = [types]
+        ignored['operations'] = [{'type': type} for type in types]
     return ignored
 
 

--- a/nncf/openvino/quantization/helpers.py
+++ b/nncf/openvino/quantization/helpers.py
@@ -69,8 +69,7 @@ def _convert_compressed_model_to_openvino_model(model: pot.graph.nx_model.Compre
 
 def _create_ignored_scope_config(ignored_scope: IgnoredScope) -> Dict:
     """
-    Creates POT ignored scope configuration from the ignored scope that is
-    defined using `IgnoredScope` class.
+    Maps the content of `IgnoredScope` class to the `ignored` section of POT config.
 
     :param ignored_scope: The ignored scope
     :return: A POT ignored scope configuration as dict

--- a/nncf/openvino/quantization/helpers.py
+++ b/nncf/openvino/quantization/helpers.py
@@ -67,7 +67,7 @@ def _convert_compressed_model_to_openvino_model(model: pot.graph.nx_model.Compre
     return ov_model
 
 
-def _create_ignored_scope_config(ignored_scope: IgnoredScope) -> Dict:
+def _create_ignored_scope_config(ignored_scope: Optional[IgnoredScope]) -> Dict:
     """
     Maps the content of `IgnoredScope` class to the `ignored` section of POT config.
 
@@ -79,19 +79,13 @@ def _create_ignored_scope_config(ignored_scope: IgnoredScope) -> Dict:
 
     ignored = {}
     if ignored_scope.names is not None:
-        names = ignored_scope.names
-        if isinstance(names, str):
-            names = [names]
-        ignored['scope'] = names
+        ignored['scope'] = ignored_scope.names
     if ignored_scope.patterns is not None:
         raise RuntimeError('Quantization algorithm form the OpenVINO backend '
                            'does not support regular expressions in the ignored '
                            'scopes yet')
     if ignored_scope.types is not None:
-        types = ignored_scope.types
-        if isinstance(types, str):
-            types = [types]
-        ignored['operations'] = [{'type': type} for type in types]
+        ignored['operations'] = [{'type': type} for type in ignored_scope.types]
     return ignored
 
 

--- a/nncf/parameters.py
+++ b/nncf/parameters.py
@@ -12,6 +12,7 @@
 """
 
 from enum import Enum
+from typing import List
 
 
 class TargetDevice(Enum):
@@ -30,3 +31,23 @@ class TargetDevice(Enum):
     CPU = 'CPU'
     GPU = 'GPU'
     VPU = 'VPU'
+
+
+class IgnoredScope:
+    """
+    Dataclass that contains description of the ignored scope
+    """
+
+    def __init__(self,
+                 node_names: List[str] = None,
+                 node_name_regexps: List[str] = None,
+                 node_types: List[str] = None):
+        """
+        :param node_names: list of ignored node names
+        :param node_name_regexps: list of regular expressions applied
+            to node names
+        :param node_types: list of ignored node types
+        """
+        self.node_names = node_names
+        self.node_name_regexps = node_name_regexps
+        self.node_types = node_types

--- a/nncf/parameters.py
+++ b/nncf/parameters.py
@@ -12,7 +12,7 @@
 """
 
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 
 class TargetDevice(Enum):
@@ -39,14 +39,14 @@ class IgnoredScope:
     """
 
     def __init__(self,
-                 node_names: List[str] = None,
-                 node_name_regexps: List[str] = None,
-                 node_types: List[str] = None):
+                 node_names: Optional[List[str]] = None,
+                 node_name_regexps: Optional[List[str]] = None,
+                 node_types: Optional[List[str]] = None):
         """
-        :param node_names: list of ignored node names
-        :param node_name_regexps: list of regular expressions applied
-            to node names
-        :param node_types: list of ignored node types
+        :param node_names: List of ignored node names
+        :param node_name_regexps: List of regular expressions specifying
+            patterns for names of ignored nodes
+        :param node_types: List of ignored node types
         """
         self.node_names = node_names
         self.node_name_regexps = node_name_regexps

--- a/nncf/parameters.py
+++ b/nncf/parameters.py
@@ -35,19 +35,48 @@ class TargetDevice(Enum):
 
 class IgnoredScope:
     """
-    Dataclass that contains description of the ignored scope
+    Dataclass that contains description of the ignored scope.
+
+    The ignored scope specify model sub-graphs which should be excluded from
+    the optimization process such as quantization, pruning and etc.
+
+    For example, you want to exclude some model nodes from the optimization
+    process by node name:
+
+    ```
+    import nncf
+    node_names = ['node_1', 'node_2', 'node_3']
+    ignored_scope = nncf.IgnoredScope(node_names=node_names)
+    ```
+
+    or using regular expressions to match node names:
+
+    ```
+    pattern = ['node_\d']
+    ignored_scope = nncf.IgnoredScope(node_name_patterns=pattern)
+    ```
+
+    to exclude some nodes of the OpenVINO model from the optimization process
+    by node type:
+
+    ```
+    node_types = ['Multiply', 'GroupConvolution', 'Interpolate']
+    ignored_scope = nncf.IgnoredScope(node_types=pattern)
+    ```
+
+    **Note** Node types must be specified according to the model framework.
     """
 
     def __init__(self,
                  node_names: Optional[List[str]] = None,
-                 node_name_regexps: Optional[List[str]] = None,
+                 node_name_patterns: Optional[List[str]] = None,
                  node_types: Optional[List[str]] = None):
         """
         :param node_names: List of ignored node names
-        :param node_name_regexps: List of regular expressions specifying
+        :param node_name_patterns: List of regular expressions specifying
             patterns for names of ignored nodes
         :param node_types: List of ignored node types
         """
         self.node_names = node_names
-        self.node_name_regexps = node_name_regexps
+        self.node_name_patterns = node_name_patterns
         self.node_types = node_types

--- a/nncf/parameters.py
+++ b/nncf/parameters.py
@@ -47,39 +47,39 @@ class IgnoredScope:
 
     # Exclude by node name:
     node_names = ['node_1', 'node_2', 'node_3']
-    ignored_scope = nncf.IgnoredScope(node_names=node_names)
+    ignored_scope = nncf.IgnoredScope(names=node_names)
 
     # Exclude using regular expressions:
-    pattern = ['node_\\d']
-    ignored_scope = nncf.IgnoredScope(node_name_patterns=pattern)
+    patterns = ['node_\\d']
+    ignored_scope = nncf.IgnoredScope(patterns=patterns)
 
-    # Exclude by node type:
+    # Exclude by operation type:
 
     # OpenVINO opset https://docs.openvino.ai/latest/openvino_docs_ops_opset.html
-    node_types = ['Multiply', 'GroupConvolution', 'Interpolate']
-    ignored_scope = nncf.IgnoredScope(node_types=pattern)
+    operation_types = ['Multiply', 'GroupConvolution', 'Interpolate']
+    ignored_scope = nncf.IgnoredScope(types=operation_types)
 
     # ONNX opset https://github.com/onnx/onnx/blob/main/docs/Operators.md
-    node_types = ['Mul', 'Conv', 'Resize']
-    ignored_scope = nncf.IgnoredScope(node_types=pattern)
+    operation_types = ['Mul', 'Conv', 'Resize']
+    ignored_scope = nncf.IgnoredScope(types=operation_types)
 
     ...
 
     ```
 
-    **Note** Node types must be specified according to the model framework.
+    **Note** Operation types must be specified according to the model framework.
     """
 
     def __init__(self,
-                 node_names: Optional[List[str]] = None,
-                 node_name_patterns: Optional[List[str]] = None,
-                 node_types: Optional[List[str]] = None):
+                 names: Optional[List[str]] = None,
+                 patterns: Optional[List[str]] = None,
+                 types: Optional[List[str]] = None):
         """
-        :param node_names: List of ignored node names
-        :param node_name_patterns: List of regular expressions specifying
-            patterns for names of ignored nodes
-        :param node_types: List of ignored node types
+        :param names: List of ignored node names
+        :param patterns: List of regular expressions that define patterns for 
+            names of ignored nodes
+        :param types: List of ignored operation types
         """
-        self.node_names = node_names
-        self.node_name_patterns = node_name_patterns
-        self.node_types = node_types
+        self.names = names
+        self.patterns = patterns
+        self.types = types

--- a/nncf/parameters.py
+++ b/nncf/parameters.py
@@ -37,31 +37,34 @@ class IgnoredScope:
     """
     Dataclass that contains description of the ignored scope.
 
-    The ignored scope specify model sub-graphs which should be excluded from
+    The ignored scope defines model sub-graphs that should be excluded from
     the optimization process such as quantization, pruning and etc.
 
-    For example, you want to exclude some model nodes from the optimization
-    process by node name:
+    Examples:
 
     ```
     import nncf
+
+    # Exclude by node name:
     node_names = ['node_1', 'node_2', 'node_3']
     ignored_scope = nncf.IgnoredScope(node_names=node_names)
-    ```
 
-    or using regular expressions to match node names:
-
-    ```
-    pattern = ['node_\d']
+    # Exclude using regular expressions:
+    pattern = ['node_\\d']
     ignored_scope = nncf.IgnoredScope(node_name_patterns=pattern)
-    ```
 
-    to exclude some nodes of the OpenVINO model from the optimization process
-    by node type:
+    # Exclude by node type:
 
-    ```
+    # OpenVINO opset https://docs.openvino.ai/latest/openvino_docs_ops_opset.html
     node_types = ['Multiply', 'GroupConvolution', 'Interpolate']
     ignored_scope = nncf.IgnoredScope(node_types=pattern)
+
+    # ONNX opset https://github.com/onnx/onnx/blob/main/docs/Operators.md
+    node_types = ['Mul', 'Conv', 'Resize']
+    ignored_scope = nncf.IgnoredScope(node_types=pattern)
+
+    ...
+
     ```
 
     **Note** Node types must be specified according to the model framework.

--- a/nncf/quantization/__init__.py
+++ b/nncf/quantization/__init__.py
@@ -13,4 +13,3 @@
 
 from nncf.common.quantization.structs import QuantizationPreset
 from nncf.quantization.helpers import quantize
-

--- a/nncf/quantization/helpers.py
+++ b/nncf/quantization/helpers.py
@@ -51,8 +51,8 @@ def quantize(model: ModelType,
         more time but requires less memory.
     :param model_type: Model type is needed to specify additional patterns
         in the model. Supported only `transformer` now.
-    :param ignored_scope: An ignored scope that defined list of model control
-        flow graph nodes be ignored during quantization.
+    :param ignored_scope: An ignored scope that defined the list of model control
+        flow graph nodes to be ignored during quantization.
     :return: The quantized model.
     """
     backend = get_backend(model)

--- a/nncf/quantization/helpers.py
+++ b/nncf/quantization/helpers.py
@@ -14,11 +14,12 @@
 from typing import Optional
 
 from nncf.api.compression import ModelType
-from nncf.common.utils.backend import get_backend
-from nncf.common.utils.backend import BackendType
 from nncf.common.quantization.structs import QuantizationPreset
+from nncf.common.utils.backend import BackendType
+from nncf.common.utils.backend import get_backend
 from nncf.data import Dataset
-from nncf.quantization.params import TargetDevice
+from nncf.parameters import IgnoredScope
+from nncf.parameters import TargetDevice
 
 
 def quantize(model: ModelType,
@@ -27,7 +28,8 @@ def quantize(model: ModelType,
              target_device: TargetDevice = TargetDevice.ANY,
              subset_size: int = 300,
              fast_error_correction: bool = True,
-             model_type: Optional[str] = None) -> ModelType:
+             model_type: Optional[str] = None,
+             ignored_scope: Optional[IgnoredScope] = None) -> ModelType:
     """
     Applies post-training quantization algorithm to provided model.
 
@@ -49,12 +51,14 @@ def quantize(model: ModelType,
         more time but requires less memory.
     :param model_type: Model type is needed to specify additional patterns
         in the model. Supported only `transformer` now.
+    :param ignored_scope: An ignored scope that defined list of model control
+        flow graph nodes be ignored during quantization.
     :return: The quantized model.
     """
     backend = get_backend(model)
     if backend == BackendType.OPENVINO:
         from nncf.openvino.quantization.helpers import quantize_impl
         return quantize_impl(model, calibration_dataset, preset, target_device, subset_size,
-                             fast_error_correction, model_type)
+                             fast_error_correction, model_type, ignored_scope)
 
     raise RuntimeError(f'Unsupported type of backend: {backend}')

--- a/tests/openvino/__init__.py
+++ b/tests/openvino/__init__.py
@@ -10,7 +10,3 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-
-from nncf.common.quantization.structs import QuantizationPreset
-from nncf.quantization.helpers import quantize
-

--- a/tests/openvino/quantization/__init__.py
+++ b/tests/openvino/quantization/__init__.py
@@ -10,7 +10,3 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-
-from nncf.common.quantization.structs import QuantizationPreset
-from nncf.quantization.helpers import quantize
-

--- a/tests/openvino/quantization/test_helpers.py
+++ b/tests/openvino/quantization/test_helpers.py
@@ -16,39 +16,39 @@ import pytest
 from nncf.parameters import IgnoredScope
 from nncf.openvino.quantization.helpers import _create_ignored_scope_config
 
-IGNORED_NODE_NAMES = [['name1', 'name2'], 'name1']
-IGNORED_NODE_TYPES = [['type1', 'type2'], 'type1']
+IGNORED_NAMES = [['name1', 'name2'], 'name1']
+IGNORED_TYPES = [['type1', 'type2'], 'type1']
 
 
-@pytest.mark.parametrize(('ignored_node_names, ignored_node_types'),
-                         zip(IGNORED_NODE_NAMES, IGNORED_NODE_TYPES),
+@pytest.mark.parametrize(('ignored_names, ignored_types'),
+                         zip(IGNORED_NAMES, IGNORED_TYPES),
                          ids=['list', 'str'])
-def test_create_ignored_scope_config(ignored_node_names, ignored_node_types):
+def test_create_ignored_scope_config(ignored_names, ignored_types):
     ignored_scope = IgnoredScope(
-        node_names=ignored_node_names,
-        node_types=ignored_node_types,
+        names=ignored_names,
+        types=ignored_types,
     )
     ignored_config = _create_ignored_scope_config(ignored_scope)
 
-    expected_node_names = ignored_node_names
-    if isinstance(expected_node_names, str):
-        expected_node_names = [expected_node_names]
+    expected_names = ignored_names
+    if isinstance(expected_names, str):
+        expected_names = [expected_names]
 
-    assert ignored_config['scope'] == expected_node_names
+    assert ignored_config['scope'] == expected_names
 
-    expected_node_types = ignored_node_types
-    if isinstance(expected_node_types, str):
-        expected_node_types = [expected_node_types]
+    expected_types = ignored_types
+    if isinstance(expected_types, str):
+        expected_types = [expected_types]
 
-    actual_node_types = [a['type'] for a in ignored_config['operations']]
-    actual_node_types = actual_node_types.sort()
-    expected_node_types = expected_node_types.sort()
-    assert actual_node_types == expected_node_types
+    actual_types = [a['type'] for a in ignored_config['operations']]
+    actual_types = actual_types.sort()
+    expected_types = expected_types.sort()
+    assert actual_types == expected_types
 
 
 def test_create_ignored_scope_config_raise_exception():
     ignored_scope = IgnoredScope(
-        node_name_patterns='.*'
+        patterns='.*'
     )
     with pytest.raises(Exception):
         _ = _create_ignored_scope_config(ignored_scope)

--- a/tests/openvino/quantization/test_helpers.py
+++ b/tests/openvino/quantization/test_helpers.py
@@ -16,34 +16,21 @@ import pytest
 from nncf.parameters import IgnoredScope
 from nncf.openvino.quantization.helpers import _create_ignored_scope_config
 
-IGNORED_NAMES = [['name1', 'name2'], 'name1']
-IGNORED_TYPES = [['type1', 'type2'], 'type1']
 
+def test_create_ignored_scope_config():
+    ignored_names = ['name1', 'name2']
+    ignored_types = ['type1', 'type2']
 
-@pytest.mark.parametrize(('ignored_names, ignored_types'),
-                         zip(IGNORED_NAMES, IGNORED_TYPES),
-                         ids=['list', 'str'])
-def test_create_ignored_scope_config(ignored_names, ignored_types):
     ignored_scope = IgnoredScope(
         names=ignored_names,
         types=ignored_types,
     )
     ignored_config = _create_ignored_scope_config(ignored_scope)
 
-    expected_names = ignored_names
-    if isinstance(expected_names, str):
-        expected_names = [expected_names]
-
-    assert ignored_config['scope'] == expected_names
-
-    expected_types = ignored_types
-    if isinstance(expected_types, str):
-        expected_types = [expected_types]
+    assert ignored_config['scope'] == ignored_names
 
     actual_types = [a['type'] for a in ignored_config['operations']]
-    actual_types = actual_types.sort()
-    expected_types = expected_types.sort()
-    assert actual_types == expected_types
+    assert actual_types.sort() == ignored_types.sort()
 
 
 def test_create_ignored_scope_config_raise_exception():

--- a/tests/openvino/quantization/test_helpers.py
+++ b/tests/openvino/quantization/test_helpers.py
@@ -1,0 +1,54 @@
+"""
+ Copyright (c) 2022 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import pytest
+
+from nncf.parameters import IgnoredScope
+from nncf.openvino.quantization.helpers import _create_ignored_scope_config
+
+IGNORED_NODE_NAMES = [['name1', 'name2'], 'name1']
+IGNORED_NODE_TYPES = [['type1', 'type2'], 'type1']
+
+
+@pytest.mark.parametrize(('ignored_node_names, ignored_node_types'),
+                         zip(IGNORED_NODE_NAMES, IGNORED_NODE_TYPES),
+                         ids=['list', 'str'])
+def test_create_ignored_scope_config(ignored_node_names, ignored_node_types):
+    ignored_scope = IgnoredScope(
+        node_names=ignored_node_names,
+        node_types=ignored_node_types,
+    )
+    ignored_config = _create_ignored_scope_config(ignored_scope)
+
+    expected_node_names = ignored_node_names
+    if isinstance(expected_node_names, str):
+        expected_node_names = [expected_node_names]
+
+    assert ignored_config['scope'] == expected_node_names
+
+    expected_node_types = ignored_node_types
+    if isinstance(expected_node_types, str):
+        expected_node_types = [expected_node_types]
+
+    actual_node_types = [a['type'] for a in ignored_config['operations']]
+    actual_node_types = actual_node_types.sort()
+    expected_node_types = expected_node_types.sort()
+    assert actual_node_types == expected_node_types
+
+
+def test_create_ignored_scope_config_raise_exception():
+    ignored_scope = IgnoredScope(
+        node_name_regexps='.*'
+    )
+    with pytest.raises(Exception):
+        _ = _create_ignored_scope_config(ignored_scope)

--- a/tests/openvino/quantization/test_helpers.py
+++ b/tests/openvino/quantization/test_helpers.py
@@ -48,7 +48,7 @@ def test_create_ignored_scope_config(ignored_node_names, ignored_node_types):
 
 def test_create_ignored_scope_config_raise_exception():
     ignored_scope = IgnoredScope(
-        node_name_regexps='.*'
+        node_name_patterns='.*'
     )
     with pytest.raises(Exception):
         _ = _create_ignored_scope_config(ignored_scope)

--- a/tests/tensorflow/README.md
+++ b/tests/tensorflow/README.md
@@ -30,8 +30,8 @@ The test result will be saved in `nncf-test.xml`, and it will returns pass, skip
 --metrics-dump-path=METRICS_DUMP_PATH
                       Path to directory to store metrics. Directory must be empty or should not exist.Metric keeps in PROJECT_ROOT/test_results/metrics_dump_timestamp if param   not specified
 --ov-data-dir=OV_DATA_DIR
-                      Path to datasets directory for OpenVino accuracy test
---run-openvino-eval   To run eval models via OpenVino
+                      Path to datasets directory for OpenVINO accuracy test
+--run-openvino-eval   To run eval models via OpenVINO
 --run-weekly-tests    To run weekly tests
 --models-dir=MODELS_DIR
                       Path to checkpoints directory for weekly tests

--- a/tests/tensorflow/conftest.py
+++ b/tests/tensorflow/conftest.py
@@ -50,10 +50,10 @@ def pytest_addoption(parser):
                                                             "if param not specified"
     )
     parser.addoption(
-        "--ov-data-dir", type=str, default=None, help="Path to datasets directory for OpenVino accuracy test"
+        "--ov-data-dir", type=str, default=None, help="Path to datasets directory for OpenVINO accuracy test"
     )
     parser.addoption(
-        "--run-openvino-eval", action="store_true", default=False, help="To run eval models via OpenVino"
+        "--run-openvino-eval", action="store_true", default=False, help="To run eval models via OpenVINO"
     )
     parser.addoption(
         "--run-weekly-tests", action="store_true", default=False, help="To run weekly tests"

--- a/tests/torch/conftest.py
+++ b/tests/torch/conftest.py
@@ -62,7 +62,7 @@ def pytest_addoption(parser):
                                                             "if param not specified"
     )
     parser.addoption(
-        "--ov-data-dir", type=str, default=None, help="Path to datasets directory for OpenVino accuracy test"
+        "--ov-data-dir", type=str, default=None, help="Path to datasets directory for OpenVINO accuracy test"
     )
     parser.addoption(
         "--imagenet", action="store_true", default=False, help="Enable tests with imagenet"
@@ -83,13 +83,13 @@ def pytest_addoption(parser):
                                                                         "on RTX3090 cards"
     )
     parser.addoption(
-        "--run-openvino-eval", action="store_true", default=False, help="To run eval models via OpenVino"
+        "--run-openvino-eval", action="store_true", default=False, help="To run eval models via OpenVINO"
     )
     parser.addoption(
         "--onnx-dir", type=str, default=None, help="Path to converted onnx models"
     )
     parser.addoption(
-        "--ov-config-dir", type=str, default=None, help="Path to OpenVino configs"
+        "--ov-config-dir", type=str, default=None, help="Path to OpenVINO configs"
     )
     parser.addoption(
         "--pip-cache-dir", type=str, default=None,


### PR DESCRIPTION
### Changes
Added the ignored scope parameter to the quantize function signature. Support the ignored scope in the OpenVINO backend.

### Reason for changes

Feature alignment with POT OpenVINO

### Related tickets

N/A

### Tests

[test_helpers.py](https://github.com/openvinotoolkit/nncf/blob/1f09ad3b4cb5c3b6805bece2abb3a4e29f564cc5/tests/openvino/quantization/test_helpers.py)
