### PR TITLE
Redundant model_transformer property was removed from algo backends

### DIFF
--- a/nncf/experimental/openvino_native/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/experimental/openvino_native/quantization/algorithms/min_max/openvino_backend.py
@@ -68,10 +68,6 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
         return DEFAULT_OV_QUANT_TRAIT_TO_OP_DICT
 
     @staticmethod
-    def model_transformer(model: ov.Model) -> OVModelTransformer:
-        return OVModelTransformer(model)
-
-    @staticmethod
     def target_point(target_type: TargetType,
                      target_node_name: str,
                      port_id: int) -> OVTargetPoint:

--- a/nncf/experimental/openvino_native/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/experimental/openvino_native/quantization/algorithms/min_max/openvino_backend.py
@@ -31,7 +31,6 @@ from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import
 from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import GENERAL_WEIGHT_LAYER_METATYPES
 from nncf.experimental.openvino_native.graph.transformations.commands import OVQuantizerInsertionCommand
 from nncf.experimental.openvino_native.graph.transformations.commands import OVTargetPoint
-from nncf.experimental.openvino_native.graph.model_transformer import OVModelTransformer
 from nncf.experimental.openvino_native.hardware.config import OVHWConfig
 from nncf.experimental.openvino_native.hardware.fused_patterns import OPENVINO_HW_FUSED_PATTERNS
 from nncf.experimental.openvino_native.quantization.default_quantization import DEFAULT_OV_QUANT_TRAIT_TO_OP_DICT

--- a/nncf/quantization/algorithms/bias_correction/algorithm.py
+++ b/nncf/quantization/algorithms/bias_correction/algorithm.py
@@ -34,6 +34,8 @@ from nncf.common.factory import NNCFGraphFactory
 from nncf.common.factory import EngineFactory
 from nncf.common.tensor_statistics.statistic_point import StatisticPoint
 from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
+from nncf.common.factory import ModelTransformerFactory
+
 
 TModel = TypeVar('TModel')
 
@@ -129,7 +131,7 @@ class BiasCorrection(Algorithm):
 
         self._set_backend_entity(model)
         main_transformations_layout = TransformationLayout()
-        main_model_transformer = self._backend_entity.model_transformer(model)
+        main_model_transformer = ModelTransformerFactory.create(model)
 
         model_copy = deepcopy(model)
         model_copy = self._remove_fq_from_inputs(model_copy)
@@ -188,7 +190,7 @@ class BiasCorrection(Algorithm):
         skip_types = []
         nncf_graph = NNCFGraphFactory.create(model)
 
-        model_transformer = self._backend_entity.model_transformer(model)
+        model_transformer = ModelTransformerFactory.create(model)
         for skip_type in self._backend_entity.quantizer_types:
             skip_types.extend(skip_type.op_names)
 
@@ -277,7 +279,7 @@ class BiasCorrection(Algorithm):
         extracted_model = self._backend_entity.extract_model(model, input_node_names, statistic_node_names)
 
         transformation_layout = TransformationLayout()
-        model_transformer = self._backend_entity.model_transformer(extracted_model)
+        model_transformer = ModelTransformerFactory.create(extracted_model)
         _, output_port_id = self._backend_entity.get_activation_port_ids_for_bias_node(model, node)
         statistic_point = self._backend_entity.target_point(TargetType.POST_LAYER_OPERATION,
                                                             node.node_name,
@@ -357,7 +359,7 @@ class BiasCorrection(Algorithm):
         :param bias_correction_command: TransformationCommand instance for the bias correction.
         :return: Backend-specific model, but with the updated bias value.
         """
-        model_transformer = self._backend_entity.model_transformer(model)
+        model_transformer = ModelTransformerFactory.create(model)
         transformation_layout = TransformationLayout()
         transformation_layout.register(bias_correction_command)
         return model_transformer.transform(transformation_layout)

--- a/nncf/quantization/algorithms/bias_correction/backend.py
+++ b/nncf/quantization/algorithms/bias_correction/backend.py
@@ -65,16 +65,6 @@ class BiasCorrectionAlgoBackend(ABC):
 
     @staticmethod
     @abstractmethod
-    def model_transformer(model: TModel) -> ModelTransformer:
-        """
-        Returns backend-specific ModelTransformer instance.
-
-        :param model: Backend-specific model to create ModelTransformer.
-        :return: ModelTransformer instance.
-        """
-
-    @staticmethod
-    @abstractmethod
     def target_point(target_type: TargetType, target_node_name: str, port_id: str = None) -> TargetPoint:
         """
         Returns backend-specific target point.

--- a/nncf/quantization/algorithms/bias_correction/backend.py
+++ b/nncf/quantization/algorithms/bias_correction/backend.py
@@ -25,7 +25,7 @@ from nncf.common.graph import NNCFNode
 from nncf.common.tensor_statistics.collectors import TensorStatisticCollectorBase
 from nncf.common.tensor_statistics.collectors import ReductionShape
 from nncf.common.utils.registry import Registry
-from nncf.common.graph.model_transformer import ModelTransformer
+
 
 TModel = TypeVar('TModel')
 OutputType = TypeVar('OutputType')

--- a/nncf/quantization/algorithms/bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/onnx_backend.py
@@ -66,10 +66,6 @@ class ONNXBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
                 ONNX_OPERATION_METATYPES.get_operator_metatype_by_op_name('DequantizeLinear')]
 
     @staticmethod
