### PR TITLE
Support PyTorch version strings with .pre

### DIFF
--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -282,6 +282,9 @@ def patch_extension_build_function():
     try:
         torch_version_numbers = torch.__version__.split('+', maxsplit=1)[0]
         split_torch_version = list(map(int, torch_version_numbers.split('.')))
+        # get major, minor and patch number, ignore other version info like .dev
+        split_torch_version = list(map(int, torch_version_numbers.split('.')[:3]))
+
     except ValueError as e:
         logger.warning('Skip applying a patch to building extension with a reason: '
                        'Cannot parse a PyTorch version with the error {}'.format(e))


### PR DESCRIPTION
### Changes

The code in this PR fixes the `patch_extension_build_function` part that tries to parse the PyTorch version string to only check for the first three elements of the version string.

### Reason for changes

When using a prerelease version of PyTorch (either 1.13 or 1.14) a warning is shown:

"WARNING:nncf:Skip applying a patch to building extension with a reason: Cannot parse a PyTorch version with the error invalid literal for int() with base 10: 'dev20221003'"

![image](https://user-images.githubusercontent.com/77325899/198102523-9fa73a65-3828-415d-9711-56c9e9db4d59.png)

I verified that with this change, the warning does not occur. I installed the PyTorch prerelease with `pip3 install --upgrade --pre torch==1.13.* --extra-index-url https://download.pytorch.org/whl/nightly/cpu`