### PR TITLE
Use new version of requesting deterministic algorithms in PyTorch

### DIFF
--- a/examples/torch/common/execution.py
+++ b/examples/torch/common/execution.py
@@ -121,4 +121,4 @@ def set_seed(config):
         manual_seed(config.seed)
         cudnn.deterministic = True
         cudnn.benchmark = False
-        torch.set_deterministic(True)
+        torch.use_deterministic_algorithms(True)


### PR DESCRIPTION
### Changes
A single-line change to reflect the new API in PyTorch.

### Reason for changes
The old way has been deprecated since 1.8. The newly re-enabled compression training tests caught this.

### Related tickets
N/A

### Tests
tests/torch/test_compression_training.py
