### PR TITLE
Time for the dataset's length estimation was improved

### DIFF
--- a/nncf/openvino/engine.py
+++ b/nncf/openvino/engine.py
@@ -72,11 +72,18 @@ class DatasetWrapper:
 
     def __len__(self) -> int:
         if self._length is None:
-            self._length = DatasetWrapper._get_length(self._iterable)
+            indices = getattr(self._iterable, '_indices', None)
+            data_source = getattr(self._iterable, '_data_source', None)
+            if indices:
+                self._length = len(indices)
+            iterable = data_source if data_source else self._iterable
+            self._length = DatasetWrapper._get_length(iterable)
         return self._length
 
     @staticmethod
     def _get_length(iterable) -> int:
+        if hasattr(iterable, '__len__'):
+            return len(iterable)
         length = 0
         for _ in iterable:
             length = length + 1

--- a/nncf/openvino/engine.py
+++ b/nncf/openvino/engine.py
@@ -23,6 +23,7 @@ import openvino.runtime as ov
 
 from nncf.api.compression import TModel
 from nncf.data import Dataset
+from nncf.data.dataset import DataProvider
 
 
 # TODO(andrey-churkin): This class should be removed after refactoring of the OVEngine class.
@@ -70,20 +71,28 @@ class DatasetWrapper:
         for idx, x in enumerate(self._iterable):
             yield (idx, x)
 
+    # pylint: disable=protected-access
     def __len__(self) -> int:
         if self._length is None:
-            indices = getattr(self._iterable, '_indices', None)
-            data_source = getattr(self._iterable, '_data_source', None)
-            if indices:
-                self._length = len(indices)
+            data_source = None
+            if isinstance(self._iterable, DataProvider):
+                indices = self._iterable._indices
+                if indices:
+                    self._length = len(indices)
+                    return self._length
+                data_source = self._iterable._data_source
             iterable = data_source if data_source else self._iterable
             self._length = DatasetWrapper._get_length(iterable)
         return self._length
 
     @staticmethod
     def _get_length(iterable) -> int:
-        if hasattr(iterable, '__len__'):
-            return len(iterable)
+        try:
+            length = len(iterable)
+            return length
+        except (TypeError, AttributeError):
+            length = None
+
         length = 0
         for _ in iterable:
             length = length + 1

--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -212,9 +212,6 @@ def quantize_model(xml_path, bin_path, accuracy_checcker_config,
     model_evaluator = create_model_evaluator(accuracy_checcker_config)
     model_evaluator.load_network([{'model': ov_model}])
     model_evaluator.select_dataset('')
-    # workaround to minimize time of estimation len of dataset
-    subset_size = quantization_parameters.get('subset_size', 300)
-    model_evaluator.dataset.make_subset(end=subset_size)
 
     def transform_fn(data_item):
         _, batch_annotation, batch_input, _ = data_item


### PR DESCRIPTION
### Changes

`DatasetWrapper` was improved. It is a temporary class. It will be removed when we will switch on native implementation. 

### Reason for changes

The `nncf.quantize()` method is slower than POT.

**Before Fix:**
Elapsed Time: 00:04:01

**After Fix:**
Elapsed Time: 00:00:31

### Related tickets

Ref: 100984

### Tests

N/A
