### PR TITLE
[PTQ][OV] Support Depthwise, Group convolutions

### DIFF
--- a/nncf/experimental/openvino_native/graph/metatypes/openvino_metatypes.py
+++ b/nncf/experimental/openvino_native/graph/metatypes/openvino_metatypes.py
@@ -11,7 +11,8 @@
  limitations under the License.
 """
 
-from typing import List, Type
+from typing import List, Optional, Type
+import openvino.runtime as ov
 
 from nncf.common.graph.operator_metatypes import INPUT_NOOP_METATYPES
 from nncf.common.graph.operator_metatypes import OUTPUT_NOOP_METATYPES
@@ -24,10 +25,32 @@ OV_OPERATOR_METATYPES = OperatorMetatypeRegistry('openvino_operator_metatypes')
 
 class OVOpMetatype(OperatorMetatype):
     op_names = []  # type: List[str]
+    subtypes = []  # type: List[Type[OperatorMetatype]]
 
     @classmethod
     def get_all_aliases(cls) -> List[str]:
         return cls.op_names
+
+    @classmethod
+    def get_subtypes(cls) -> List[Type[OperatorMetatype]]:
+        return cls.subtypes
+
+    @classmethod
+    def matches(cls, node: ov.Node) -> Optional[bool]:
+        return node.op_type in cls.op_names
+
+    @classmethod
+    def determine_subtype(cls, node: ov.Node) -> Optional[Type[OperatorMetatype]]:
+        matches = []
+        for subtype in cls.get_subtypes():
+            if subtype.matches(node):
+                matches.append(subtype)
+        if len(matches) > 1:
+            raise RuntimeError('Multiple subtypes match operator call - '
+                               'can not determine single subtype.')
+        if not matches:
+            return None
+        return matches[0]
 
 
 @OV_OPERATOR_METATYPES.register()
@@ -41,6 +64,32 @@ class OVConvolutionMetatype(OVOpMetatype):
 class OVConvolutionBackpropDataMetatype(OVOpMetatype):
     name = 'ConvBackpropDataOp'
     op_names = ['ConvolutionBackpropData']
+    hw_config_names = [HWConfigOpName.CONVOLUTION]
+
+
+@OV_OPERATOR_METATYPES.register()
+class OVDepthwiseConvolutionMetatype(OVOpMetatype):
+    name = 'DepthwiseConvolutionOp'
+    op_names = ['GroupConvolution']
+    hw_config_names = [HWConfigOpName.DEPTHWISECONVOLUTION]
+
+    @classmethod
+    def matches(cls, node: ov.Node) -> bool:
+        return _is_depthwise_conv(node)
+
+
+@OV_OPERATOR_METATYPES.register()
+class OVGroupConvolutionMetatype(OVOpMetatype):
+    name = 'GroupConvolutionOp'
+    op_names = ['GroupConvolution']
+    hw_config_names = [HWConfigOpName.CONVOLUTION]
+    subtypes = [OVDepthwiseConvolutionMetatype]
+
+
+@OV_OPERATOR_METATYPES.register()
+class OVGroupConvolutionBackpropDataMetatype(OVOpMetatype):
+    name = 'GroupConvolutionBackpropDataOp'
+    op_names = ['GroupConvolutionBackpropData']
     hw_config_names = [HWConfigOpName.CONVOLUTION]
 
 
@@ -510,10 +559,13 @@ class OVResultMetatype(OVOpMetatype):
 
 
 GENERAL_WEIGHT_LAYER_METATYPES = [OVConvolutionMetatype,
+                                  OVGroupConvolutionMetatype,
+                                  OVDepthwiseConvolutionMetatype,
                                   OVConvolutionBackpropDataMetatype,
+                                  OVGroupConvolutionBackpropDataMetatype,
                                   OVMatMulMetatype]
 
-METATYPES_WITH_WEIGHT_PORT_ID = GENERAL_WEIGHT_LAYER_METATYPES + [OVAddMetatype]
+METATYPES_WITH_CONST_PORT_ID = GENERAL_WEIGHT_LAYER_METATYPES + [OVAddMetatype]
 
 # Contains the operation metatypes for which bias can be applied.
 OPERATIONS_WITH_BIAS_METATYPES = [OVConvolutionMetatype,
@@ -527,3 +579,19 @@ def get_operator_metatypes() -> List[Type[OperatorMetatype]]:
     :return: List of operator metatypes .
     """
     return list(OV_OPERATOR_METATYPES.registry_dict.values())
