### PR TITLE
Remove direct setup.py installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,23 +169,26 @@ If you want to optimize a model from TensorFlow, install TensorFlow by following
 
 Install the package and its dependencies by running the following in the repository root directory:
 ```
-python setup.py install
+pip install .
 ```
-Alternatively, If you don't install any backend you can install NNCF and PyTorch in one line with:
+
+Note that if you install NNCF in this manner, the backend frameworks supported by NNCF will not be explicitly installed. NNCF will try to work with whatever backend versions you have installed in your Python environment.
+
+If you want to install both NNCF and the supported PyTorch version in one line, you can do this by running:
 ```
-python setup.py install --torch
+pip install .[torch]
 ```
-Install NNCF and TensorFlow in one line:
+For installation of NNCF along with TensorFlow, run:
 ```
-python setup.py install --tf
+pip install .[tf]
 ```
-(Experimental) Install NNCF for ONNXRuntime-OpenVINO
+(Experimental) For installation of NNCF for ONNXRuntime-OpenVINO, run:
 ```bash
-python setup.py install --onnx
+pip install .[onnx]
 ```
 
 
-_NB_: For launching example scripts in this repository, we recommend replacing the `install` option above with `develop` and setting the `PYTHONPATH` variable to the root of the checked-out repository.
+_NB_: For launching example scripts in this repository, we recommend setting the `PYTHONPATH` variable to the root of the checked-out repository once the installation is completed.
 
 #### As a PyPI package:
 
@@ -193,15 +196,15 @@ NNCF can be installed as a regular PyPI package via pip:
 ```
 pip install nncf
 ```
-Alternatively, If you don't install any backend you can install NNCF and PyTorch in one line with:
+Use the same `pip install` syntax as above to install NNCF along with the backend package versions in one go, i.e. for NNCF with PyTorch, run:
 ```
 pip install nncf[torch]
 ```
-Install NNCF and TensorFlow in one line:
+For installation of NNCF along with TensorFlow, run:
 ```
 pip install nncf[tf]
 ```
