### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/examples/tensorflow/requirements.txt
+++ b/examples/tensorflow/requirements.txt
@@ -1,3 +1,4 @@
+addict
 absl-py==0.10
 tensorflow_datasets==4.2.0
 tensorflow_hub

--- a/nncf/common/hardware/config.py
+++ b/nncf/common/hardware/config.py
@@ -22,7 +22,6 @@ from typing import Optional
 from typing import Set
 from typing import Type
 
-import addict as ad
 import jstyleson as json
 
 from nncf.common.graph.operator_metatypes import OperatorMetatype
@@ -134,7 +133,7 @@ class HWConfig(list, ABC):
 
                 op_dict[algorithm_name] = tmp_config
 
-            hw_config.append(ad.Dict(op_dict))
+            hw_config.append(op_dict)
 
         return hw_config
 
@@ -205,7 +204,7 @@ class HWConfig(list, ABC):
         retval = {k: None for k in self._get_available_operator_metatypes_for_matching()}
         config_key = 'weights' if for_weights else 'activations'
         for op_dict in self:
-            hw_config_op_name = op_dict.type
+            hw_config_op_name = op_dict["type"]
 
             metatypes = self._get_metatypes_for_hw_config_op(hw_config_op_name)
             if not metatypes:
@@ -214,7 +213,7 @@ class HWConfig(list, ABC):
                     'metatype - will be ignored'.format(hw_config_op_name))
 
             if self.QUANTIZATION_ALGORITHM_NAME in op_dict:
-                allowed_qconfs = op_dict[self.QUANTIZATION_ALGORITHM_NAME][config_key]
+                allowed_qconfs = op_dict[self.QUANTIZATION_ALGORITHM_NAME].get(config_key, [])
             else:
                 allowed_qconfs = []
 
@@ -237,10 +236,10 @@ class HWConfig(list, ABC):
             if self.ATTRIBUTES_NAME not in op_dict:
                 continue
             for attr_name, attr_value in attribute_name_vs_required_value.items():
-                is_value_matched = op_dict[self.ATTRIBUTES_NAME][attr_name] == attr_value
+                is_value_matched = op_dict[self.ATTRIBUTES_NAME].get(attr_name) == attr_value
                 is_attr_set = attr_name in op_dict[self.ATTRIBUTES_NAME]
                 if is_value_matched and is_attr_set:
-                    hw_config_op_name = op_dict.type
+                    hw_config_op_name = op_dict["type"]
                     metatypes = self._get_metatypes_for_hw_config_op(hw_config_op_name)
                     if not metatypes:
                         nncf_logger.debug(

--- a/nncf/openvino/quantization/accuracy_aware.py
+++ b/nncf/openvino/quantization/accuracy_aware.py
@@ -10,12 +10,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-
 from typing import List
 from functools import partial
 
 import numpy as np
-from addict import Dict
 
 from openvino.tools import pot
 
@@ -35,21 +33,28 @@ class NMSEBasedAccuracyAware(pot.AccuracyAwareCommon):
     def __init__(self, config, engine):
         super().__init__(config, engine)
         if not engine.use_original_metric:
-            self._metrics_config['original_metric'].persample = Dict(
-                name='nmse',
-                type='nmse',
-                is_special=True,
-                comparator=lambda a: -a,
-                sort_fn=partial(pot.algorithms.quantization.accuracy_aware_common.utils.sort_by_logit_distance,
-                                distance='nmse')
+            self._metrics_config['original_metric'].persample.clear()
+            self._metrics_config['original_metric'].persample.update(
+                {
+                    "name": 'nmse',
+                    "type": 'nmse',
+                    "is_special": True,
+                    "comparator": lambda a: -a,
+                    "sort_fn": partial(
+                        pot.algorithms.quantization.accuracy_aware_common.utils.sort_by_logit_distance,
+                        distance='nmse')
+                }
             )
-            self._metrics_config['original_metric'].ranking = Dict(
-                name='nmse',
-                type='nmse',
-                is_special=True,
-                comparator=lambda a: -a,
-                sort_fn=partial(pot.algorithms.quantization.accuracy_aware_common.utils.sort_by_logit_distance,
-                                distance='nmse')
+            self._metrics_config['original_metric'].ranking.clear()
+            self._metrics_config['original_metric'].ranking.update(
+                {
+                    "name": "nmse",
+                    "type": "nmse",
+                    "is_special": True,
+                    "comparator": lambda a: -a,
+                    "sort_fn": partial(pot.algorithms.quantization.accuracy_aware_common.utils.sort_by_logit_distance,
+                                       distance='nmse')
+                }
             )
 
     def _get_score(self, model, ranking_subset: List[int], metric_name: str) -> float:

--- a/setup.py
+++ b/setup.py
@@ -98,12 +98,10 @@ def find_version(*file_paths):
 
 
 INSTALL_REQUIRES = ["ninja>=1.10.0.post2, <1.11",
-                    "addict>=2.4.0",
                     "texttable>=1.6.3",
                     "scipy>=1.3.2, <=1.10.0",
                     "networkx>=2.6, <=2.8.2",  # see ticket 94048 or https://github.com/networkx/networkx/issues/5962
                     "numpy>=1.19.1, <1.24",
-                    "pillow>=9.0.0",
 
                     # The recent pyparsing major version update seems to break
                     # integration with networkx - the graphs parsed from current .dot
@@ -119,9 +117,7 @@ INSTALL_REQUIRES = ["ninja>=1.10.0.post2, <1.11",
                     "natsort>=7.1.0",
                     "pandas>=1.1.5,<=1.5.2",
                     "scikit-learn>=0.24.0",
-                    "wheel>=0.36.1",
                     "openvino-telemetry"]
-
 
 
 TF_EXTRAS = [
@@ -143,7 +139,8 @@ OPENVINO_EXTRAS = [
 
 
 EXTRAS_REQUIRE = {
-    "dev": ["matplotlib>=3.3.4, <3.6"],
+    "dev": ["matplotlib>=3.3.4, <3.6",
+            "pillow>=9.0.0"],
     "tests": ["pytest"],
     "docs": [],
 

--- a/tests/experimental/tensorflow/test_compressed_graph.py
+++ b/tests/experimental/tensorflow/test_compressed_graph.py
@@ -84,11 +84,11 @@ def check_model_graph_v2(compressed_model, ref_graph_filename, ref_graph_dir, re
 
 
 @pytest.mark.parametrize('desc', MODELS, ids=MODELS_IDS)
-def test_quantize_network_v2(desc: ModelDesc, _quantization_case_config_v2):
+def test_quantize_network_v2(desc: ModelDesc, _quantization_case_config_v2: QuantizeTestCaseConfiguration):
     model = desc.model_builder()
 
-    config = get_basic_quantization_config(_quantization_case_config_v2.qconfig,
-                                        input_sample_sizes=desc.input_sample_sizes)
+    config = get_basic_quantization_config(_quantization_case_config_v2,
+                                           input_sample_sizes=desc.input_sample_sizes)
     config['compression']['algorithm'] = 'experimental_quantization'
     if desc.ignored_scopes is not None:
         if 'activations' in config['compression']:

--- a/tests/experimental/tensorflow/test_context_independence.py
+++ b/tests/experimental/tensorflow/test_context_independence.py
@@ -65,7 +65,7 @@ def test_context_independence():
     graph_dir = os.path.join('quantized', create_test_name(params))
     case = QuantizeTestCaseConfiguration(params, graph_dir)
     input_sample_sizes = ([1, 28, 28, 1], [1, 28, 28, 1])
-    config = get_basic_quantization_config(case.qconfig, input_sample_sizes)
+    config = get_basic_quantization_config(case, input_sample_sizes)
     config['compression']['algorithm'] = 'experimental_quantization'
     models = []
     for _ in range(2):

--- a/tests/openvino/pot/test_engine.py
+++ b/tests/openvino/pot/test_engine.py
@@ -19,7 +19,6 @@ from typing import List
 import numpy as np
 import openvino.runtime as ov
 from openvino.tools import pot
-from addict import Dict
 
 from nncf.data.dataset import Dataset
 from nncf.openvino.engine import OVEngine
@@ -84,7 +83,7 @@ def test_predict_original_metric():
                                                         use_output=False)
 
     pot_model = convert_openvino_model_to_compressed_model(ov_model, target_device='CPU')
-    engine = OVEngine(Dict(device='CPU'), dataset, dataset, val_func, use_original_metric=True)
+    engine = OVEngine({"device": 'CPU'}, dataset, dataset, val_func, use_original_metric=True)
     engine.set_model(pot_model)
 
     (actual_per_sample, actual_metric), _ = engine.predict(sampler=DummySampler(subset_indices),
@@ -104,7 +103,7 @@ def test_predict_output():
                                                         dataset.get_data(),
                                                         use_output=True)
     pot_model = convert_openvino_model_to_compressed_model(ov_model, target_device='CPU')
-    engine = OVEngine(Dict(device='CPU'), dataset, dataset, val_func, use_original_metric=False)
+    engine = OVEngine({'device': 'CPU'}, dataset, dataset, val_func, use_original_metric=False)
     engine.set_model(pot_model)
 
     stats_layout = {}

--- a/tests/openvino/requirements.txt
+++ b/tests/openvino/requirements.txt
@@ -1,4 +1,3 @@
-addict
 pytest
 virtualenv
 pytest-mock>=3.3.1

--- a/tests/openvino/requirements.txt
+++ b/tests/openvino/requirements.txt
@@ -1,3 +1,4 @@
+addict
 pytest
 virtualenv
 pytest-mock>=3.3.1

--- a/tests/tensorflow/pruning/helpers.py
+++ b/tests/tensorflow/pruning/helpers.py
@@ -10,7 +10,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from addict import Dict
 
 from tensorflow.keras import layers
 import tensorflow as tf
@@ -20,7 +19,7 @@ from nncf import NNCFConfig
 
 def get_basic_pruning_config(model_size=8):
     config = NNCFConfig()
-    config.update(Dict({
+    config.update({
         "model": "basic",
         "input_info":
             {
@@ -34,7 +33,7 @@ def get_basic_pruning_config(model_size=8):
                     "prune_first_conv": True,
                 }
             }
-    }))
+    })
     return config
 
 

--- a/tests/tensorflow/quantization/utils.py
+++ b/tests/tensorflow/quantization/utils.py
@@ -11,14 +11,13 @@
  limitations under the License.
 """
 
-from addict import Dict
 
 from nncf import NNCFConfig
 
 
 def get_basic_quantization_config(model_size=4):
     config = NNCFConfig()
-    config.update(Dict({
+    config.update({
         'model': 'basic_quant_conv',
         'input_info':
             {
@@ -28,7 +27,7 @@ def get_basic_quantization_config(model_size=4):
             {
                 'algorithm': 'quantization',
             }
-    }))
+    })
     return config
 
 

--- a/tests/tensorflow/sparsity/magnitude/test_algorithm.py
+++ b/tests/tensorflow/sparsity/magnitude/test_algorithm.py
@@ -14,7 +14,6 @@
 import numpy as np
 import pytest
 import tensorflow as tf
-from addict import Dict
 from pytest import approx
 
 from nncf.api.compression import CompressionStage
@@ -139,7 +138,7 @@ def test_magnitude_algo_binary_masks_are_applied():
     input_shape = (1, 5, 5, 1)
     model = get_basic_conv_test_model(input_shape=input_shape[1:])
     config = get_empty_config(input_sample_sizes=input_shape)
-    config.update(Dict({'compression': {'algorithm': "magnitude_sparsity"}}))
+    config.update({'compression': {'algorithm': "magnitude_sparsity"}})
     compressed_model, _ = create_compressed_model_and_algo_for_test(model, config)
     conv = compressed_model.layers[1]
     op_name = list(conv.ops_weights.keys())[0]

--- a/tests/tensorflow/sparsity/magnitude/test_scheduler.py
+++ b/tests/tensorflow/sparsity/magnitude/test_scheduler.py
@@ -12,7 +12,6 @@
 """
 
 import pytest
-from addict import Dict
 
 from tests.tensorflow.helpers import get_empty_config, create_compressed_model_and_algo_for_test
 from tests.tensorflow.sparsity.magnitude.test_helpers import get_magnitude_test_model
@@ -72,8 +71,8 @@ def test_magnitude_scheduler_can_do_epoch_step__with_last():
 
 def test_magnitude_scheduler_can_do_epoch_step__with_multistep():
     config = get_empty_config()
-    config["compression"] = Dict({"algorithm": "magnitude_sparsity",
-                                  "params": {"schedule": "multistep", 'multistep_steps': [1]}})
+    config["compression"] = {"algorithm": "magnitude_sparsity",
+                                  "params": {"schedule": "multistep", 'multistep_steps': [1]}}
     model = get_magnitude_test_model(config['input_info'][0]['sample_size'][1:])
     _, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
     scheduler = compression_ctrl.scheduler

--- a/tests/tensorflow/sparsity/rb/test_components.py
+++ b/tests/tensorflow/sparsity/rb/test_components.py
@@ -19,7 +19,6 @@ from unittest.mock import patch
 
 import pytest
 import tensorflow as tf
-from addict import Dict
 from nncf.common.compression import BaseCompressionAlgorithmController
 
 from nncf import NNCFConfig
@@ -276,8 +275,8 @@ class TestSparseModules:
                              ids=('default', 'min', 'middle', 'max', 'more_than_max', 'less_then_min'))
     def test_get_target_sparsity_rate(self, model_name, local_mode, target, expected_rate):
         config = get_empty_config()
-        config['compression'] = Dict({'algorithm': 'rb_sparsity',
-                                      'params': {'sparsity_init': 0}})
+        config['compression'] = {'algorithm': 'rb_sparsity',
+                                      'params': {'sparsity_init': 0}}
         _, algo, _ = get_basic_rb_sparse_model(model_name, local_mode, config=config)
         loss = algo.loss
         if target is not None:

--- a/tests/tensorflow/sparsity/test_common.py
+++ b/tests/tensorflow/sparsity/test_common.py
@@ -15,7 +15,6 @@ from typing import List
 from typing import Optional
 
 import pytest
-from addict import Dict
 
 from nncf.common.sparsity.schedulers import AdaptiveSparsityScheduler
 from nncf.common.sparsity.schedulers import ExponentialSparsityScheduler
@@ -37,7 +36,7 @@ from tests.tensorflow.helpers import get_mock_model
                          ))
 def test_can_choose_scheduler(algo, schedule_type, scheduler_class):
     config = get_empty_config()
-    config['compression'] = Dict({'algorithm': algo, 'params': {'schedule': schedule_type}})
+    config['compression'] = {'algorithm': algo, 'params': {'schedule': schedule_type}}
     _, compression_ctrl = create_compressed_model_and_algo_for_test(get_mock_model(), config)
     assert isinstance(compression_ctrl.scheduler, scheduler_class)
 
@@ -77,7 +76,7 @@ class TestSparseModules:
     def test_can_create_sparse_scheduler__with_defaults(self, algo):
         config = get_empty_config()
 
-        config['compression'] = Dict({'algorithm': algo, 'params': {'schedule': 'polynomial'}})
+        config['compression'] = {'algorithm': algo, 'params': {'schedule': 'polynomial'}}
         _, compression_ctrl = create_compressed_model_and_algo_for_test(get_mock_model(), config)
         scheduler = compression_ctrl.scheduler
         assert scheduler.initial_level == 0
@@ -92,8 +91,12 @@ class TestSparseModules:
     def test_scheduler_can_do_epoch_step(self, algo, schedule, get_params, ref_levels):
         model = get_basic_conv_test_model()
         config = get_empty_config()
-        config['compression'] = Dict(
-            {'algorithm': algo, 'sparsity_init': 0.2, "params": {**get_params(), "schedule": schedule}})
+        config['compression'] = {
+            'algorithm': algo,
+            'sparsity_init': 0.2,
+            "params": {**get_params(),
+                       "schedule": schedule}
+        }
 
         _, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
 

--- a/tests/tensorflow/test_bn_adaptation.py
+++ b/tests/tensorflow/test_bn_adaptation.py
@@ -14,7 +14,6 @@
 from copy import deepcopy
 
 import tensorflow as tf
-from addict import Dict
 
 from nncf import NNCFConfig
 from nncf.common.initialization.batchnorm_adaptation import BatchnormAdaptationAlgorithm
@@ -38,7 +37,7 @@ def get_dataset_for_test(batch_size=10, shape=None):
 
 def get_config_for_test(batch_size=10, num_bn_adaptation_samples=100):
     config = NNCFConfig()
-    config.update(Dict({
+    config.update({
         "compression":
             {
                 "algorithm": "quantization",
@@ -48,7 +47,7 @@ def get_config_for_test(batch_size=10, num_bn_adaptation_samples=100):
                     }
                 }
             }
-    }))
+    })
 
     dataset = get_dataset_for_test()
     config = register_default_init_args(config,

--- a/tests/tensorflow/test_ignored_scopes.py
+++ b/tests/tensorflow/test_ignored_scopes.py
@@ -31,8 +31,8 @@ def test_ignored_scopes():
         'conv1',
         '{re}.*conv2.*'
     ]
-    config['compression']['weights']['ignored_scopes'] = ['{re}.*conv3/c[23]']
-    config['compression']['activations']['ignored_scopes'] = ['{re}.*c3$']
+    config['compression']['weights'] = {'ignored_scopes': ['{re}.*conv3/c[23]']}
+    config['compression']['activations'] = {'ignored_scopes': ['{re}.*c3$']}
 
     model = tf.keras.Sequential([
         layers.Conv2D(3, 3, name='conv1', input_shape=config['input_info']['sample_size'][1:]),


### PR DESCRIPTION
### Changes

Removed `addict` and `wheel` from NNCF package dependencies and moved `pillow` dependency to the `[dev]` extra.

### Reason for changes
These dependencies are not strictly necessary for NNCF to function across the supported frameworks.

### Related tickets
N/A

### Tests
Precommit scope
