### PR TITLE
Fix export of SOTA checkpoints for e2e validation

### DIFF
--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elasticity_controller.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elasticity_controller.py
@@ -12,6 +12,9 @@
 """
 from typing import Any
 from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
 
 from nncf.api.compression import CompressionLoss
 from nncf.api.compression import CompressionScheduler
@@ -19,6 +22,7 @@ from nncf.api.compression import CompressionStage
 from nncf.common.schedulers import BaseCompressionScheduler
 from nncf.common.statistics import NNCFStatistics
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.multi_elasticity_handler import MultiElasticityHandler
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.onnx_export import NASExporter
 from nncf.torch.algo_selector import ZeroCompressionLoss
 from nncf.torch.compression_method_api import PTCompressionAlgorithmController
 from nncf.torch.nncf_network import NNCFNetwork
@@ -100,3 +104,31 @@ class ElasticityController(PTCompressionAlgorithmController):
         state = super().get_state()
         state[self._ec_state_names.MULTI_ELASTICITY_HANDLER_STATE] = self.multi_elasticity_handler.get_state()
         return state
+
+    def export_model(self, save_path: str,
+                     save_format: Optional[str] = None,
+                     input_names: Optional[List[str]] = None,
+                     output_names: Optional[List[str]] = None,
+                     model_args: Optional[Tuple[Any, ...]] = None) -> None:
+        """
+        Exports the compressed model to the specified format for deployment.
+
+        Makes method-specific preparations of the model, (e.g. removing auxiliary
+        layers that were used for the model compression), then exports the model to
+        the specified path.
+
+        :param save_path: The path where the model will be saved.
+        :param save_format: Saving format. The default format will
+            be used if `save_format` is not specified.
+        :param input_names: Names to be assigned to the input tensors of the model.
+        :param output_names: Names to be assigned to the output tensors of the model.
+        :param model_args: Tuple of additional positional and keyword arguments
+            which are required for the model's forward during export. Should be
+            specified in the following format:
+                - (a, b, {'x': None, 'y': y}) for positional and keyword arguments.
+                - (a, b, {}) for positional arguments only.
+                - ({'x': None, 'y': y},) for keyword arguments only.
+        """
+        self.prepare_for_export()
+        exporter = NASExporter(self.model, input_names, output_names, model_args)
+        exporter.export_model(save_path, save_format)

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/onnx_export.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/onnx_export.py
@@ -1,0 +1,94 @@
+"""
+ Copyright (c) 2022 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+from typing import List
+
+import torch
+from torch import nn
+from torch.utils.hooks import RemovableHandle
+
+from nncf.torch.exporter import PTExporter
+
+
+class BNTrainingStateSwitcher:
+    """
+    Context manager for switching between evaluation and training mode of BatchNormalization module.
+    At the enter, it sets a forward pre-hook for setting BatchNormalization layers to the given state whether training
+    or evaluation.
+    At the exit, restore original BatchNormalization layer mode.
+    """
+
+    def __init__(self, model: nn.Module, is_training: bool = True):
+        self.original_training_state = {}
+        self.model = model
+        self.is_training = is_training
+        self.handles: List[RemovableHandle] = []
+
+    @staticmethod
+    def _apply_to_batchnorms(func):
+        def func_apply_to_bns(module):
+            if isinstance(module, (torch.nn.modules.batchnorm.BatchNorm1d,
+                                   torch.nn.modules.batchnorm.BatchNorm2d,
+                                   torch.nn.modules.batchnorm.BatchNorm3d)):
+                func(module)
+
+        return func_apply_to_bns
+
+    def __enter__(self):
+        def save_original_bn_training_state(module: torch.nn.Module):
+            self.original_training_state[module] = module.training
+
+        self.model.apply(self._apply_to_batchnorms(save_original_bn_training_state))
+
+        def hook(module, _) -> None:
+            module.training = self.is_training
+
+        def register_hook(module: torch.nn.Module):
+            handle = module.register_forward_pre_hook(hook)
+            self.handles.append(handle)
+
+        self.model.apply(self._apply_to_batchnorms(register_hook))
+        return self
+
+    def __exit__(self, *args):
+        def restore_original_bn_training_state(module: torch.nn.Module):
+            module.training = self.original_training_state[module]
+
+        self.model.apply(self._apply_to_batchnorms(restore_original_bn_training_state))
+        for handle in self.handles:
+            handle.remove()
+
+
+class NASExporter(PTExporter):
+    """
+    This class provides export of the NAS model to the ONNX format. The ordinary compressed models are exported in
+    torch.onnx.TrainingMode.EVAL mode. This way leads to a hang for NAS model with elastic depth enabled.
+    That's why NAS model is exported in torch.onnx.TrainingMode.TRAINING mode.
+    """
+    def _torch_export_call(self, model, input_tensor_list, save_path, input_names, output_names, opset_version):
+        """
+        Call of torch.onnx.export function.
+        @param model: torch.nn.Module to be exported.
+        @param input_tensor_list: the list containing model inputs.
+        @param save_path: a string containing a path for saving onnx model.
+        @param opset_version: the version of the onnx opset.
+        @param output_names: Names to be assigned to the output tensors of the model.
+        @param input_names: Names to be assigned to the input tensors of the model.
+        """
+        with BNTrainingStateSwitcher(model, is_training=False):
+            torch.onnx.export(
+                model, tuple(input_tensor_list), save_path,
+                input_names=input_names,
+                output_names=output_names,
+                opset_version=opset_version,
+                training=torch.onnx.TrainingMode.TRAINING
+            )