-(Experimental) Install NNCF for ONNXRuntime-OpenVINO
+(Experimental) For installation of NNCF for ONNXRuntime-OpenVINO, run:
 ```bash
 pip install nncf[onnx]
 ```

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,28 @@
  limitations under the License.
 """
 
+# *WARNING*: Do not run this file directly by `python setup.py install`
+# or with any other parameter - this is an outdated and error-prone way
+# to install Python packages and causes particular problems with namespace
+# packages such as `protobuf`.
+# Refer to the table below for well-known and supported alternatives with
+# the same behaviour:
+# +-------------------------------------------------------------------------------+
+# |           Old command           |                New command                  |
+# +---------------------------------+---------------------------------------------+
+# | python setup.py install         |  pip install .                              |
+# | python setup.py develop         |  pip install -e .                           |
+# | python setup.py develop --*arg* |  pip install --install-option="*arg*" -e  . |
+# | python setup.py sdist           |  python -m build -s                         | <-- using the "build" package
+# | python setup.py bdist_wheel     |  python -m build -w                         | <-- https://pypi.org/project/build/
+# +---------------------------------+---------------------------------------------+
+#
+# PyPA in general recommends to move away from setup.py and use pyproject.toml
+# instead. This doesn't fit us as we currently want to do custom stuff during
+# installation such as setting version based on the commit SHA for repo-based
+# installs.
+
+
 import glob
 import stat
 import sys
@@ -22,22 +44,25 @@ import re
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
-proper_version = '59.5.0'
+BKC_SETUPTOOLS_VERSION = '59.5.0'
 
-with open("{}/README.md".format(here), "r", encoding="utf8") as fh:
-    long_description = fh.read()
 
-if "--tf" in sys.argv:
-    import setuptools
-    from pkg_resources import parse_version
-    setuptools_version = parse_version(setuptools.__version__).base_version
-    if setuptools_version < '43.0.0':
-        raise RuntimeError(
-            "To properly install NNCF, please install setuptools>=43.0.0, "
-            f"while current setuptools version is {setuptools.__version__}. "
-            f"Recommended version is {proper_version}."
-        )
+import setuptools
+from pkg_resources import parse_version
+setuptools_version = parse_version(setuptools.__version__).base_version
+if setuptools_version < '43.0.0':
+    raise RuntimeError(
+        "To properly install NNCF, please install setuptools>=43.0.0, "
+        f"while current setuptools version is {setuptools.__version__}. "
+        f"Recommended version is {BKC_SETUPTOOLS_VERSION}."
+    )
 
+python_version = sys.version_info
+if python_version < (3, 7, 0):
+    print("Only Python >= 3.7.0 is supported")
+    sys.exit(0)
+
+version_string = "{}{}".format(sys.version_info[0], sys.version_info[1])
 
 is_installing_editable = "develop" in sys.argv
 is_building_release = not is_installing_editable and "--release" in sys.argv
@@ -99,13 +124,6 @@ INSTALL_REQUIRES = ["ninja>=1.10.0.post2, <1.11",
                     "wheel>=0.36.1"]
 
 
-python_version = sys.version_info
-if python_version < (3, 7, 0):
-    print("Only Python >= 3.7.0 is supported")
-    sys.exit(0)
-
-version_string = "{}{}".format(sys.version_info[0], sys.version_info[1])
-
 EXTRAS_REQUIRE = {
     "tests": ["pytest"],
     "docs": [],
@@ -114,9 +132,6 @@ EXTRAS_REQUIRE = {
     ],
     "torch": [
         "torch==1.12.1",
-        # Please see
-        # https://stackoverflow.com/questions/70520120/attributeerror-module-setuptools-distutils-has-no-attribute-version
-        "setuptools==59.5.0"
     ],
     "onnx": [
         "torch==1.12.1",
@@ -132,33 +147,14 @@ EXTRAS_REQUIRE = {
 
 EXTRAS_REQUIRE["all"] = [
     EXTRAS_REQUIRE["tf"],
-    EXTRAS_REQUIRE["torch"]
+    EXTRAS_REQUIRE["torch"],
+    EXTRAS_REQUIRE["onnx"],
+    EXTRAS_REQUIRE["openvino"],
 ]
 
-SETUP_REQUIRES = []
 
-if "--torch" in sys.argv:
-    INSTALL_REQUIRES.extend(EXTRAS_REQUIRE["torch"])
-    sys.argv.remove("--torch")
-
-if "--tf" in sys.argv:
-    # See also: https://github.com/tensorflow/tensorflow/issues/56077
-    # This is a temporary patch, that limites the protobuf version from above
-    INSTALL_REQUIRES.extend(EXTRAS_REQUIRE["tf"])
-    sys.argv.remove("--tf")
-
-if "--onnx" in sys.argv:
-    INSTALL_REQUIRES.extend(EXTRAS_REQUIRE["onnx"])
-    sys.argv.remove("--onnx")
-
-if "--openvino" in sys.argv:
-    INSTALL_REQUIRES.extend(EXTRAS_REQUIRE["openvino"])
-    SETUP_REQUIRES.extend(EXTRAS_REQUIRE["openvino"])
-    sys.argv.remove("--openvino")
-
-if "--all" in sys.argv:
-    INSTALL_REQUIRES.extend(EXTRAS_REQUIRE["all"])
-    sys.argv.remove("--all")
+with open("{}/README.md".format(here), "r", encoding="utf8") as fh:
+    long_description = fh.read()
 
 setup(
     name="nncf",
@@ -178,7 +174,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=INSTALL_REQUIRES,
-    setup_requires=SETUP_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
     keywords=["compression", "quantization", "sparsity", "mixed-precision-training",
               "quantization-aware-training", "hawq", "classification",

--- a/tests/cross_fw/install/install_checks_torch.py
+++ b/tests/cross_fw/install/install_checks_torch.py
@@ -53,7 +53,7 @@ if execution_type == "cpu":
     output_tensor = QuantizedFunctionsCPU.Quantize_forward(input_tensor, input_low_tensor, input_high_tensor, levels)
     output_tensor = BinarizedFunctionsCPU.ActivationBinarize_forward(output_tensor, scale_tensor, threshold_tensor)
     output_tensor = BinarizedFunctionsCPU.WeightBinarize_forward(output_tensor, True)
-elif execution_type == "cuda":
+elif execution_type == "gpu":
     input_tensor = input_tensor.cuda()
     input_low_tensor = input_low_tensor.cuda()
     input_high_tensor = input_high_tensor.cuda()


### PR DESCRIPTION
### Changes

READMEs and tests are adjusted to use the `pip install` approach instead of the `python setup.py` approach.

### Reason for changes
`python setup.py` direct calls are deprecated in the community.

### Related tickets
N/A

### Tests
cross_fw/install/test_install
