### PR TITLE
[Torch] Weekly test with mixed precision

### DIFF
--- a/examples/torch/common/utils.py
+++ b/examples/torch/common/utils.py
@@ -265,3 +265,18 @@ class MockDataset(data.Dataset):
                 img = self._transform(img)
             return img, 0
         raise ValueError
+
+
+class NullContextManager:
+    """
+    Dummy context manager that do nothing.
+    """
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self, *args, **kwargs):
+        pass
+
+    def __exit__(self, *args, **kwargs):
+        pass

--- a/tests/torch/conftest.py
+++ b/tests/torch/conftest.py
@@ -49,6 +49,10 @@ def pytest_addoption(parser):
         "--weekly-models", type=str, default=None, help="Path to models' weights for weekly tests"
     )
     parser.addoption(
+        "--weekly-with-mixed-precision", action="store_true", default=False, help="Enable mixed precision for the"
+                                                                                  " nncf weekly test"
+    )
+    parser.addoption(
         "--sota-checkpoints-dir", type=str, default=None, help="Path to checkpoints directory for sota accuracy test"
     )
     parser.addoption(
@@ -120,6 +124,11 @@ def enable_imagenet(request):
 @pytest.fixture(scope="module")
 def weekly_models_path(request):
     return request.config.getoption("--weekly-models")
+
+
+@pytest.fixture(scope="module")
+def weekly_with_mixed_precision(request):
+    return request.config.getoption("--weekly-with-mixed-precision")
 
 
 @pytest.fixture(scope="module")

--- a/tests/torch/conftest.py
+++ b/tests/torch/conftest.py
@@ -49,7 +49,7 @@ def pytest_addoption(parser):
         "--weekly-models", type=str, default=None, help="Path to models' weights for weekly tests"
     )
     parser.addoption(
-        "--weekly-with-mixed-precision", action="store_true", default=False, help="Enable mixed precision for the"
+        "--mixed-precision", action="store_true", default=False, help="Enable mixed precision for the"
                                                                                   " nncf weekly test"
     )
     parser.addoption(
@@ -127,8 +127,8 @@ def weekly_models_path(request):
 
 
 @pytest.fixture(scope="module")
-def weekly_with_mixed_precision(request):
-    return request.config.getoption("--weekly-with-mixed-precision")
+def mixed_precision(request):
+    return request.config.getoption("--mixed-precision")
 
 
 @pytest.fixture(scope="module")

--- a/tests/torch/test_compression_training.py
+++ b/tests/torch/test_compression_training.py
@@ -413,9 +413,9 @@ def finalize_desc(desc, dataset_dir, tmp_path_factory, weekly_models_path, enabl
 @pytest.fixture(name='desc', scope='module',
                 params=TEST_CASE_DESCRIPTORS, ids=map(str, TEST_CASE_DESCRIPTORS))
 def fixture_desc(request, dataset_dir, tmp_path_factory, weekly_models_path, enable_imagenet,
-                 weekly_with_mixed_precision):
+                 mixed_precision):
     desc: CompressionTrainingTestDescriptor = request.param
-    if weekly_with_mixed_precision:
+    if mixed_precision:
         desc.use_mixed_precision()
     return finalize_desc(desc, dataset_dir, tmp_path_factory, weekly_models_path, enable_imagenet)
 
@@ -434,6 +434,7 @@ def fixture_nas_desc(request, dataset_dir, tmp_path_factory, weekly_models_path,
     return finalize_desc(desc, dataset_dir, tmp_path_factory, weekly_models_path, enable_imagenet)
 
 
+@pytest.mark.weekly
 class TestCompression:
     @pytest.mark.dependency(name="train")
     def test_compression_train(self, desc: CompressionTrainingTestDescriptor, tmp_path, mocker):

--- a/tests/torch/test_compression_training.py
+++ b/tests/torch/test_compression_training.py
@@ -68,6 +68,8 @@ class CompressionTrainingValidator(BaseSampleValidator):
             args['checkpoint-save-dir'] = self._desc.checkpoint_save_dir
         if self._desc.execution_arg:
             args[self._desc.execution_arg] = None
+        if self._desc.mixed_precision:
+            args['mixed-precision'] = None
         return args
 
     def _create_command_line(self, args):
@@ -94,6 +96,7 @@ class CompressionTrainingTestDescriptor(BaseSampleTestCaseDescriptor):
         self.checkpoint_save_dir = None
         self.checkpoint_name = None
         self.seed = 1
+        self._mixed_precision = False
         self.weights_filename_ = None
         self.weights_path = None
         self.timeout_ = 30 * 60  # 30 min
@@ -142,6 +145,13 @@ class CompressionTrainingTestDescriptor(BaseSampleTestCaseDescriptor):
     def cpu_only(self):
         self.execution_arg = 'cpu-only'
         return self
+
+    @property
+    def mixed_precision(self):
+        return self._mixed_precision
+
+    def use_mixed_precision(self):
+        self._mixed_precision = True
 
     def data_parallel(self):
         self.execution_arg = ''
@@ -402,8 +412,11 @@ def finalize_desc(desc, dataset_dir, tmp_path_factory, weekly_models_path, enabl
 
 @pytest.fixture(name='desc', scope='module',
                 params=TEST_CASE_DESCRIPTORS, ids=map(str, TEST_CASE_DESCRIPTORS))
-def fixture_desc(request, dataset_dir, tmp_path_factory, weekly_models_path, enable_imagenet):
+def fixture_desc(request, dataset_dir, tmp_path_factory, weekly_models_path, enable_imagenet,
+                 weekly_with_mixed_precision):
     desc: CompressionTrainingTestDescriptor = request.param
+    if weekly_with_mixed_precision:
+        desc.use_mixed_precision()
     return finalize_desc(desc, dataset_dir, tmp_path_factory, weekly_models_path, enable_imagenet)
 
 

--- a/tests/torch/test_sota_checkpoints.py
+++ b/tests/torch/test_sota_checkpoints.py
@@ -68,6 +68,7 @@ class EvalRunParamsStruct:
         self.multiprocessing_distributed = multiprocessing_distributed
 
 
+@pytest.mark.nightly
 class TestSotaCheckpoints:
     param_list = []
     train_param_list = []


### PR DESCRIPTION
### Changes

Support of mixed precision training in NNCF PT classification sample by torch.cuda.amp autocasting. Mixed precision mode is being enabled by `--mixed-precision` key. Default behavior - FP32 training.
Weekly test with mixed precision is introduced.

### Reason for changes

To test FP16 kernels by the NNCF weekly test

### Related tickets

79587

