### PR TITLE
Removing matplotlib from the mandatory requirements

### DIFF
--- a/nncf/common/utils/decorators.py
+++ b/nncf/common/utils/decorators.py
@@ -19,14 +19,14 @@ from nncf.common.logging import nncf_logger
 IMPORTED_DEPENDENCIES = {}
 
 
-def bypass_noreturn_function(dependencies: List[str]) -> Callable:
+def skip_if_dependency_unavailable(dependencies: List[str]) -> Callable:
     """
-    Decorator to bypass a noreturn function if dependencies are not met.
+    Decorator factory to skip a noreturn function if dependencies are not met.
 
-    :param func: A noreturn function to decorate
-    :return: Decorated function
+    :param dependencies: A list of dependencies
+    :return: A decorator
     """
-    def wrap(func: Callable) -> Callable:
+    def wrap(func: Callable[..., None]) -> Callable[..., None]:
         def wrapped_f(*args, **kwargs):
             for libname in dependencies:
                 if libname in IMPORTED_DEPENDENCIES:

--- a/nncf/common/utils/decorators.py
+++ b/nncf/common/utils/decorators.py
@@ -1,0 +1,51 @@
+"""
+ Copyright (c) 2022 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from importlib import import_module
+from typing import Callable, List
+
+from nncf.common.logging import nncf_logger
+
+IMPORTED_DEPENDENCIES = {}
+
+
+def bypass_noreturn_function(dependencies: List[str]) -> Callable:
+    """
+    Decorator to bypass a noreturn function if dependencies are not met.
+
+    :param func: A noreturn function to decorate
+    :return: Decorated function
+    """
+    def wrap(func: Callable) -> Callable:
+        def wrapped_f(*args, **kwargs):
+            for libname in dependencies:
+                if libname in IMPORTED_DEPENDENCIES:
+                    if IMPORTED_DEPENDENCIES[libname]:
+                        continue
+                    break
+                try:
+                    _ = import_module(libname)
+                    IMPORTED_DEPENDENCIES[libname] = True
+                except ImportError as ex:
+                    nncf_logger.warning(
+                        f'{ex.msg} Please install NNCF package with dev '
+                        'extra. Use one of the following commands '
+                        '"pip install .[dev]" running from the repository '
+                        'root directory or "pip install nncf[dev]"')
+                    IMPORTED_DEPENDENCIES[libname] = False
+                    break
+            else:
+                return func(*args, **kwargs)
+            return None
+        return wrapped_f
+    return wrap

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elasticity_controller.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elasticity_controller.py
@@ -12,9 +12,6 @@
 """
 from typing import Any
 from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Tuple
 
 from nncf.api.compression import CompressionLoss
 from nncf.api.compression import CompressionScheduler

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/search.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/search.py
@@ -13,6 +13,7 @@
 import csv
 from abc import abstractmethod
 from enum import Enum
+from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -23,40 +24,30 @@ from typing import Tuple
 from typing import TypeVar
 
 import numpy as np
-from pathlib import Path
+import torch
 from pymoo.algorithms.moo.nsga2 import NSGA2
 from pymoo.core.problem import Problem
 from pymoo.factory import get_crossover
 from pymoo.factory import get_mutation
 from pymoo.factory import get_sampling
 from pymoo.optimize import minimize
-import torch
 from torch.utils.data.dataloader import DataLoader
 from torch.utils.tensorboard import SummaryWriter
 
-from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator import AccuracyEvaluator
-from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator import BaseEvaluator
-from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator import MACsEvaluator
-from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator_handler import BaseEvaluatorHandler
-from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator_handler import AccuracyEvaluatorHandler
-from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator_handler import EfficiencyEvaluatorHandler
 from nncf import NNCFConfig
 from nncf.common.initialization.batchnorm_adaptation import BatchnormAdaptationAlgorithm
 from nncf.common.logging import nncf_logger
