### PR TITLE
BNAS: State for depth and width indicators

### DIFF
--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/base_handler.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/base_handler.py
@@ -135,6 +135,7 @@ class SingleElasticityHandler(ElasticityHandler, ABC):
     """
     An interface for handling a single elasticity dimension in the network, e.g. elastic width or depth.
     """
+    _state_names = SEHandlerStateNames
 
     @abstractmethod
     def get_search_space(self) -> ElasticSearchSpace:
@@ -170,7 +171,7 @@ class SingleElasticityHandler(ElasticityHandler, ABC):
 
         :param state: Output of `get_state()` method.
         """
-        active_config = state[SEHandlerStateNames.ACTIVE_CONFIG]
+        active_config = state[self._state_names.ACTIVE_CONFIG]
         self.activate_subnet_for_config(active_config)
 
     def get_state(self) -> Dict[str, Any]:
@@ -182,7 +183,7 @@ class SingleElasticityHandler(ElasticityHandler, ABC):
         """
         active_config = self.get_active_config()
         return {
-            SEHandlerStateNames.ACTIVE_CONFIG: active_config,
+            self._state_names.ACTIVE_CONFIG: active_config,
         }
 
 

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/base_handler.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/base_handler.py
@@ -135,7 +135,6 @@ class SingleElasticityHandler(ElasticityHandler, ABC):
     """
     An interface for handling a single elasticity dimension in the network, e.g. elastic width or depth.
     """
-    _state_names = SEHandlerStateNames
 
     @abstractmethod
     def get_search_space(self) -> ElasticSearchSpace:
@@ -171,7 +170,7 @@ class SingleElasticityHandler(ElasticityHandler, ABC):
 
         :param state: Output of `get_state()` method.
         """
-        active_config = state[self._state_names.ACTIVE_CONFIG]
+        active_config = state[SEHandlerStateNames.ACTIVE_CONFIG]
         self.activate_subnet_for_config(active_config)
 
     def get_state(self) -> Dict[str, Any]:
@@ -183,7 +182,7 @@ class SingleElasticityHandler(ElasticityHandler, ABC):
         """
         active_config = self.get_active_config()
         return {
-            self._state_names.ACTIVE_CONFIG: active_config,
+            SEHandlerStateNames.ACTIVE_CONFIG: active_config,
         }
 
 

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/base_handler.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/base_handler.py
@@ -12,7 +12,7 @@
 """
 from abc import ABC
 from abc import abstractmethod
-from typing import Any, NoReturn
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -70,23 +70,6 @@ class ElasticityHandler(ABC):
 
         :return: elasticity configuration
         """
-
-    def get_elasticity_indicator(self) -> int:
-        """
-
-        Returns: None if elastic indicator is not used by the derived class.
-
-        """
-        return None
-
-    def set_elasticity_indicator(self, elasticity_indicator: int = None) -> NoReturn:
-        """
-        Args:
-            if elasticity_indicator is used, it is implemented in derived class. Otherwise is None.
-        Returns:
-
-        """
-        pass
 
     @abstractmethod
     def activate_supernet(self) -> None:
@@ -146,7 +129,6 @@ class ElasticityHandler(ABC):
 
 class SEHandlerStateNames:
     ACTIVE_CONFIG = 'active_config'
-    ELASTICITY_INDICATOR = 'elasticity_indicator'
 
 
 class SingleElasticityHandler(ElasticityHandler, ABC):
@@ -190,10 +172,7 @@ class SingleElasticityHandler(ElasticityHandler, ABC):
         :param state: Output of `get_state()` method.
         """
         active_config = state[self._state_names.ACTIVE_CONFIG]
-        elasticity_indicator = state[self._state_names.ELASTICITY_INDICATOR]
         self.activate_subnet_for_config(active_config)
-        if elasticity_indicator:
-            self.set_elasticity_indicator(elasticity_indicator)
 
     def get_state(self) -> Dict[str, Any]:
         """
@@ -203,10 +182,8 @@ class SingleElasticityHandler(ElasticityHandler, ABC):
         :return: state of the object
         """
         active_config = self.get_active_config()
-        elasticity_indicator = self.get_elasticity_indicator()
         return {
             self._state_names.ACTIVE_CONFIG: active_config,
-            self._state_names.ELASTICITY_INDICATOR: elasticity_indicator
         }
 
 

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/base_handler.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/base_handler.py
@@ -12,7 +12,7 @@
 """
 from abc import ABC
 from abc import abstractmethod
