### PR TITLE
tensorflow_addons~=0.16.1

### DIFF
--- a/examples/tensorflow/requirements.txt
+++ b/examples/tensorflow/requirements.txt
@@ -1,6 +1,6 @@
 absl-py==0.10
 tensorflow_datasets==4.2.0
 tensorflow_hub
-tensorflow_addons==0.14.0
+tensorflow_addons~=0.16.1
 opencv-python
 pycocotools==2.0.4

--- a/tests/tensorflow/requirements.txt
+++ b/tests/tensorflow/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
-tensorflow_addons==0.14.0
+tensorflow_addons~=0.16.1
 pytest
 pytest-mock
 pytest-dependency


### PR DESCRIPTION
### Changes

Bump tensorflow_addons version

### Reason for changes

Fix user warning:

```
Tensorflow Addons supports using Python ops for all Tensorflow versions above or equal to 2.4.0 and strictly below 2.7.0 (nightly versions are not supported). 
   The versions of TensorFlow you are currently using is 2.8.4 and is not supported.
```

### Related tickets

N/A

### Tests

e2e 197
