### PR TITLE
No weights override on sparsity model's export

### DIFF
--- a/nncf/torch/sparsity/layers.py
+++ b/nncf/torch/sparsity/layers.py
@@ -17,7 +17,7 @@ from torch import nn
 
 from nncf.torch.layer_utils import COMPRESSION_MODULES
 from nncf.torch.sparsity.functions import apply_binary_mask as apply_binary_mask_impl
-from nncf.torch.utils import is_tracing_state, no_jit_trace
+from nncf.torch.utils import is_tracing_state
 
 
 @COMPRESSION_MODULES.register()
@@ -38,8 +38,7 @@ class BinaryMask(nn.Module):
 
     def forward(self, weight):
         if is_tracing_state():
-            with no_jit_trace():
-                return weight.mul_(self.binary_mask)
+            return weight.mul(self.binary_mask)
         tmp_tensor = self._calc_training_binary_mask(weight)
         return apply_binary_mask_impl(tmp_tensor, weight)
 

--- a/tests/torch/pruning/filter_pruning/test_layers.py
+++ b/tests/torch/pruning/filter_pruning/test_layers.py
@@ -17,8 +17,7 @@ from torch import nn
 
 from nncf.torch.layers import NNCFConv2d
 from nncf.torch.module_operations import UpdateWeightAndBias
-from nncf.torch.pruning.filter_pruning.layers import FilterPruningMask, inplace_apply_filter_binary_mask, \
-    apply_filter_binary_mask
+from nncf.torch.pruning.filter_pruning.layers import FilterPruningMask, apply_filter_binary_mask
 from tests.torch.helpers import fill_conv_weight, fill_bias
 
 
@@ -76,9 +75,6 @@ def test_assert_broadcastable_mask_and_weight_shape():
     mask = torch.zeros(10)
 
     with pytest.raises(RuntimeError):
-        inplace_apply_filter_binary_mask(mask, nncf_module.weight.data, Scope())
-
-    with pytest.raises(RuntimeError):
         apply_filter_binary_mask(mask, nncf_module.weight.data)
 
 
@@ -90,23 +86,6 @@ def test_assert_broadcastable_mask_and_weight_shape():
                            torch.tensor([0, 1], dtype=torch.float32)),
                           ])
 class TestApplyMasks:
