### PR TITLE
Fixed the issue with num_bn_adaptation_samples=0

### DIFF
--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -411,7 +411,8 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
     def initialize(self, model: tf.keras.Model) -> None:
         if self._range_init_params is not None:
             self._run_range_initialization(model)
-        self._run_batchnorm_adaptation(model)
+        if self._bn_adapt_params is not None:
+            self._run_batchnorm_adaptation(model)
 
     def _run_range_initialization(self, model: tf.keras.Model) -> None:
         if self._range_initializer is None:


### PR DESCRIPTION
### Changes

Fixed the issue with num_bn_adaptation_samples=0

### Reason for changes

The quantization algorithm for Tensorflow backend fails if num_bn_adaptation_samples=0 with the following error message:

```
  def _run_batchnorm_adaptation(self, model: tf.keras.Model) -> None:
        if self._bn_adaptation is None:
>           self._bn_adaptation = BatchnormAdaptationAlgorithm(self._bn_adapt_params['data_loader'],
                                                               self._bn_adapt_params['num_bn_adaptation_samples'],
                                                               self._bn_adapt_params['device'])
E           TypeError: 'NoneType' object is not subscriptable
```  

### Related tickets

N/A

### Tests

test_quantization_with_bn_adaptation_disable