### PR TITLE
Fix the rest of the log string creation

### DIFF
--- a/nncf/common/accuracy_aware_training/runner.py
+++ b/nncf/common/accuracy_aware_training/runner.py
@@ -273,7 +273,7 @@ class BaseAccuracyAwareTrainingRunner(TrainingRunner):
         else:
             checkpoint_path = self._make_checkpoint_path(is_best=False)
             self._save_checkpoint(model, compression_controller, checkpoint_path)
-        nncf_logger.info("Saved the checkpoint to {}".format(checkpoint_path))
+        nncf_logger.info(f"Saved the checkpoint to {checkpoint_path}")
 
         if is_best_checkpoint:
             self._save_best_checkpoint(model, compression_controller)
@@ -306,11 +306,11 @@ class BaseAccuracyAwareTrainingRunner(TrainingRunner):
         best_path = self._make_checkpoint_path(is_best=True)
         self._best_checkpoint = (best_path, compression_controller.compression_rate)
         self._save_checkpoint(model, compression_controller, best_path)
-        nncf_logger.info('Saved the best model to {}'.format(best_path))
+        nncf_logger.info(f'Saved the best model to {best_path}')
 
     def load_best_checkpoint(self, model):
         resuming_checkpoint_path, compression_rate = self._best_checkpoint
-        nncf_logger.info('Loading the best checkpoint found during training: {}'.format(resuming_checkpoint_path))
+        nncf_logger.info(f'Loading the best checkpoint found during training: {resuming_checkpoint_path}')
         self._load_checkpoint(model, resuming_checkpoint_path)
         return compression_rate
 
