### PR TITLE
Export Q-DQ for correct axis in torch

### DIFF
--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -445,8 +445,8 @@ class BaseQuantizer(nn.Module):
                 # Impossible to determine proper axis for per-channel quantization because we have
                 # scale shape ~ [1, 1, 1, 1], therefore falling back to per-tensor style export
                 axis = 1  # default value by opset, ignored in per-tensor quantization anyway
-                y_scale = y_scale.flatten()
-                y_zero_point = y_zero_point.flatten()
+                y_scale = y_scale.flatten()[0]
+                y_zero_point = y_zero_point.flatten()[0]
             else:
                 axis = possible_axes[0]
 

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -33,8 +33,9 @@ from nncf.common.quantization.quantizer_setup import QuantizerSetupBase
 from nncf.common.quantization.quantizer_setup import QuantizationPointId
 from nncf.torch.graph.transformations.commands import TargetType
 from nncf.torch.graph.transformations.commands import PTTargetPoint
+from nncf.torch.quantization.quantize_functions import ExportQuantizeToONNXQuantDequant
 from nncf.torch.quantization.quantize_functions import symmetric_quantize, asymmetric_quantize, \
-    ExportQuantizeToFakeQuantize, get_scale_zp_from_input_low_input_high, ExportQuantizeToONNXQuantDequant, TuneRange
+    ExportQuantizeToFakeQuantize, get_scale_zp_from_input_low_input_high, TuneRange
 from nncf.torch.layer_utils import COMPRESSION_MODULES, CompressionParameter
 from nncf.common.utils.registry import Registry
 from nncf.torch.utils import get_flat_tensor_contents_string, no_jit_trace, is_tracing_state
@@ -428,14 +429,31 @@ class BaseQuantizer(nn.Module):
             levels = level_high - level_low + 1
         return x, levels, input_low, input_high
 
-    def _prepare_qdq_export_quantization(self, x: torch.Tensor):
+    def _prepare_qdq_export_quantization(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
         x, level_high, level_low, input_low, input_high = self._prepare_export_quantization(x)
         with no_jit_trace():
             y_scale, y_zero_point = get_scale_zp_from_input_low_input_high(level_low,
                                                                            level_high,
                                                                            input_low,
                                                                            input_high)
-        return x, y_scale, y_zero_point
+            possible_axes = self._possible_per_channel_dimensions()
+            if len(possible_axes) > 1:
+                raise RuntimeError(
+                    f"Impossible to determine the per-channel axis for a scale shape {self.scale_shape} - "
+                    f"more than one dimension is >1")
+            if not possible_axes:
+                # Impossible to determine proper axis for per-channel quantization because we have
+                # scale shape ~ [1, 1, 1, 1], therefore falling back to per-tensor style export
+                axis = 1  # default value by opset, ignored in per-tensor quantization anyway
+                y_scale = y_scale.flatten()
+                y_zero_point = y_zero_point.flatten()
+            else:
+                axis = possible_axes[0]
+
+        return x, y_scale, y_zero_point, axis
+
+    def _possible_per_channel_dimensions(self) -> List[int]:
+        return [i for i in range(len(self.scale_shape)) if self.scale_shape[i] > 1]
 
     def run_export_quantization(self, x: torch.Tensor):
         with torch.no_grad():
@@ -447,13 +465,8 @@ class BaseQuantizer(nn.Module):
                                                           input_low,
                                                           input_high)
             if self._export_mode == QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS:
-                x, y_scale, y_zero_point = self._prepare_qdq_export_quantization(x)
-                if self.per_channel and y_zero_point.numel() > 1:
-                    if torch.allclose(y_scale - y_scale[0], torch.zeros_like(y_scale)) and \
-                            torch.allclose(y_zero_point - y_zero_point[0], torch.zeros_like(y_zero_point)):
-                        y_scale, y_zero_point = y_scale[0], y_zero_point[0]
-                        return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
-                return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point)
+                x, y_scale, y_zero_point, axis = self._prepare_qdq_export_quantization(x)
+                return ExportQuantizeToONNXQuantDequant.apply(x, y_scale, y_zero_point, axis)
         raise RuntimeError('Unknown export mode')
 
     def extra_repr(self):

--- a/nncf/torch/quantization/quantize_functions.py
+++ b/nncf/torch/quantization/quantize_functions.py
@@ -158,13 +158,13 @@ class ExportQuantizeToFakeQuantize(torch.autograd.Function):
 # pylint:disable=abstract-method
 class ExportQuantizeToONNXQuantDequant(torch.autograd.Function):
     @staticmethod
-    def symbolic(g, input_, y_scale, y_zero_point):
-        quantized = g.op("QuantizeLinear", input_, y_scale, y_zero_point, axis_i=0)
-        dequantized = g.op("DequantizeLinear", quantized, y_scale, y_zero_point, axis_i=0)
+    def symbolic(g, input_, y_scale, y_zero_point, axis):
+        quantized = g.op("QuantizeLinear", input_, y_scale, y_zero_point, axis_i=axis)
+        dequantized = g.op("DequantizeLinear", quantized, y_scale, y_zero_point, axis_i=axis)
         return dequantized
 
     @staticmethod
-    def forward(ctx, input_, y_scale, y_zero_point):
+    def forward(ctx, input_, y_scale, y_zero_point, axis):
         return torch.clone(input_)
 
     @staticmethod


### PR DESCRIPTION
### Changes
Added detection of the per-channel axis in Q-DQ export in PT and proper setting of the `axis_i` attribute for the ONNX ops

### Reason for changes
mobilenet_v2_imagenet_int8 fails to be converted by MO in Q-DQ export mode due to presence of per-channel activation quantized eltwise convs which had `axis` erroneously set to 0 in Q-DQ ops

### Related tickets
N/A

### Tests
e2e_pt, unit tests TBA
