### PR TITLE
Disable sporadically hanging test for accuracy aware training

### DIFF
--- a/tests/torch/test_sanity_sample.py
+++ b/tests/torch/test_sanity_sample.py
@@ -529,6 +529,8 @@ def fixture_accuracy_aware_config(request):
     "multiprocessing_distributed", [True, False],
     ids=['distributed', 'dataparallel'])
 def test_accuracy_aware_training_pipeline(accuracy_aware_config, tmp_path, multiprocessing_distributed):
+    if multiprocessing_distributed:
+        pytest.skip('DDP mode sporadically fails in CI. ticket 68302')
     config_factory = ConfigFactory(accuracy_aware_config['nncf_config'], tmp_path / 'config.json')
     log_dir = tmp_path / 'accuracy_aware'
     log_dir = log_dir / 'distributed' if multiprocessing_distributed else log_dir / 'dataparallel'


### PR DESCRIPTION
### Changes

Skip `test_sanity_sample.test_accuracy_aware_training_pipeline[accuracy_aware_config1-distributed]`

### Reason for changes

Test sporadically fails and leads to re-running Pytorch precommit. 1-2 hours of validation is wasted for the team. 

### Related tickets

68302

### Tests

![image](https://user-images.githubusercontent.com/4014476/210213256-f2158e69-7aca-4087-8059-d3264fcfe05a.png)
