### PR TITLE
Use parse_voc_xml in a backwards-compatible way with old torchvision

### DIFF
--- a/examples/torch/object_detection/datasets/voc0712.py
+++ b/examples/torch/object_detection/datasets/voc0712.py
@@ -189,7 +189,10 @@ class VOCDetection(data.Dataset):
         img_name = self.ids[index]
         anno = ET.parse(self._annopath % img_name).getroot()
         _, gt_res = self.target_transform(None,
-                                          datasets.VOCDetection.parse_voc_xml(node=anno),
+                                          # Instantiating an object is required here for backwards compatibility with
+                                          # pre-torchvision 0.13 versions, where `parse_voc_xml` was not yet a static
+                                          # method
+                                          datasets.VOCDetection(self.root).parse_voc_xml(node=anno),
                                           pull=True)
         return img_name[1], gt_res
 


### PR DESCRIPTION
### Changes

As stated in the title.

### Reason for changes
Fixes some of the issues in PT compat E2E tests for 1.8.2 and 1.9.1

### Related tickets

N/A

### Tests
e2e compat PT tests