### PR TITLE
Add aliases for backend extra installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,32 +123,48 @@ INSTALL_REQUIRES = ["ninja>=1.10.0.post2, <1.11",
                     "openvino-telemetry"]
 
 
+
+TF_EXTRAS = [
+        "tensorflow~=2.8.4",
+    ]
+
+TORCH_EXTRAS = [
+        "torch>=1.8.2,<1.14",
+    ]
+
+ONNX_EXTRAS = [
+        "onnx==1.12.0",
+        "onnxruntime==1.13.1"
+    ]
+
+OPENVINO_EXTRAS = [
+        "openvino-dev"
+    ]
+
+
 EXTRAS_REQUIRE = {
     "dev": ["matplotlib>=3.3.4, <3.6"],
     "tests": ["pytest"],
     "docs": [],
-    "tf": [
-        "tensorflow~=2.8.4",
-    ],
-    "torch": [
-        "torch>=1.8.2,<1.14",
-    ],
-    "onnx": [
-        "onnx==1.12.0",
-        "onnxruntime==1.13.1"
-    ],
-    "openvino": [
-        "openvino-dev"
+
+    "tf": TF_EXTRAS,
+    "tensorflow": TF_EXTRAS,
+    "tensorflow2": TF_EXTRAS,
+
+    "torch": TORCH_EXTRAS,
+    "pytorch": TORCH_EXTRAS,
+
+    "onnx": ONNX_EXTRAS,
+
+    "openvino": OPENVINO_EXTRAS,
+
+    "all": [
+        TF_EXTRAS,
+        TORCH_EXTRAS,
+        ONNX_EXTRAS,
+        OPENVINO_EXTRAS,
     ]
 }
-
-EXTRAS_REQUIRE["all"] = [
-    EXTRAS_REQUIRE["tf"],
-    EXTRAS_REQUIRE["torch"],
-    EXTRAS_REQUIRE["onnx"],
-    EXTRAS_REQUIRE["openvino"],
-]
-
 
 with open("{}/README.md".format(here), "r", encoding="utf8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
### Changes
Add synonyms for the `tf` and `torch` in context of extra dependency installation, i.e. now can run `pip install .[tensorflow]` to do the same thing as `pip install .[tf]`.

### Reason for changes
Consistency with `openvino-dev` extras syntax makes for better UX.

### Related tickets
N/A

### Tests
N/A