+from nncf.common.utils.decorators import bypass_noreturn_function
 from nncf.config.extractors import get_bn_adapt_algo_kwargs
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_controller import ElasticityController
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.multi_elasticity_handler import SubnetConfig
+from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator import AccuracyEvaluator
+from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator import BaseEvaluator
+from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator import MACsEvaluator
+from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator_handler import AccuracyEvaluatorHandler
+from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator_handler import BaseEvaluatorHandler
+from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator_handler import EfficiencyEvaluatorHandler
 from nncf.torch.nncf_network import NNCFNetwork
-
-try:
-    import matplotlib.pyplot as plt
-    MATPLOTLIB_PACKAGES_AVAILABLE = True
-except ImportError as ex:
-    nncf_logger.warning(
-        f'{ex.msg} Please install NNCF package with dev extra. Use one of '
-        'the following commands "pip install .[dev]" running from '
-        'the repository root directory or "pip install nncf[dev]"')
-    MATPLOTLIB_PACKAGES_AVAILABLE = False
 
 DataLoaderType = TypeVar('DataLoaderType')
 TModel = TypeVar('TModel')
@@ -366,6 +357,7 @@ class SearchAlgorithm(BaseSearchAlgorithm):
 
         return self._elasticity_ctrl, self.best_config, [abs(elem) for elem in ret_vals if elem is not None]
 
+    @bypass_noreturn_function(dependencies=['matplotlib.pyplot'])
     def visualize_search_progression(self, filename='search_progression') -> NoReturn:
         """
         Visualizes search progression and saves the resulting figure.
@@ -373,9 +365,7 @@ class SearchAlgorithm(BaseSearchAlgorithm):
         :param filename:
         :return:
         """
-        if not MATPLOTLIB_PACKAGES_AVAILABLE:
-            return
-
+        import matplotlib.pyplot as plt
         plt.figure()
         colormap = plt.cm.get_cmap('viridis')
         col = range(int(self.search_params.num_evals / self.search_params.population))

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/search.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/search.py
@@ -37,7 +37,7 @@ from torch.utils.tensorboard import SummaryWriter
 from nncf import NNCFConfig
 from nncf.common.initialization.batchnorm_adaptation import BatchnormAdaptationAlgorithm
 from nncf.common.logging import nncf_logger
-from nncf.common.utils.decorators import bypass_noreturn_function
+from nncf.common.utils.decorators import skip_if_dependency_unavailable
 from nncf.config.extractors import get_bn_adapt_algo_kwargs
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_controller import ElasticityController
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.multi_elasticity_handler import SubnetConfig
@@ -357,7 +357,7 @@ class SearchAlgorithm(BaseSearchAlgorithm):
 
         return self._elasticity_ctrl, self.best_config, [abs(elem) for elem in ret_vals if elem is not None]
 
-    @bypass_noreturn_function(dependencies=['matplotlib.pyplot'])
+    @skip_if_dependency_unavailable(dependencies=['matplotlib.pyplot'])
     def visualize_search_progression(self, filename='search_progression') -> NoReturn:
         """
         Visualizes search progression and saves the resulting figure.

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/search.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/search.py
@@ -33,8 +33,6 @@ from pymoo.optimize import minimize
 import torch
 from torch.utils.data.dataloader import DataLoader
 from torch.utils.tensorboard import SummaryWriter
-import matplotlib.pyplot as plt
-
 
 from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator import AccuracyEvaluator
 from nncf.experimental.torch.nas.bootstrapNAS.search.evaluator import BaseEvaluator
@@ -49,6 +47,16 @@ from nncf.config.extractors import get_bn_adapt_algo_kwargs
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_controller import ElasticityController
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.multi_elasticity_handler import SubnetConfig
 from nncf.torch.nncf_network import NNCFNetwork
+
+try:
+    import matplotlib.pyplot as plt
+    MATPLOTLIB_PACKAGES_AVAILABLE = True
+except ImportError as ex:
+    nncf_logger.warning(
+        f'{ex.msg} Please install NNCF package with dev extra. Use one of '
+        'the following commands "pip install .[dev]" running from '
+        'the repository root directory or "pip install nncf[dev]"')
+    MATPLOTLIB_PACKAGES_AVAILABLE = False
 
 DataLoaderType = TypeVar('DataLoaderType')
 TModel = TypeVar('TModel')
@@ -365,6 +373,9 @@ class SearchAlgorithm(BaseSearchAlgorithm):
         :param filename:
         :return:
         """
