### PR TITLE
Wrap telemetry object to ignore exceptions triggered in the telemetry backend

### DIFF
--- a/nncf/telemetry/__init__.py
+++ b/nncf/telemetry/__init__.py
@@ -11,7 +11,7 @@
  limitations under the License.
 """
 
-from nncf.telemetry.wrapper import NNCFTelemetry
+from nncf.telemetry.wrapper import telemetry
 from nncf.telemetry.decorator import tracked_function
 from nncf.telemetry.extractors import TelemetryExtractor
 

--- a/nncf/telemetry/decorator.py
+++ b/nncf/telemetry/decorator.py
@@ -17,7 +17,7 @@ from typing import List, Union
 
 from nncf.telemetry.events import get_current_category
 from nncf.telemetry.events import telemetry_category
-from nncf.telemetry.wrapper import NNCFTelemetry
+from nncf.telemetry.wrapper import telemetry
 from nncf.telemetry.extractors import TelemetryExtractor
 from nncf.telemetry.extractors import VerbatimTelemetryExtractor
 
@@ -60,9 +60,9 @@ class tracked_function:
             with telemetry_category(self._category) as category:
                 if category is not None:
                     if category != previous_category:
-                        NNCFTelemetry.start_session(self._category)
+                        telemetry.start_session(self._category)
                     for event in events:
-                        NNCFTelemetry.send_event(event_category=category,
+                        telemetry.send_event(event_category=category,
                                                  event_action=event.name,
                                                  event_label=event.data,
                                                  event_value=event.int_data)
@@ -70,7 +70,7 @@ class tracked_function:
                 retval = fn(*args, **kwargs)
 
                 if category is not None and category != previous_category:
-                    NNCFTelemetry.end_session(self._category)
+                    telemetry.end_session(self._category)
             return retval
 
         return wrapped

--- a/nncf/telemetry/wrapper.py
+++ b/nncf/telemetry/wrapper.py
@@ -12,6 +12,9 @@
 """
 import os
 import sys
+from abc import ABC
+from abc import abstractmethod
+from typing import Callable
 from unittest.mock import MagicMock
 
 from nncf import __version__
@@ -19,22 +22,98 @@ from nncf.common.logging import nncf_logger
 from nncf.definitions import NNCF_CI_ENV_VAR_NAME
 from nncf.definitions import NNCF_DEV_ENV_VAR_NAME
 
-MEASUREMENT_ID = 'UA-17808594-29'
 
 NNCFTelemetryStub = MagicMock
 
-# For recommendations on proper usage of categories, actions, labels and values, see:
-# https://support.google.com/analytics/answer/1033068
+class ITelemetry(ABC):
+    # For recommendations on proper usage of categories, actions, labels and values, see:
+    # https://support.google.com/analytics/answer/1033068
+
+    @abstractmethod
+    def start_session(self, category: str, **kwargs):
+        """
+        Sends a message about starting of a new session.
+
+        :param kwargs: additional parameters
+        :param category: the application code
+        :return: None
+        """
+        pass
+
+    @abstractmethod
+    def send_event(self, event_category: str, event_action: str, event_label: str, event_value: int = 1,
+                   force_send=False, **kwargs):
+        """
+        Send single event.
+
+        :param event_category: category of the event
+        :param event_action: action of the event
+        :param event_label: the label associated with the action
+        :param event_value: the integer value corresponding to this label
+        :param force_send: forces to send event ignoring the consent value
+        :param kwargs: additional parameters
+        :return: None
+        """
+        pass
+
+    @abstractmethod
+    def end_session(self, category: str, **kwargs):
+        """
+        Sends a message about ending of the current session.
+
+        :param kwargs: additional parameters
+        :param category: the application code
+        :return: None
+        """
+        pass
+
+
+def skip_if_raised(func: Callable[..., None]) -> Callable[..., None]:
+    """
+    For the calls on the decorated function the execution will continue from the statement after the function
+    even if an exception was triggered inside the function. The function to be wrapped must return nothing or None.
+    """
+    def wrapped(*args, **kwargs):
+        try:
+            func()
+        except Exception as e:
+            nncf_logger.debug(f"Skipped calling {func.__name__} - internally triggered exception {e}")
+    return wrapped
+
+
+class NNCFTelemetry(ITelemetry):
+    MEASUREMENT_ID = 'UA-17808594-29'
+
+    def __init__(self):
+        try:
+            self._impl = Telemetry(app_name='nncf', app_version=__version__, tid=self.MEASUREMENT_ID)
+        except Exception as e:
+            nncf_logger.debug(f"Failed to instantiate telemetry object: exception {e}")
+
+    @skip_if_raised
+    def start_session(self, category: str, **kwargs):
+        self._impl.start_session(category, **kwargs)
+
+    @skip_if_raised
+    def send_event(self, event_category: str, event_action: str, event_label: str, event_value: int = 1,
+                   force_send=False, **kwargs):
+        self._impl.send_event(event_category, event_action, event_label, event_value, force_send, **kwargs)
+
+    @skip_if_raised
+    def end_session(self, category: str, **kwargs):
+        self._impl.end_session(category, **kwargs)
+
+
 try:
     from openvino_telemetry import Telemetry