-    @staticmethod
-    def test_inplace_apply_filter_binary_mask(mask, reference_weight, reference_bias):
-        """
-        Test that inplace_apply_filter_binary_mask changes the input weight and returns valid result.
-        """
-        nncf_module = NNCFConv2d(1, 2, 2)
-        fill_conv_weight(nncf_module, 1)
-        fill_bias(nncf_module, 1)
-
-        result_weight = inplace_apply_filter_binary_mask(mask, nncf_module.weight.data, Scope())
-        assert torch.allclose(result_weight, reference_weight)
-        assert torch.allclose(nncf_module.weight, reference_weight)
-
-        result_bias = inplace_apply_filter_binary_mask(mask, nncf_module.bias.data, Scope())
-        assert torch.allclose(result_bias, reference_bias)
-        assert torch.allclose(nncf_module.bias, reference_bias)
-
     @staticmethod
     def test_apply_filter_binary_mask(mask, reference_weight, reference_bias):
         """

--- a/tests/torch/test_algo_common.py
+++ b/tests/torch/test_algo_common.py
@@ -13,10 +13,12 @@
 import copy
 import os
 from functools import reduce
-from typing import Dict, List
+from typing import Dict
+from typing import List
 
 import onnx
 import pytest
+import torch
 from torch import cuda
 from torch import nn
 
@@ -24,12 +26,15 @@ from nncf import NNCFConfig
 from nncf.api.compression import CompressionStage
 from nncf.torch.compression_method_api import DOMAIN_CUSTOM_OPS_NAME
 from tests.torch.helpers import BasicConvTestModel
+from tests.torch.helpers import PTTensorListComparator
 from tests.torch.helpers import create_compressed_model_and_algo_for_test
 from tests.torch.helpers import get_empty_config
 from tests.torch.helpers import register_bn_adaptation_init_args
+from tests.torch.pruning.helpers import get_basic_pruning_config
 from tests.torch.quantization.quantization_helpers import get_quantization_config_without_range_init
 from tests.torch.sparsity.magnitude.test_helpers import get_basic_magnitude_sparsity_config
 from tests.torch.sparsity.rb.test_algo import get_basic_sparsity_config
+from tests.torch.test_models.synthetic import ConvRelu6HSwishHSigmoid
 
 
 class BasicLinearTestModel(nn.Module):
@@ -64,12 +69,22 @@ def get_basic_asym_quantization_config(model_size=4):
     return config
 
 
+def get_filter_pruning_config():
+    config = get_basic_pruning_config()
+    config['compression']['algorithm'] = 'filter_pruning'
+    config['compression']['params']['prune_first_conv'] = True
+    return config
+
+
 @pytest.mark.parametrize('config_provider',
                          (get_quantization_config_without_range_init, get_basic_asym_quantization_config,
-                          get_basic_sparsity_config,
-                          get_basic_magnitude_sparsity_config, get_const_sparsity_config),
-                         ids=('SymQuantization', 'AsymQuantization', 'Sparsity', 'MagnitudeSparsity', 'ConstSparsity'))
-@pytest.mark.parametrize('model_provider', (BasicConvTestModel, BasicLinearTestModel),
+                          get_basic_sparsity_config, get_basic_magnitude_sparsity_config,
+                          get_const_sparsity_config, get_filter_pruning_config),
+                         ids=('SymQuantization', 'AsymQuantization',
+                              'Sparsity', 'MagnitudeSparsity',
+                              'ConstSparsity', 'FilterPruning')
+                         )
+@pytest.mark.parametrize('model_provider', (ConvRelu6HSwishHSigmoid, BasicLinearTestModel),
                          ids=('Conv2d', 'Linear'))
 class TestCompressionAlgos:
     def test_can_export_compressed_model(self, tmp_path, config_provider, model_provider):
@@ -77,10 +92,38 @@ class TestCompressionAlgos:
         model = model_provider()
         config = config_provider()
         register_bn_adaptation_init_args(config)
-        _, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
+        compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
 
+        state_before = copy.deepcopy(compressed_model.state_dict())
         compression_ctrl.export_model(test_path)
+        state_after = compressed_model.state_dict()
+
         assert os.path.exists(test_path)
+        PTTensorListComparator.check_equal(list(state_before.values()), list(state_after.values()))
+
+
+@pytest.mark.parametrize(('config_provider', 'mask_getter'),
+                         [
+                             (get_basic_sparsity_config, lambda x: x.mask),
+                             (get_filter_pruning_config, lambda x: x.binary_filter_pruning_mask)
+                         ],
+                         ids=('sparsity', 'filter_pruning'))
+def test_no_weight_override_on_pruning_export(tmp_path, config_provider, mask_getter):
+    test_path = str(tmp_path.joinpath('test.onnx'))
+    model = ConvRelu6HSwishHSigmoid()
+    config = config_provider()
+    register_bn_adaptation_init_args(config)
+    compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
+
+    operand = compressed_model.conv1.get_pre_op('0').op
+    with torch.no_grad():
+        mask = mask_getter(operand)
+        mask[mask != 0] = 0  # intentionally corrupt mask to zero out weights
+    state_before = copy.deepcopy(compressed_model.state_dict())
+    compression_ctrl.export_model(test_path)
+    state_after = compressed_model.state_dict()
+
+    PTTensorListComparator.check_equal(list(state_before.values()), list(state_after.values()))
 
 
 class ConfigCreator:


### PR DESCRIPTION
### Changes

Export sparsity models with non-in-place (`mul` instead of `mul_`) multiply operation.

### Reason for changes

User doesn't expect that export to onnx would do something with parameters. 
It could break convergence if user wants export on each epoch (e.g. saving checkpoint in Optimum requires export to ONNX and conversion to IR).

### Related tickets

n/a

### Tests

- [x] test checking that after export model has the same parameters
- [x] add test for filter pruning
- [x] e2e for resnet50-rb-sparsity-int8 (build 128)
- [x] e2e for unet_mapillary_pruning_geometric_median (build 135)