@@ -412,7 +412,7 @@ class BaseAdaptiveCompressionLevelTrainingRunner(BaseAccuracyAwareTrainingRunner
 
         self._best_checkpoints[self.compression_rate_target] = (best_path, accuracy_budget)
         self._save_checkpoint(model, compression_controller, best_path)
-        nncf_logger.info('Saved the best model to {}'.format(best_path))
+        nncf_logger.info(f'Saved the best model to {best_path}')
 
     def load_best_checkpoint(self, model):
         # load checkpoint with the highest compression rate and positive acc budget
@@ -434,7 +434,7 @@ class BaseAdaptiveCompressionLevelTrainingRunner(BaseAccuracyAwareTrainingRunner
             return self.compression_rate_target
 
         resuming_checkpoint_path = self._best_checkpoints[best_checkpoint_compression_rate][0]
-        nncf_logger.info('Loading the best checkpoint found during training: {}'.format(resuming_checkpoint_path))
+        nncf_logger.info(f'Loading the best checkpoint found during training: {resuming_checkpoint_path}')
         self._load_checkpoint(model, resuming_checkpoint_path)
         return best_checkpoint_compression_rate
 

--- a/nncf/common/accuracy_aware_training/training_loop.py
+++ b/nncf/common/accuracy_aware_training/training_loop.py
@@ -109,11 +109,11 @@ class BaseEarlyExitCompressionTrainingLoop(TrainingLoop, ABC):
             self._current_compression_rate = self.compression_controller.compression_rate
             self.runner.dump_statistics(model, self.compression_controller)
             if self._accuracy_criterion_satisfied():
-                nncf_logger.info('Reached the accuracy criteria after epoch {}.'.format(epoch))
+                nncf_logger.info(f'Reached the accuracy criteria after epoch {epoch}.')
                 self.log_accuracy_statistics()
                 break
 
-            nncf_logger.info('Epoch {} results:'.format(epoch))
+            nncf_logger.info(f'Epoch {epoch} results:')
             self.log_accuracy_statistics()
 
             if self.runner.stop_training(self.compression_controller):

--- a/nncf/common/quantization/quantizer_propagation/solver.py
+++ b/nncf/common/quantization/quantizer_propagation/solver.py
@@ -781,7 +781,7 @@ class QuantizerPropagationSolver:
 
                 quant_det_id = node[QuantizerPropagationStateGraph.OPERATOR_METATYPE_NODE_ATTR]
                 if quant_det_id is None:
-                    nncf_logger.debug("Unknown metatype for operator node: {}".format(node_key))
+                    nncf_logger.debug(f"Unknown metatype for operator node: {node_key}")
                     trait = QuantizationTrait.QUANTIZATION_AGNOSTIC
                 elif quant_det_id is UnknownMetatype:
                     trait = QuantizationTrait.NON_QUANTIZABLE

--- a/nncf/experimental/torch/sparsity/movement/algo.py
+++ b/nncf/experimental/torch/sparsity/movement/algo.py
@@ -87,10 +87,10 @@ class MovementSparsityBuilder(BaseSparsityAlgoBuilder):
             node_name = module_node.node_name
 
             if not self._should_consider_scope(node_name):
-                nncf_logger.info('Ignored adding Weight Sparsifier in scope: %s', node_name)
+                nncf_logger.info(f'Ignored adding weight sparsifier in scope: {node_name}')
                 continue
 
-            nncf_logger.debug('Adding Weight Sparsifier in scope: %s', node_name)
+            nncf_logger.debug('Adding weight sparsifier in scope: {node_name}')
             compression_lr_multiplier = self.config.get_redefinable_global_param_value_for_algo(
                 'compression_lr_multiplier', self.name
             )

--- a/nncf/experimental/torch/sparsity/movement/scheduler.py
+++ b/nncf/experimental/torch/sparsity/movement/scheduler.py
@@ -311,6 +311,6 @@ class MovementPolynomialThresholdScheduler(BaseCompressionScheduler):
 
         if self._steps_per_epoch is None:
             self._should_skip = True
-            nncf_logger.info('Movement Sparsity scheduler updates importance threshold and regularization'
+            nncf_logger.info('Movement sparsity scheduler updates importance threshold and regularization'
                              'factor per optimizer step, but steps_per_epoch was not set in config. Will '
                              'measure the actual steps per epoch as signaled by a .epoch_step() call.')

--- a/nncf/experimental/torch/sparsity/movement/structured_mask_handler.py
+++ b/nncf/experimental/torch/sparsity/movement/structured_mask_handler.py
@@ -124,7 +124,7 @@ class StructuredMaskContext:
             self._independent_structured_mask = tensor.clone()
         else:
             if self._independent_structured_mask.device != tensor.device:
-                nncf_logger.debug('Changing independent_structured_mask device to %s', tensor.device)
+                nncf_logger.debug(f'Changing independent_structured_mask device to {tensor.device}')
                 self._independent_structured_mask = self._independent_structured_mask.to(tensor.device)
             self._independent_structured_mask.copy_(tensor)
 
@@ -143,7 +143,7 @@ class StructuredMaskContext:
             self._dependent_structured_mask = tensor.clone()
         else:
             if self._dependent_structured_mask.device != tensor.device:
-                nncf_logger.debug('Changing dependent_structured_mask device to %s', tensor.device)
+                nncf_logger.debug(f'Changing dependent_structured_mask device to {tensor.device}', )
                 self._dependent_structured_mask = self._dependent_structured_mask.to(tensor.device)
             self._dependent_structured_mask.copy_(tensor)
 
@@ -292,7 +292,7 @@ class StructuredMaskHandler:
 
         nncf_logger.debug('Totally %d structured mask context groups.', len(self._structured_mask_ctx_groups))
         for structured_mask_ctx_group in self._structured_mask_ctx_groups:
-            nncf_logger.debug('%s', structured_mask_ctx_group)
+            nncf_logger.debug(f'{structured_mask_ctx_group}')
 
     def update_independent_structured_mask(self):
         """

--- a/nncf/quantization/algorithms/bias_correction/algorithm.py
+++ b/nncf/quantization/algorithms/bias_correction/algorithm.py
@@ -394,7 +394,7 @@ class BiasCorrection(Algorithm):
         node_inputs_name = subgraphs_data[node_name]['input_node_names']
         for node_input_name in node_inputs_name:
             if node_input_name not in needed_stats_list and node_input_name in self._fp_inputs:
-                nncf_logger.debug('Dropped %s', node_input_name)
+                nncf_logger.debug(f'Dropped {node_input_name}')
                 self._fp_inputs[node_input_name] = []
 
     def _get_current_stats_list(self, current_node_name: str, subgraphs_data: Dict[str, Dict]) -> List[str]:

--- a/nncf/torch/debug.py
+++ b/nncf/torch/debug.py
@@ -27,7 +27,7 @@ class CallCountTracker:
 
     def register_call(self, key, counts=None):
         if key not in self.call_counts:
-            nncf_logger.debug("DEBUG: {} tracker: called an unregistered module: {}".format(self.name, key))
+            nncf_logger.debug(f"DEBUG: {self.name} tracker: called an unregistered module: {key}")
             return
         if counts is None:
             self.call_counts[key] += 1

--- a/nncf/torch/dynamic_graph/io_handling.py
+++ b/nncf/torch/dynamic_graph/io_handling.py
@@ -109,7 +109,7 @@ class InputInfoWrapManager:
                 # Default was None - cannot wrap as-is. Will wrap a dummy tensor as specified in
                 # input infos - will preserve the call order of nncf_model_input nodes,
                 # and the post-hooks for the input node will execute. The result won't go anywhere, though.
-                nncf_logger.info("Wrapping a dummy tensor for input {}".format(param_name))
+                nncf_logger.info(f"Wrapping a dummy tensor for input {param_name}")
                 info_for_missing_input = self._fwd_params_to_input_infos_odict[param_name]
                 device = 'cuda'
                 if self._module_ref_for_device is not None:

--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -157,7 +157,7 @@ def patch_namespace_opname(namespace, op_info: PatchedOperatorInfo):
         ORIGINAL_OPERATORS.append(OriginalOpInfo(op_name, namespace, orig))
         setattr(namespace, op_name, wrap_operator(orig, op_info))
     else:
-        nncf_logger.debug("Not patching {} since it is missing in this version of PyTorch".format(op_name))
+        nncf_logger.debug(f"Not patching {op_name} since it is missing in this version of PyTorch")
 
 
 def get_all_functions_from_namespace(namespace: NamespaceTarget, do_filter: bool = True) -> List[str]:

--- a/nncf/torch/dynamic_graph/wrappers.py
+++ b/nncf/torch/dynamic_graph/wrappers.py
@@ -79,7 +79,7 @@ def wrap_operator(operator, operator_info: 'PatchedOperatorInfo'):
     # do not wrap function twice
     _orig_op = getattr(operator, '_original_op', None)
     if _orig_op is not None:
-        nncf_logger.debug("Operator: {} is already wrapped".format(_orig_op.__name__))
+        nncf_logger.debug(f"Operator: {_orig_op.__name__} is already wrapped")
         return operator
 
     def wrapped(*args, **kwargs):

--- a/nncf/torch/extensions/__init__.py
+++ b/nncf/torch/extensions/__init__.py
@@ -20,7 +20,7 @@ class ExtensionsType(enum.Enum):
 def get_build_directory_for_extension(name: str) -> Path:
     build_dir = Path(_get_build_directory('nncf/' + name, verbose=False)) / torch.__version__
     if not build_dir.exists():
-        nncf_logger.debug("Creating build directory: {}".format(str(build_dir)))
+        nncf_logger.debug(f"Creating build directory: {str(build_dir)}")
         build_dir.mkdir(parents=True, exist_ok=True)
     return build_dir
 

--- a/nncf/torch/pruning/base_algo.py
+++ b/nncf/torch/pruning/base_algo.py
@@ -114,7 +114,7 @@ class BasePruningAlgoBuilder(PTCompressionAlgorithmBuilder):
                 # Check that we need to prune weights in this op
                 assert self._is_pruned_module(module)
 
-                nncf_logger.info(f"Will prune the weights for the operation: {node_name}")
+                nncf_logger.debug(f"Will prune the weights for the operation: {node_name}")
                 pruning_block = self.create_weight_pruning_operation(module, node_name)
                 # Hook for weights and bias
                 hook = UpdateWeightAndBias(pruning_block).to(device)

--- a/nncf/torch/pruning/filter_pruning/algo.py
+++ b/nncf/torch/pruning/filter_pruning/algo.py
@@ -584,7 +584,7 @@ class FilterPruningController(BasePruningAlgoController):
         self._propagate_masks()
 
         pruned_layers_stats = self.get_stats_for_pruned_modules()
-        nncf_logger.info('Pruned layers statistics: \n%s', pruned_layers_stats.draw())
+        nncf_logger.info(f'Pruned layers statistics: \n{pruned_layers_stats.draw()}')
 
     def compression_stage(self) -> CompressionStage:
         target_pruning_level = self.scheduler.target_level

--- a/nncf/torch/quantization/precision_init/autoq_init.py
+++ b/nncf/torch/quantization/precision_init/autoq_init.py
@@ -193,8 +193,8 @@ class AutoQPrecisionInitializer(BasePrecisionInitializer):
 
         str_bw = [str(element) for element in self.get_bitwidth_per_scope(final_quantizer_setup)]
         nncf_logger.info('\n'.join(['[AutoQ]\n\"bitwidth_per_scope\": [', ',\n'.join(str_bw), ']']))
-        nncf_logger.info('[AutoQ] best_reward: {}'.format(best_reward))
-        nncf_logger.info('[AutoQ] best_policy: {}'.format(best_policy))
+        nncf_logger.info(f'[AutoQ] best_reward: {best_reward}')
+        nncf_logger.info(f'[AutoQ] best_policy: {best_policy}')
         nncf_logger.info("[AutoQ] Search completed.")
         nncf_logger.info("[AutoQ] Elapsed time of AutoQ Precision Initialization (): {}".format(end_ts - start_ts))
         return final_quantizer_setup

--- a/tests/onnx/opset_converter.py
+++ b/tests/onnx/opset_converter.py
@@ -33,11 +33,9 @@ def convert_opset_version(model: onnx.ModelProto, opset_version: int = TARGET_OP
         modified_model = convert_version(model, opset_version)
         onnx.checker.check_model(modified_model)
         nncf_logger.info(
-            'The model was successfully converted  to the Opset Version = {}'.format(
-                modified_model.opset_import[0].version))
+            f'The model was successfully converted to the opset version = {modified_model.opset_import[0].version}')
         return modified_model
     except (RuntimeError, ConvertError):
         nncf_logger.error(
-            f"Couldn't convert target model to the Opset Version {opset_version}. "
-            f"Using the copy of the original model")
+            f"Couldn't convert target model to the opset version {opset_version}. Using the copy of the original model")
         return model


### PR DESCRIPTION
### Changes

Forgot to set a proper log level at nncf/torch/pruning/base_algo.py:117 so that a message was printed for every weight pruned in INFO level, while it should have been printed to DEBUG. Also made the rest of the non-f-string-constructed parametrized log strings actually use f-strings.

### Reason for changes
Follow-up for the things that slipped away in the previous log-related PR.

### Related tickets
N/A

### Tests
N/A