### PR TITLE
[OV]: fixes for quantize_with_accuracy_control

### DIFF
--- a/nncf/openvino/quantization/quantize.py
+++ b/nncf/openvino/quantization/quantize.py
@@ -177,8 +177,9 @@ def quantize_with_accuracy_control_impl(model: ov.Model,
         _ = validation_fn(compiled_model, validation_dataset.get_data(indices=[0]))
     except Exception:
         use_original_metric = False
-
-    pot.algorithms.algorithm_selector.COMPRESSION_ALGORITHMS.register('NMSEBasedAccuracyAware')(NMSEBasedAccuracyAware)
+    compression_algorithms = pot.algorithms.algorithm_selector.COMPRESSION_ALGORITHMS
+    if 'NMSEBasedAccuracyAware' not in compression_algorithms.registry_dict:
+        compression_algorithms.register('NMSEBasedAccuracyAware')(NMSEBasedAccuracyAware)
 
     algorithms = [
         {
@@ -190,7 +191,7 @@ def quantize_with_accuracy_control_impl(model: ov.Model,
                 'metric_subset_ratio': 0.5,
                 'preset': preset.value,
                 'use_fast_bias': fast_bias_correction,
-                'model_type': model_type,
+                'model_type': None if model_type is None else model_type.value,
                 'ignored': _create_ignored_scope_config(ignored_scope),
             }
         }


### PR DESCRIPTION
### Changes

<!--- What was changed (briefly), how to reproduce (if applicable), what the reviewers should focus on -->

- fix model_type config providing for pot configuration
- allow to run with openvino 2022.3 where algo already registred

### Reason for changes

<!--- Why should the change be applied -->
inability to successfully run quantization for openvino notebooks

### Related tickets

<!--- Post the numerical ID of the ticket, if available -->

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
