### PR TITLE
[Torch] `replace_modules` fix

### DIFF
--- a/nncf/torch/dynamic_graph/transform_graph.py
+++ b/nncf/torch/dynamic_graph/transform_graph.py
@@ -123,6 +123,9 @@ def replace_modules(model: nn.Module, replace_fn, affected_scopes, ignored_scope
                 affected_scopes.append(replaced_scope)
                 if reset:
                     replaced_module.reset()
-        _, affected_scopes = replace_modules(module, replace_fn, affected_scopes, ignored_scopes, target_scopes,
+        if replaced_module is None:
+            replaced_module = module
+
+        _, affected_scopes = replace_modules(replaced_module, replace_fn, affected_scopes, ignored_scopes, target_scopes,
                                              memo, child_scope, eval_op_scopes, reset=reset)
     return model, affected_scopes

--- a/nncf/torch/dynamic_graph/transform_graph.py
+++ b/nncf/torch/dynamic_graph/transform_graph.py
@@ -126,6 +126,6 @@ def replace_modules(model: nn.Module, replace_fn, affected_scopes, ignored_scope
         if replaced_module is None:
             replaced_module = module
 
-        _, affected_scopes = replace_modules(replaced_module, replace_fn, affected_scopes, ignored_scopes, target_scopes,
-                                             memo, child_scope, eval_op_scopes, reset=reset)
+        _, affected_scopes = replace_modules(replaced_module, replace_fn, affected_scopes, ignored_scopes,
+                                             target_scopes, memo, child_scope, eval_op_scopes, reset=reset)
     return model, affected_scopes

--- a/tests/torch/nas/test_elastic_depth.py
+++ b/tests/torch/nas/test_elastic_depth.py
@@ -10,7 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from pathlib import Path
+
 from typing import List
 from typing import Optional
 

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -161,8 +161,7 @@ class ModuleOfUser(torch.nn.Module):
         x += torch.rand_like(x)
         x = F.conv2d(x, self.conv.weight)
         x = self.conv(x)
-        shape = x.shape
-        return x.view(-1).view(shape)
+        return x
 
 
 @register_module()
@@ -189,6 +188,7 @@ def test_custom_module_registering():
 
     from nncf.torch.layers import UNWRAPPED_USER_MODULES
     assert RegisteredModuleOfUser in UNWRAPPED_USER_MODULES.registry_dict.values()
+    assert ModuleOfUser not in UNWRAPPED_USER_MODULES.registry_dict.values()
 
     # pylint: disable=protected-access
     modules = [nncf_model.registered_user_module, nncf_model.registered_user_module.conv,


### PR DESCRIPTION
### Changes

`replace_modules` now could modifies nested target operations

### Reason for changes

In case one will make a registered user module which contains other registered module (`nn.Conv2d` for example), user registered module WILL BE REPLACED by NNCFUserModule but nested registered module WILL REMAIN UNCHANGED. In case someone will decide to quantize such module `nncf_network.get_weighted_original_graph_nodes()` will return this internal not wrapped module and then model transformer will try to add preops to it, which will lead to runtime error.

### Related tickets

<!--- Post the numerical ID of the ticket, if available -->

### Tests

`test_custom_module_registering` is updated
<!--- How was the correctness of changes tested and whether new tests were added -->
