### PR TITLE
Recover pytorch version < 1.12

### DIFF
--- a/examples/torch/README.md
+++ b/examples/torch/README.md
@@ -1,0 +1,22 @@
+Install the packages needed for samples by running the following in the current directory:
+
+```
+pip install -r requirements.txt
+```
+
+One of the needed package - torchvision.
+The minor version of torchvision should always match the minor version of installed torch package.
+torchvision minor version is torch minor version +1. For instance, torch 1.8.2 goes with torchvision 0.9.2.
+
+By default, if there is no torchvision in your Python environment it installs the package that is compatible with 
+the best known torch version (`BKC_TORCH_VERSION` in the code). In that case if your environment has the torch version, 
+which is different from best known one, you should install the corresponding torchvision package by yourself.
+
+For example, if you need torch 1.9.1 (not best known version) with CUDA11 support, we recommend specifying the 
+corresponding torchvision version as follows in the root nncf directory: 
+
+```
+pip install torch==1.9.1+cu111 torchvision==0.10.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html
+pip install .[torch]
+pip install -r examples/torch/requirements.txt
+```

--- a/examples/torch/requirements.txt
+++ b/examples/torch/requirements.txt
@@ -6,5 +6,5 @@ defusedxml>=0.7.0rc1
 mlflow>=1.12.1
 returns==0.14
 opencv-python>=4.4.0.46
