### PR TITLE
Fixed weekly NAS tests

### DIFF
--- a/tests/torch/data/configs/weekly/classification/cifar10/mobilenet_v2_nas_SMALL.json
+++ b/tests/torch/data/configs/weekly/classification/cifar10/mobilenet_v2_nas_SMALL.json
@@ -37,6 +37,9 @@
                 },
                 "kernel": {
                     "max_num_kernels": 3
+                },
+                "depth": {
+                    "max_block_size": 8
                 }
             }
         },

--- a/tests/torch/test_compression_training.py
+++ b/tests/torch/test_compression_training.py
@@ -337,7 +337,7 @@ NAS_DESCRIPTORS = [
     NASTrainingTestDescriptor()
         .real_dataset('cifar10')
         .config_name('vgg11_bn_nas_SMALL.json')
-        .subnet_expected_accuracy(88.67)
+        .subnet_expected_accuracy(85.09)
         .expected_accuracy(89.43)
         .weights_filename('vgg11_bn_cifar10_92.39.pth')
         .absolute_tolerance_train(2.0)


### PR DESCRIPTION
### Changes

1) Restricted the maximum number of nodes in block for mobilenet-v2 in order to match previous setup in weekly test.
2) Decreased expected accuracy for vgg, since after #1281 B-NAS skip 1 block. Previously, it skipped nothing and consequently accuracy was higher.

### Reason for changes

2 failures in the test_compression_training.py (build 3)

### Related tickets

n/a

### Tests

local run of test_compression_training.py
