### PR TITLE
Fix for compression_rate property of PTCompositeCompressionAlgorithmController

### DIFF
--- a/nncf/torch/composite_compression.py
+++ b/nncf/torch/composite_compression.py
@@ -124,6 +124,11 @@ class PTCompositeCompressionAlgorithmController(
 
     @property
     def compression_rate(self) -> float:
-        sum_compression_rate = sum(child_ctrl.compression_rate for child_ctrl in self.child_ctrls)
-        mean_compression_rate = sum_compression_rate / max(len(self.child_ctrls), 1)
-        return mean_compression_rate
+        sum_compression_rate = 0
+        non_none_compression_rate_cnt = 0
+        for child_ctrl in self.child_ctrls:
+            compression_rate = child_ctrl.compression_rate
+            if compression_rate is not None:
+                sum_compression_rate += sum_compression_rate
+                non_none_compression_rate_cnt += 1
+        return sum_compression_rate / max(non_none_compression_rate_cnt, 1)

--- a/nncf/torch/composite_compression.py
+++ b/nncf/torch/composite_compression.py
@@ -125,10 +125,10 @@ class PTCompositeCompressionAlgorithmController(
     @property
     def compression_rate(self) -> float:
         sum_compression_rate = 0
-        non_none_compression_rate_cnt = 0
+        not_none_compression_rate_cnt = 0
         for child_ctrl in self.child_ctrls:
             compression_rate = child_ctrl.compression_rate
             if compression_rate is not None:
                 sum_compression_rate += sum_compression_rate
-                non_none_compression_rate_cnt += 1
-        return sum_compression_rate / max(non_none_compression_rate_cnt, 1)
+                not_none_compression_rate_cnt += 1
+        return sum_compression_rate / max(not_none_compression_rate_cnt, 1)

--- a/tests/torch/composite/test_sparsity_quantization.py
+++ b/tests/torch/composite/test_sparsity_quantization.py
@@ -52,3 +52,11 @@ def test_can_quantize_inputs_for_sparsity_plus_quantization():
 
     assert len(input_quantizer) == 1
     assert isinstance(list(input_quantizer.values())[0], SymmetricQuantizer)
+
+
+def test_compression_rate_for_sparsity_plus_quantization():
+    model = BasicConvTestModel()
+    config = get_basic_sparsity_plus_quantization_config()
+    register_bn_adaptation_init_args(config)
+    sparse_quantized_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
+    assert compression_ctrl.compression_rate == 0.0

--- a/tests/torch/composite/test_sparsity_quantization.py
+++ b/tests/torch/composite/test_sparsity_quantization.py
@@ -58,5 +58,5 @@ def test_compression_rate_for_sparsity_plus_quantization():
     model = BasicConvTestModel()
     config = get_basic_sparsity_plus_quantization_config()
     register_bn_adaptation_init_args(config)
-    sparse_quantized_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
+    _, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
     assert compression_ctrl.compression_rate == 0.0


### PR DESCRIPTION


### Changes
- Fixed implementation of `compression_rate` property for `PTCompositeCompressionAlgorithmController`: it did not work correctly when some of the child controllers didn't implement the property
- Added a corresponding test

### Reason for changes

PR #1437 introduced a wrong implementation of the property

### Related tickets

101212

### Tests

Added a simple test based on quantization + sparsity composite controller 