+
+
+def _is_depthwise_conv(node: ov.Node) -> bool:
+    """
+    Returns True if the group convolution is depthwise, False - otherwise.
+    Depthwise convolution is a convolution satisfies the following rule:
+    groups == in_channels and inp_channels > 1.
+    Weight tensor layout is [groups, output channels / groups, input channels / groups, Z, Y, X],
+    where Z, Y, X - spatial axes.
+
+    :param node: GroupConvolution node to check whether it is depthwise.
+    :return: True if the convolution is depthwise, False - otherwise.
+    """
+    inp_channels = node.input_value(0).get_shape()[1]
+    groups = node.input_value(1).get_shape()[0]
+    return groups == inp_channels and inp_channels > 1

--- a/nncf/experimental/openvino_native/graph/nncf_graph_builder.py
+++ b/nncf/experimental/openvino_native/graph/nncf_graph_builder.py
@@ -18,10 +18,12 @@ from nncf.common.graph import BaseLayerAttributes
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph.layer_attributes import Dtype
 from nncf.common.graph.operator_metatypes import OperatorMetatype
+from nncf.common.graph.operator_metatypes import UnknownMetatype
 
 from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OV_OPERATOR_METATYPES
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import METATYPES_WITH_WEIGHT_PORT_ID
+from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import METATYPES_WITH_CONST_PORT_ID
 from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVConvolutionBackpropDataMetatype
+from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVGroupConvolutionBackpropDataMetatype
 
 
 class GraphConverter:
@@ -64,9 +66,26 @@ class GraphConverter:
         :param metatype: NNCF meta type which corresponds to operation.
         :return: OpenVINO node inputs that may contain weights.
         """
-        if metatype == OVConvolutionBackpropDataMetatype:
+        if metatype in [OVConvolutionBackpropDataMetatype, OVGroupConvolutionBackpropDataMetatype]:
             return inputs[:2]
         return inputs
+
+    @staticmethod
+    def _get_node_metatype(node: ov.Node) -> Type[OperatorMetatype]:
+        """
+        Determine NNCF meta type for OpenVINO node.
+
+        :param node: OpenVINO node.
+        :return: NNCF meta type which corresponds to OpenVINO node.
+        """
+        node_type = node.get_type_name()
+        metatype = OV_OPERATOR_METATYPES.get_operator_metatype_by_op_name(node_type)
+        if metatype is not UnknownMetatype:
+            if metatype.get_subtypes():
+                subtype = metatype.determine_subtype(node)
+                if subtype is not None:
+                    metatype = subtype
+        return metatype
 
     @staticmethod
     def _add_edges_to_nncf_graph(model: ov.Model, graph: NNCFGraph) -> None:
@@ -103,7 +122,7 @@ class GraphConverter:
         :param graph: NNCFGraph.
         """
         node_type = node.get_type_name()
-        metatype = OV_OPERATOR_METATYPES.get_operator_metatype_by_op_name(node_type)
+        metatype = GraphConverter._get_node_metatype(node)
         graph.add_nncf_node(node_name=node.get_friendly_name(),
                             node_type=node_type,
                             node_metatype=metatype)
@@ -134,13 +153,12 @@ class GraphConverter:
                         inference_nodes.append(inp.get_node())
 
         for node in model.get_ops():
