### PR TITLE
Improved Adaptive Compression Training Loop support by OTX 

### DIFF
--- a/nncf/common/accuracy_aware_training/runner.py
+++ b/nncf/common/accuracy_aware_training/runner.py
@@ -135,7 +135,7 @@ class TrainingRunner(ABC):
     def initialize_training_loop_fns(self, train_epoch_fn: Callable[[CompressionAlgorithmController, TModel,
                                                                      Optional[int],
                                                                      Optional[OptimizerType],
-                                                                     Optional[LRSchedulerType]], None],
+                                                                     Optional[LRSchedulerType]], float],
                                      validate_fn: Callable[[TModel, Optional[int]], float],
                                      configure_optimizers_fn: Callable[[], Tuple[OptimizerType, LRSchedulerType]],
                                      dump_checkpoint_fn: Callable[
@@ -201,6 +201,7 @@ class BaseAccuracyAwareTrainingRunner(TrainingRunner):
         self.cumulative_epoch_count = 0
         self.best_val_metric_value = 0
         self.current_val_metric_value = 0
+        self.current_loss = 0
 
         self._compressed_training_history = []
         self._best_checkpoint = None
@@ -220,11 +221,11 @@ class BaseAccuracyAwareTrainingRunner(TrainingRunner):
     def train_epoch(self, model, compression_controller):
         compression_controller.scheduler.epoch_step()
         # assuming that epoch number is only used for logging in train_fn:
-        self._train_epoch_fn(compression_controller,
-                             model,
-                             epoch=self.cumulative_epoch_count,
-                             optimizer=self.optimizer,
-                             lr_scheduler=self.lr_scheduler)
+        self.current_loss = self._train_epoch_fn(compression_controller,
+                                                 model,
+                                                 epoch=self.cumulative_epoch_count,
+                                                 optimizer=self.optimizer,
+                                                 lr_scheduler=self.lr_scheduler)
         self.training_epoch_count += 1
         self.cumulative_epoch_count += 1
 

--- a/nncf/common/accuracy_aware_training/training_loop.py
+++ b/nncf/common/accuracy_aware_training/training_loop.py
@@ -435,7 +435,7 @@ class AccuracyAwareTrainingMode:
 
 def create_accuracy_aware_training_loop(nncf_config: NNCFConfig,
                                         compression_ctrl: CompressionAlgorithmController,
-                                        **additional_runner_args) -> TrainingLoop:
+                                        **additional_runner_args) -> BaseEarlyExitCompressionTrainingLoop:
     """
     Creates an accuracy aware training loop corresponding to NNCFConfig and CompressionAlgorithmController.
     :param: nncf_config: An instance of the NNCFConfig.

--- a/nncf/tensorflow/accuracy_aware_training/runner.py
+++ b/nncf/tensorflow/accuracy_aware_training/runner.py
@@ -69,7 +69,8 @@ class TFAccuracyAwareTrainingRunner(BaseAccuracyAwareTrainingRunner):
         if self._update_learning_rate_fn is not None:
             self._update_learning_rate_fn(self.lr_scheduler,
                                           self.training_epoch_count,
-                                          self.current_val_metric_value)
+                                          self.current_val_metric_value,
+                                          self.current_loss)
 
     def _save_checkpoint(self, model, compression_controller, checkpoint_path):
         model.save_weights(checkpoint_path)

--- a/nncf/torch/accuracy_aware_training/runner.py
+++ b/nncf/torch/accuracy_aware_training/runner.py
@@ -70,7 +70,8 @@ class PTAccuracyAwareTrainingRunner(BaseAccuracyAwareTrainingRunner):
         if self._update_learning_rate_fn is not None:
             self._update_learning_rate_fn(self.lr_scheduler,
                                           self.training_epoch_count,
-                                          self.current_val_metric_value)
+                                          self.current_val_metric_value,
+                                          self.current_loss)
         else:
             if self.lr_scheduler is not None and self.lr_updates_needed:
                 self.lr_scheduler.step(


### PR DESCRIPTION
### Changes

- Changed signature of `train_epoch_fn` to return loss value
- Changed signature of `update_learning_rate_fn` to take current loss value as an argument

### Reason for changes

Support of ACTL from OTX

### Related tickets

95048


