### PR TITLE
Renamed pruning_rate to pruning_level for TF pruning controller

### DIFF
--- a/docs/compression_algorithms/Pruning.md
+++ b/docs/compression_algorithms/Pruning.md
@@ -40,7 +40,7 @@ The zeroed filters are frozen afterwards and the remaining model parameters are 
 **Exponential scheduler**
 
 Similar to the Baseline scheduler, during `num_init_steps` epochs model is pretrained without pruning.
-During the next `pruning steps` epochs `Exponential scheduler` gradually increasing pruning level from `pruning_init` to `pruning_target`. After each pruning training epoch pruning algorithm calculates filter importances for all convolutional filters and prune (setting to zero) `current_pruning_rate` part of filters with the smallest importance in each Convolution.  After `num_init_steps` + `pruning_steps` epochs algorithm with zeroed filters is frozen and remaining model parameters only fine-tunes.
+During the next `pruning steps` epochs `Exponential scheduler` gradually increasing pruning level from `pruning_init` to `pruning_target`. After each pruning training epoch pruning algorithm calculates filter importances for all convolutional filters and prune (setting to zero) `current_pruning_level` part of filters with the smallest importance in each Convolution.  After `num_init_steps` + `pruning_steps` epochs algorithm with zeroed filters is frozen and remaining model parameters only fine-tunes.
 
 Current pruning level $P_{i}$ (on i-th epoch) during training calculates by equation:
 $P_i = a * e^{- k * i}$

--- a/nncf/common/pruning/shape_pruning_processor.py
+++ b/nncf/common/pruning/shape_pruning_processor.py
@@ -85,13 +85,13 @@ class ShapePruningProcessor:
         pruning_level: float) -> \
         Tuple[Dict[str, int], Dict[str, int]]:
         """
-        Imitates filters pruning by removing `pruning_rate` percent of output filters in each pruning group
+        Imitates filters pruning by removing `pruning_level` percent of output filters in each pruning group
         and updating corresponding input channels number in `pruning_groups_next_nodes` nodes.
 
         :param graph: NNCFGraph.
         :param pruning_groups: A list of pruning groups.
         :param pruning_groups_next_nodes: A dictionary of next nodes of each pruning group.
-        :param pruning_level: Target pruning rate.
+        :param pruning_level: Target pruning level.
         :return Tuple of dictionarise of new input and output channels number {node_name: channels_num}
         """
 

--- a/nncf/tensorflow/pruning/filter_pruning/algorithm.py
+++ b/nncf/tensorflow/pruning/filter_pruning/algorithm.py
@@ -163,7 +163,7 @@ class FilterPruningController(BasePruningAlgoController):
 
     def compression_stage(self) -> CompressionStage:
         target_pruning_level = self.scheduler.target_level
-        actual_pruning_level = self.pruning_rate
+        actual_pruning_level = self.pruning_level
         if actual_pruning_level == 0:
             return CompressionStage.UNCOMPRESSED
         if isclose(actual_pruning_level, target_pruning_level, abs_tol=1e-5) or \
@@ -175,7 +175,7 @@ class FilterPruningController(BasePruningAlgoController):
     def compression_rate(self) -> float:
         if self.prune_flops:
             return 1 - self.current_flops / self.full_flops
-        return self.pruning_rate
+        return self.pruning_level
 
     @compression_rate.setter
     def compression_rate(self, compression_rate: float) -> None:
@@ -219,11 +219,11 @@ class FilterPruningController(BasePruningAlgoController):
                           run_batchnorm_adaptation: bool = False):
         """
         Setup pruning masks in accordance to provided pruning level
-        :param pruning_level: pruning ration
+        :param pruning_level: pruning ratio
         :return:
         """
-        # Pruning rate from scheduler can be percentage of params that should be pruned
-        self.pruning_rate = pruning_level
+        # Pruning level from scheduler can be percentage of params that should be pruned
+        self.pruning_level = pruning_level
         if not self.frozen:
             nncf_logger.info('Computing filter importance scores and binary masks...')
             if self.all_weights:

--- a/nncf/tensorflow/pruning/filter_pruning/algorithm.py
+++ b/nncf/tensorflow/pruning/filter_pruning/algorithm.py
@@ -233,7 +233,7 @@ class FilterPruningController(BasePruningAlgoController):
                     self._set_binary_masks_for_pruned_layers_globally(pruning_level)
             else:
                 if self.prune_flops:
-                    # Looking for a layerwise pruning rate needed for the required flops pruning rate
+                    # Looking for a layerwise pruning level needed for the required flops pruning level
                     pruning_level = self._find_uniform_pruning_level_for_target_flops(pruning_level)
                 self._set_binary_masks_for_pruned_layers_groupwise(pruning_level)
 

--- a/nncf/torch/pruning/filter_pruning/algo.py
+++ b/nncf/torch/pruning/filter_pruning/algo.py
@@ -603,10 +603,10 @@ class FilterPruningController(BasePruningAlgoController):
         return self.pruning_level
 
     @compression_rate.setter
-    def compression_rate(self, pruning_rate):
+    def compression_rate(self, compression_rate):
         is_pruning_controller_frozen = self.frozen
         self.freeze(False)
-        self.set_pruning_level(pruning_rate)
+        self.set_pruning_level(compression_rate)
         self.freeze(is_pruning_controller_frozen)
 
     def disable_scheduler(self):

--- a/tests/tensorflow/pruning/test_algorithm.py
+++ b/tests/tensorflow/pruning/test_algorithm.py
@@ -28,8 +28,8 @@ from tests.tensorflow.pruning.helpers import get_batched_linear_model
 from tests.tensorflow.pruning.helpers import get_diff_cluster_channels_model
 
 
