### PR TITLE
Added __matmul__ magic functions to the list of patched ops

### DIFF
--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -92,7 +92,7 @@ class FunctionsToPatchWithoutTracing:
 class MagicFunctionsToPatch:
     MAGIC_FUNCTIONS_TO_PATCH = {
         NamespaceTarget.TORCH_TENSOR: ["__add__", "__iadd__", "__radd__", "__sub__", "__isub__",
-                                       "__rsub__", "__mul__",
+                                       "__rsub__", "__mul__", "__matmul__", "__rmatmul__",
                                        "__imul__", "__rmul__", "__div__", "__idiv__",
                                        "__truediv__", "__floordiv__",
                                        "__ifloordiv__", "__rfloordiv__", "__getitem__",

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/__matmul__.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/__matmul__.dot
@@ -1,0 +1,9 @@
+strict digraph  {
+"0 /nncf_model_input_0" [id=0, type=nncf_model_input];
+"1 /nncf_model_input_1" [id=1, type=nncf_model_input];
+"2 TestModel/__matmul___0" [id=2, type=__matmul__];
+"3 /nncf_model_output_0" [id=3, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "2 TestModel/__matmul___0";
+"1 /nncf_model_input_1" -> "2 TestModel/__matmul___0";
+"2 TestModel/__matmul___0" -> "3 /nncf_model_output_0";
+}

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/__rmatmul__.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/__rmatmul__.dot
@@ -1,0 +1,9 @@
+strict digraph  {
+"0 /nncf_model_input_0" [id=0, type=nncf_model_input];
+"1 /nncf_model_input_1" [id=1, type=nncf_model_input];
+"2 TestModel/__rmatmul___0" [id=2, type=__rmatmul__];
+"3 /nncf_model_output_0" [id=3, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "2 TestModel/__rmatmul___0";
+"1 /nncf_model_input_1" -> "2 TestModel/__rmatmul___0";
+"2 TestModel/__rmatmul___0" -> "3 /nncf_model_output_0";
+}

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -593,6 +593,8 @@ SYNTHETIC_MODEL_DESC_LIST = [
     TensorBinaryMethodsDesc('__mul__'),
     TensorBinaryMethodsDesc('__rmul__'),
     TensorBinaryMethodsDesc('__imul__'),
+    TensorBinaryMethodsDesc('__matmul__'),
+    TensorBinaryMethodsDesc('__rmatmul__'),
 
     TorchBinaryMethodDesc('Div', torch.div),
     TensorBinaryMethodsDesc('__div__'),


### PR DESCRIPTION
### Changes

as stated in the title

### Reason for changes

To support tracing of matmul expressed in the following way: a @ b
It's used in official implementation of SwinTransformer by Microsoft. 
NNCFGraph is disjointed without it.

### Related tickets

n/a

### Tests

graph tests
