### PR TITLE
Set attributes to the underlying model object when setting an attribute on NNCFNetwork

### DIFF
--- a/nncf/torch/exporter.py
+++ b/nncf/torch/exporter.py
@@ -134,10 +134,10 @@ class PTExporter(Exporter):
             single_batch_info.shape = input_shape
             input_tensor_list.append(create_mock_tensor(single_batch_info, 'cpu'))
 
-        original_forward = model.forward
+        original_forward = model.get_nncf_wrapped_model().forward
         args = self._model_args[:-1]
         kwargs = self._model_args[-1]
-        model.forward = partial(model.forward, *args, **kwargs)
+        model.forward = partial(original_forward, *args, **kwargs)
 
         if self._input_names is not None:
             input_names = self._input_names

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -275,6 +275,10 @@ class NNCFNetwork(nn.Module, PostGraphBuildActing):
                                                               ShapeIgnoringTensorMetaComparator())
             self._load_listener = None
 
+    @property
+    def input_infos(self) -> List[ModelInputInfo]:
+        return deepcopy(self._input_infos)
+
     @debuggable_forward
     def forward(self, *args, **kwargs):
         with self._compressed_context as ctx:  # type: TracingContext


### PR DESCRIPTION
### Changes
Previously, setting an attribute on the wrapped NNCFNetwork object would only set attribute on the wrapper, but not on the wrapped object. As a result, writes to the underlying model object outside of the original `forward` method were impossible. The PR fixes this and changes the behaviour of setting attributes on `NNCFNetwork` - it is now only possible to set `NNCFNetwork` attributes inside the `NNCFNetwork` methods themselves, and only under a special context manager.

This also leads to a change in assigning new values to `forward` when doing so starting with the wrapped object. The code:
```
nncf_network = NNCFNetwork(original_model, ...)
nncf_network.forward = new_forward
nncf_network(x)
```
will now lead to the `forward` being replaced in the underlying `original_model`, while preserving the NNCF wrapper over this changed `forward`. Prior to this PR, the code above would replace the entire wrapped `forward` in the NNCFNetwork.

### Reason for changes
Some training pipelines seem to change the model object fields outside the `forward` call.

### Related tickets
79448

### Tests

test_setting_attrs, test_replacing_forward