-            node_type = node.get_type_name()
-            metatype = OV_OPERATOR_METATYPES.get_operator_metatype_by_op_name(node_type)
+            metatype = GraphConverter._get_node_metatype(node)
             # Add nodes from constant subgraphs
             if node.get_friendly_name() not in visited:
                 GraphConverter._add_nncf_node(node, nncf_graph)
-            # Set weight port id
-            elif metatype in METATYPES_WITH_WEIGHT_PORT_ID:
+            # Set const port id
+            elif metatype in METATYPES_WITH_CONST_PORT_ID:
                 for inp in GraphConverter._filter_weight_input_ports(node.inputs(), metatype):
                     inp_name = inp.get_source_output().get_node().get_friendly_name()
                     if inp_name not in visited:

--- a/nncf/experimental/openvino_native/hardware/pattern_operations.py
+++ b/nncf/experimental/openvino_native/hardware/pattern_operations.py
@@ -15,7 +15,10 @@ from nncf.common.graph.graph_matching import GraphPattern
 from nncf.experimental.openvino_native.graph.metatypes import openvino_metatypes as ov_metatypes
 
 LINEAR_OPERATIONS = {GraphPattern.METATYPE_ATTR: [ov_metatypes.OVConvolutionMetatype,
+                                                  ov_metatypes.OVGroupConvolutionMetatype,
+                                                  ov_metatypes.OVDepthwiseConvolutionMetatype,
                                                   ov_metatypes.OVConvolutionBackpropDataMetatype,
+                                                  ov_metatypes.OVGroupConvolutionBackpropDataMetatype,
                                                   ov_metatypes.OVMatMulMetatype
                                                   ],
                      GraphPattern.LABEL_ATTR: 'LINEAR'}

