### PR TITLE
Type hints were fixed

### DIFF
--- a/nncf/openvino/quantization/quantize.py
+++ b/nncf/openvino/quantization/quantize.py
@@ -152,7 +152,7 @@ def quantize_with_accuracy_control_impl(model: ov.Model,
                                         target_device: TargetDevice = TargetDevice.ANY,
                                         subset_size: int = 300,
                                         fast_bias_correction: bool = True,
-                                        model_type: Optional[str] = None,
+                                        model_type: Optional[ModelType] = None,
                                         ignored_scope: Optional[IgnoredScope] = None) -> ov.Model:
     """
     Implementation of the `quantize_with_accuracy_control()` method for the OpenVINO backend.

--- a/nncf/quantization/quantize.py
+++ b/nncf/quantization/quantize.py
@@ -92,7 +92,7 @@ def quantize_with_accuracy_control(model: ModelType,
                                    target_device: TargetDevice = TargetDevice.ANY,
                                    subset_size: int = 300,
                                    fast_bias_correction: bool = True,
-                                   model_type: Optional[str] = None,
+                                   model_type: Optional[ModelType] = None,
                                    ignored_scope: Optional[IgnoredScope] = None) -> ModelType:
     """
     Applies post-training quantization algorithm with accuracy control to provided model.


### PR DESCRIPTION
### Changes
Type hints were fixed for the `quantize_with_accuracy_control` method.

### Reason for changes
Type hints were wrong.

### Related tickets
N/A

### Tests
N/A