+        if not MATPLOTLIB_PACKAGES_AVAILABLE:
+            return
+
         plt.figure()
         colormap = plt.cm.get_cmap('viridis')
         col = range(int(self.search_params.num_evals / self.search_params.population))

--- a/nncf/torch/quantization/precision_init/hawq_debug.py
+++ b/nncf/torch/quantization/precision_init/hawq_debug.py
@@ -18,10 +18,10 @@ from typing import List
 import torch
 from torch import Tensor
 
-from nncf.common.utils.dot_file_rw import write_dot_graph
 from nncf.common.logging import nncf_logger
-from nncf.torch.nncf_network import ExtraCompressionModuleType
-from nncf.torch.nncf_network import NNCFNetwork
+from nncf.common.utils.decorators import bypass_noreturn_function
+from nncf.common.utils.dot_file_rw import write_dot_graph
+from nncf.torch.nncf_network import ExtraCompressionModuleType, NNCFNetwork
 from nncf.torch.quantization.adjust_padding import add_adjust_padding_nodes
 from nncf.torch.quantization.layers import QUANTIZATION_MODULES
 from nncf.torch.quantization.precision_init.adjacent_quantizers import GroupsOfAdjacentQuantizers
@@ -79,6 +79,7 @@ class HAWQDebugger:
         all_quantizations = OrderedDict(sorted(all_quantizations.items(), key=lambda x: str(x[0])))
         return all_quantizations
 
+    @bypass_noreturn_function(dependencies=['matplotlib.pyplot'])
     def dump_avg_traces(self):
         import matplotlib.pyplot as plt
         dump_file = os.path.join(self._dump_dir, 'avg_traces_per_layer')
@@ -92,6 +93,7 @@ class HAWQDebugger:
         ax.plot(self._traces_per_layer.cpu().numpy())
         plt.savefig(dump_file)
 
+    @bypass_noreturn_function(dependencies=['matplotlib.pyplot'])
     def dump_metric_MB(self, metric_per_qconfig_sequence: List[Tensor]):
         import matplotlib.pyplot as plt
         list_to_plot = [cm.item() for cm in metric_per_qconfig_sequence]
@@ -117,6 +119,7 @@ class HAWQDebugger:
             f'median_index={qconfig_index}, '
             f'total_number={len(metric_per_qconfig_sequence)}')
 
+    @bypass_noreturn_function(dependencies=['matplotlib.pyplot'])
     def dump_metric_flops(self, metric_per_qconfig_sequence: List[Tensor], flops_per_config: List[float],
                           choosen_qconfig_index: int):
         import matplotlib.pyplot as plt
@@ -140,6 +143,7 @@ class HAWQDebugger:
         ax.legend()
         plt.savefig(os.path.join(self._dump_dir, 'Pareto_Frontier_compress_ratio'))
 
+    @bypass_noreturn_function(dependencies=['matplotlib.pyplot'])
     def dump_density_of_quantization_noise(self):
         noise_per_config = []  # type: List[Tensor]
         for qconfig_sequence in self._weight_qconfig_sequences_in_trace_order:
@@ -161,6 +165,7 @@ class HAWQDebugger:
         ax.legend()
         plt.savefig(os.path.join(self._dump_dir, 'Density_of_quantization_noise'))
 
+    @bypass_noreturn_function(dependencies=['matplotlib.pyplot'])
     def dump_perturbations_ratio(self):
         import matplotlib.pyplot as plt
         fig = plt.figure()

--- a/nncf/torch/quantization/precision_init/hawq_debug.py
+++ b/nncf/torch/quantization/precision_init/hawq_debug.py
@@ -19,7 +19,7 @@ import torch
 from torch import Tensor
 
 from nncf.common.logging import nncf_logger