-    NNCFTelemetry = Telemetry(app_name='nncf', app_version=__version__, tid=MEASUREMENT_ID)
+    telemetry = NNCFTelemetry()
 except ImportError:
     nncf_logger.debug("openvino_telemetry package not found. No telemetry will be sent.")
-    NNCFTelemetry = None
+    telemetry = NNCFTelemetryStub()
 
 # Currently the easiest way to disable telemetry in tests. Will break telemetry if pytest is used in NNCF package code.
 _IS_IN_PYTEST_CONTEXT = "pytest" in sys.modules
 
 if os.getenv(NNCF_CI_ENV_VAR_NAME) or os.getenv(NNCF_DEV_ENV_VAR_NAME) \
-        or _IS_IN_PYTEST_CONTEXT or NNCFTelemetry is None:
-    NNCFTelemetry = NNCFTelemetryStub()
+        or _IS_IN_PYTEST_CONTEXT:
+    telemetry = NNCFTelemetryStub()

--- a/tests/common/test_telemetry.py
+++ b/tests/common/test_telemetry.py
@@ -43,8 +43,8 @@ def test_telemetry_is_not_mocked_in_normal_conditions(hide_pytest):
 
         # telemetry alias will no longer be available after reload,
         # so importing via a full name
-        from nncf.telemetry.wrapper import NNCFTelemetry
-        assert not isinstance(NNCFTelemetry, NNCFTelemetryStub)
+        from nncf.telemetry.wrapper import telemetry
+        assert not isinstance(telemetry, NNCFTelemetryStub)
     # cleanup
     importlib.reload(wrapper)
 
@@ -60,18 +60,18 @@ def test_telemetry_is_mocked_if_env_vars_defined(env_var_to_define, hide_pytest)
 
         # telemetry alias will no longer be available after reload,
         # so importing via a full name
-        from nncf.telemetry.wrapper import NNCFTelemetry
-        assert isinstance(NNCFTelemetry, NNCFTelemetryStub)
+        from nncf.telemetry.wrapper import telemetry
+        assert isinstance(telemetry, NNCFTelemetryStub)
     # cleanup
     importlib.reload(wrapper)
 
 
 @pytest.fixture(name="spies")
 def spies_(request, mocker) -> Tuple[MagicMock, MagicMock, MagicMock]:
-    from nncf.telemetry import NNCFTelemetry
-    send_event_spy = mocker.spy(NNCFTelemetry, "send_event")
-    start_session_event_spy = mocker.spy(NNCFTelemetry, "start_session")
-    end_session_event_spy = mocker.spy(NNCFTelemetry, "end_session")
+    from nncf.telemetry import telemetry
+    send_event_spy = mocker.spy(telemetry, "send_event")
+    start_session_event_spy = mocker.spy(telemetry, "start_session")
+    end_session_event_spy = mocker.spy(telemetry, "end_session")
     return (send_event_spy, start_session_event_spy, end_session_event_spy)
 
 

--- a/tests/shared/helpers.py
+++ b/tests/shared/helpers.py
@@ -141,7 +141,7 @@ class BaseTensorListComparator(ABC):
 
 
 def telemetry_send_event_test_driver(mocker, use_nncf_fn: Callable):
-    from nncf.telemetry import NNCFTelemetry
-    telemetry_send_event_spy = mocker.spy(NNCFTelemetry, "send_event")
+    from nncf.telemetry import telemetry
+    telemetry_send_event_spy = mocker.spy(telemetry, "send_event")
     use_nncf_fn()
     telemetry_send_event_spy.assert_called()


### PR DESCRIPTION
### Changes
As stated in the title

### Reason for changes
Better UX - the telemetry calls are not essential and failures therein must be ignored.

### Related tickets
100503

### Tests
test_telemetry
