### PR TITLE
Fix CUDA version in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ See [third_party_integration](./third_party_integration) for examples of code mo
   - PyTorch\* 1.12.1
   - TensorFlow\* >=2.4.0, <=2.8.2
 
-This repository is tested on Python* 3.8.10, PyTorch* 1.12.1 (NVidia CUDA\* Toolkit 11.7) and TensorFlow* 2.8.2 (NVidia CUDA\* Toolkit 11.2).
+This repository is tested on Python* 3.8.10, PyTorch* 1.12.1 (NVidia CUDA\* Toolkit 11.6) and TensorFlow* 2.8.2 (NVidia CUDA\* Toolkit 11.2).
 
 ## Installation
 We suggest to install or use the package in the [Python virtual environment](https://docs.python.org/3/tutorial/venv.html).


### PR DESCRIPTION
### Changes

CUDA version was changed from `11.7` to `11.6` in the readme
### Reason for changes
According to official documentation torch1.12.1 works only with CUDA versions `10.2`, `11.3`, `11.6` and not working with `11.7`

https://pytorch.org/get-started/previous-versions/
<!--- Why should the change be applied -->

### Related tickets

<!--- Post the numerical ID of the ticket, if available -->

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
