### PR TITLE
Removed `from_str` methods from Enum classes

### DIFF
--- a/nncf/common/hardware/config.py
+++ b/nncf/common/hardware/config.py
@@ -35,20 +35,11 @@ from nncf.definitions import HW_CONFIG_RELATIVE_DIR
 from nncf.definitions import NNCF_PACKAGE_ROOT_DIR
 from nncf.common.utils.logger import logger as nncf_logger
 
+
 class HWConfigType(Enum):
     CPU = 'CPU'
     GPU = 'GPU'
     VPU = 'VPU'
-
-    @staticmethod
-    def from_str(config_value: str) -> 'HWConfigType':
-        if config_value == HWConfigType.CPU.value:
-            return HWConfigType.CPU
-        if config_value == HWConfigType.GPU.value:
-            return HWConfigType.GPU
-        if config_value == HWConfigType.VPU.value:
-            return HWConfigType.VPU
-        raise RuntimeError('Unknown HW config type string')
 
 
 HW_CONFIG_TYPE_TARGET_DEVICE_MAP = {

--- a/nncf/common/quantization/initialization/range.py
+++ b/nncf/common/quantization/initialization/range.py
@@ -106,7 +106,7 @@ class PerLayerRangeInitConfig(RangeInitConfig):
         target_group_str = dct.get('target_quantizer_group')
         target_group = None
         if target_group_str is not None:
-            target_group = QuantizerGroup.from_str(target_group_str)
+            target_group = QuantizerGroup(target_group_str)
 
         return cls(base_config, target_scopes, ignored_scopes, target_group)
 

--- a/nncf/common/quantization/structs.py
+++ b/nncf/common/quantization/structs.py
@@ -232,14 +232,6 @@ class QuantizerGroup(Enum):
     ACTIVATIONS = 'activations'
     WEIGHTS = 'weights'
 
-    @staticmethod
-    def from_str(str_: str) -> 'QuantizerGroup':
-        if str_ == QuantizerGroup.ACTIVATIONS.value:
-            return QuantizerGroup.ACTIVATIONS
-        if str_ == QuantizerGroup.WEIGHTS.value:
-            return QuantizerGroup.WEIGHTS
-        raise RuntimeError('Unknown quantizer group string')
-
 
 class QuantizableWeightedLayerNode:
     def __init__(self, node: NNCFNode, qconfig_list: List[QuantizerConfig]):
@@ -315,17 +307,10 @@ class UnifiedScaleType(Enum):
     UNIFY_ONLY_PER_TENSOR = 0
     UNIFY_ALWAYS = 1
 
+
 class QuantizationPreset(Enum):
     PERFORMANCE = 'performance'
     MIXED = 'mixed'
-
-    @staticmethod
-    def from_str(str_: str) -> 'QuantizationPreset':
-        if str_ == QuantizationPreset.PERFORMANCE.value:
-            return QuantizationPreset.PERFORMANCE
-        if str_ == QuantizationPreset.MIXED.value:
-            return QuantizationPreset.MIXED
-        raise RuntimeError('Unknown preset string.')
 
     def get_params_configured_by_preset(self, quant_group: QuantizerGroup) -> Dict:
         if quant_group == QuantizerGroup.ACTIVATIONS and self == QuantizationPreset.MIXED:

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elasticity_builder.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elasticity_builder.py
@@ -66,7 +66,7 @@ class ElasticityBuilder(PTCompressionAlgorithmBuilder):
 
         all_elasticity_dims = {e.value for e in ElasticityDim}
         available_elasticity_dims_str = self._algo_config.get('available_elasticity_dims', all_elasticity_dims)
-        self._available_elasticity_dims = list(map(ElasticityDim.from_str, available_elasticity_dims_str))
+        self._available_elasticity_dims = list(map(ElasticityDim, available_elasticity_dims_str))
         self._elasticity_builders = OrderedDict()  # type: Dict[ElasticityDim, SingleElasticityBuilder]
         self._builder_states = None
 
@@ -113,7 +113,7 @@ class ElasticityBuilder(PTCompressionAlgorithmBuilder):
 
         if self._builder_states is not None:
             for dim_str, builder_state in self._builder_states.items():
-                dim = ElasticityDim.from_str(dim_str)
+                dim = ElasticityDim(dim_str)
                 if dim in self._elasticity_builders:
                     self._elasticity_builders[dim].load_state(builder_state)
 
@@ -154,4 +154,4 @@ class ElasticityBuilder(PTCompressionAlgorithmBuilder):
         available_elasticity_dims_state = state_without_name[self._state_names.AVAILABLE_ELASTICITY_DIMS]
 
         # No conflict resolving with the related config options, parameters are overridden by compression state
-        self._available_elasticity_dims = list(map(ElasticityDim.from_str, available_elasticity_dims_state))
+        self._available_elasticity_dims = list(map(ElasticityDim, available_elasticity_dims_state))

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elasticity_dim.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elasticity_dim.py
@@ -20,14 +20,3 @@ class ElasticityDim(Enum):
     KERNEL = 'kernel'
     WIDTH = 'width'
     DEPTH = 'depth'
-
-    @classmethod
-    def from_str(cls, dim: str) -> 'ElasticityDim':
-        if dim == ElasticityDim.KERNEL.value:
-            return ElasticityDim.KERNEL
-        if dim == ElasticityDim.WIDTH.value:
-            return ElasticityDim.WIDTH
-        if dim == ElasticityDim.DEPTH.value:
-            return ElasticityDim.DEPTH
-        raise RuntimeError(f"Unknown elasticity dimension: {dim}."
-                           f"List of supported: {[e.value for e in ElasticityDim]}")

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/multi_elasticity_handler.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/multi_elasticity_handler.py
@@ -187,12 +187,12 @@ class MultiElasticityHandler(ElasticityHandler):
         is_handler_enabled_map = state[self._state_names.IS_HANDLER_ENABLED_MAP]
 
         for dim_str, handler_state in states_of_handlers.items():
-            dim = ElasticityDim.from_str(dim_str)
+            dim = ElasticityDim(dim_str)
             if dim in self._handlers:
                 self._handlers[dim].load_state(handler_state)
 
         for dim_str, is_enabled in is_handler_enabled_map.items():
-            dim = ElasticityDim.from_str(dim_str)
+            dim = ElasticityDim(dim_str)
             self._is_handler_enabled_map[dim] = is_enabled
 
     def get_state(self) -> Dict[str, Any]:

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_builder.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_builder.py
@@ -53,7 +53,7 @@ class ProgressiveShrinkingBuilder(PTCompressionAlgorithmBuilder):
 
         default_progressivity = map(lambda x: x.value, self.DEFAULT_PROGRESSIVITY)
         progressivity_of_elasticity = self._algo_config.get('progressivity_of_elasticity', default_progressivity)
-        self._progressivity_of_elasticity = list(map(ElasticityDim.from_str, progressivity_of_elasticity))
+        self._progressivity_of_elasticity = list(map(ElasticityDim, progressivity_of_elasticity))
         self._elasticity_builder = ElasticityBuilder(self.config, self.should_init)
 
         self._lr_schedule_config = self._algo_config.get('lr_schedule', {})
@@ -120,7 +120,7 @@ class ProgressiveShrinkingBuilder(PTCompressionAlgorithmBuilder):
         self._elasticity_builder.load_state(elasticity_builder_state)
         progressivity_of_elasticity = state_without_name[self._state_names.PROGRESSIVITY_OF_ELASTICITY]
         # No conflict resolving with the related config options, parameters are overridden by compression state
-        self._progressivity_of_elasticity = [ElasticityDim.from_str(dim) for dim in progressivity_of_elasticity]
+        self._progressivity_of_elasticity = [ElasticityDim(dim) for dim in progressivity_of_elasticity]
         self._bn_adapt_params = state_without_name[self._state_names.BN_ADAPTATION_PARAMS]
         bn_adapt_algo_kwargs = get_bn_adapt_algo_kwargs(self.config,
                                                         self._bn_adapt_params)

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/stage_descriptor.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/stage_descriptor.py
@@ -70,7 +70,7 @@ class StageDescriptor:
         """
         train_dims = config.get(cls._state_names.TRAIN_DIMS, ['kernel'])
         kwargs = {
-            cls._state_names.TRAIN_DIMS: [ElasticityDim.from_str(dim) for dim in train_dims],
+            cls._state_names.TRAIN_DIMS: [ElasticityDim(dim) for dim in train_dims],
             cls._state_names.EPOCHS: config.get(cls._state_names.EPOCHS, 1),
             cls._state_names.REORG_WEIGHTS: config.get(cls._state_names.REORG_WEIGHTS, False),
             cls._state_names.WIDTH_INDICATOR: config.get(cls._state_names.WIDTH_INDICATOR, 1),
@@ -91,7 +91,7 @@ class StageDescriptor:
         """
         kwargs = state.copy()
         train_dims = state[cls._state_names.TRAIN_DIMS]
-        kwargs[cls._state_names.TRAIN_DIMS] = [ElasticityDim.from_str(dim) for dim in train_dims]
+        kwargs[cls._state_names.TRAIN_DIMS] = [ElasticityDim(dim) for dim in train_dims]
         return cls(**kwargs)
 
     def get_state(self) -> Dict[str, Any]:

--- a/nncf/experimental/torch/search_building_blocks/search_blocks.py
+++ b/nncf/experimental/torch/search_building_blocks/search_blocks.py
@@ -117,14 +117,6 @@ class BuildingBlockType(Enum):
     FF = 'FF'
     Unknown = 'unknown'
 
-    @staticmethod
-    def from_str(config_value: str) -> 'BuildingBlockType':
-        if config_value == BuildingBlockType.MSHA.value:
-            return BuildingBlockType.MSHA
-        if config_value == BuildingBlockType.FF.value:
-            return BuildingBlockType.FF
-        return BuildingBlockType.Unknown
-
     def __eq__(self, other: 'BuildingBlockType'):
         return self.__dict__ == other.__dict__
 
@@ -172,7 +164,7 @@ class ExtendedBuildingBlock:
 
         :param state: Output of `get_state()` method.
         """
-        bbtype = BuildingBlockType.from_str(state[cls._state_names.BLOCK_TYPE])
+        bbtype = BuildingBlockType(state[cls._state_names.BLOCK_TYPE])
         bblock = BuildingBlock.from_state(state[cls._state_names.BASIC_BLOCK])
         op_addresses = {OperationAddress.from_str(op_address_state) for op_address_state in
                         state[cls._state_names.OP_ADDRESSES]}
@@ -344,14 +336,6 @@ class BlockFilteringStrategy(Enum):
     """
     KEEP_SMALL = 'keep_small'
     KEEP_SEQUENTIAL = 'keep_sequential'
-
-    @staticmethod
-    def from_str(config_value: str) -> 'BlockFilteringStrategy':
-        if config_value == BlockFilteringStrategy.KEEP_SMALL.value:
-            return BlockFilteringStrategy.KEEP_SMALL
-        if config_value == BlockFilteringStrategy.KEEP_SEQUENTIAL.value:
-            return BlockFilteringStrategy.KEEP_SEQUENTIAL
-        raise RuntimeError('Unknown Block Filtering Strategy string')
 
 
 def get_building_blocks(compressed_model: NNCFNetwork,

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -84,7 +84,7 @@ class MinMaxQuantizationParameters(AlgorithmParameters):
         self.activation_quantizer_config = self._determine_quantizer_config(activation_bits, activation_granularity,
                                                                             activation_mode)
         self.number_samples = number_samples
-        self.target_device = HWConfigType.from_str(HW_CONFIG_TYPE_TARGET_DEVICE_MAP[target_device.value])
+        self.target_device = HWConfigType(HW_CONFIG_TYPE_TARGET_DEVICE_MAP[target_device.value])
         self.range_type = range_type
         self.quantize_outputs = quantize_outputs
         self.ignored_scopes = [] if ignored_scopes is None else ignored_scopes

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -269,7 +269,7 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
 
         self.hw_config = None
         if self._target_device != "TRIAL":
-            hw_config_type = HWConfigType.from_str(HW_CONFIG_TYPE_TARGET_DEVICE_MAP[self._target_device])
+            hw_config_type = HWConfigType(HW_CONFIG_TYPE_TARGET_DEVICE_MAP[self._target_device])
             hw_config_path = TFHWConfig.get_path_to_hw_config(hw_config_type)
             self.hw_config = TFHWConfig.from_json(hw_config_path)
 
@@ -306,7 +306,7 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
         params_dict_from_config = quant_config.get(group_name, {})
         preset = quant_config.get('preset')
         if self._target_device in ['ANY', 'CPU', 'GPU'] or self._target_device == 'TRIAL' and preset is not None:
-            preset = QuantizationPreset.from_str(quant_config.get('preset', 'performance'))
+            preset = QuantizationPreset(quant_config.get('preset', 'performance'))
             params_dict = preset.get_params_configured_by_preset(quantizer_group)
             overrided_params = params_dict.keys() & params_dict_from_config.keys()
             if overrided_params:

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -203,7 +203,7 @@ class QuantizerSetupGeneratorBase:
         preset = quant_config.get('preset')
         if self._target_device in ['ANY', 'CPU', 'GPU'] or \
                 (self._target_device is None and preset is not None):
-            preset = QuantizationPreset.from_str(quant_config.get('preset', QUANTIZATION_PRESET))
+            preset = QuantizationPreset(quant_config.get('preset', QUANTIZATION_PRESET))
             params_dict = preset.get_params_configured_by_preset(quantizer_group)
             overridden_params = params_dict.keys() & params_dict_from_config.keys()
             if overridden_params:
@@ -468,7 +468,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
         hw_config_type = None
         target_device = self.config.get('target_device', 'ANY')
         if target_device != 'TRIAL':
-            hw_config_type = HWConfigType.from_str(HW_CONFIG_TYPE_TARGET_DEVICE_MAP[target_device])
+            hw_config_type = HWConfigType(HW_CONFIG_TYPE_TARGET_DEVICE_MAP[target_device])
         if hw_config_type is not None:
             hw_config_path = PTHWConfig.get_path_to_hw_config(hw_config_type)
             self.hw_config = PTHWConfig.from_json(hw_config_path)
@@ -572,7 +572,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
 
             hw_config_type = None
             if self.hw_config is not None:
-                hw_config_type = HWConfigType.from_str(self.hw_config.target_device)
+                hw_config_type = HWConfigType(self.hw_config.target_device)
             precision_init_params = AutoQPrecisionInitParams.from_config(init_precision_config,
                                                                          precision_init_args,
                                                                          hw_config_type)

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -49,14 +49,6 @@ class QuantizerExportMode(Enum):
     FAKE_QUANTIZE = "fake_quantize"
     ONNX_QUANTIZE_DEQUANTIZE_PAIRS = "quantize_dequantize"
 
-    @staticmethod
-    def from_str(config_value: str) -> 'HWConfigType':
-        if config_value == QuantizerExportMode.FAKE_QUANTIZE.value:
-            return QuantizerExportMode.FAKE_QUANTIZE
-        if config_value == QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS.value:
-            return QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS
-        raise RuntimeError("Unknown quantizer ONNX export mode string")
-
 
 class PTQSpecStateNames:
     NUM_BITS = 'num_bits'

--- a/nncf/torch/quantization/precision_init/hawq_init.py
+++ b/nncf/torch/quantization/precision_init/hawq_init.py
@@ -62,14 +62,6 @@ class BitwidthAssignmentMode(Enum):
     STRICT = 'strict'
     LIBERAL = 'liberal'
 
-    @staticmethod
-    def from_str(config_value: str) -> 'BitwidthAssignmentMode':
-        if config_value == BitwidthAssignmentMode.STRICT.value:
-            return BitwidthAssignmentMode.STRICT
-        if config_value == BitwidthAssignmentMode.LIBERAL.value:
-            return BitwidthAssignmentMode.LIBERAL
-        raise RuntimeError("Unknown bitwidth assignment mode")
-
 
 class HAWQPrecisionInitParams(BasePrecisionInitParams):
     def __init__(self,
@@ -106,7 +98,7 @@ class HAWQPrecisionInitParams(BasePrecisionInitParams):
             tolerance=hawq_init_config_dict.get('tolerance', HAWQ_TOLERANCE),
             compression_ratio=hawq_init_config_dict.get('compression_ratio', HAWQ_COMPRESSION_RATIO),
             dump_hawq_data=hawq_init_config_dict.get('dump_init_precision_data', HAWQ_DUMP_INIT_PRECISION_DATA),
-            bitwidth_assignment_mode=BitwidthAssignmentMode.from_str(
+            bitwidth_assignment_mode=BitwidthAssignmentMode(
                 hawq_init_config_dict.get('bitwidth_assignment_mode', BitwidthAssignmentMode.LIBERAL.value)
             )
         )


### PR DESCRIPTION
### Changes

Removed `from_str` methods from `Enum` classes

### Reason for changes

Enum has almost the same functionality in ctor. The difference is only in the more informative message that is not really needed.
Instead, there will be the following message:
```
ValueError: 'some_wrong_enum_value' is not a valid `DerivedEnumClass`
```

### Related tickets

n/a

### Tests

pre-commit scope
