### PR TITLE
Support for Python 3.6 was removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ See [third_party_integration](./third_party_integration) for examples of code mo
 
 ## System requirements
 - Ubuntu\* 18.04 or later (64-bit)
-- Python\* 3.6.2 or later
+- Python\* 3.7 or later
 - Supported frameworks:
   - PyTorch\* >=1.5.0, <=1.9.1 (1.8.0 not supported)
   - TensorFlow\* >=2.4.0, <=2.8.2
 
-This repository is tested on Python* 3.6.2+, PyTorch* 1.9.1 (NVidia CUDA\* Toolkit 10.2) and TensorFlow* 2.8.2 (NVidia CUDA\* Toolkit 11.2).
+This repository is tested on Python* 3.7+, PyTorch* 1.9.1 (NVidia CUDA\* Toolkit 10.2) and TensorFlow* 2.8.2 (NVidia CUDA\* Toolkit 11.2).
 
 ## Installation
 We suggest to install or use the package in the [Python virtual environment](https://docs.python.org/3/tutorial/venv.html).

--- a/setup.py
+++ b/setup.py
@@ -76,14 +76,11 @@ def find_version(*file_paths):
 INSTALL_REQUIRES = ["ninja>=1.10.0.post2, <1.11",
                     "addict>=2.4.0",
                     "texttable>=1.6.3",
-                    "scipy<=1.5.4, >=1.3.2; python_version<'3.7'",
-                    "scipy>=1.3.2, <=1.9.1; python_version>='3.7'",
-                    "matplotlib~=3.3.4; python_version<'3.7'",
-                    "matplotlib>=3.3.4, <3.6; python_version>='3.7'",
+                    "scipy>=1.3.2, <=1.9.1",
+                    "matplotlib>=3.3.4, <3.6",
                     "networkx>=2.6, <=2.8.2",  # see ticket 94048 or https://github.com/networkx/networkx/issues/5962
                     "numpy>=1.19.1, <1.24",
-                    "pillow~=8.4.0; python_version<'3.7'",
-                    "pillow>=9.0.0; python_version>='3.7'",
+                    "pillow>=9.0.0",
 
                     # The recent pyparsing major version update seems to break
                     # integration with networkx - the graphs parsed from current .dot
@@ -97,16 +94,14 @@ INSTALL_REQUIRES = ["ninja>=1.10.0.post2, <1.11",
                     "jstyleson>=0.0.2",
                     "tqdm>=4.54.1",
                     "natsort>=7.1.0",
-                    "pandas~=1.1.5; python_version<'3.7'",
-                    "pandas>=1.1.5,<1.4.0rc0; python_version>='3.7'",
-                    "scikit-learn~=0.24.0; python_version<'3.7'",
-                    "scikit-learn>=0.24.0; python_version>='3.7'",
+                    "pandas>=1.1.5,<1.4.0rc0",
+                    "scikit-learn>=0.24.0",
                     "wheel>=0.36.1"]
 
 
 python_version = sys.version_info
-if python_version < (3, 6, 2):
-    print("Only Python >= 3.6.2 is supported")
+if python_version < (3, 7, 0):
+    print("Only Python >= 3.7.0 is supported")
     sys.exit(0)
 
 version_string = "{}{}".format(sys.version_info[0], sys.version_info[1])


### PR DESCRIPTION
### Changes

The lowest supported python version was increased to 3.7.0

### Reason for changes

OpenVINO will deprecate support for the 3.6 version.

### Related tickets

N/A

### Tests

N/A