-from typing import Any
+from typing import Any, NoReturn
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -70,6 +70,23 @@ class ElasticityHandler(ABC):
 
         :return: elasticity configuration
         """
+
+    def get_elasticity_indicator(self) -> int:
+        """
+
+        Returns: None if elastic indicator is not used by the derived class.
+
+        """
+        return None
+
+    def set_elasticity_indicator(self, elasticity_indicator: int = None) -> NoReturn:
+        """
+        Args:
+            if elasticity_indicator is used, it is implemented in derived class. Otherwise is None.
+        Returns:
+
+        """
+        pass
 
     @abstractmethod
     def activate_supernet(self) -> None:
@@ -129,6 +146,7 @@ class ElasticityHandler(ABC):
 
 class SEHandlerStateNames:
     ACTIVE_CONFIG = 'active_config'
+    ELASTICITY_INDICATOR = 'elasticity_indicator'
 
 
 class SingleElasticityHandler(ElasticityHandler, ABC):
@@ -172,7 +190,10 @@ class SingleElasticityHandler(ElasticityHandler, ABC):
         :param state: Output of `get_state()` method.
         """
         active_config = state[self._state_names.ACTIVE_CONFIG]
+        elasticity_indicator = state[self._state_names.ELASTICITY_INDICATOR]
         self.activate_subnet_for_config(active_config)
+        if elasticity_indicator:
+            self.set_elasticity_indicator(elasticity_indicator)
 
     def get_state(self) -> Dict[str, Any]:
         """
@@ -182,8 +203,10 @@ class SingleElasticityHandler(ElasticityHandler, ABC):
         :return: state of the object
         """
         active_config = self.get_active_config()
+        elasticity_indicator = self.get_elasticity_indicator()
         return {
             self._state_names.ACTIVE_CONFIG: active_config,
+            self._state_names.ELASTICITY_INDICATOR: elasticity_indicator
         }
 
 

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_depth.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_depth.py
@@ -50,7 +50,7 @@ class ElasticDepthHandler(SingleElasticityHandler):
     """
     An interface for handling elastic depth dimension in the network, i.e. skip some layers in the model.
     """
