### PR TITLE
Corrected README since "import nncf" is not enough to call patch pytorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This function returns a model with additional modifications necessary to enable 
 
 ```python
 import torch
-import nncf  # Important - must be imported before any other external package that depends on torch
+import nncf.torch  # Important - must be imported before any other external package that depends on torch
 
 from nncf import NNCFConfig
 from nncf.torch import create_compressed_model, register_default_init_args

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -21,7 +21,7 @@ The framework is designed so that the modifications to your original training co
  1. **Add** the imports required for NNCF:
     ```python
     import torch
-    import nncf  # Important - must be imported before any other external package that depends on torch
+    import nncf.torch  # Important - must be imported before any other external package that depends on torch
     from nncf import NNCFConfig, create_compressed_model, load_state
     ```
     **NOTE (PyTorch)**: Due to the way NNCF works within the PyTorch backend, `import nncf` must be done before any other import of `torch` in your package _or_ in third-party packages that your code utilizes, otherwise the compression may be applied incompletely.


### PR DESCRIPTION
### Changes

as stated in the title

### Reason for changes

Patching Transformers doesn't work with simple `import torch` because of links to activations: https://github.com/openvinotoolkit/nncf/issues/1283#issuecomment-1267026563
`import torch` doesn't call `patch_torch_operators`. Need explicitly call `import nncf.torch`

### Related tickets

n/a

### Tests

n/a
