### PR TITLE
Restore logging imports and mark legacy import as deprecated

### DIFF
--- a/nncf/common/logging/logger.py
+++ b/nncf/common/logging/logger.py
@@ -45,7 +45,7 @@ def set_log_level(level: int):
 
 def disable_logging():
     """
-    Disables NNCF logging entirely. `DeprecationWarning`s are still shown.
+    Disables NNCF logging entirely. `FutureWarning`s are still shown.
     """
     nncf_logger.handlers = []
 
@@ -60,9 +60,12 @@ class DuplicateFilter:
         return retval
 
 
+NNCFDeprecationWarning = FutureWarning
+
+
 def warning_deprecated(msg):
     # Note: must use FutureWarning in order not to get suppressed by default
-    warnings.warn(msg, FutureWarning, stacklevel=2)
+    warnings.warn(msg, NNCFDeprecationWarning, stacklevel=2)
 
 
 @contextmanager

--- a/nncf/common/logging/logger.py
+++ b/nncf/common/logging/logger.py
@@ -61,7 +61,8 @@ class DuplicateFilter:
 
 
 def warning_deprecated(msg):
-    warnings.warn(msg, DeprecationWarning)
+    # Note: must use FutureWarning in order not to get suppressed by default
+    warnings.warn(msg, FutureWarning, stacklevel=2)
 
 
 @contextmanager

--- a/nncf/common/utils/logger/__init__.py
+++ b/nncf/common/utils/logger/__init__.py
@@ -1,0 +1,26 @@
+"""
+ Copyright (c) 2022 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+#pylint:disable=wrong-import-position
+from nncf.common.logging.logger import warning_deprecated
+
+warning_deprecated(
+    "Importing from nncf.common.utils.logger is deprecated. "
+    "Import `from nncf` directly instead, i.e.: \n"
+    "`from nncf import set_log_level` instead of `from nncf.common.utils.logger import set_log_level`, and:\n"
+    "`from nncf import nncf_logger` instead of `from nncf.common.utils.logger import logger as nncf_logger`")
+
+#pylint:disable=unused-import
+from nncf.common.logging.logger import nncf_logger as logger
+from nncf.common.logging.logger import set_log_level
+from nncf.common.logging.logger import disable_logging

--- a/tests/torch/test_backward_compat.py
+++ b/tests/torch/test_backward_compat.py
@@ -23,6 +23,7 @@ from examples.torch.common.execution import prepare_model_for_execution
 from examples.torch.common.model_loader import load_model
 from examples.torch.common.sample_config import SampleConfig
 from nncf.api.compression import CompressionStage
+from nncf.common.logging.logger import NNCFDeprecationWarning
 from nncf.torch import register_default_init_args
 from nncf.torch.checkpoint_loading import load_state
 from nncf.common.graph.definitions import MODEL_INPUT_OP_NAME
@@ -172,7 +173,7 @@ def test_renamed_activation_quantizer_storage_in_state_dict():
     register_bn_adaptation_init_args(config)
     compressed_model, _ = create_compressed_model_and_algo_for_test(model, config)
 
-    with pytest.deprecated_call():
+    with pytest.warns(NNCFDeprecationWarning):
         _ = load_state(compressed_model, old_style_sd, is_resume=True)
 
 
@@ -276,11 +277,11 @@ def test_quantization_ckpt_without_wrapped_bn_loading():
         "sample_size": [1, 3, 100, 100]
     })
     register_bn_adaptation_init_args(config)
-    with pytest.deprecated_call():
+    with pytest.warns(NNCFDeprecationWarning):
         compressed_model, _ = \
             create_compressed_model_and_algo_for_test(model, config,
                                                       compression_state=compression_state_without_bn_wrapping)
-    with pytest.deprecated_call():
+    with pytest.warns(NNCFDeprecationWarning):
         _ = load_state(compressed_model, sd_without_nncf_bn_wrapping, is_resume=True)
 
 

--- a/tests/torch/test_load_model_state.py
+++ b/tests/torch/test_load_model_state.py
@@ -19,6 +19,7 @@ import pytest
 import torch
 
 from examples.torch.common.model_loader import load_model
+from nncf.common.logging.logger import NNCFDeprecationWarning
 from nncf.torch.checkpoint_loading import KeyMatcher
 from nncf.torch.checkpoint_loading import OPTIONAL_PARAMETERS_REGISTRY
 from nncf.torch.checkpoint_loading import ProcessedKeyStatus
@@ -548,7 +549,7 @@ def test_match_key(desc: MatchKeyDesc, mocker, nncf_caplog):
 
     key_matcher = KeyMatcher(desc.is_resume, desc.state_dict_to_load, desc.model_state_dict, desc.ignored_keys)
     if desc.has_deprecation_warning:
-        with pytest.deprecated_call():
+        with pytest.warns(NNCFDeprecationWarning):
             new_dict = key_matcher.run()
     else:
         new_dict = key_matcher.run()


### PR DESCRIPTION
### Changes
As stated in the title

### Reason for changes
Some code seems to rely on the old import paths.

### Related tickets
N/A

### Tests
Manual (`from nncf.common.utils.logger import logger`, `from nncf.common.utils.logger import set_log_level` etc.)