-torchvision~=0.14.0  # the minor version should always match the torch minor version that is installed via NNCF's `pip install nncf[torch]`; TV minor version is torch minor version +1
+torchvision>=0.9.2,<0.15  # the minor version should always match the torch minor version that is installed via NNCF's `pip install nncf[torch]`; TV minor version is torch minor version +1
 efficientnet_pytorch

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ EXTRAS_REQUIRE = {
         "tensorflow~=2.8.4",
     ],
     "torch": [
-        "torch~=1.13.0",
+        "torch>=1.8.2,<1.14",
     ],
     "onnx": [
         "onnx==1.12.0",

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/ConvRelu6HSwishHSigmoid.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/ConvRelu6HSwishHSigmoid.dot
@@ -4,14 +4,14 @@ strict digraph  {
 "2 ConvRelu6HSwishHSigmoid/NNCFConv2d[conv1]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" [id=2, type=symmetric_quantize];
 "3 ConvRelu6HSwishHSigmoid/NNCFConv2d[conv1]/conv2d_0" [id=3, type=conv2d];
 "4 ConvRelu6HSwishHSigmoid/__add___0" [id=4, type=__add__];
-"5 ConvRelu6HSwishHSigmoid/relu6_0" [id=5, type=relu6];
+"5 ConvRelu6HSwishHSigmoid/ReLU6[relu6]/hardtanh_0" [id=5, type=hardtanh];
 "6 ConvRelu6HSwishHSigmoid/__mul___0" [id=6, type=__mul__];
 "7 ConvRelu6HSwishHSigmoid/__truediv___0" [id=7, type=__truediv__];
 "8 ConvRelu6HSwishHSigmoid/SymmetricQuantizer/symmetric_quantize_0" [id=8, type=symmetric_quantize];
 "9 ConvRelu6HSwishHSigmoid/NNCFConv2d[conv2]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" [id=9, type=symmetric_quantize];
 "10 ConvRelu6HSwishHSigmoid/NNCFConv2d[conv2]/conv2d_0" [id=10, type=conv2d];
 "11 ConvRelu6HSwishHSigmoid/__add___1" [id=11, type=__add__];
-"12 ConvRelu6HSwishHSigmoid/relu6_1" [id=12, type=relu6];
+"12 ConvRelu6HSwishHSigmoid/ReLU6[relu6]/hardtanh_1" [id=12, type=hardtanh];
 "13 ConvRelu6HSwishHSigmoid/__truediv___1" [id=13, type=__truediv__];
 "14 /nncf_model_output_0" [id=14, type=nncf_model_output];
 "0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
@@ -19,14 +19,14 @@ strict digraph  {
 "2 ConvRelu6HSwishHSigmoid/NNCFConv2d[conv1]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" -> "3 ConvRelu6HSwishHSigmoid/NNCFConv2d[conv1]/conv2d_0";
 "3 ConvRelu6HSwishHSigmoid/NNCFConv2d[conv1]/conv2d_0" -> "4 ConvRelu6HSwishHSigmoid/__add___0";
 "3 ConvRelu6HSwishHSigmoid/NNCFConv2d[conv1]/conv2d_0" -> "6 ConvRelu6HSwishHSigmoid/__mul___0";
-"4 ConvRelu6HSwishHSigmoid/__add___0" -> "5 ConvRelu6HSwishHSigmoid/relu6_0";
-"5 ConvRelu6HSwishHSigmoid/relu6_0" -> "6 ConvRelu6HSwishHSigmoid/__mul___0";
+"4 ConvRelu6HSwishHSigmoid/__add___0" -> "5 ConvRelu6HSwishHSigmoid/ReLU6[relu6]/hardtanh_0";
+"5 ConvRelu6HSwishHSigmoid/ReLU6[relu6]/hardtanh_0" -> "6 ConvRelu6HSwishHSigmoid/__mul___0";
 "6 ConvRelu6HSwishHSigmoid/__mul___0" -> "7 ConvRelu6HSwishHSigmoid/__truediv___0";
 "7 ConvRelu6HSwishHSigmoid/__truediv___0" -> "8 ConvRelu6HSwishHSigmoid/SymmetricQuantizer/symmetric_quantize_0";
 "8 ConvRelu6HSwishHSigmoid/SymmetricQuantizer/symmetric_quantize_0" -> "10 ConvRelu6HSwishHSigmoid/NNCFConv2d[conv2]/conv2d_0";
 "9 ConvRelu6HSwishHSigmoid/NNCFConv2d[conv2]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" -> "10 ConvRelu6HSwishHSigmoid/NNCFConv2d[conv2]/conv2d_0";
 "10 ConvRelu6HSwishHSigmoid/NNCFConv2d[conv2]/conv2d_0" -> "11 ConvRelu6HSwishHSigmoid/__add___1";
-"11 ConvRelu6HSwishHSigmoid/__add___1" -> "12 ConvRelu6HSwishHSigmoid/relu6_1";
-"12 ConvRelu6HSwishHSigmoid/relu6_1" -> "13 ConvRelu6HSwishHSigmoid/__truediv___1";
+"11 ConvRelu6HSwishHSigmoid/__add___1" -> "12 ConvRelu6HSwishHSigmoid/ReLU6[relu6]/hardtanh_1";
+"12 ConvRelu6HSwishHSigmoid/ReLU6[relu6]/hardtanh_1" -> "13 ConvRelu6HSwishHSigmoid/__truediv___1";
 "13 ConvRelu6HSwishHSigmoid/__truediv___1" -> "14 /nncf_model_output_0";
 }

--- a/tests/torch/experimental/search_building_blocks/test_transformer_blocks.py
+++ b/tests/torch/experimental/search_building_blocks/test_transformer_blocks.py
@@ -23,6 +23,7 @@ from typing import Union
 import numpy as np
 import pytest
 import torch
+from pkg_resources import parse_version
 from torch import nn
 from transformers import AutoModelForAudioClassification
 from transformers import AutoModelForImageClassification
@@ -128,6 +129,8 @@ def fixture_transformer_search_params_desc(request):
     return request.param
 
 
+@pytest.mark.skipif(parse_version(torch.__version__) < parse_version("1.9"),
+                    reason=f"torch {torch.__version__} is not compatible with installed transformers package")
 def test_transformer_building_blocks(desc: TransformerSearchBBlockParamsCase):
     model = desc.model_creator()
     move_model_to_cuda_if_available(model)

--- a/tests/torch/nas/test_elastic_depth.py
+++ b/tests/torch/nas/test_elastic_depth.py
@@ -18,6 +18,7 @@ import onnx
 import onnxruntime as rt
 import pytest
 import torch
+from pkg_resources import parse_version
 from torch import nn
 
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_dim import ElasticityDim
@@ -439,6 +440,8 @@ class TwoBranchesAfterInput(nn.Module):
         return x * self.dummy + x
 
 
+@pytest.mark.skipif(parse_version(torch.__version__) < parse_version("1.9"),
+                    reason="Test uses torch.permute attribute, which is not presented in the current torch version")
 @pytest.mark.parametrize('model_creator', (
         TwoPermute, ChunkConcat, TwoBranchesBeforeInput, TwoBranchesAfterInput))
 def test_can_skip_trivial_block(model_creator):

--- a/tests/torch/nas/test_elastic_depth.py
+++ b/tests/torch/nas/test_elastic_depth.py
@@ -218,8 +218,14 @@ def test_can_export_model_with_one_skipped_block_resnet18(tmp_path):
     # of nodes it tries to output the whole expression (onnx node), and sometimes it causes pytest to freeze.
     num_all_nodes = len(onnx_resnet18_orig.graph.node)
     num_not_skipped_nodes = len(onnx_resnet18_without_one_block.graph.node)
-    assert num_all_nodes == 65
-    assert num_not_skipped_nodes == 63
+    ref_num_nodes = 65
+    ref_not_skipped_nodes = 63
+    if parse_version(torch.__version__) < parse_version('1.12'):
+        # different ONNX format for older pytorch version - no Identity nodes
+        ref_num_nodes = 49
+        ref_not_skipped_nodes = 48
+    assert num_all_nodes == ref_num_nodes
+    assert num_not_skipped_nodes == ref_not_skipped_nodes
 
     input_tensor = np.ones(nncf_config['input_info'][0]['sample_size'])
     device = get_model_device(compressed_model)

--- a/tests/torch/nas/test_sanity_sample.py
+++ b/tests/torch/nas/test_sanity_sample.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from typing import Dict
 
 import pytest
+import torch
+from pkg_resources import parse_version
 
 from nncf.common.initialization.batchnorm_adaptation import BatchnormAdaptationAlgorithm
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elastic_depth import ElasticDepthHandler
@@ -98,6 +100,10 @@ def fixture_nas_desc(request, dataset_dir):
 
 
 def test_e2e_supernet_training(nas_desc: NASSampleTestDescriptor, tmp_path, mocker):
+    if parse_version(torch.__version__) < parse_version("1.9") and \
+            ('efficient_net' in nas_desc.config_name_ or 'mobilenet_v3' in nas_desc.config_name_):
+        pytest.skip(f'Test exports model with hardsigmoid operator to ONNX opset version 13.\n'
+                    f'It is not supported in the current torch version: {torch.__version__}')
     validator = nas_desc.get_validator()
     args = validator.get_default_args(tmp_path)
     validator.validate_sample(args, mocker)

--- a/tests/torch/sparsity/movement/test_model_saving.py
+++ b/tests/torch/sparsity/movement/test_model_saving.py
@@ -19,6 +19,7 @@ import onnx
 from onnx import numpy_helper
 import onnxruntime
 import pytest
+from pkg_resources import parse_version
 from scipy.special import softmax
 import torch
 
@@ -71,6 +72,9 @@ class TestONNXExport:
             list(state_before.values()), list(state_after.values())
         )
 
+    @pytest.mark.skipif(parse_version(torch.__version__) < parse_version("1.12"),
+                        reason=f"torch {torch.__version__} is not compatible with installed transformers package. "
+                               f"Some tests may fail with segmentation fault")
     @pytest.mark.parametrize('recipe', [
         BertRunRecipe(),
         Wav2Vec2RunRecipe(),

--- a/tests/torch/sparsity/movement/test_structured_mask.py
+++ b/tests/torch/sparsity/movement/test_structured_mask.py
@@ -19,6 +19,7 @@ from unittest.mock import Mock
 import pandas as pd
 import pytest
 import torch
+from pkg_resources import parse_version
 
 from nncf.common.logging import nncf_logger
 from nncf.config import NNCFConfig
@@ -180,6 +181,9 @@ class TestStructuredMaskContext:
         with pytest.raises(ValueError, match='Wrong shape'):
             setattr(ctx, mask_name, torch.ones(2))
 
+    @pytest.mark.skipif(parse_version(torch.__version__) < parse_version("1.12"),
+                        reason=f"torch {torch.__version__} may not compatible with installed transformers package. "
+                               f"Some tests may fail with error")
     @pytest.mark.parametrize('is_dependent_mask', [True, False],
                              ids=['dependent', 'independent'])
     def test_structured_mask_setter_with_device_change(self, is_dependent_mask: bool,

--- a/tests/torch/sparsity/movement/test_training.py
+++ b/tests/torch/sparsity/movement/test_training.py
@@ -18,6 +18,7 @@ from typing import Dict, Union
 
 import jstyleson as json
 import pytest
+from pkg_resources import parse_version
 from pytest import approx
 import torch.cuda
 
@@ -323,6 +324,9 @@ class TestMovementTraining:
         self._validate_model_is_saved(movement_desc_long)
         self._validate_train_metric(movement_desc_long)
 
+    @pytest.mark.skipif(parse_version(torch.__version__) < parse_version("1.12"),
+                        reason=f"torch {torch.__version__} may not compatible with installed transformers package. "
+                               f"Some tests may fail with error")
     @pytest.mark.nightly
     def test_compression_movement_short_train(self, movement_desc_short: MovementTrainingTestDescriptor, mocker):
         if (not movement_desc_short.cpu_only_) and torch.cuda.device_count() < movement_desc_short.n_card:

--- a/tests/torch/test_graph_building.py
+++ b/tests/torch/test_graph_building.py
@@ -14,6 +14,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 from copy import deepcopy
+from pkg_resources import parse_version
 from torch import nn
 from typing import List
 from typing import Tuple
@@ -584,6 +585,10 @@ def test_integer_path_marking():
     assert num_integer_edges == 4
 
 
+@pytest.mark.skipif(parse_version(torch.__version__) < parse_version("1.11"),
+                    reason="__getitem__ works unexpectedly for TracedTensor until fix in torch 1.11.\n"
+                           "Fix in pytorch: https://github.com/pytorch/pytorch/pull/67202\n"
+                           "Related ticket: 82065")
 def test_torch_tensor_getitem_behavior(mocker):
     x = torch.ones((10, 4, 4, 4))
     indexes = torch.LongTensor([0, 1, 2])

--- a/tests/torch/test_models/synthetic.py
+++ b/tests/torch/test_models/synthetic.py
@@ -259,14 +259,13 @@ class ConvRelu6HSwishHSigmoid(nn.Module):
         super().__init__()
         self.conv1 = create_conv(1, 2, 2, 2)
         self.conv2 = create_conv(2, 2, 2, 2)
+        self.relu6 = torch.nn.ReLU6()
 
-    @staticmethod
-    def _hswish(x: torch.Tensor) -> torch.Tensor:
-        return x * torch.nn.functional.relu6(x + 3) / 6
+    def _hswish(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.relu6(x + 3) / 6
 
-    @staticmethod
-    def _hsigmoid(x: torch.Tensor) -> torch.Tensor:
-        return torch.nn.functional.relu6(x + 3) / 6
+    def _hsigmoid(self, x: torch.Tensor) -> torch.Tensor:
+        return self.relu6(x + 3) / 6
 
     def forward(self, x: torch.Tensor):
         z = self.conv1(x)

--- a/tests/torch/test_sanity_sample.py
+++ b/tests/torch/test_sanity_sample.py
@@ -18,6 +18,8 @@ import tempfile
 
 import pytest
 import torch
+import torchvision
+from pkg_resources import parse_version
 from pytest_dependency import depends
 
 from examples.torch.common.model_loader import COMPRESSION_STATE_ATTR
@@ -168,6 +170,10 @@ def fixture_case_common_dirs(tmp_path_factory):
                          (True, False),
                          ids=['distributed', 'dataparallel'])
 def test_pretrained_model_eval(config, tmp_path, multiprocessing_distributed, case_common_dirs):
+    if parse_version(torchvision.__version__) < parse_version("0.13") and 'voc' in str(config["dataset_path"]):
+        pytest.skip(f'Test calls sample that uses `datasets.VOCDetection.parse_voc_xml` function from latest '
+                    f'torchvision.\nThe signature of the function is not compatible with the corresponding signature '
+                    f'from the current torchvision version : {torchvision.__version__}')
     config_factory = ConfigFactory(config['nncf_config'], tmp_path / 'config.json')
     config_factory.config = update_compression_algo_dict_with_legr_save_load_params(config_factory.config,
                                                                                     case_common_dirs[

--- a/tests/torch/test_sanity_sample.py
+++ b/tests/torch/test_sanity_sample.py
@@ -253,6 +253,10 @@ def depends_on_pretrained_train(request, test_case_id: str, current_multiprocess
     "multiprocessing_distributed", [True, False],
     ids=['distributed', 'dataparallel'])
 def test_trained_model_eval(request, config, tmp_path, multiprocessing_distributed, case_common_dirs):
+    if parse_version(torchvision.__version__) < parse_version("0.13") and 'voc' in str(config["dataset_path"]):
+        pytest.skip(f'Test calls sample that uses `datasets.VOCDetection.parse_voc_xml` function from latest '
+                    f'torchvision.\nThe signature of the function is not compatible with the corresponding signature '
+                    f'from the current torchvision version : {torchvision.__version__}')
     depends_on_pretrained_train(request, config["test_case_id"], multiprocessing_distributed)
     config_factory = ConfigFactory(config['nncf_config'], tmp_path / 'config.json')
     config_factory.config = update_compression_algo_dict_with_legr_save_load_params(config_factory.config,


### PR DESCRIPTION
### Changes

Loosened requirements for torch and torchvision:
```
0.9.2<=torchvision<0.15
1.8.2<=torch<1.14
```
Fixed failures in pre-commit tests. 
Some of them were conditionally skipped, some were adapted for different torch versions.
Some modification were made in NNCF as well (e.g. fix binarize functions for torch 1.8.2).

### Reason for changes

Support of PyTorch versions <1.12 has been broken in #1323. It should be recovered. 
It's proposed to manually validate 1.8.2 as Geti uses it. Then recover it for 1.9.1.

### Related tickets

99051

### Tests

Besides pre-commit scope on torch 1.13.1, manual test for torch 1.8.2, torch 1.9.1 and torch 1.12.1
