### PR TITLE
Fix calibrate tool

### DIFF
--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -220,7 +220,7 @@ def quantize_model(xml_path, bin_path, accuracy_checcker_config,
         _, batch_annotation, batch_input, _ = data_item
         filled_inputs, _, _ = model_evaluator._get_batch_input(
             batch_input, batch_annotation)
-        return filled_inputs
+        return filled_inputs[0]
 
     calibration_dataset = nncf.Dataset(model_evaluator.dataset, transform_fn)
     if quantization_impl == 'pot':


### PR DESCRIPTION
### Changes

The `transform_fn()` was fixed.

### Reason for changes

I got the following error:

```
  File "openvino/tools/pot/engines/ie_engine.py", line 242, in process_input
      is_loader_batchfied = input_dim(input_blob) == input_data[0].ndim
      AttributeError: 'list' object has no attribute 'ndim'
```


### Related tickets

N/A

### Tests

N/A