-from nncf.common.utils.decorators import bypass_noreturn_function
+from nncf.common.utils.decorators import skip_if_dependency_unavailable
 from nncf.common.utils.dot_file_rw import write_dot_graph
 from nncf.torch.nncf_network import ExtraCompressionModuleType, NNCFNetwork
 from nncf.torch.quantization.adjust_padding import add_adjust_padding_nodes
@@ -79,7 +79,7 @@ class HAWQDebugger:
         all_quantizations = OrderedDict(sorted(all_quantizations.items(), key=lambda x: str(x[0])))
         return all_quantizations
 
-    @bypass_noreturn_function(dependencies=['matplotlib.pyplot'])
+    @skip_if_dependency_unavailable(dependencies=['matplotlib.pyplot'])
     def dump_avg_traces(self):
         import matplotlib.pyplot as plt
         dump_file = os.path.join(self._dump_dir, 'avg_traces_per_layer')
@@ -93,7 +93,7 @@ class HAWQDebugger:
         ax.plot(self._traces_per_layer.cpu().numpy())
         plt.savefig(dump_file)
 
-    @bypass_noreturn_function(dependencies=['matplotlib.pyplot'])
+    @skip_if_dependency_unavailable(dependencies=['matplotlib.pyplot'])
     def dump_metric_MB(self, metric_per_qconfig_sequence: List[Tensor]):
         import matplotlib.pyplot as plt
         list_to_plot = [cm.item() for cm in metric_per_qconfig_sequence]
@@ -119,7 +119,7 @@ class HAWQDebugger:
             f'median_index={qconfig_index}, '
             f'total_number={len(metric_per_qconfig_sequence)}')
 
-    @bypass_noreturn_function(dependencies=['matplotlib.pyplot'])
+    @skip_if_dependency_unavailable(dependencies=['matplotlib.pyplot'])
     def dump_metric_flops(self, metric_per_qconfig_sequence: List[Tensor], flops_per_config: List[float],
                           choosen_qconfig_index: int):
         import matplotlib.pyplot as plt
@@ -143,7 +143,7 @@ class HAWQDebugger:
         ax.legend()
         plt.savefig(os.path.join(self._dump_dir, 'Pareto_Frontier_compress_ratio'))
 
-    @bypass_noreturn_function(dependencies=['matplotlib.pyplot'])
+    @skip_if_dependency_unavailable(dependencies=['matplotlib.pyplot'])
     def dump_density_of_quantization_noise(self):
         noise_per_config = []  # type: List[Tensor]
         for qconfig_sequence in self._weight_qconfig_sequences_in_trace_order:
@@ -165,7 +165,7 @@ class HAWQDebugger:
         ax.legend()
         plt.savefig(os.path.join(self._dump_dir, 'Density_of_quantization_noise'))
 
-    @bypass_noreturn_function(dependencies=['matplotlib.pyplot'])
+    @skip_if_dependency_unavailable(dependencies=['matplotlib.pyplot'])
     def dump_perturbations_ratio(self):
         import matplotlib.pyplot as plt
         fig = plt.figure()

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ INSTALL_REQUIRES = ["ninja>=1.10.0.post2, <1.11",
                     "addict>=2.4.0",
                     "texttable>=1.6.3",
                     "scipy>=1.3.2, <=1.10.0",
-                    "matplotlib>=3.3.4, <3.6",
                     "networkx>=2.6, <=2.8.2",  # see ticket 94048 or https://github.com/networkx/networkx/issues/5962
                     "numpy>=1.19.1, <1.24",
                     "pillow>=9.0.0",
@@ -126,6 +125,7 @@ INSTALL_REQUIRES = ["ninja>=1.10.0.post2, <1.11",
 
 
 EXTRAS_REQUIRE = {
+    "dev": ["matplotlib>=3.3.4, <3.6"],
     "tests": ["pytest"],
     "docs": [],
     "tf": [


### PR DESCRIPTION
### Changes

matplotlib dependency has been moved under dev extra.

### Reason for changes

OpenVINO notebooks have compatibility issues with matplotlib dependency.

### Related tickets

Custom request

### Tests

N/A