-def check_pruning_mask(mask, pruning_rate, layer_name):
-    assert np.sum(mask) == mask.size * pruning_rate, f"Incorrect masks for {layer_name}"
+def check_pruning_mask(mask, pruning_level, layer_name):
+    assert np.sum(mask) == mask.size * pruning_level, f"Incorrect masks for {layer_name}"
 
 
 @pytest.mark.parametrize(('all_weights', 'prune_batch_norms', 'ref_num_wrapped_layer'),
@@ -58,10 +58,10 @@ def test_masks_in_concat_model(all_weights, prune_batch_norms, ref_num_wrapped_l
 
         # Check masks correctness
         if not all_weights:
-            target_pruning_rate = 0.625 if layer.name == 'bn_concat' else 0.5
+            target_pruning_level = 0.625 if layer.name == 'bn_concat' else 0.5
             assert len(layer.ops_weights) == 2
             for op in layer.ops_weights.values():
-                check_pruning_mask(op['mask'].numpy(), target_pruning_rate, layer.name)
+                check_pruning_mask(op['mask'].numpy(), target_pruning_level, layer.name)
 
 @pytest.mark.parametrize(('all_weights', 'ref_num_wrapped_layer'),
                          [
@@ -88,7 +88,7 @@ def test_masks_in_split_model(all_weights, ref_num_wrapped_layer):
         if not all_weights:
             assert len(layer.ops_weights) == 2
             for op in layer.ops_weights.values():
-                check_pruning_mask(op['mask'].numpy(), pruning_rate=0.5, layer_name=layer.name)
+                check_pruning_mask(op['mask'].numpy(), pruning_level=0.5, layer_name=layer.name)
 
 
 @pytest.mark.parametrize('model_fn,ref_output_shapes',

--- a/tests/torch/pruning/filter_pruning/test_flops_pruning.py
+++ b/tests/torch/pruning/filter_pruning/test_flops_pruning.py
@@ -113,7 +113,7 @@ def test_init_params_for_flops_calculation(model, ref_params):
 def test_flops_calulation_for_spec_layers(model, all_weights, pruning_flops_target,
                                           ref_full_flops, ref_current_flops, ref_sizes):
     # Need check models with large size of layers because in other case
-    # different value of pruning rate give the same final size of model
+    # different value of pruning level give the same final size of model
     config = get_basic_pruning_config([1, 1, 8, 8])
     config['compression']['algorithm'] = 'filter_pruning'
     config['compression']['pruning_init'] = pruning_flops_target

--- a/tests/torch/pruning/filter_pruning/test_set_pruning_rate.py
+++ b/tests/torch/pruning/filter_pruning/test_set_pruning_rate.py
@@ -37,16 +37,16 @@ def create_pruning_algo_with_config(config):
 
 
 @pytest.mark.parametrize(
-    ('all_weights', 'pruning_rate_to_set', 'ref_pruning_rates', 'ref_global_pruning_rate'),
+    ('all_weights', 'pruning_level_to_set', 'ref_pruning_levels', 'ref_global_pruning_level'),
     [
         (False, 0.5, [0.5, 0.5, 0.5], 0.5),
         (True, 0.5, [0.03125, 0.421875, 0.65625], 0.5),
         (False, {0: 0.6, 1: 0.8, 2: 0.4}, [0.5, 0.75, 0.375], 0.3926983648557004),
     ]
 )
-def test_setting_pruning_rate(all_weights, pruning_rate_to_set, ref_pruning_rates, ref_global_pruning_rate):
+def test_setting_pruning_level(all_weights, pruning_level_to_set, ref_pruning_levels, ref_global_pruning_level):
     """
-    Test setting global and groupwise pruning rates via the set_pruning_rate method.
+    Test setting global and groupwise pruning levels via the set_pruning_level method.
     """
     # Creating algorithm with empty config
     config = get_basic_pruning_config(input_sample_size=[1, 1, 8, 8])
@@ -56,15 +56,15 @@ def test_setting_pruning_rate(all_weights, pruning_rate_to_set, ref_pruning_rate
     _, pruning_controller, _ = create_pruning_algo_with_config(config)
     assert isinstance(pruning_controller, FilterPruningController)
 
-    pruning_controller.set_pruning_level(pruning_rate_to_set)
-    groupwise_pruning_rates = list(pruning_controller.current_groupwise_pruning_level.values())
-    assert np.isclose(groupwise_pruning_rates, ref_pruning_rates).all()
-    assert np.isclose(pruning_controller.pruning_level, ref_global_pruning_rate).all()
+    pruning_controller.set_pruning_level(pruning_level_to_set)
+    groupwise_pruning_levels = list(pruning_controller.current_groupwise_pruning_level.values())
+    assert np.isclose(groupwise_pruning_levels, ref_pruning_levels).all()
+    assert np.isclose(pruning_controller.pruning_level, ref_global_pruning_level).all()
 
 
 def test_can_set_compression_rate_in_filter_pruning_algo():
     """
-    Test setting the global pruning rate via the compression_rate property.
+    Test setting the global pruning level via the compression_rate property.
     """
     # Creating algorithm with empty config
     config = get_basic_pruning_config(input_sample_size=[1, 1, 8, 8])


### PR DESCRIPTION
Renamed `pruning_rate` to `pruning_level` for TF pruning controller

### Reason for changes

Everywhere in the codebase `pruning_level` is used for compression rate of pruning controller except multiple places in TF implementation of pruning controller
