### PR TITLE
Fix ignored scope setting in compression training test

### DIFF
--- a/nncf/torch/model_creation.py
+++ b/nncf/torch/model_creation.py
@@ -100,6 +100,9 @@ def create_compressed_model(model: Module,
 
     nncf_network = create_nncf_network(model, config, dummy_forward_fn, wrap_inputs_fn, wrap_outputs_fn)
 
+    if dump_graphs and is_main_process():
+        nncf_network.get_graph().visualize_graph(osp.join(config.get("log_dir", "."), "original_graph.dot"))
+
     builder = create_compression_algorithm_builder(config, should_init)
 
     is_state_loadable = not is_legacy_model_state_dict and compression_state is not None

--- a/tests/torch/data/configs/weekly/classification/cifar100/mobilenet_v2_rb_sparsity_int8.json
+++ b/tests/torch/data/configs/weekly/classification/cifar100/mobilenet_v2_rb_sparsity_int8.json
@@ -36,7 +36,7 @@
                 "sparsity_freeze_epoch": 45
             },
             "ignored_scopes": [
-                "MobileNetV2/Sequential[features]/Sequential[0]/Conv2d[0]"
+                "MobileNetV2For32x32/Sequential[features]/Conv2dNormActivation[0]/NNCFConv2d[0]/conv2d_0"
             ]
         },
         {


### PR DESCRIPTION
### Changes
Ignored scope was assigned incorrectly in the config used in a case in test_compression_training. Also restored dumps of `original_graph.dot` at model creation in PT.

### Reason for changes
Tests failing.

### Related tickets
N/A

### Tests

PT test_compression_train[mobilenet_v2_rb_sparsity_int8_cifar100_multiprocessing-distributed]