-    def model_transformer(model: onnx.ModelProto) -> ONNXModelTransformer:
-        return ONNXModelTransformer(model)
-
-    @staticmethod
     def target_point(target_type: TargetType,
                      target_node_name: str = None,
                      port_id: str = None) -> ONNXTargetPoint:

--- a/nncf/quantization/algorithms/fast_bias_correction/algorithm.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/algorithm.py
@@ -29,6 +29,8 @@ from nncf.common.factory import NNCFGraphFactory
 from nncf.common.factory import EngineFactory
 from nncf.common.tensor_statistics.statistic_point import StatisticPoint
 from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
+from nncf.common.factory import ModelTransformerFactory
+
 
 TModel = TypeVar('TModel')
 
@@ -109,7 +111,7 @@ class FastBiasCorrection(Algorithm):
                dataset: Optional[Dataset] = None) -> TModel:
         self._set_backend_entity(model)
 
-        model_transformer = self._backend_entity.model_transformer(model)
+        model_transformer = ModelTransformerFactory.create(model)
         transformation_layout = TransformationLayout()
         nncf_graph = NNCFGraphFactory.create(model)
 
@@ -221,7 +223,7 @@ class FastBiasCorrection(Algorithm):
         :param output_names: list of the output names
         :return: backend-specific sub-model
         """
-        model_transformer = self._backend_entity.model_transformer(model)
+        model_transformer = ModelTransformerFactory.create(model)
         model_extraction_command = self._backend_entity.model_extraction_command(input_names,
                                                                                  output_names)
         me_transformation_layout = TransformationLayout()

--- a/nncf/quantization/algorithms/fast_bias_correction/backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/backend.py
@@ -63,16 +63,6 @@ class FBCAlgoBackend(ABC):
 
     @staticmethod
     @abstractmethod
-    def model_transformer(model: TModel) -> ModelTransformer:
-        """
-        Returns backend-specific ModelTransformer instance.
-
-        :param model: Backend-specific model to create ModelTransformer.
-        :return: ModelTransformer instance.
-        """
-
-    @staticmethod
-    @abstractmethod
     def target_point(target_type: TargetType, target_node_name: str, port_id: int) -> TargetPoint:
         """
         Returns backend-specific target point.

--- a/nncf/quantization/algorithms/fast_bias_correction/backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/backend.py
@@ -24,7 +24,7 @@ from nncf.common.graph import NNCFNode
 from nncf.common.tensor_statistics.collectors import TensorStatisticCollectorBase
 from nncf.common.tensor_statistics.collectors import ReductionShape
 from nncf.common.utils.registry import Registry
-from nncf.common.graph.model_transformer import ModelTransformer
+
 
 TModel = TypeVar('TModel')
 OutputType = TypeVar('OutputType')

--- a/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
@@ -56,10 +56,6 @@ class ONNXFBCAlgoBackend(FBCAlgoBackend):
         return ONNXNNCFCollectorTensorProcessor()
 
     @staticmethod
-    def model_transformer(model: onnx.ModelProto) -> ONNXModelTransformer:
-        return ONNXModelTransformer(model)
-
-    @staticmethod
     def target_point(target_type: TargetType,
                      target_node_name: str,
                      port_id: int) -> ONNXTargetPoint:

--- a/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
@@ -24,7 +24,6 @@ from nncf.onnx.graph.metatypes.onnx_metatypes import LAYERS_WITH_BIAS_METATYPES
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNX_OPERATION_METATYPES
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXIdentityMetatype
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXDequantizeLinearMetatype
-from nncf.onnx.graph.model_transformer import ONNXModelTransformer
 from nncf.onnx.graph.transformations.commands import ONNXBiasCorrectionCommand
 from nncf.onnx.graph.transformations.commands import ONNXModelExtractionCommand
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -14,6 +14,7 @@
 from copy import deepcopy
 from typing import Dict, List, TypeVar, Optional, OrderedDict, Tuple
 import collections
+
 from nncf import Dataset
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.transformations.commands import TargetType
@@ -36,7 +37,6 @@ from nncf.common.tensor_statistics.collectors import TensorStatisticCollectorBas
 from nncf.common.utils.backend import BackendType
 from nncf.common.utils.backend import get_backend
 from nncf.common.logging import nncf_logger
-
 from nncf.quantization.algorithms.algorithm import Algorithm
 from nncf.quantization.algorithms.algorithm import AlgorithmParameters
 from nncf.quantization.algorithms.min_max.backend import ALGO_BACKENDS
@@ -45,6 +45,8 @@ from nncf.quantization.algorithms.definitions import Granularity
 from nncf.common.factory import NNCFGraphFactory
 from nncf.common.tensor_statistics.statistic_point import StatisticPoint
 from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
+from nncf.common.factory import ModelTransformerFactory
+
 
 TModel = TypeVar('TModel')
 
@@ -352,7 +354,7 @@ class MinMaxQuantization(Algorithm):
                dataset: Optional[Dataset] = None) -> TModel:
         transformation_layout, transformation_commands = TransformationLayout(), []
         nncf_graph = NNCFGraphFactory.create(model) if self.nncf_graph is None else self.nncf_graph
-        model_transformer = self._backend_entity.model_transformer(model)
+        model_transformer = ModelTransformerFactory.create(model)
 
         quantization_target_points = self._get_quantization_target_points(model)
         weight_tensor_names = set()

--- a/nncf/quantization/algorithms/min_max/backend.py
+++ b/nncf/quantization/algorithms/min_max/backend.py
@@ -73,16 +73,6 @@ class MinMaxAlgoBackend(ABC):
 
     @staticmethod
     @abstractmethod
-    def model_transformer(model: TModel) -> ModelTransformer:
-        """
-        Returns backend-specific ModelTransformer instance.
-
-        :param model: Backend-specific model to create ModelTransformer.
-        :return: ModelTransformer instance.
-        """
-
-    @staticmethod
-    @abstractmethod
     def target_point(target_type: TargetType, target_node_name: str, port_id: int) -> TargetPoint:
         """
         Returns backend-specific target point.

--- a/nncf/quantization/algorithms/min_max/backend.py
+++ b/nncf/quantization/algorithms/min_max/backend.py
@@ -28,7 +28,7 @@ from nncf.common.tensor_statistics.collectors import TensorStatisticCollectorBas
 from nncf.common.tensor_statistics.statistics import MinMaxTensorStatistic
 from nncf.common.utils.registry import Registry
 from nncf.common.quantization.structs import QuantizerConfig
-from nncf.common.graph.model_transformer import ModelTransformer
+
 
 TModel = TypeVar('TModel')
 ALGO_BACKENDS = Registry('algo_backends')

--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -70,10 +70,6 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
         return DEFAULT_ONNX_QUANT_TRAIT_TO_OP_DICT
 
     @staticmethod
-    def model_transformer(model: onnx.ModelProto) -> ONNXModelTransformer:
-        return ONNXModelTransformer(model)
-
-    @staticmethod
     def target_point(target_type: TargetType,
                      target_node_name: str,
                      port_id: int) -> ONNXTargetPoint:

--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -30,7 +30,6 @@ from nncf.common.logging import nncf_logger
 from nncf.onnx.graph.metatypes.onnx_metatypes import WEIGHT_LAYER_METATYPES
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXNonMaxSuppressionMetatype
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXTopKMetatype
-from nncf.onnx.graph.model_transformer import ONNXModelTransformer
 from nncf.onnx.graph.transformations.commands import ONNXQuantizerInsertionCommand
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
 from nncf.onnx.hardware.config import ONNXHWConfig


### PR DESCRIPTION
### Changes

Redundant model_transformer property was removed from the algorithm's backends.

### Reason for changes

- `ModelTransformerFactory` is not used.

### Related tickets

N/A

### Tests

N/A
