### PR TITLE
Workaround for the hang in sanity tests with --cpu-only option

### DIFF
--- a/tests/torch/data/configs/unet_camvid_int8.json
+++ b/tests/torch/data/configs/unet_camvid_int8.json
@@ -33,7 +33,8 @@
     },
 
     "model_params": {
-         "input_size_hw": [368, 480]
+        "input_size_hw": [368, 480],
+        "depth": 1
     },
     "compression": {
         "algorithm": "quantization",

--- a/tests/torch/data/configs/unet_camvid_rb_sparsity.json
+++ b/tests/torch/data/configs/unet_camvid_rb_sparsity.json
@@ -33,7 +33,8 @@
     },
 
     "model_params": {
-         "input_size_hw": [368, 480]
+         "input_size_hw": [368, 480],
+        "depth": 1
     },
     "compression": {
         "algorithm": "rb_sparsity",


### PR DESCRIPTION
### Changes

Workaround for the hang on CPU: https://discuss.pytorch.org/t/backward-hangs-on-torch-for-cpu/169282
Set number of threads = 1 to avoid hang for backward on UNet.
Presumably, it might happen when OpenMP is used before fork.

Sanity test was simplified in order to compensate slowdown on a single CPU thread. It takes 10 seconds more than without the workaround, but still 7 seconds faster than it was on develop branch.

### Reason for changes

permanent hang of tests on hosts with `Intel(R) Core™ i9-10980XE CPU @ 3.00GHz`

### Related tickets

100106

### Tests

- [x] pytorch precommit on host when the hang was always reproduced (build 76)