### PR TITLE
Linear output shape collection fix

### DIFF
--- a/tests/torch/pruning/filter_pruning/test_algo.py
+++ b/tests/torch/pruning/filter_pruning/test_algo.py
@@ -18,7 +18,6 @@ import pytest
 import torch
 import numpy as np
 
-from nncf.torch.layers import NNCF_LINEAR_MODULES_DICT
 from nncf.torch.module_operations import UpdateWeightAndBias
 from nncf.torch.pruning.filter_pruning.algo import FilterPruningController
 from nncf.torch.pruning.filter_pruning.functions import l2_filter_norm

--- a/tests/torch/pruning/helpers.py
+++ b/tests/torch/pruning/helpers.py
@@ -17,6 +17,7 @@ import torch
 from torch import nn
 
 from nncf.config import NNCFConfig
+from nncf.torch.dynamic_graph.context import no_nncf_trace
 from tests.torch.test_models.pnasnet import CellB
 from tests.torch.helpers import create_bn, create_conv, fill_linear_weight
 from tests.torch.helpers import create_transpose_conv
@@ -633,14 +634,17 @@ class DisconectedGraphModel(nn.Module):
 
     def forward(self, x):
         x = self.conv1(x)
-        # Broke tracing graph by copy function
-        x = copy.copy(x)
+        # Broke tracing graph by no_nncf_trace
+        with no_nncf_trace():
+            x = self.relu(x)
         x = self.relu(x)
         x = self.conv2(x)
         x = self.conv3(x)
         x = x.view(-1, 64)
         x = self.fc(x)
-        # Broke tracing graph by copy function
+        # Broke tracing graph by no_nncf_trace
+        with no_nncf_trace():
+            x = self.relu(x)
         x = copy.copy(x)
         return x
 


### PR DESCRIPTION
### Changes

Output shape calculation for linear layers in case of the output edge is absent was added.

`DisconectedGraphModel` in tests was fixed to be actually disconnected

### Reason for changes

Pruning isn't working in DOR due to latest linear layer has no output edge because of output node absence

### Tests

Tests was updated
