### PR TITLE
FLOPS calculation for matmul operation with 4D inputs in NAS

### DIFF
--- a/nncf/common/graph/graph.py
+++ b/nncf/common/graph/graph.py
@@ -656,6 +656,6 @@ class NNCFGraph:
                              data[NNCFGraph.DTYPE_EDGE_ATTR])
 
     def get_all_edges(self) -> Generator[NNCFGraphEdge, None, None]:
-        for nx_edge in self._nx_graph.edges:
+        for nx_edge in self._nx_graph.in_edges:
             yield self.get_edge(self.get_node_by_key(nx_edge[0]),
                                 self.get_node_by_key(nx_edge[1]))

--- a/nncf/common/graph/layer_attributes.py
+++ b/nncf/common/graph/layer_attributes.py
@@ -125,6 +125,15 @@ class LinearLayerAttributes(WeightedLayerAttributes):
         return 0
 
 
+class MatmulAttributes(BaseLayerAttributes):
+    def __init__(self,
+                 in_features: int,
+                 out_features: int):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+
+
 class ConvolutionLayerAttributes(WeightedLayerAttributes):
     """
     This class stores attributes of convolution modules/layers

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/multi_elasticity_handler.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/multi_elasticity_handler.py
@@ -31,6 +31,7 @@ from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elastic_kernel import E
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elastic_width import ElasticWidthHandler
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elastic_width import ElasticWidthSearchSpace
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_dim import ElasticityDim
+from nncf.torch.graph.operator_metatypes import PTMatMulMetatype
 from nncf.torch.graph.operator_metatypes import PTModuleConv1dMetatype
 from nncf.torch.graph.operator_metatypes import PTModuleConv2dMetatype
 from nncf.torch.graph.operator_metatypes import PTModuleConv3dMetatype
@@ -83,7 +84,9 @@ class MultiElasticityHandler(ElasticityHandler):
         self._is_handler_enabled_map = {elasticity_dim: True for elasticity_dim in handlers}
         self._weights_calc = WeightsFlopsCalculator(
             conv_op_metatypes=GENERAL_CONV_LAYER_METATYPES,
-            linear_op_metatypes=LINEAR_LAYER_METATYPES)
+            linear_op_metatypes=LINEAR_LAYER_METATYPES,
+            matmul_op_metatypes=[PTMatMulMetatype]
+        )
         self.activate_supernet()
 
     @property

--- a/nncf/torch/dynamic_graph/wrappers.py
+++ b/nncf/torch/dynamic_graph/wrappers.py
@@ -173,7 +173,7 @@ def wrap_module_call(module_call):
 def _add_operation_attributes(node: 'DynamicGraphNode', ctx: TracingContext):
     op_address = node.op_exec_context.op_address
     # TODO(nlyalyus): support other operations: torch.addmm, torch.nn.functional.Linear, torch.bmm, torch.mm
-    if op_address.operator_name == 'matmul':
+    if op_address.operator_name in ('matmul', 'bmm'):
         graph = ctx.graph
         input_edges = graph.get_input_edges(node)
         # no input nodes when input_info tensor was bound to a *args or **kwargs on graph tracing
@@ -182,7 +182,7 @@ def _add_operation_attributes(node: 'DynamicGraphNode', ctx: TracingContext):
             activation_edge, weight_edge = input_edges
             activation_shape = activation_edge.activation_shape
             weight_shape = weight_edge.activation_shape
-            # TODO(nlyalyus): support other shapes: 1D x 1D, 1D x 2D, 2D x 1D, 1D x ND, ND x 1D
+            # TODO(nlyalyus): support other shapes: 1D x 2D, 2D x 1D, 1D x ND, ND x 1D
             # https://pytorch.org/docs/stable/generated/torch.matmul.html
             activation_dims = len(activation_shape)
             weight_dims = len(weight_shape)

--- a/nncf/torch/pruning/utils.py
+++ b/nncf/torch/pruning/utils.py
@@ -118,7 +118,7 @@ def collect_output_shapes(graph: NNCFGraph) -> Dict[NNCFNodeName, List[int]]:
                                   shape_slice=slice(2, None)),
         OutputShapeCollectionInfo(node_types=[v.op_func_name for v in NNCF_LINEAR_MODULES_DICT],
                                   shape_slice=slice(None)),
-        OutputShapeCollectionInfo(node_types=['matmul'],
+        OutputShapeCollectionInfo(node_types=['matmul', 'bmm'],
                                   shape_slice=slice(None)),
     ]
     for info in output_shape_collecting_info:

--- a/tests/torch/nas/creators.py
+++ b/tests/torch/nas/creators.py
@@ -52,10 +52,11 @@ from tests.torch.nas.models.vgg_k7 import VGG11_K7
 # TODO(nlyalyus) reduce number of creators and descriptors. create wrapper of TrainingAlgorithm  (ticket 81015)
 def create_bootstrap_training_model_and_ctrl(model,
                                              nncf_config: NNCFConfig,
-                                             register_bn_adapt: bool = True) \
+                                             register_bn_adapt: bool = True,
+                                             wrap_inputs_fn = None) \
                                              -> Tuple[NNCFNetwork, BNASTrainingController]:
     algo_name = nncf_config.get('bootstrapNAS', {}).get('training', {}).get('algorithm', 'progressive_shrinking')
-    nncf_network = create_nncf_network(model, nncf_config)
+    nncf_network = create_nncf_network(model, nncf_config, wrap_inputs_fn=wrap_inputs_fn)
     if register_bn_adapt:
         register_bn_adaptation_init_args(nncf_config)
     ctrl, model = create_compressed_model_from_algo_names(nncf_network, nncf_config, [algo_name], False)
@@ -67,8 +68,9 @@ def create_bootstrap_training_model_and_ctrl(model,
 
 
 def create_bnas_model_and_ctrl_by_test_desc(desc: MultiElasticityTestDesc):
+    input_info = desc.input_info if desc.input_info else {"sample_size": desc.input_sizes}
     config = {
-        "input_info": {"sample_size": desc.input_sizes},
+        "input_info": input_info,
         "bootstrapNAS": {
             "training": {
                 "elasticity": {

--- a/tests/torch/nas/descriptors.py
+++ b/tests/torch/nas/descriptors.py
@@ -18,6 +18,7 @@ from typing import List
 from typing import NamedTuple
 from typing import Optional
 from typing import Tuple
+from typing import Union
 
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.base_handler import SingleElasticityBuilder
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.base_handler import create_elasticity_builder_from_config
@@ -113,6 +114,7 @@ class MultiElasticityTestDesc(NamedTuple):
     ref_model_stats: RefModelStats = None
     blocks_to_skip: List[List[str]] = None
     input_sizes: List[int] = [1, 3, 32, 32]
+    input_info: Union[List, Dict] = None
     algo_params: Dict = {}
     name: str = None
 

--- a/tests/torch/nas/test_flops.py
+++ b/tests/torch/nas/test_flops.py
@@ -16,8 +16,13 @@ from functools import partial
 import pytest
 import torch
 from torchvision.models import resnet50
+from transformers import AutoModelForAudioClassification
+from transformers import AutoModelForImageClassification
 from transformers import AutoModelForQuestionAnswering
 from transformers import BertConfig
+from transformers import SwinConfig
+from transformers import ViTConfig
+from transformers import Wav2Vec2Config
 
 from examples.torch.common.models.classification.mobilenet_v2_cifar10 import mobilenet_v2_cifar10
 from examples.torch.common.models.classification.resnet_cifar10 import resnet50_cifar10
@@ -217,10 +222,34 @@ FLOPS_DESC_LIST = [
         model_desc=GeneralModelDesc(
             model_name='BERT',
             model_builder=partial(AutoModelForQuestionAnswering.from_config, BertConfig()),
-            input_info=[dict(sample_size=[1, 10], type='long')] * 3
+            input_info=[dict(sample_size=[1, 10], type='long')] * 3,
         ),
         ref_model_stats=ModelStats(1_702_410_240, 84_936_192)
     ),
+    TestFlopsDesc(
+        model_desc=GeneralModelDesc(
+            model_name='ViT',
+            model_builder=partial(AutoModelForImageClassification.from_config, ViTConfig()),
+            input_info=[dict(sample_size=[1, 3, 224, 224])],
+        ),
+        ref_model_stats=ModelStats(35_126_123_520, 85_526_016),
+    ),
+    TestFlopsDesc(
+        model_desc=GeneralModelDesc(
+            model_name='Swin',
+            model_builder=partial(AutoModelForImageClassification.from_config, SwinConfig()),
+            input_info=[dict(sample_size=[1, 3, 224, 224])],
+        ),
+        ref_model_stats=ModelStats(8979_600_384, 27_432_960)
+    ),
+    TestFlopsDesc(
+        model_desc=GeneralModelDesc(
+            model_name='Wave2Vec2.0',
+            model_builder=partial(AutoModelForAudioClassification.from_config, Wav2Vec2Config()),
+            input_info=[dict(sample_size=[1, 400])],
+        ),
+        ref_model_stats=ModelStats(305_589_248, 94_443_008)
+    )
 ]
 
 

--- a/tests/torch/nas/test_search.py
+++ b/tests/torch/nas/test_search.py
@@ -36,6 +36,7 @@ class SearchTestDesc(NamedTuple):
     model_creator: Any
     blocks_to_skip: List[List[str]] = None
     input_sizes: List[int] = [1, 3, 32, 32]
+    input_info = None
     algo_params: Dict = {}
     name: str = None
     mode: str = "auto"

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -463,7 +463,8 @@ class BaseDesc(IModelDesc):
 class GeneralModelDesc(BaseDesc):
     def __init__(self,
                  input_sample_sizes: Union[Tuple[List[int], ...], List[int]] = None,
-                 model_name: str = None, wrap_inputs_fn: Callable = None, model_builder=None, input_info: Dict = None):
+                 model_name: str = None, wrap_inputs_fn: Callable = None, model_builder=None,
+                 input_info: Union[Dict, List] = None):
         super().__init__(input_sample_sizes, model_name, wrap_inputs_fn, input_info)
         if not model_name and hasattr(model_builder, '__name__'):
             self.model_name = model_builder.__name__
@@ -496,14 +497,16 @@ class SingleLayerModelDesc(BaseDesc):
                 self._layer = layer
 
             def forward(self, *args, **kwargs):
-                return self._layer(*args, **kwargs)
+                output = self._layer(*args, **kwargs)
+                return output
 
         return TestModel(self.layer)
 
 
 class TorchBinaryMethodDesc(SingleLayerModelDesc):
-    def __init__(self, model_name: str, torch_method: Callable, input_info=None):
-        super().__init__(layer=torch_method, model_name=model_name, input_sample_sizes=([1], [1]),
+    def __init__(self, model_name: str, torch_method: Callable, input_info=None,
+                 input_sample_sizes: Union[Tuple[List[int], ...], List[int]] = ([1], [1])):
+        super().__init__(layer=torch_method, model_name=model_name, input_sample_sizes=input_sample_sizes,
                          wrap_inputs_fn=n_inputs_fn, input_info=input_info)
 
 


### PR DESCRIPTION
### Changes

This PR proposes how to support FLOPS calculation for (`matmul`, `bmm`) represented as torch functions on two tensors, not by module with weights. It's not a final solution, subject to discussion and modifications.

Note, there are many limitations: 
- All other operations associated with `matmul`  are not supported: `torch.addmm`, `torch.nn.functional.Linear`, `torch.mm`. 
- covered inputs of the same shape, but matmul also supports: 1D x 2D, 2D x 1D, 1D x ND, ND x 1D https://pytorch.org/docs/stable/generated/torch.matmul.html
- Filter pruning is not covered. Changes were made and tested for NAS part.
- FLOPS calculation was verified for FP32 model only. FLOPS of the pruned model is not verified.
- matmul, which takes learnable parameter on second input, is not supported (GNMT case) 
- `t.matmul(t)` is not supported

### Reason for changes

Currently, NNCF for Torch supports FLOPS calculation for modules only (e.g. `nn.Linear` or `nn.Conv2d`), because all required layer attributes are collected for modules now.
However, modern architectures (e.g., Transformers) are constructed not from modules only. Usually there is a multiplication of two activations represented as `torch.matmul` operation. For such operations, there was no extraction of layer attributes that is needed for FLOPS calculation.

### Related tickets

n/a

### Tests

`test_flops_and_weights_calculation`
