### PR TITLE
The example of quantization with accuracy control for OpenVINO backend

### DIFF
--- a/examples/post_training_quantization/openvino/quantize_with_accuracy_control/README.md
+++ b/examples/post_training_quantization/openvino/quantize_with_accuracy_control/README.md
@@ -1,0 +1,33 @@
+# Post-Training Quantization of Anomaly Classification OpenVINO model with control of accuracy metric
+
+The anomaly detection domain is one of the domains in which models are used in scenarios where the cost of model error is high and accuracy cannot be sacrificed for better model performance. For such cases, it is necessary to use quantization methods with accuracy control where the maximum accuracy drop can be specified as an argument of the method.
+
+This example demonstrates how to quantize [Student-Teacher Feature Pyramid Matching (SFTPM)](https://huggingface.co/alexsu52/stfpm_mvtec_capsule) OpenVINO model from [Anomalib](https://github.com/openvinotoolkit/anomalib) using Post-Training Quantization with accuracy control API from Neural Network Compression Framework (NNCF). 
+
+The `nncf.quantize_with_accuracy_control()` method quantizes a model with a specified accuracy drop and the `max_drop` parameter is passed to specify the maximum absolute difference between the quantized and pre-trained model.
+
+The example includes the following steps:
+- 
+- Loading the [MVTec (capsule category)](https://www.mvtec.com/company/research/datasets/mvtec-ad) dataset (~385 Mb) and the [SFTPM OpenVINO model](https://huggingface.co/alexsu52/stfpm_mvtec_capsule) pretrained on this dataset.
+- Quantizing the model using NNCF Post-Training Quantization algorithm with accuracy control.
+- Output of the following characteristics of the quantized model:
+    - Accuracy drop between the quantized model (INT8) and the pre-trained model (FP32)
+    - Compression rate of the quantized model file size relative to the pre-trained model file size
+    - Performance speed up of the quantized model (INT8)
+
+# Install requirements
+At this point it is assumed that you have already installed NNCF. You can find information on installation NNCF [here](https://github.com/openvinotoolkit/nncf#user-content-installation).
+
+To work with the example you should install the corresponding Python package dependencies:
+```
+pip install -r requirements.txt
+```
+
+# Run Example
+It's pretty simple. The example does not require additional preparation. It will do the preparation itself, such as loading the dataset and model, etc.
+
+The maximum accuracy drop you can pass as a command line argument. F1 score is calculted in range [0,1] for SFTPM. Thus if you want to specify the maximum accuracy drop between the quantized and pre-trained model of 0.5% you must specify 0.005 as a command line argument:
+
+```
+python main.py 0.005
+```

--- a/examples/post_training_quantization/openvino/quantize_with_accuracy_control/README.md
+++ b/examples/post_training_quantization/openvino/quantize_with_accuracy_control/README.md
@@ -2,7 +2,7 @@
 
 The anomaly detection domain is one of the domains in which models are used in scenarios where the cost of model error is high and accuracy cannot be sacrificed for better model performance. For such cases, it is necessary to use quantization methods with accuracy control where the maximum accuracy drop can be specified as an argument of the method.
 
-This example demonstrates how to quantize [Student-Teacher Feature Pyramid Matching (SFTPM)](https://huggingface.co/alexsu52/stfpm_mvtec_capsule) OpenVINO model from [Anomalib](https://github.com/openvinotoolkit/anomalib) using Post-Training Quantization with accuracy control API from Neural Network Compression Framework (NNCF). 
+This example demonstrates how to quantize [Student-Teacher Feature Pyramid Matching (STFPM)](https://huggingface.co/alexsu52/stfpm_mvtec_capsule) OpenVINO model from [Anomalib](https://github.com/openvinotoolkit/anomalib) using Post-Training Quantization with accuracy control API from Neural Network Compression Framework (NNCF). 
 
 The `nncf.quantize_with_accuracy_control()` method quantizes a model with a specified accuracy drop and the `max_drop` parameter is passed to specify the maximum absolute difference between the quantized and pre-trained model.
 

--- a/examples/post_training_quantization/openvino/quantize_with_accuracy_control/main.py
+++ b/examples/post_training_quantization/openvino/quantize_with_accuracy_control/main.py
@@ -126,9 +126,9 @@ datamodule.setup()
 test_loader = datamodule.test_dataloader()
 
 download_and_extract(MODEL_PATH, MODEL_INFO)
-model = ov.Core().read_model(MODEL_PATH / 'sftpm_capsule.xml')
+model = ov.Core().read_model(MODEL_PATH / 'stfpm_capsule.xml')
 
-with open(MODEL_PATH / 'meta_data_sftpm_capsule.json', 'r') as f:
+with open(MODEL_PATH / 'meta_data_stfpm_capsule.json', 'r') as f:
     validation_params = json.load(f)
 
 ###############################################################################
@@ -161,12 +161,12 @@ quantized_model = nncf.quantize_with_accuracy_control(
 ###############################################################################
 # Benchmark performance, calculate compression rate and validate accuracy
 
-fp32_ir_path = f'{ROOT}/sftpm_fp32.xml'
+fp32_ir_path = f'{ROOT}/stfpm_fp32.xml'
 ov.serialize(model, fp32_ir_path)
 print(f'[1/7] Save FP32 model: {fp32_ir_path}')
 fp32_size = get_model_size(fp32_ir_path, verbose=True)
 
-int8_ir_path = f'{ROOT}/sftpm_int8.xml'
+int8_ir_path = f'{ROOT}/stfpm_int8.xml'
 ov.serialize(quantized_model, int8_ir_path)
 print(f'[2/7] Save INT8 model: {int8_ir_path}')
 int8_size = get_model_size(int8_ir_path, verbose=True)

--- a/examples/post_training_quantization/openvino/quantize_with_accuracy_control/main.py
+++ b/examples/post_training_quantization/openvino/quantize_with_accuracy_control/main.py
@@ -1,0 +1,194 @@
+"""
+ Copyright (c) 2023 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from functools import partial
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import nncf
+import numpy as np
+import openvino.runtime as ov
+import torch
+
+from anomalib.data.mvtec import MVTec
+from anomalib.data.utils import download
+from anomalib.post_processing.normalization.min_max import normalize
+from anomalib.utils.metrics import create_metric_collection
+
+ROOT = Path(__file__).parent.resolve()
+HOME_PATH = Path.home()
+MODEL_INFO = download.DownloadInfo(
+    name="stfpm_mvtec_capsule",
+    url='https://huggingface.co/alexsu52/stfpm_mvtec_capsule/resolve/main/openvino_model.tar',
+    hash='b75ce461aa17b1b33673ebcea0f6b846')
+MODEL_PATH = HOME_PATH / '.cache/nncf/models/stfpm_mvtec_capsule'
+
+DATASET_INFO = download.DownloadInfo(
+    name="mvtec_capsule",
+    url='https://www.mydrive.ch/shares/38536/3830184030e49fe74747669442f0f282/download/420937454-1629951595/capsule.tar.xz',
+    hash='380afc46701c99cb7b9a928edbe16eb5')
+DATASET_PATH = HOME_PATH / '.cache/nncf/datasets/mvtec_capsule'
+
+max_accuracy_drop = 0.005 if len(sys.argv) < 2 else sys.argv[1]
+
+
+def download_and_extract(root: Path, info: download.DownloadInfo) -> None:
+    if not root.is_dir():
+        download.download_and_extract(root, info)
+
+
+def get_anomaly_images(data_loader: Iterable[Any]) -> List[Dict[str, torch.Tensor]]:
+    anomaly_images = []
+    for data_item in data_loader:
+        if data_item['label'].int() == 1:
+            anomaly_images.append({'image': data_item['image']})
+    return anomaly_images
+
+
+def validate(model: ov.CompiledModel, 
+             val_loader: Iterable[Any],
+             val_params: Dict[str, float]) -> float:
+    metric = create_metric_collection(['F1Score'], prefix='image_')['F1Score']
+    metric.threshold = 0.5
+    
+    output = model.outputs[0]
+
+    counter = 0
+    for batch in val_loader:
+        anomaly_maps = model(batch["image"])[output]
+        pred_scores = np.max(anomaly_maps, axis=(1,2,3))
+        pred_scores = normalize(pred_scores, val_params['image_threshold'],
+                                val_params['min'], val_params['max'])
+        metric.update(torch.from_numpy(pred_scores), batch['label'].int())
+        counter+=1
+           
+    metric_value = metric.compute()
+    print(f'Validate: dataset lenght = {counter}, '
+          f'metric value = {metric_value:.3f}')
+    return metric_value
+
+
+def run_benchmark(model_path: str, shape: Optional[List[int]] = None, 
+                  verbose: bool = True) -> float:
+    command = f'benchmark_app -m {model_path} -d CPU -api async -t 15'
+    if shape is not None:
+        command += f' -shape [{",".join(str(x) for x in shape)}]'
+    cmd_output = subprocess.check_output(command, shell=True)
+    if verbose:
+        print(*str(cmd_output).split('\\n')[-9:-1], sep='\n')
+    match = re.search(r"Throughput\: (.+?) FPS", str(cmd_output))
+    return float(match.group(1))
+
+
+def get_model_size(ir_path: str, m_type: str = 'Mb', 
+                   verbose: bool = True) -> float:
+    xml_size = os.path.getsize(ir_path)
+    bin_size = os.path.getsize(ir_path.replace('xml', 'bin'))
+    for t in ['bytes', 'Kb', 'Mb']:
+        if m_type == t:
+            break
+        xml_size /= 1024
+        bin_size /= 1024
+    model_size = xml_size + bin_size 
+    if verbose:
+        print(f'Model graph (xml):   {xml_size:.3f} Mb')
+        print(f'Model weights (bin): {bin_size:.3f} Mb')
+        print(f'Model size:          {model_size:.3f} Mb')      
+    return model_size
+
+###############################################################################
+# Create an OpenVINO model and dataset
+
+download_and_extract(DATASET_PATH, DATASET_INFO)
+
+datamodule = MVTec(root=DATASET_PATH,
+                   category="capsule",
+                   image_size=(256, 256),
+                   train_batch_size=1,
+                   eval_batch_size=1,
+                   num_workers=1)
+datamodule.setup()
+test_loader = datamodule.test_dataloader()
+
+download_and_extract(MODEL_PATH, MODEL_INFO)
+model = ov.Core().read_model(MODEL_PATH / 'sftpm_capsule.xml')
+
+with open(MODEL_PATH / 'meta_data_sftpm_capsule.json', 'r') as f:
+    validation_params = json.load(f)
+
+###############################################################################
+# Quantize an OpenVINO model with accuracy control
+#
+# The transformation function transforms a data item into model input data.
+#
+# To validate the transform function use the following code:
+# >> for data_item in val_loader:
+# >>    model(transform_fn(data_item))
+
+def transform_fn(data_item):
+    return data_item["image"]
+
+# Uses only anomaly images for calibration process
+anomaly_images = get_anomaly_images(test_loader)
+calibration_dataset = nncf.Dataset(anomaly_images, transform_fn)
+
+# Whole test dataset is used for validation
+validation_fn = partial(validate, val_params=validation_params)
+validation_dataset = nncf.Dataset(test_loader, transform_fn)
+
+quantized_model = nncf.quantize_with_accuracy_control(
+    model=model,
+    calibration_dataset = calibration_dataset,
+    validation_dataset = validation_dataset,
+    validation_fn=validation_fn,
+    max_drop=max_accuracy_drop)
+
+###############################################################################
+# Benchmark performance, calculate compression rate and validate accuracy
+
+fp32_ir_path = f'{ROOT}/sftpm_fp32.xml'
+ov.serialize(model, fp32_ir_path)
+print(f'[1/7] Save FP32 model: {fp32_ir_path}')
+fp32_size = get_model_size(fp32_ir_path, verbose=True)
+
+int8_ir_path = f'{ROOT}/sftpm_int8.xml'
+ov.serialize(quantized_model, int8_ir_path)
+print(f'[2/7] Save INT8 model: {int8_ir_path}')
+int8_size = get_model_size(int8_ir_path, verbose=True)
+
+print('[3/7] Benchmark FP32 model:')
+fp32_fps = run_benchmark(fp32_ir_path, shape=[1,3,256,256], verbose=True)
+print('[4/7] Benchmark INT8 model:')
+int8_fps = run_benchmark(int8_ir_path, shape=[1,3,256,256], verbose=True)
+
+print('[5/7] Validate OpenVINO FP32 model:')
+compiled_model = ov.compile_model(model)
+fp32_top1 = validate(compiled_model, test_loader, validation_params)
+print(f'Accuracy @ top1: {fp32_top1:.3f}')
+
+print('[6/7] Validate OpenVINO INT8 model:')
+quantized_compiled_model = ov.compile_model(quantized_model)
+int8_top1 = validate(quantized_compiled_model, test_loader, validation_params)
+print(f'Accuracy @ top1: {int8_top1:.3f}')
+
+print('[7/7] Report:')
+print(f'Maximum accuracy drop:                  {max_accuracy_drop}')
+print(f'Accuracy drop:                          {fp32_top1 - int8_top1:.3f}')
+print(f'Model compression rate:                 {fp32_size / int8_size:.3f}')
+# https://docs.openvino.ai/latest/openvino_docs_optimization_guide_dldt_optimization_guide.html
+print(f'Performance speed up (throughput mode): {int8_fps / fp32_fps:.3f}')

--- a/examples/post_training_quantization/openvino/quantize_with_accuracy_control/requirements.txt
+++ b/examples/post_training_quantization/openvino/quantize_with_accuracy_control/requirements.txt
@@ -1,0 +1,2 @@
+anomalib@ git+https://github.com/openvinotoolkit/anomalib@8a6c6ea115ad2c460a9beaee85736d1180eaa996#egg=anomalib
+openvino-dev


### PR DESCRIPTION
### Changes

The example of quantization with accuracy control for OpenVINO backend

### Reason for changes

Demonstrate how to use Post-Training Quantization with accuracy control API.
`nncf.quantize_with_accuracy_control()` 

### Related tickets

ref: 98687

### Tests

TBD