--- a/nncf/experimental/openvino_native/quantization/default_quantization.py
+++ b/nncf/experimental/openvino_native/quantization/default_quantization.py
@@ -19,7 +19,10 @@ from nncf.experimental.openvino_native.graph.metatypes import openvino_metatypes
 DEFAULT_OV_QUANT_TRAIT_TO_OP_DICT = {
     QuantizationTrait.INPUTS_QUANTIZABLE: [
         ov_metatypes.OVConvolutionMetatype,
+        ov_metatypes.OVGroupConvolutionMetatype,
+        ov_metatypes.OVDepthwiseConvolutionMetatype,
         ov_metatypes.OVConvolutionBackpropDataMetatype,
+        ov_metatypes.OVGroupConvolutionBackpropDataMetatype,
         ov_metatypes.OVMatMulMetatype,
         ov_metatypes.OVBatchNormMetatype,
         ov_metatypes.OVAddMetatype,

--- a/tests/openvino/native/models.py
+++ b/tests/openvino/native/models.py
@@ -77,6 +77,23 @@ class ConvModel(OVReferenceModel):
         return model
 
 
+class DepthwiseConvModel(OVReferenceModel):
+    def _create_ov_model(self):
+        input_1 = opset.parameter([1, 3, 5, 5], name="Input_1")
+        kernel = self._rng.random((3, 1, 1, 3, 3)).astype(np.float32)
+        strides = [1, 1]
+        pads = [0, 0]
+        dilations = [1, 1]
+        conv = opset.group_convolution(input_1, kernel, strides, pads, pads, dilations, name="Conv")
+        relu = opset.relu(conv, name="Relu")
+        bias = self._rng.random((1, 3, 1, 1)).astype(np.float32)
+        add = opset.add(relu, bias, name="Add")
+
+        result = opset.result(add, name="Result")
+        model = ov.Model([result], [input_1])
+        return model
+
+
 class QuantizedModel(OVReferenceModel):
     @staticmethod
     def _create_fq_node(parent_node, name):

--- a/tests/openvino/native/models.py
+++ b/tests/openvino/native/models.py
@@ -85,11 +85,11 @@ class DepthwiseConvModel(OVReferenceModel):
         pads = [0, 0]
         dilations = [1, 1]
         conv = opset.group_convolution(input_1, kernel, strides, pads, pads, dilations, name="Conv")
-        relu = opset.relu(conv, name="Relu")
         bias = self._rng.random((1, 3, 1, 1)).astype(np.float32)
-        add = opset.add(relu, bias, name="Add")
+        add = opset.add(conv, bias, name="Add")
+        relu = opset.relu(add, name="Relu")
 
-        result = opset.result(add, name="Result")
+        result = opset.result(relu, name="Result")
         model = ov.Model([result], [input_1])
         return model
 

--- a/tests/openvino/native/quantization/test_ptq_params.py
+++ b/tests/openvino/native/quantization/test_ptq_params.py
@@ -64,7 +64,7 @@ def test_range_type_per_channel(range_type, original_model):
     algo = PostTrainingQuantization(PostTrainingQuantizationParameters(range_type=range_type))
     min_max_algo = algo.algorithms[0]
     min_max_algo._backend_entity = OVMinMaxAlgoBackend()
-    model = original_model.onnx_model
+    model = original_model.ov_model
     assert min_max_algo._parameters.range_type == range_type
     stat_points = min_max_algo.get_statistic_points(model)
 

--- a/tests/openvino/native/quantization/test_ptq_params.py
+++ b/tests/openvino/native/quantization/test_ptq_params.py
@@ -25,6 +25,7 @@ from nncf.experimental.openvino_native.statistics.collectors import OVMeanMinMax
 from nncf.experimental.openvino_native.statistics.collectors import OVMinMaxStatisticCollector
 
 from tests.openvino.native.models import LinearModel
+from tests.openvino.native.models import DepthwiseConvModel
 
 
 # pylint: disable=protected-access
@@ -55,6 +56,23 @@ def test_range_type_per_tensor(range_type):
                     assert isinstance(tensor_collector, OVMinMaxStatisticCollector)
                 elif range_type == RangeType.MEAN_MINMAX:
                     assert isinstance(tensor_collector, OVMeanMinMaxStatisticCollector)
+
+
+@pytest.mark.parametrize('range_type', [RangeType.MINMAX, RangeType.MEAN_MINMAX, None])
+@pytest.mark.parametrize('original_model', [DepthwiseConvModel()])
+def test_range_type_per_channel(range_type, original_model):
+    algo = PostTrainingQuantization(PostTrainingQuantizationParameters(range_type=range_type))
+    min_max_algo = algo.algorithms[0]
+    min_max_algo._backend_entity = OVMinMaxAlgoBackend()
+    model = original_model.onnx_model
+    assert min_max_algo._parameters.range_type == range_type
+    stat_points = min_max_algo.get_statistic_points(model)
+
+    for _, stat_point in stat_points.items():
+        for stat_point_ in stat_point:
+            for tensor_collector in stat_point_.algorithm_to_tensor_collectors[MinMaxQuantization]:
+                # Range_type does not affect per-channel tensor_collector
+                assert isinstance(tensor_collector, OVMinMaxStatisticCollector)
 
 
 @pytest.mark.parametrize('quantize_outputs', [False, True])

--- a/tests/openvino/native/quantization/test_quantizer_config.py
+++ b/tests/openvino/native/quantization/test_quantizer_config.py
@@ -27,6 +27,7 @@ from nncf.experimental.openvino_native.statistics.collectors import OVMeanMinMax
 from nncf.experimental.openvino_native.quantization.algorithms.min_max.openvino_backend import OVMinMaxAlgoBackend
 from nncf.experimental.openvino_native.statistics.collectors import OVMinMaxStatisticCollector
 from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVConvolutionMetatype
+from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVDepthwiseConvolutionMetatype
 
 from tests.common.quantization.test_filter_constant_nodes import create_mock_graph
 from tests.common.quantization.test_filter_constant_nodes import get_nncf_graph_from_mock_nx_graph
@@ -45,6 +46,23 @@ class NNCFGraphToTest:
         #           Output_1
         nodes = [NodeWithType('Input_1', InputNoopMetatype),
                  NodeWithType('Conv_1', OVConvolutionMetatype),
+                 NodeWithType('Output_1', OutputNoopMetatype),
+                 ]
+        node_edges = [('Input_1', 'Conv_1'), ('Conv_1', 'Output_1')]
+        original_mock_graph = create_mock_graph(nodes, node_edges)
+        self.nncf_graph = get_nncf_graph_from_mock_nx_graph(original_mock_graph)
+
+
+class NNCFGraphToTestDepthwiseConv:
+    def __init__(self):
+        #       Original graph
+        #          Input_1
+        #             |
+        #        DepthwiseConv_1
+        #             |
+        #           Output_1
+        nodes = [NodeWithType('Input_1', InputNoopMetatype),
+                 NodeWithType('Conv_1', OVDepthwiseConvolutionMetatype),
                  NodeWithType('Output_1', OutputNoopMetatype),
                  ]
         node_edges = [('Input_1', 'Conv_1'), ('Conv_1', 'Output_1')]
@@ -114,6 +132,29 @@ def test_quantizer_config_from_ptq_params(weight_granularity, activation_granula
             assert quantization_point.qconfig.mode == q_g_to_quantization_mode[QuantizerGroup.ACTIVATIONS]
             if signed_activations is not None:
                 assert quantization_point.qconfig.signedness_to_force == signed_activations
+
+
+@pytest.mark.parametrize('nncf_graph', [NNCFGraphToTestDepthwiseConv()])
+def test_depthwise_conv_default_quantizer_config(nncf_graph):
+    algo = PostTrainingQuantization(PostTrainingQuantizationParameters())
+    min_max_algo = algo.algorithms[0]
+    min_max_algo._backend_entity = OVMinMaxAlgoBackend()
+    q_setup = min_max_algo._get_quantizer_setup(nncf_graph.nncf_graph)
+
+    weight_default_config = QuantizerConfig(mode=QuantizationMode.SYMMETRIC,
+                                            num_bits=8,
+                                            signedness_to_force=True,
+                                            per_channel=True)
+    activation_default_config = QuantizerConfig(mode=QuantizationMode.SYMMETRIC,
+                                                num_bits=8,
+                                                signedness_to_force=None,
+                                                per_channel=True)
+
+    for quantization_point in q_setup.quantization_points.values():
+        if quantization_point.is_weight_quantization_point():
+            assert quantization_point.qconfig == weight_default_config
+        if quantization_point.is_activation_quantization_point():
+            assert quantization_point.qconfig == activation_default_config
 
 
 @pytest.mark.parametrize('range_type', [RangeType.MINMAX, RangeType.MEAN_MINMAX])

--- a/tests/openvino/native/test_metatypes.py
+++ b/tests/openvino/native/test_metatypes.py
@@ -30,7 +30,8 @@ REF_METATYPES_COUNTERS = [
     [ovm.OVParameterMetatype, ovm.OVParameterMetatype, ovm.OVConstantMetatype, ovm.OVMultiplyMetatype,
      ovm.OVConstantMetatype, ovm.OVAddMetatype, ovm.OVConstantMetatype, ovm.OVSubtractMetatype,
      ovm.OVConstantMetatype, ovm.OVConvolutionMetatype, ovm.OVReluMetatype, ovm.OVConcatMetatype,
-     ovm.OVTransposeMetatype, ovm.OVConstantMetatype, ovm.OVResultMetatype],
+     ovm.OVTransposeMetatype, ovm.OVConstantMetatype, ovm.OVResultMetatype,
+     ovm.OVAddMetatype, ovm.OVConstantMetatype],
     [ovm.OVParameterMetatype, ovm.OVConstantMetatype, ovm.OVDepthwiseConvolutionMetatype,
      ovm.OVConstantMetatype, ovm.OVAddMetatype, ovm.OVReluMetatype, ovm.OVResultMetatype]]
 

--- a/tests/openvino/native/test_metatypes.py
+++ b/tests/openvino/native/test_metatypes.py
@@ -14,35 +14,25 @@
 import pytest
 from collections import Counter
 
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVAddMetatype
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVConcatMetatype
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVConstantMetatype
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVConvolutionMetatype
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVMatMulMetatype
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVMultiplyMetatype
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVReluMetatype
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVReshapeMetatype
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVSubtractMetatype
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVTransposeMetatype
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVParameterMetatype
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import OVResultMetatype
-from nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes import GENERAL_WEIGHT_LAYER_METATYPES
+import nncf.experimental.openvino_native.graph.metatypes.openvino_metatypes as ovm
 from nncf.experimental.openvino_native.graph.nncf_graph_builder import GraphConverter
 
 from tests.openvino.native.models import ConvModel
 from tests.openvino.native.models import LinearModel
 from tests.openvino.native.models import WeightsModel
+from tests.openvino.native.models import DepthwiseConvModel
 
-TEST_MODELS = [LinearModel, ConvModel]
+TEST_MODELS = [LinearModel, ConvModel, DepthwiseConvModel]
 REF_METATYPES_COUNTERS = [
-    [OVParameterMetatype, OVConstantMetatype, OVReshapeMetatype,
-     OVConstantMetatype, OVAddMetatype, OVConstantMetatype, OVMatMulMetatype,
-     OVResultMetatype, OVResultMetatype],
-    [OVParameterMetatype, OVParameterMetatype, OVConstantMetatype, OVMultiplyMetatype,
-     OVConstantMetatype, OVAddMetatype, OVConstantMetatype, OVSubtractMetatype,
-     OVConstantMetatype, OVConvolutionMetatype, OVReluMetatype, OVConcatMetatype,
-     OVTransposeMetatype, OVConstantMetatype, OVResultMetatype,
-     OVConstantMetatype, OVAddMetatype]]
+    [ovm.OVParameterMetatype, ovm.OVConstantMetatype, ovm.OVReshapeMetatype,
+     ovm.OVConstantMetatype, ovm.OVAddMetatype, ovm.OVConstantMetatype, ovm.OVMatMulMetatype,
+     ovm.OVResultMetatype, ovm.OVResultMetatype],
+    [ovm.OVParameterMetatype, ovm.OVParameterMetatype, ovm.OVConstantMetatype, ovm.OVMultiplyMetatype,
+     ovm.OVConstantMetatype, ovm.OVAddMetatype, ovm.OVConstantMetatype, ovm.OVSubtractMetatype,
+     ovm.OVConstantMetatype, ovm.OVConvolutionMetatype, ovm.OVReluMetatype, ovm.OVConcatMetatype,
+     ovm.OVTransposeMetatype, ovm.OVConstantMetatype, ovm.OVResultMetatype],
+    [ovm.OVParameterMetatype, ovm.OVConstantMetatype, ovm.OVDepthwiseConvolutionMetatype,
+     ovm.OVConstantMetatype, ovm.OVAddMetatype, ovm.OVReluMetatype, ovm.OVResultMetatype]]
 
 
 @pytest.mark.parametrize(("model_creator_func, ref_metatypes"),
@@ -67,7 +57,7 @@ def test_determining_weights_port():
     nncf_graph = GraphConverter.create_nncf_graph(model)
     counter = 0
     for node in nncf_graph.get_all_nodes():
-        if node.metatype not in GENERAL_WEIGHT_LAYER_METATYPES:
+        if node.metatype not in ovm.GENERAL_WEIGHT_LAYER_METATYPES:
             continue
         if node.layer_attributes is not None:
             counter += 1


### PR DESCRIPTION
### Changes

* Add `OVDepthwiseConvolutionMetatype` as a subtype of `OVGroupConvolutionMetatype`

### Reason for changes

* To correctly quantize depthwise and group convolutions.

### Related tickets

* 101928

### Tests

* Added `DepthwiseConvModel` synthetic model for tests
