### PR TITLE
Use ONNX opset 13 on torch export

### DIFF
--- a/nncf/torch/exporter.py
+++ b/nncf/torch/exporter.py
@@ -50,7 +50,7 @@ class PTExporter(Exporter):
     """
 
     _ONNX_FORMAT = 'onnx'
-    _ONNX_DEFAULT_OPSET = 10
+    _ONNX_DEFAULT_OPSET = 13
 
 
     @staticmethod

--- a/tests/torch/quantization/test_adjust_padding.py
+++ b/tests/torch/quantization/test_adjust_padding.py
@@ -194,7 +194,8 @@ def test_onnx_export_to_fake_quantize_with_adjust_pad(tmp_path):
     register_bn_adaptation_init_args(nncf_config)
 
     onnx_model_proto = load_exported_onnx_version(nncf_config, model,
-                                                  path_to_storage_dir=tmp_path)
+                                                  path_to_storage_dir=tmp_path,
+                                                  save_format='onnx_10')
     num_fq = 0
     num_model_nodes = 0
     num_adjust_pad_nodes = 0

--- a/tests/torch/test_onnx_export.py
+++ b/tests/torch/test_onnx_export.py
@@ -86,8 +86,9 @@ def test_exporter_parser_format(save_format: str, refs: Any):
 
 @pytest.mark.parametrize('save_format, ref_opset',
                          (
-                             ('onnx', 10),
+                             ('onnx', 13),
                              ('onnx_9', 9),
+                             ('onnx_10', 10),
                              ('onnx_11', 11)
                          )
                         )


### PR DESCRIPTION
### Changes

Bumped onnx opset version on export to support Q-DQ format for per-channel quantization

One commit on top of https://github.com/openvinotoolkit/nncf/pull/1384, which should be merged soon.

### Reason for changes

e2e tests fail for Q-DQ mode

### Related tickets

96710

### Tests

e2e torch
