### PR TITLE
ProgressBar formatting improvement

### DIFF
--- a/nncf/common/utils/progress_bar.py
+++ b/nncf/common/utils/progress_bar.py
@@ -75,5 +75,5 @@ class ProgressBar:
             num_empty = self._width - num_filled
             filled = '█' * num_filled
             empty = ' ' * num_empty
-            self._logger.info('{desc} {filled} {empty} | {index} / {total}'.format(
+            self._logger.info('{desc} |{filled}{empty}| {index} / {total}'.format(
                 desc=self._desc, filled=filled, empty=empty, index=self._index, total=self._total))

--- a/tests/common/test_progress_bar.py
+++ b/tests/common/test_progress_bar.py
@@ -32,9 +32,9 @@ def test_can_print_by_default(_nncf_caplog):
         pass
 
     assert _nncf_caplog.record_tuples == [
-        ('nncf', 20, ' █████             | 1 / 3'),
-        ('nncf', 20, ' ██████████        | 2 / 3'),
-        ('nncf', 20, ' ████████████████  | 3 / 3')
+        ('nncf', 20, ' |█████           | 1 / 3'),
+        ('nncf', 20, ' |██████████      | 2 / 3'),
+        ('nncf', 20, ' |████████████████| 3 / 3')
     ]
 
 
@@ -43,9 +43,9 @@ def test_can_print_by_default__with_enumerate_and_total(_nncf_caplog):
         pass
 
     assert _nncf_caplog.record_tuples == [
-        ('nncf', 20, ' █████             | 1 / 3'),
-        ('nncf', 20, ' ██████████        | 2 / 3'),
-        ('nncf', 20, ' ████████████████  | 3 / 3')
+        ('nncf', 20, ' |█████           | 1 / 3'),
+        ('nncf', 20, ' |██████████      | 2 / 3'),
+        ('nncf', 20, ' |████████████████| 3 / 3')
     ]
 
 
@@ -57,8 +57,8 @@ def test_can_print_with_another_logger(_nncf_caplog):
         pass
 
     assert _nncf_caplog.record_tuples == [
-        ('test', 20, ' ████████          | 1 / 2'),
-        ('test', 20, ' ████████████████  | 2 / 2')
+        ('test', 20, ' |████████        | 1 / 2'),
+        ('test', 20, ' |████████████████| 2 / 2')
     ]
 
 
@@ -101,9 +101,9 @@ def test_can_print_collections_less_than_num_lines(_nncf_caplog):
         pass
 
     assert _nncf_caplog.record_tuples == [
-        ('nncf', 20, 'desc █████             | 1 / 3'),
-        ('nncf', 20, 'desc ██████████        | 2 / 3'),
-        ('nncf', 20, 'desc ████████████████  | 3 / 3')
+        ('nncf', 20, 'desc |█████           | 1 / 3'),
+        ('nncf', 20, 'desc |██████████      | 2 / 3'),
+        ('nncf', 20, 'desc |████████████████| 3 / 3')
     ]
 
 
@@ -112,9 +112,9 @@ def test_can_print_collections_bigger_than_num_lines(_nncf_caplog):
         pass
 
     assert _nncf_caplog.record_tuples == [
-        ('nncf', 20, ' ███████           | 5 / 11'),
-        ('nncf', 20, ' ██████████████    | 10 / 11'),
-        ('nncf', 20, ' ████████████████  | 11 / 11')
+        ('nncf', 20, ' |███████         | 5 / 11'),
+        ('nncf', 20, ' |██████████████  | 10 / 11'),
+        ('nncf', 20, ' |████████████████| 11 / 11')
     ]
 
 
@@ -132,6 +132,6 @@ def test_can_limit_number_of_iterations(_nncf_caplog):
         pass
 
     assert _nncf_caplog.record_tuples == [
-        ('nncf', 20, ' ████████          | 1 / 2'),
-        ('nncf', 20, ' ████████████████  | 2 / 2')
+        ('nncf', 20, ' |████████        | 1 / 2'),
+        ('nncf', 20, ' |████████████████| 2 / 2')
     ]


### PR DESCRIPTION
### Changes

In the examples below whitespaces got squashed. Couldn't find a way to format it properly here. In reality, all "|" symbols are below each other.

**Before:**
INFO:nncf:Collecting tensor statistics █                 | 1 / 16
INFO:nncf:Collecting tensor statistics ██                | 2 / 16
INFO:nncf:Collecting tensor statistics ███               | 3 / 16
INFO:nncf:Collecting tensor statistics ████              | 4 / 16
INFO:nncf:Collecting tensor statistics █████             | 5 / 16
INFO:nncf:Collecting tensor statistics ██████            | 6 / 16
INFO:nncf:Collecting tensor statistics ███████           | 7 / 16
INFO:nncf:Collecting tensor statistics ████████          | 8 / 16
INFO:nncf:Collecting tensor statistics █████████         | 9 / 16
INFO:nncf:Collecting tensor statistics ██████████        | 10 / 16
INFO:nncf:Collecting tensor statistics ███████████       | 11 / 16
INFO:nncf:Collecting tensor statistics ████████████      | 12 / 16
INFO:nncf:Collecting tensor statistics █████████████     | 13 / 16
INFO:nncf:Collecting tensor statistics ██████████████    | 14 / 16
INFO:nncf:Collecting tensor statistics ███████████████   | 15 / 16
INFO:nncf:Collecting tensor statistics ████████████████  | 16 / 16

**After:**
INFO:nncf:Collecting tensor statistics |█               | 1 / 16
INFO:nncf:Collecting tensor statistics |██              | 2 / 16
INFO:nncf:Collecting tensor statistics |███             | 3 / 16
INFO:nncf:Collecting tensor statistics |████            | 4 / 16
INFO:nncf:Collecting tensor statistics |█████           | 5 / 16
INFO:nncf:Collecting tensor statistics |██████          | 6 / 16
INFO:nncf:Collecting tensor statistics |███████         | 7 / 16
INFO:nncf:Collecting tensor statistics |████████        | 8 / 16
INFO:nncf:Collecting tensor statistics |█████████       | 9 / 16
INFO:nncf:Collecting tensor statistics |██████████      | 10 / 16
INFO:nncf:Collecting tensor statistics |███████████     | 11 / 16
INFO:nncf:Collecting tensor statistics |████████████    | 12 / 16
INFO:nncf:Collecting tensor statistics |█████████████   | 13 / 16
INFO:nncf:Collecting tensor statistics |██████████████  | 14 / 16
INFO:nncf:Collecting tensor statistics |███████████████ | 15 / 16
INFO:nncf:Collecting tensor statistics |████████████████| 16 / 16

### Reason for changes

ProgressBar formatting is not ideal:
```
self._logger.info('{desc} {filled} {empty} | {index} / {total}'.format(...)
```

1. Extra space between `{filled}` and `{empty}` parts leads to incorrect spacing
2. Trailing white-space after `{empty}` makes it appear as progress bar is never fully finished

