### PR TITLE
[Torch][Microfix] PTTarget point translation fix

### DIFF
--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -126,7 +126,8 @@ class PTInsertionPoint:
     }
 
     def _get_pt_insertion_type(self, target_type: TargetType) -> PTInsertionType:
-        if target_type not in PTInsertionPoint.TARGET_TYPE_VS_PT_INSERTION_TYPE_DICT:
+        if not isinstance(target_type, TargetType) or\
+            target_type not in PTInsertionPoint.TARGET_TYPE_VS_PT_INSERTION_TYPE_DICT:
             raise RuntimeError("Unsupported target type for PyTorch: {}".format(target_type))
         return PTInsertionPoint.TARGET_TYPE_VS_PT_INSERTION_TYPE_DICT[target_type]
 

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -39,6 +39,7 @@ from nncf.common.utils.dot_file_rw import get_graph_without_data
 from nncf.common.utils.dot_file_rw import read_dot_graph
 from nncf.common.utils.dot_file_rw import write_dot_graph
 from nncf.torch import register_module
+from nncf.torch.dynamic_graph.scope import Scope
 from nncf.torch.dynamic_graph.context import PreHookId
 from nncf.torch.dynamic_graph.graph_tracer import ModelInputInfo
 from nncf.torch.dynamic_graph.operation_address import OperationAddress
@@ -778,3 +779,12 @@ def test_deepcopy_nncf_network():
     register_bn_adaptation_init_args(config)
     sparse_quantized_model, _ = create_compressed_model_and_algo_for_test(model, config)
     _ = deepcopy(sparse_quantized_model)
+
+
+def test_insertion_point_target_point_translation():
+    op_address = OperationAddress('dummy', Scope(), 0)
+    for target_type in [PTInsertionType.NNCF_MODULE_POST_OP, TargetType.AFTER_LAYER]:
+        with pytest.raises(RuntimeError):
+            PTInsertionPoint(target_type, op_address)
+    target_type = TargetType.POST_LAYER_OPERATION
+    assert PTInsertionPoint(target_type, op_address).insertion_type == PTInsertionType.NNCF_MODULE_POST_OP


### PR DESCRIPTION
### Changes

Type checking fixed in insertion type translation inside `PTInsertionPoint`

### Reason for changes

In case `PTInsertionType` is passed to `PTInsertionPoint` and its id will match `InsertionType` id, it will be translated in a wrong way

### Related tickets

### Tests


