### PR TITLE
Fixed OpenVINO version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ EXTRAS_REQUIRE = {
         "onnxruntime-openvino==1.13.1"
     ],
     "openvino": [
-        "openvino-dev"
+        "openvino-dev~=2022.2.0"
     ]
 }
 


### PR DESCRIPTION
### Changes

Fixed OpenVINO version "openvino-dev~=2022.2.0"

### Reason for changes

Workaround for the OpenVINO pre-commit CI issue.

### Related tickets

N/A

### Tests

N/A
