### PR TITLE
Pylint happy

### DIFF
--- a/nncf/experimental/openvino_native/graph/transformations/command_creation.py
+++ b/nncf/experimental/openvino_native/graph/transformations/command_creation.py
@@ -20,7 +20,9 @@ from nncf.experimental.openvino_native.graph.transformations.commands import OVT
 from nncf.experimental.openvino_native.graph.transformations.commands import OVBiasCorrectionCommand
 
 
-def create_bias_correction_command(node: NNCFNode, bias_value: np.ndarray, nncf_graph: NNCFGraph) -> OVBiasCorrectionCommand:
+def create_bias_correction_command(node: NNCFNode,
+                                   bias_value: np.ndarray,
+                                   nncf_graph: NNCFGraph) -> OVBiasCorrectionCommand:
     """
     Creates bias correction command.
 

--- a/nncf/experimental/openvino_native/hardware/fused_patterns.py
+++ b/nncf/experimental/openvino_native/hardware/fused_patterns.py
@@ -43,7 +43,8 @@ def _get_openvino_hw_fused_patterns() -> HWFusedPatterns:
     hw_fused_patterns.register(arithmetic_ops, ARITHMETIC_OPERATIONS['label'], match=False)
 
     hw_fused_patterns.register(linear_ops + arithmetic_ops, 'LINEAR + ARITHMETIC', match=True)
-    hw_fused_patterns.register(linear_ops + arithmetic_ops + activations, 'LINEAR + ARITHMETIC + ACTIVATIONS', match=True)
+    hw_fused_patterns.register(linear_ops + arithmetic_ops + activations,
+                               'LINEAR + ARITHMETIC + ACTIVATIONS', match=True)
     hw_fused_patterns.register(arithmetic_ops + activations, 'ARITHMETIC + ACTIVATIONS', match=True)
     hw_fused_patterns.register(batch_norm + activations, 'BN + ACTIVATIONS', match=True)
     hw_fused_patterns.register(activations + batch_norm, 'ACTIVATIONS + BN', match=True)

--- a/nncf/experimental/openvino_native/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/experimental/openvino_native/quantization/algorithms/min_max/openvino_backend.py
@@ -34,8 +34,10 @@ from nncf.experimental.openvino_native.graph.transformations.commands import OVT
 from nncf.experimental.openvino_native.hardware.config import OVHWConfig
 from nncf.experimental.openvino_native.hardware.fused_patterns import OPENVINO_HW_FUSED_PATTERNS
 from nncf.experimental.openvino_native.quantization.default_quantization import DEFAULT_OV_QUANT_TRAIT_TO_OP_DICT
-from nncf.experimental.openvino_native.quantization.quantizer_parameters import calculate_activation_quantizer_parameters
-from nncf.experimental.openvino_native.quantization.quantizer_parameters import calculate_weight_quantizer_parameters
+from nncf.experimental.openvino_native.quantization.quantizer_parameters import (
+    calculate_activation_quantizer_parameters,
+    calculate_weight_quantizer_parameters
+)
 from nncf.experimental.openvino_native.statistics.collectors import OVMeanMinMaxStatisticCollector
 from nncf.experimental.openvino_native.statistics.collectors import OVMinMaxStatisticCollector
 


### PR DESCRIPTION
### Changes

Fixed pylint errors were found by the following command: `make pylint-openvino`

### Reason for changes

pylint errors

### Related tickets

N/A

### Tests

N/A