--- a/nncf/torch/exporter.py
+++ b/nncf/torch/exporter.py
@@ -205,12 +205,12 @@ class PTExporter(Exporter):
                 retval = dummy_forward(self._model)
                 output_names = generate_output_names_list(count_tensors(retval))
 
-            with BNTrainingStateSwitcher(model, False):
-                torch.onnx.export(model, tuple(input_tensor_list), save_path,
-                                  input_names=input_names,
-                                  output_names=output_names,
-                                  opset_version=opset_version,
-                                  training=torch.onnx.TrainingMode.TRAINING)
+            torch.onnx.export(model, tuple(input_tensor_list), save_path,
+                              input_names=input_names,
+                              output_names=output_names,
+                              opset_version=opset_version,
+                              training=torch.onnx.TrainingMode.EVAL
+            )
             model.enable_dynamic_graph_building()
         model.forward = original_forward
         model.to(original_device)

--- a/nncf/torch/exporter.py
+++ b/nncf/torch/exporter.py
@@ -11,14 +11,11 @@
  limitations under the License.
 """
 from typing import Any
-from typing import List
 from typing import Optional
 from typing import Tuple
 from functools import partial
 from copy import copy
 import torch
-from torch import nn
-from torch.utils.hooks import RemovableHandle
 
 from nncf.common.exporter import Exporter
 from nncf.common.utils.logger import logger as nncf_logger
@@ -34,51 +31,6 @@ def generate_input_names_list(num_inputs: int):
 
 def generate_output_names_list(num_outputs: int):
     return [f'output.{idx}' for idx in range(0, num_outputs)]
-
-
-class BNTrainingStateSwitcher:
-    """
-    Context manager for switching between evaluation and training mode of BatchNormalization module.
-    At the enter, it sets a forward pre-hook for setting BatchNormalization layers to the given state whether training
-    or evaluation.
-    At the exit, restore original BatchNormalization layer mode.
-    """
-    def __init__(self, model: nn.Module, is_training: bool = True):
-        self.original_training_state = {}
-        self.model = model
-        self.is_training = is_training
-        self.handles: List[RemovableHandle] = []
-
-    @staticmethod
-    def _apply_to_batchnorms(func):
-        def func_apply_to_bns(module):
-            if isinstance(module, (torch.nn.modules.batchnorm.BatchNorm1d,
-                                   torch.nn.modules.batchnorm.BatchNorm2d,
-                                   torch.nn.modules.batchnorm.BatchNorm3d)):
-                func(module)
-        return func_apply_to_bns
-
-    def __enter__(self):
-        def save_original_bn_training_state(module: torch.nn.Module):
-            self.original_training_state[module] = module.training
-        self.model.apply(self._apply_to_batchnorms(save_original_bn_training_state))
-
-        def hook(module, _) -> None:
-            module.training = self.is_training
-
-        def register_hook(module: torch.nn.Module):
-            handle = module.register_forward_pre_hook(hook)
-            self.handles.append(handle)
-
-        self.model.apply(self._apply_to_batchnorms(register_hook))
-        return self
-
-    def __exit__(self, *args):
-        def restore_original_bn_training_state(module: torch.nn.Module):
-            module.training = self.original_training_state[module]
-        self.model.apply(self._apply_to_batchnorms(restore_original_bn_training_state))
-        for handle in self.handles:
-            handle.remove()
 
 
 def count_tensors(model_retval: Any) -> int:
@@ -205,12 +157,26 @@ class PTExporter(Exporter):
                 retval = dummy_forward(self._model)
                 output_names = generate_output_names_list(count_tensors(retval))
 
-            torch.onnx.export(model, tuple(input_tensor_list), save_path,
-                              input_names=input_names,
-                              output_names=output_names,
-                              opset_version=opset_version,
-                              training=torch.onnx.TrainingMode.EVAL
-            )
+            self._torch_export_call(model, input_tensor_list, save_path, input_names, output_names, opset_version)
+
             model.enable_dynamic_graph_building()
         model.forward = original_forward
         model.to(original_device)
+
+    def _torch_export_call(self, model, input_tensor_list, save_path, input_names, output_names, opset_version):
+        """
+        Call of torch.onnx.export function.
+        @param model: torch.nn.Module to be exported.
+        @param input_tensor_list: the list containing model inputs.
+        @param save_path: a string containing a path for saving onnx model.
+        @param input_names: Names to be assigned to the input tensors of the model.
+        @param output_names: Names to be assigned to the output tensors of the model.
+        @param opset_version: the version of the onnx opset.
+        """
+        torch.onnx.export(
+            model, tuple(input_tensor_list), save_path,
+            input_names=input_names,
+            output_names=output_names,
+            opset_version=opset_version,
+            training=torch.onnx.TrainingMode.EVAL
+        )

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -453,8 +453,6 @@ class BaseQuantizer(nn.Module):
                             torch.allclose(y_zero_point - y_zero_point[0], torch.zeros_like(y_zero_point)):
                         y_scale, y_zero_point = y_scale[0], y_zero_point[0]
                         return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
-                    raise RuntimeError("PyTorch export to ONNX using QuantizeLinear-DequantizeLinear "
-                                       "doesn't support per channel quantization")
                 return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
         raise RuntimeError('Unknown export mode')
 

--- a/nncf/torch/quantization/quantize_functions.py
+++ b/nncf/torch/quantization/quantize_functions.py
@@ -154,8 +154,8 @@ class ExportQuantizeToFakeQuantize(torch.autograd.Function):
 class ExportQuantizeToONNXQuantDequant(torch.autograd.Function):
     @staticmethod
     def symbolic(g, input_, y_scale, y_zero_point):
-        quantized = g.op("QuantizeLinear", input_, y_scale, y_zero_point)
-        dequantized = g.op("DequantizeLinear", quantized, y_scale, y_zero_point)
+        quantized = g.op("QuantizeLinear", input_, y_scale, y_zero_point, axis_i=0)
+        dequantized = g.op("DequantizeLinear", quantized, y_scale, y_zero_point, axis_i=0)
         return dequantized
 
     @staticmethod

--- a/nncf/torch/quantization/quantize_functions.py
+++ b/nncf/torch/quantization/quantize_functions.py
@@ -138,7 +138,12 @@ def _quantize_autograd_to_range(input_, input_low, input_high, levels):
 class ExportQuantizeToFakeQuantize(torch.autograd.Function):
     @staticmethod
     def symbolic(g, input_, levels, input_low, input_high, output_low, output_high):
-        return g.op(add_domain("FakeQuantize"), input_, input_low, input_high, output_low, output_high, levels_i=levels)
+        output = g.op(
+            add_domain("FakeQuantize"), input_, input_low, input_high, output_low, output_high, levels_i=levels
+        )
+        # setType is needed for proper shape inference of custom op on ONNX export. Should work for torch >= 1.14
+        output.setType(input_.type())
+        return output
 
     @staticmethod
     def forward(ctx, input_, levels, input_low, input_high, output_low, output_high):

--- a/tests/torch/helpers.py
+++ b/tests/torch/helpers.py
@@ -73,16 +73,18 @@ def fill_params_of_model_by_normal(model, std=1.0):
         param.data = torch.normal(0, std, size=param.data.size())
 
 
-def create_conv(in_channels, out_channels, kernel_size, weight_init=1, bias_init=0, padding=0, stride=1, dim=2):
+def create_conv(in_channels, out_channels, kernel_size,
+                weight_init=1, bias_init=0, padding=0, stride=1, dim=2, bias=True):
     conv_dim_map = {
         1: nn.Conv1d,
         2: nn.Conv2d,
         3: nn.Conv3d,
     }
 
-    conv = conv_dim_map[dim](in_channels, out_channels, kernel_size, padding=padding, stride=stride)
+    conv = conv_dim_map[dim](in_channels, out_channels, kernel_size, padding=padding, stride=stride, bias=bias)
     fill_conv_weight(conv, weight_init, dim)
-    fill_bias(conv, bias_init)
+    if bias:
+        fill_bias(conv, bias_init)
 
     return conv
 
@@ -485,9 +487,10 @@ def create_dataloader_with_num_workers(create_dataloader, num_workers, sample_ty
 
 
 def load_exported_onnx_version(nncf_config: NNCFConfig, model: torch.nn.Module,
-                               path_to_storage_dir: Path) -> onnx.ModelProto:
+                               path_to_storage_dir: Path,
+                               save_format: str = None) -> onnx.ModelProto:
     _, compression_ctrl = create_compressed_model_and_algo_for_test(model, nncf_config)
     onnx_checkpoint_path = path_to_storage_dir / 'model.onnx'
-    compression_ctrl.export_model(str(onnx_checkpoint_path))
+    compression_ctrl.export_model(str(onnx_checkpoint_path), save_format=save_format)
     model_proto = onnx.load_model(str(onnx_checkpoint_path))
     return model_proto

--- a/tests/torch/nas/models/synthetic.py
+++ b/tests/torch/nas/models/synthetic.py
@@ -55,8 +55,8 @@ class ThreeConvModel(nn.Module):
 
     def __init__(self):
         super().__init__()
-        self.conv1 = create_conv(1, 3, 5)
-        self.conv_to_skip = create_conv(3, 3, 1)
+        self.conv1 = create_conv(1, 3, 5, bias=False)
+        self.conv_to_skip = create_conv(3, 3, 1, bias=False)
         self.last_conv = create_conv(3, 1, 1)
         self.mode = ThreeConvModelMode.ORIGINAL
         self._forward_fn_per_mode = {
@@ -109,8 +109,7 @@ class ThreeConvModel(nn.Module):
         # there may be a minor floating-point error in the 6th sign
         ref_weights = self.conv1.weight[:1, :, :, :]
         ref_weights = ref_kernel_transform(ref_weights, transition_matrix=self._transition_matrix)
-        ref_bias = self.conv1.bias[:1]
-        o1 = do_conv2d(self.conv1, x, padding=1, weight=ref_weights, bias=ref_bias)
+        o1 = do_conv2d(self.conv1, x, padding=1, weight=ref_weights)
         o3 = o1 + o1
         ref_weights_last = self.last_conv.weight[:, :1, :, :]
         ref_bias_last = self.last_conv.bias[:1]

--- a/tests/torch/nas/test_all_elasticity.py
+++ b/tests/torch/nas/test_all_elasticity.py
@@ -13,6 +13,7 @@
 
 import pytest
 import torch
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.onnx_export import NASExporter
 from torch.backends import cudnn
 
 from examples.torch.common.models.classification.resnet_cifar10 import resnet50_cifar10
@@ -433,3 +434,28 @@ def test_can_restore_and_get_the_same_output():
     ref_model.mode = ThreeConvModelMode.WIDTH_STAGE
     ref_output = ref_model(input_)
     assert torch.equal(actual_output, ref_output)
+
+
+###########################
+# Export to ONNX
+###########################
+
+def test_export_to_onnx(tmp_path, mocker):
+    _, ctrl, _ = create_bootstrap_nas_training_algo('resnet18')
+    multi_elasticity_handler = ctrl.multi_elasticity_handler
+    export_spy = mocker.spy(NASExporter, '_torch_export_call')
+
+    multi_elasticity_handler.disable_all()
+    multi_elasticity_handler.enable_elasticity(ElasticityDim.KERNEL)
+    multi_elasticity_handler.activate_minimum_subnet()
+    ctrl.export_model(str(tmp_path / 'kernel.onnx'))
+
+    multi_elasticity_handler.enable_elasticity(ElasticityDim.DEPTH)
+    multi_elasticity_handler.activate_minimum_subnet()
+    ctrl.export_model(str(tmp_path / 'depth.onnx'))
+
+    multi_elasticity_handler.enable_elasticity(ElasticityDim.WIDTH)
+    multi_elasticity_handler.width_handler.width_num_params_indicator = 1
+    multi_elasticity_handler.activate_minimum_subnet()
+    ctrl.export_model(str(tmp_path / 'width.onnx'))
+    assert export_spy.call_count == 3

--- a/tests/torch/nas/test_elastic_depth.py
+++ b/tests/torch/nas/test_elastic_depth.py
@@ -10,6 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from pathlib import Path
 from typing import List
 from typing import Optional
 
@@ -21,6 +22,7 @@ import torch
 from torch import nn
 
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_dim import ElasticityDim
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.onnx_export import NASExporter
 from nncf.experimental.torch.search_building_blocks.search_blocks import BuildingBlock
 from nncf.experimental.torch.search_building_blocks.search_blocks import get_building_blocks
 from nncf.torch import register_operator
@@ -187,48 +189,52 @@ def test_skip_one_block_resnet18(mocker):
     assert id(spy_agent_conv2d.call_args_list[2][0][1]) != id(spy_agent_bn.call_args_list[2][0][1])  # TracedTensor
 
 
-# @pytest.mark.xfail(reason="hang on export with EVAL mode, might be a conflict with some optimization in ONNX")
-# def test_can_export_model_with_one_skipped_block_resnet18(tmp_path):
-#     model = ResNet18()
-#     move_model_to_cuda_if_available(model)
-#
-#     nncf_config = get_empty_config(input_sample_sizes=RESNET50_INPUT_SIZE)
-#     skipped_blocks = [BuildingBlock('ResNet/Sequential[layer1]/BasicBlock[0]/relu_0',
-#                                     'ResNet/Sequential[layer1]/BasicBlock[0]/NNCFBatchNorm2d[bn2]/batch_norm_0')]
-#     orig_onnx_model_path = tmp_path / "resnet18.onnx"
-#     onnx_model_without_block_path = tmp_path / "resnet18_with_one_skipped_block.onnx"
-#
-#     compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, nncf_config)
-#     compressed_model.get_tracing_context().set_elastic_blocks(skipped_blocks)
-#     # export model to onnx
-#     ctx = compressed_model.get_tracing_context()
-#     compression_ctrl.export_model(orig_onnx_model_path)
-#
-#     ctx.elastic_depth = True  # activate mode with elastic depth
-#     ctx.set_active_skipped_block([0])
-#     compression_ctrl.export_model(onnx_model_without_block_path)
-#
-#     # load onnx graphs
-#     # pylint:disable=no-member
-#     load_model_fn = onnx.load_model
-#     onnx_resnet18_without_one_block = load_model_fn(onnx_model_without_block_path)
-#     onnx_resnet18_orig = load_model_fn(orig_onnx_model_path)
-#
-#     # count of node in skipped block  == 5
-#     assert len(onnx_resnet18_orig.graph.node) == 69
-#     assert len(onnx_resnet18_without_one_block.graph.node) == 67
-#
-#     input_tensor = np.ones(nncf_config['input_info'][0]['sample_size'])
-#     device = get_model_device(compressed_model)
-#     torch_input = torch.tensor(input_tensor, dtype=torch.float32).to(device)
-#     with torch.no_grad():
-#         torch_model_output = compressed_model(torch_input)
-#
-#     # ONNXRuntime
-#     sess = rt.InferenceSession(str(onnx_model_without_block_path))
-#     input_name = sess.get_inputs()[0].name
-#     onnx_model_output = sess.run(None, {input_name: input_tensor.astype(np.float32)})[0]
-#     assert np.allclose(torch_model_output.cpu().numpy(), onnx_model_output)
+def nas_export(model, save_path: Path):
+    exporter = NASExporter(model)
+    exporter.export_model(str(save_path))
+
+
+def test_can_export_model_with_one_skipped_block_resnet18(tmp_path):
+    model = ResNet18()
+    move_model_to_cuda_if_available(model)
+
+    nncf_config = get_empty_config(input_sample_sizes=RESNET50_INPUT_SIZE)
+    skipped_blocks = [BuildingBlock('ResNet/Sequential[layer1]/BasicBlock[0]/relu_0',
+                                    'ResNet/Sequential[layer1]/BasicBlock[0]/NNCFBatchNorm2d[bn2]/batch_norm_0')]
+    orig_onnx_model_path = tmp_path / "resnet18.onnx"
+    onnx_model_without_block_path = tmp_path / "resnet18_with_one_skipped_block.onnx"
+
+    compressed_model, _ = create_compressed_model_and_algo_for_test(model, nncf_config)
+    compressed_model.get_tracing_context().set_elastic_blocks(skipped_blocks)
+    # export model to onnx
+    ctx = compressed_model.get_tracing_context()
+    nas_export(compressed_model, orig_onnx_model_path)
+
+    ctx.elastic_depth = True  # activate mode with elastic depth
+    ctx.set_active_skipped_block([0])
+    nas_export(compressed_model, onnx_model_without_block_path)
+
+    # load onnx graphs
+    # pylint:disable=no-member
+    load_model_fn = onnx.load_model
+    onnx_resnet18_without_one_block = load_model_fn(onnx_model_without_block_path)
+    onnx_resnet18_orig = load_model_fn(orig_onnx_model_path)
+
+    # count of node in skipped block  == 5
+    assert len(onnx_resnet18_orig.graph.node) == 69
+    assert len(onnx_resnet18_without_one_block.graph.node) == 67
+
+    input_tensor = np.ones(nncf_config['input_info'][0]['sample_size'])
+    device = get_model_device(compressed_model)
+    torch_input = torch.tensor(input_tensor, dtype=torch.float32).to(device)
+    with torch.no_grad():
+        torch_model_output = compressed_model(torch_input)
+
+    # ONNXRuntime
+    sess = rt.InferenceSession(str(onnx_model_without_block_path))
+    input_name = sess.get_inputs()[0].name
+    onnx_model_output = sess.run(None, {input_name: input_tensor.astype(np.float32)})[0]
+    assert np.allclose(torch_model_output.cpu().numpy(), onnx_model_output, atol=1.e-5)
 
 
 def test_skip_one_block_resnet50(mocker):

--- a/tests/torch/nas/test_onnx_export.py
+++ b/tests/torch/nas/test_onnx_export.py
@@ -13,6 +13,7 @@
 import numpy as np
 import onnx
 import onnxruntime as rt
+import pytest
 import torch
 
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_dim import ElasticityDim
@@ -36,6 +37,7 @@ def check_onnx_weights(ctrl, path_to_onnx, ref_orig_weights, expected_num_nodes)
     assert len(onnx_model.graph.node) == expected_num_nodes
 
 
+# @pytest.mark.xfail(reason="unexpected Identity node on export with EVAL mode. Need to change the way of comparing")
 def test_multi_elasticity_weights_in_onnx(tmp_path):
     _, ctrl = create_bnas_model_and_ctrl_by_test_desc(THREE_CONV_TEST_DESC)
     multi_elasticity_handler = ctrl.multi_elasticity_handler
@@ -45,7 +47,7 @@ def test_multi_elasticity_weights_in_onnx(tmp_path):
     last_conv = orig_model.last_conv
 
     path_to_onnx = tmp_path / 'supernet.onnx'
-    ref_orig_weights = [conv1.weight, conv1.bias, conv2.weight, conv2.bias, last_conv.weight, last_conv.bias]
+    ref_orig_weights = [conv1.weight, conv2.weight, last_conv.weight, last_conv.bias]
     check_onnx_weights(ctrl, path_to_onnx, ref_orig_weights, 5)
 
     multi_elasticity_handler.disable_all()
@@ -53,19 +55,19 @@ def test_multi_elasticity_weights_in_onnx(tmp_path):
     multi_elasticity_handler.activate_minimum_subnet()
     path_to_onnx = tmp_path / 'kernel_stage.onnx'
     ref_weight1 = ref_kernel_transform(conv1.weight)
-    ref_orig_weights = [ref_weight1, conv1.bias, conv2.weight, conv2.bias, last_conv.weight, last_conv.bias]
+    ref_orig_weights = [ref_weight1, conv2.weight, last_conv.weight, last_conv.bias]
     check_onnx_weights(ctrl, path_to_onnx, ref_orig_weights, 5)
 
     multi_elasticity_handler.enable_elasticity(ElasticityDim.DEPTH)
     multi_elasticity_handler.activate_minimum_subnet()
     path_to_onnx = tmp_path / 'depth_stage.onnx'
-    ref_orig_weights = [ref_weight1, conv1.bias, last_conv.weight, last_conv.bias]
+    ref_orig_weights = [ref_weight1, last_conv.weight, last_conv.bias]
     check_onnx_weights(ctrl, path_to_onnx, ref_orig_weights, 4)
 
     multi_elasticity_handler.enable_elasticity(ElasticityDim.WIDTH)
     multi_elasticity_handler.activate_minimum_subnet()
     path_to_onnx = tmp_path / 'width_stage.onnx'
-    ref_orig_weights = [ref_weight1[:1], conv1.bias[:1], last_conv.weight[:, :1, :, :], last_conv.bias[:1]]
+    ref_orig_weights = [ref_weight1[:1], last_conv.weight[:, :1, :, :], last_conv.bias[:1]]
     check_onnx_weights(ctrl, path_to_onnx, ref_orig_weights, 4)
 
 

--- a/tests/torch/nas/test_onnx_export.py
+++ b/tests/torch/nas/test_onnx_export.py
@@ -13,7 +13,6 @@
 import numpy as np
 import onnx
 import onnxruntime as rt
-import pytest
 import torch
 
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_dim import ElasticityDim
@@ -37,7 +36,6 @@ def check_onnx_weights(ctrl, path_to_onnx, ref_orig_weights, expected_num_nodes)
     assert len(onnx_model.graph.node) == expected_num_nodes
 
 
-# @pytest.mark.xfail(reason="unexpected Identity node on export with EVAL mode. Need to change the way of comparing")
 def test_multi_elasticity_weights_in_onnx(tmp_path):
     _, ctrl = create_bnas_model_and_ctrl_by_test_desc(THREE_CONV_TEST_DESC)
     multi_elasticity_handler = ctrl.multi_elasticity_handler

--- a/tests/torch/quantization/test_onnx_export.py
+++ b/tests/torch/quantization/test_onnx_export.py
@@ -79,7 +79,8 @@ def test_onnx_export_to_quantize_dequantize(tmp_path):
     nncf_config = get_config_for_export_mode(should_be_onnx_standard=True)
     nncf_config['target_device'] = 'TRIAL'
     onnx_model_proto = load_exported_onnx_version(nncf_config, model,
-                                                  path_to_storage_dir=tmp_path)
+                                                  path_to_storage_dir=tmp_path,
+                                                  save_format='onnx_13')
     num_q = 0
     num_dq = 0
     num_model_nodes = 0
@@ -136,11 +137,7 @@ def test_onnx_export_to_quantize_dequantize_per_channel(per_channel: bool,
     quantizer._export_mode = export_mode
 
     x = torch.rand(INPUT_TENSOR_SHAPE)
-    if quantizer.per_channel and export_mode is QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS:
-        with pytest.raises(RuntimeError):
-            quantizer.run_export_quantization(x)
-    else:
-        quantizer.run_export_quantization(x)
+    quantizer.run_export_quantization(x)
 
 
 class TargetCompressionIdxTestModel(torch.nn.Module):

--- a/tests/torch/quantization/test_overflow_issue_export.py
+++ b/tests/torch/quantization/test_overflow_issue_export.py
@@ -332,7 +332,7 @@ def test_are_qdq_exported_per_tensor_weights_tensors_clipped(tmp_path):
         assert quantizer.quantizer_module_ref._half_range  # pylint: disable=protected-access
 
     onnx_checkpoint_path = str(tmp_path / 'model.onnx')
-    compression_ctrl.export_model(onnx_checkpoint_path, input_names=['input'])
+    compression_ctrl.export_model(onnx_checkpoint_path, input_names=['input'], save_format='onnx_13')
 
     onnx_model = onnx.load(onnx_checkpoint_path)  # pylint: disable=no-member
 
@@ -372,7 +372,7 @@ def test_is_pytorch_output_the_same_as_onnx_qdq_overflow_fix_applied(tmp_path, m
     compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, nncf_config)
 
     onnx_checkpoint_path = str(tmp_path / 'model.onnx')
-    compression_ctrl.export_model(onnx_checkpoint_path)
+    compression_ctrl.export_model(onnx_checkpoint_path, save_format='onnx_13')
     input_tensors = [np.random.normal(size=[1, 1, 20, 20]), np.random.uniform(size=[1, 1, 20, 20]),
                      100 * np.random.normal(size=[1, 1, 20, 20]), 100 * np.random.uniform(size=[1, 1, 20, 20])]
     for input_tensor in input_tensors:


### PR DESCRIPTION
### Changes

- export to ONNX in EVAL mode by default
- export to ONNX in TRAINING mode for NAS in order to avoid hang. Most probably it happens because of incompatibility of skipped layer in Elastic Depth with optimizations/fusings on export in EVAL mode.
- remove error for per-channel Q-DQ export

### Reason for changes

The behavior of exporting in training mode had been changed, and it started producing invalid graph for evaluation, as result e2e validation started to fail on accuracy validation

### Related tickets

96710

### Tests

e2e torch
