### PR TITLE
Fix NNCFGraph building for OpenVINO backend

### DIFF
--- a/nncf/experimental/openvino_native/graph/nncf_graph_builder.py
+++ b/nncf/experimental/openvino_native/graph/nncf_graph_builder.py
@@ -66,42 +66,39 @@ class GraphConverter:
         """
         nncf_graph = NNCFGraph()
 
-        for param in model.get_parameters():
-            nncf_graph.add_nncf_node(node_name=param.get_friendly_name(),
-                                     node_type=NNCFGraphNodeType.INPUT_NODE,
-                                     node_metatype=InputNoopMetatype)
-
-        for result in model.get_results():
-            nncf_graph.add_nncf_node(node_name=result.get_friendly_name(),
-                                     node_type=NNCFGraphNodeType.OUTPUT_NODE,
-                                     node_metatype=OutputNoopMetatype)
-
-        for node in model.get_ops():
-            ov_dtype = node.get_element_type().get_type_name()
-            nncf_dtype = GraphConverter.convert_ov_dtype_to_nncf_dtype(ov_dtype)
-            node_type = node.get_type_name()
-            metatype = OV_OPERATION_METATYPES.get_operator_metatype_by_op_name(node_type)
-            if metatype not in [OVResultMetatype, OVParameterMetatype]:
-                nncf_graph.add_nncf_node(node_name=node.get_friendly_name(),
-                                        node_type=nncf_dtype,
-                                        node_metatype=metatype)
-
+        op_name_to_node_id_map = {}
         for op in model.get_ops():
-            in_node_id = nncf_graph.get_node_by_name(op.get_friendly_name()).node_id
-            for output_port_id, out in enumerate(op.outputs()):
-                for inp in out.get_target_inputs():
-                    out_node = inp.get_node()
-                    tensor_shape = list(out.shape)
-                    output_node_id = nncf_graph.get_node_by_name(out_node.get_friendly_name()).node_id
-                    ov_dtype = op.get_element_type().get_type_name()
-                    nncf_dtype = GraphConverter.convert_ov_dtype_to_nncf_dtype(ov_dtype)
+            op_name = op.get_friendly_name()
+            op_type_name = op.get_type_name()
+            metatype = OV_OPERATION_METATYPES.get_operator_metatype_by_op_name(op_type_name)
+
+            nncf_node = nncf_graph.add_nncf_node(
+                node_name=op_name,
+                node_type=op_type_name,
+                node_metatype=metatype
+            )
+
+            op_name_to_node_id_map[op_name] = nncf_node.node_id
+
+        for producer_op in model.get_ops():
+            for output in producer_op.outputs():
+                output_port_id = output.get_index()
+                tensor_shape = list(output.shape)
+                tensor_dtype = output.get_element_type().get_type_name()
+
+                # List of the (consumer_op, input_port_id) pairs
+                consumer_ops = [
+                    (input.get_node(), input.get_index()) for input in output.get_target_inputs()
+                ]
+
+                for consumer_op, input_port_id in consumer_ops:
                     nncf_graph.add_edge_between_nncf_nodes(
-                        from_node_id=in_node_id,
-                        to_node_id=output_node_id,
+                        from_node_id=op_name_to_node_id_map[producer_op.get_friendly_name()],
+                        to_node_id=op_name_to_node_id_map[consumer_op.get_friendly_name()],
                         tensor_shape=tensor_shape,
-                        input_port_id=inp.get_index(),
+                        input_port_id=input_port_id,
                         output_port_id=output_port_id,
-                        dtype=Dtype(nncf_dtype)
+                        dtype=GraphConverter.convert_ov_dtype_to_nncf_dtype(tensor_dtype)
                     )
 
         return nncf_graph


### PR DESCRIPTION
### Changes

- NNCFGraph building was fixed for OpenVINO backend
- Minor refactoring

### Reason for changes

```
Traceback (most recent call last):
  File "app.py", line 16, in <module>
    main()
  File "app.py", line 11, in main
    graph = GraphConverter.create_nncf_graph(quantized_model)
  File "nncf/nncf/experimental/openvino_native/graph/nncf_graph_builder.py", line 80, in create_nncf_graph
    ov_dtype = node.get_element_type().get_type_name()
RuntimeError: get_element_type() must be called on a node with exactly one output.
```

### Related tickets

N/A

### Tests

N/A