-    _state_names = EDHandlerStateNames
+    _depth_state_names = EDHandlerStateNames
 
     def __init__(self, target_model: NNCFNetwork,
                  skipped_blocks: BuildingBlocks,
@@ -104,7 +104,7 @@ class ElasticDepthHandler(SingleElasticityHandler):
         :param state: Output of `get_state()` method.
         """
         super().load_state(state)
-        self.depth_indicator = state[self._state_names.DEPTH_INDICATOR]
+        self.depth_indicator = state[self._depth_state_names.DEPTH_INDICATOR]
 
     def get_state(self) -> Dict[str, Any]:
         """
@@ -113,7 +113,7 @@ class ElasticDepthHandler(SingleElasticityHandler):
         :return: state of the object
         """
         state = super().get_state()
-        state[self._state_names.DEPTH_INDICATOR] = self.depth_indicator
+        state[self._depth_state_names.DEPTH_INDICATOR] = self.depth_indicator
         return state
 
     def get_search_space(self) -> ElasticDepthSearchSpace:

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_depth.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_depth.py
@@ -42,16 +42,10 @@ ElasticDepthConfig = List[BlockId]  # list of block indexes
 ElasticDepthSearchSpace = List[ElasticDepthConfig]  # grouped list of block indexes
 
 
-class EDHandlerStateNames:
-    ACTIVE_CONFIG = 'active_config'
-    DEPTH_INDICATOR = 'depth_indicator'
-
-
 class ElasticDepthHandler(SingleElasticityHandler):
     """
     An interface for handling elastic depth dimension in the network, i.e. skip some layers in the model.
     """
-    _state_names = EDHandlerStateNames
 
     def __init__(self, target_model: NNCFNetwork,
                  skipped_blocks: BuildingBlocks,
@@ -99,26 +93,11 @@ class ElasticDepthHandler(SingleElasticityHandler):
         self._depth_indicator = depth_indicator
         self._is_search_space_obsolete = True
 
-    def load_state(self, state: Dict[str, Any]) -> None:
-        """
-        Initializes object from the state.
-        :param state: Output of `get_state()` method.
-        """
-        active_config = state[self._state_names.ACTIVE_CONFIG]
-        self.activate_subnet_for_config(active_config)
-        self.depth_indicator = state[self._state_names.DEPTH_INDICATOR]
+    def get_elasticity_indicator(self):
+        return self.depth_indicator
 
-    def get_state(self) -> Dict[str, Any]:
-        """
-        Returns a dictionary with Python data structures (dict, list, tuple, str, int, float, True, False, None) that
-        represents state of the object.
-        :return: state of the object
-        """
-        active_config = self.get_active_config()
-        return {
-            self._state_names.ACTIVE_CONFIG: active_config,
-            self._state_names.DEPTH_INDICATOR: self.depth_indicator,
-        }
+    def set_elasticity_indicator(self, depth_indicator: int) -> None:
+        self.depth_indicator = depth_indicator
 
     def get_search_space(self) -> ElasticDepthSearchSpace:
         """

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_depth.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_depth.py
@@ -42,10 +42,16 @@ ElasticDepthConfig = List[BlockId]  # list of block indexes
 ElasticDepthSearchSpace = List[ElasticDepthConfig]  # grouped list of block indexes
 
 
+class EDHandlerStateNames:
+    ACTIVE_CONFIG = 'active_config'
+    DEPTH_INDICATOR = 'depth_indicator'
+
+
 class ElasticDepthHandler(SingleElasticityHandler):
     """
     An interface for handling elastic depth dimension in the network, i.e. skip some layers in the model.
     """
+    _state_names = EDHandlerStateNames
 
     def __init__(self, target_model: NNCFNetwork,
                  skipped_blocks: BuildingBlocks,
@@ -93,11 +99,26 @@ class ElasticDepthHandler(SingleElasticityHandler):
         self._depth_indicator = depth_indicator
         self._is_search_space_obsolete = True
 
-    def get_elasticity_indicator(self):
-        return self.depth_indicator
+    def load_state(self, state: Dict[str, Any]) -> None:
+        """
+        Initializes object from the state.
+        :param state: Output of `get_state()` method.
+        """
+        active_config = state[self._state_names.ACTIVE_CONFIG]
+        self.activate_subnet_for_config(active_config)
+        self.depth_indicator = state[self._state_names.DEPTH_INDICATOR]
 
-    def set_elasticity_indicator(self, depth_indicator: int) -> None:
-        self.depth_indicator = depth_indicator
+    def get_state(self) -> Dict[str, Any]:
+        """
+        Returns a dictionary with Python data structures (dict, list, tuple, str, int, float, True, False, None) that
+        represents state of the object.
+        :return: state of the object
+        """
+        active_config = self.get_active_config()
+        return {
+            self._state_names.ACTIVE_CONFIG: active_config,
+            self._state_names.DEPTH_INDICATOR: self.depth_indicator,
+        }
 
     def get_search_space(self) -> ElasticDepthSearchSpace:
         """

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_depth.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_depth.py
@@ -43,7 +43,6 @@ ElasticDepthSearchSpace = List[ElasticDepthConfig]  # grouped list of block inde
 
 
 class EDHandlerStateNames:
-    ACTIVE_CONFIG = 'active_config'
     DEPTH_INDICATOR = 'depth_indicator'
 
 
@@ -104,8 +103,7 @@ class ElasticDepthHandler(SingleElasticityHandler):
         Initializes object from the state.
         :param state: Output of `get_state()` method.
         """
-        active_config = state[self._state_names.ACTIVE_CONFIG]
-        self.activate_subnet_for_config(active_config)
+        super().load_state(state)
         self.depth_indicator = state[self._state_names.DEPTH_INDICATOR]
 
     def get_state(self) -> Dict[str, Any]:
@@ -114,11 +112,9 @@ class ElasticDepthHandler(SingleElasticityHandler):
         represents state of the object.
         :return: state of the object
         """
-        active_config = self.get_active_config()
-        return {
-            self._state_names.ACTIVE_CONFIG: active_config,
-            self._state_names.DEPTH_INDICATOR: self.depth_indicator,
-        }
+        state = super().get_state()
+        state[self._state_names.DEPTH_INDICATOR] = self.depth_indicator
+        return state
 
     def get_search_space(self) -> ElasticDepthSearchSpace:
         """

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_depth.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_depth.py
@@ -42,10 +42,16 @@ ElasticDepthConfig = List[BlockId]  # list of block indexes
 ElasticDepthSearchSpace = List[ElasticDepthConfig]  # grouped list of block indexes
 
 
+class EDHandlerStateNames:
+    ACTIVE_CONFIG = 'active_config'
+    DEPTH_INDICATOR = 'depth_indicator'
+
+
 class ElasticDepthHandler(SingleElasticityHandler):
     """
     An interface for handling elastic depth dimension in the network, i.e. skip some layers in the model.
     """
+    _state_names = EDHandlerStateNames
 
     def __init__(self, target_model: NNCFNetwork,
                  skipped_blocks: BuildingBlocks,
@@ -92,6 +98,27 @@ class ElasticDepthHandler(SingleElasticityHandler):
         """
         self._depth_indicator = depth_indicator
         self._is_search_space_obsolete = True
+
+    def load_state(self, state: Dict[str, Any]) -> None:
+        """
+        Initializes object from the state.
+        :param state: Output of `get_state()` method.
+        """
+        active_config = state[self._state_names.ACTIVE_CONFIG]
+        self.activate_subnet_for_config(active_config)
+        self.depth_indicator = state[self._state_names.DEPTH_INDICATOR]
+
+    def get_state(self) -> Dict[str, Any]:
+        """
+        Returns a dictionary with Python data structures (dict, list, tuple, str, int, float, True, False, None) that
+        represents state of the object.
+        :return: state of the object
+        """
+        active_config = self.get_active_config()
+        return {
+            self._state_names.ACTIVE_CONFIG: active_config,
+            self._state_names.DEPTH_INDICATOR: self.depth_indicator,
+        }
 
     def get_search_space(self) -> ElasticDepthSearchSpace:
         """

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -479,11 +479,16 @@ class ElasticOutputWidthLinearOp(ElasticOutputWidthOp, nn.Module):
         new_bias = None if bias is None else bias[:self._active_width]
         return [weight[:self._active_width, :], new_bias]
 
+class EWHandlerStateNames:
+    ACTIVE_CONFIG = 'active_config'
+    WIDTH_NUM_PARAMS_INDICATOR = 'width_num_params_indicator'
+
 
 class ElasticWidthHandler(SingleElasticityHandler):
     """
     An interface for handling elastic width dimension in the network, i.e. define number of channels in the layers.
     """
+    _state_names = EWHandlerStateNames
 
     def __init__(self, target_model: NNCFNetwork,
                  filter_importance_fn: Callable[[torch.Tensor, int], torch.Tensor],
@@ -541,6 +546,27 @@ class ElasticWidthHandler(SingleElasticityHandler):
         :return: nncf graph that is used for propagating pruning and reordering masks
         """
         return self._propagation_graph
+
+    def load_state(self, state: Dict[str, Any]) -> None:
+        """
+        Initializes object from the state.
+        :param state: Output of `get_state()` method.
+        """
+        active_config = state[self._state_names.ACTIVE_CONFIG]
+        self.activate_subnet_for_config(active_config)
+        self.width_num_params_indicator = state[self._state_names.WIDTH_NUM_PARAMS_INDICATOR]
+
+    def get_state(self) -> Dict[str, Any]:
+        """
+        Returns a dictionary with Python data structures (dict, list, tuple, str, int, float, True, False, None) that
+        represents state of the object.
+        :return: state of the object
+        """
+        active_config = self.get_active_config()
+        return {
+            self._state_names.ACTIVE_CONFIG: active_config,
+            self._state_names.WIDTH_NUM_PARAMS_INDICATOR: self.width_num_params_indicator,
+        }
 
     def get_transformation_commands(self) -> List[TransformationCommand]:
         """

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -479,16 +479,11 @@ class ElasticOutputWidthLinearOp(ElasticOutputWidthOp, nn.Module):
         new_bias = None if bias is None else bias[:self._active_width]
         return [weight[:self._active_width, :], new_bias]
 
-class EWHandlerStateNames:
-    ACTIVE_CONFIG = 'active_config'
-    WIDTH_NUM_PARAMS_INDICATOR = 'width_num_params_indicator'
-
 
 class ElasticWidthHandler(SingleElasticityHandler):
     """
     An interface for handling elastic width dimension in the network, i.e. define number of channels in the layers.
     """
-    _state_names = EWHandlerStateNames
 
     def __init__(self, target_model: NNCFNetwork,
                  filter_importance_fn: Callable[[torch.Tensor, int], torch.Tensor],
@@ -540,33 +535,18 @@ class ElasticWidthHandler(SingleElasticityHandler):
             raise RuntimeError(f"Invalid width indicator: {width_num_params_indicator}")
         self._width_num_params_indicator = width_num_params_indicator
 
+    def get_elasticity_indicator(self):
+        return self.width_num_params_indicator
+
+    def set_elasticity_indicator(self, width_num_params_indicator: int) -> None:
+        self._width_num_params_indicator = width_num_params_indicator
+
     @property
     def propagation_graph(self) -> PTNNCFGraph:
         """
         :return: nncf graph that is used for propagating pruning and reordering masks
         """
         return self._propagation_graph
-
-    def load_state(self, state: Dict[str, Any]) -> None:
-        """
-        Initializes object from the state.
-        :param state: Output of `get_state()` method.
-        """
-        active_config = state[self._state_names.ACTIVE_CONFIG]
-        self.activate_subnet_for_config(active_config)
-        self.width_num_params_indicator = state[self._state_names.WIDTH_NUM_PARAMS_INDICATOR]
-
-    def get_state(self) -> Dict[str, Any]:
-        """
-        Returns a dictionary with Python data structures (dict, list, tuple, str, int, float, True, False, None) that
-        represents state of the object.
-        :return: state of the object
-        """
-        active_config = self.get_active_config()
-        return {
-            self._state_names.ACTIVE_CONFIG: active_config,
-            self._state_names.WIDTH_NUM_PARAMS_INDICATOR: self.width_num_params_indicator,
-        }
 
     def get_transformation_commands(self) -> List[TransformationCommand]:
         """

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -480,7 +480,6 @@ class ElasticOutputWidthLinearOp(ElasticOutputWidthOp, nn.Module):
         return [weight[:self._active_width, :], new_bias]
 
 class EWHandlerStateNames:
-    ACTIVE_CONFIG = 'active_config'
     WIDTH_NUM_PARAMS_INDICATOR = 'width_num_params_indicator'
 
 
@@ -552,8 +551,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         Initializes object from the state.
         :param state: Output of `get_state()` method.
         """
-        active_config = state[self._state_names.ACTIVE_CONFIG]
-        self.activate_subnet_for_config(active_config)
+        super().load_state(state)
         self.width_num_params_indicator = state[self._state_names.WIDTH_NUM_PARAMS_INDICATOR]
 
     def get_state(self) -> Dict[str, Any]:
@@ -562,11 +560,9 @@ class ElasticWidthHandler(SingleElasticityHandler):
         represents state of the object.
         :return: state of the object
         """
-        active_config = self.get_active_config()
-        return {
-            self._state_names.ACTIVE_CONFIG: active_config,
-            self._state_names.WIDTH_NUM_PARAMS_INDICATOR: self.width_num_params_indicator,
-        }
+        state = super().get_state()
+        state[self._state_names.WIDTH_NUM_PARAMS_INDICATOR] = self.width_num_params_indicator
+        return state
 
     def get_transformation_commands(self) -> List[TransformationCommand]:
         """

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -479,11 +479,16 @@ class ElasticOutputWidthLinearOp(ElasticOutputWidthOp, nn.Module):
         new_bias = None if bias is None else bias[:self._active_width]
         return [weight[:self._active_width, :], new_bias]
 
+class EWHandlerStateNames:
+    ACTIVE_CONFIG = 'active_config'
+    WIDTH_NUM_PARAMS_INDICATOR = 'width_num_params_indicator'
+
 
 class ElasticWidthHandler(SingleElasticityHandler):
     """
     An interface for handling elastic width dimension in the network, i.e. define number of channels in the layers.
     """
+    _state_names = EWHandlerStateNames
 
     def __init__(self, target_model: NNCFNetwork,
                  filter_importance_fn: Callable[[torch.Tensor, int], torch.Tensor],
@@ -535,18 +540,33 @@ class ElasticWidthHandler(SingleElasticityHandler):
             raise RuntimeError(f"Invalid width indicator: {width_num_params_indicator}")
         self._width_num_params_indicator = width_num_params_indicator
 
-    def get_elasticity_indicator(self):
-        return self.width_num_params_indicator
-
-    def set_elasticity_indicator(self, width_num_params_indicator: int) -> None:
-        self._width_num_params_indicator = width_num_params_indicator
-
     @property
     def propagation_graph(self) -> PTNNCFGraph:
         """
         :return: nncf graph that is used for propagating pruning and reordering masks
         """
         return self._propagation_graph
+
+    def load_state(self, state: Dict[str, Any]) -> None:
+        """
+        Initializes object from the state.
+        :param state: Output of `get_state()` method.
+        """
+        active_config = state[self._state_names.ACTIVE_CONFIG]
+        self.activate_subnet_for_config(active_config)
+        self.width_num_params_indicator = state[self._state_names.WIDTH_NUM_PARAMS_INDICATOR]
+
+    def get_state(self) -> Dict[str, Any]:
+        """
+        Returns a dictionary with Python data structures (dict, list, tuple, str, int, float, True, False, None) that
+        represents state of the object.
+        :return: state of the object
+        """
+        active_config = self.get_active_config()
+        return {
+            self._state_names.ACTIVE_CONFIG: active_config,
+            self._state_names.WIDTH_NUM_PARAMS_INDICATOR: self.width_num_params_indicator,
+        }
 
     def get_transformation_commands(self) -> List[TransformationCommand]:
         """

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -487,7 +487,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
     """
     An interface for handling elastic width dimension in the network, i.e. define number of channels in the layers.
     """
-    _state_names = EWHandlerStateNames
+    _width_state_names = EWHandlerStateNames
 
     def __init__(self, target_model: NNCFNetwork,
                  filter_importance_fn: Callable[[torch.Tensor, int], torch.Tensor],
@@ -552,7 +552,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         :param state: Output of `get_state()` method.
         """
         super().load_state(state)
-        self.width_num_params_indicator = state[self._state_names.WIDTH_NUM_PARAMS_INDICATOR]
+        self.width_num_params_indicator = state[self._width_state_names.WIDTH_NUM_PARAMS_INDICATOR]
 
     def get_state(self) -> Dict[str, Any]:
         """
@@ -561,7 +561,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         :return: state of the object
         """
         state = super().get_state()
-        state[self._state_names.WIDTH_NUM_PARAMS_INDICATOR] = self.width_num_params_indicator
+        state[self._width_state_names.WIDTH_NUM_PARAMS_INDICATOR] = self.width_num_params_indicator
         return state
 
     def get_transformation_commands(self) -> List[TransformationCommand]:

--- a/tests/torch/nas/test_all_elasticity.py
+++ b/tests/torch/nas/test_all_elasticity.py
@@ -301,11 +301,11 @@ REF_COMPRESSION_STATE_FOR_TWO_CONV = {
                 'states_of_handlers': {
                     'depth': {
                         'active_config': [0],
-                        'elasticity_indicator': 1
+                        'depth_indicator': 1
                     },
                     'width': {
                         'active_config': {0: 1},
-                        'elasticity_indicator': -1
+                        'width_num_params_indicator': -1
                     }
                 }
             }

--- a/tests/torch/nas/test_all_elasticity.py
+++ b/tests/torch/nas/test_all_elasticity.py
@@ -301,11 +301,11 @@ REF_COMPRESSION_STATE_FOR_TWO_CONV = {
                 'states_of_handlers': {
                     'depth': {
                         'active_config': [0],
-                        'depth_indicator': 1
+                        'elasticity_indicator': 1
                     },
                     'width': {
                         'active_config': {0: 1},
-                        'width_num_params_indicator': -1
+                        'elasticity_indicator': -1
                     }
                 }
             }

--- a/tests/torch/nas/test_all_elasticity.py
+++ b/tests/torch/nas/test_all_elasticity.py
@@ -300,10 +300,12 @@ REF_COMPRESSION_STATE_FOR_TWO_CONV = {
                 },
                 'states_of_handlers': {
                     'depth': {
-                        'active_config': [0]
+                        'active_config': [0],
+                        'depth_indicator': 1
                     },
                     'width': {
-                        'active_config': {0: 1}
+                        'active_config': {0: 1},
+                        'width_num_params_indicator': -1
                     }
                 }
             }


### PR DESCRIPTION
### Changes

(1) Add depth_indicator in ctrl_state.
(2) Add width_num_params_indicator in ctrl state.

### Reason for changes

The current version of the training controller state does not save 'depth_indicator' and 'width_num_params_indicator'.

When we load 'last_elasticity.pth' in 'bootstrap_nas_search.py', 'depth_indicator' and 'width_num_params_indicator' will use default values (1 and -1 respectively) instead of values in the config.

This means that in some cases(e.g. 'depth_indicator' > 1 in config), when we use 'bootstrap_nas_search.py' to search the best subnet, the search space is different from what we designed due to different values of 'depth_indicator' and 'width_num_params_indicator'.

### Related tickets

N/A

### Tests

Fixed test_all_elasticity