### PR TITLE
Disallow hooking in-place ops

### DIFF
--- a/nncf/common/insertion_point_graph.py
+++ b/nncf/common/insertion_point_graph.py
@@ -40,7 +40,7 @@ class PreHookInsertionPoint:
         self.input_port_id = input_port_id
 
     def __str__(self):
-        return str(self.input_port_id) + ' ' + self.target_node_name
+        return f"PreHookInsertionPoint {self.target_node_name} input_port={str(self.input_port_id)}"
 
 
 class PostHookInsertionPoint:
@@ -48,7 +48,7 @@ class PostHookInsertionPoint:
         self.target_node_name = target_node_name
 
     def __str__(self):
-        return self.target_node_name
+        return f"PostHookInsertionPoint {self.target_node_name}"
 
 
 class InsertionPointGraph(nx.DiGraph):

--- a/nncf/common/quantization/quantizer_propagation/solver.py
+++ b/nncf/common/quantization/quantizer_propagation/solver.py
@@ -1085,7 +1085,8 @@ class QuantizerPropagationSolver:
             pred_node = quant_prop_graph.nodes[pred_ip_key]
             pred_node_type = pred_node[QuantizerPropagationStateGraph.NODE_TYPE_NODE_ATTR]
             assert QuantizerPropagationStateGraph.is_insertion_point(pred_node_type), \
-                "Invalid insertion point graph supplied for quantizer propagation!"
+                f"Invalid insertion point graph supplied for quantizer propagation - no pre-hook insertion points " \
+                f"available for the input-quantizable op: {nncf_node_ref.node_name}!"
 
             edge = quant_prop_graph.edges[pred_ip_key, operator_node_key]
             if not edge[QuantizerPropagationStateGraph.IS_INTEGER_PATH_EDGE_ATTR]:

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -862,7 +862,7 @@ class PTLogicalAndMetatype(PTOperatorMetatype):
 class PTLogicalNotMetatype(PTOperatorMetatype):
     name = "LogicalNotOp"
     module_to_function_names = {
-        NamespaceTarget.TORCH_TENSOR: ["logical_not_"]
+        NamespaceTarget.TORCH_TENSOR: ["logical_not"]
     }
     hw_config_names = [HWConfigOpName.LOGICALNOT]
 

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/InplaceThenQuantizableOpModel.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/InplaceThenQuantizableOpModel.dot
@@ -1,0 +1,17 @@
+strict digraph  {
+"0 /nncf_model_input_0" [id=0, type=nncf_model_input];
+"1 SymmetricQuantizer/symmetric_quantize_0" [id=1, type=symmetric_quantize];
+"2 InplaceThenQuantizableOpModel/__mul___0" [id=2, type=__mul__];
+"3 InplaceThenQuantizableOpModel/unsqueeze__0" [id=3, type=unsqueeze_];
+"4 InplaceThenQuantizableOpModel/SymmetricQuantizer/symmetric_quantize_0" [id=4, type=symmetric_quantize];
+"5 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" [id=5, type=symmetric_quantize];
+"6 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/conv2d_0" [id=6, type=conv2d];
+"7 /nncf_model_output_0" [id=7, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
+"1 SymmetricQuantizer/symmetric_quantize_0" -> "2 InplaceThenQuantizableOpModel/__mul___0";
+"2 InplaceThenQuantizableOpModel/__mul___0" -> "3 InplaceThenQuantizableOpModel/unsqueeze__0";
+"3 InplaceThenQuantizableOpModel/unsqueeze__0" -> "4 InplaceThenQuantizableOpModel/SymmetricQuantizer/symmetric_quantize_0";
+"3 InplaceThenQuantizableOpModel/unsqueeze__0" -> "6 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/conv2d_0";
+"5 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" -> "6 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/conv2d_0";
+"6 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/conv2d_0" -> "7 /nncf_model_output_0";
+}

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/InplaceThenQuantizableOpModel.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/InplaceThenQuantizableOpModel.dot
@@ -3,15 +3,19 @@ strict digraph  {
 "1 SymmetricQuantizer/symmetric_quantize_0" [id=1, type=symmetric_quantize];
 "2 InplaceThenQuantizableOpModel/__mul___0" [id=2, type=__mul__];
 "3 InplaceThenQuantizableOpModel/unsqueeze__0" [id=3, type=unsqueeze_];
-"4 InplaceThenQuantizableOpModel/SymmetricQuantizer/symmetric_quantize_0" [id=4, type=symmetric_quantize];
-"5 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" [id=5, type=symmetric_quantize];
-"6 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/conv2d_0" [id=6, type=conv2d];
-"7 /nncf_model_output_0" [id=7, type=nncf_model_output];
+"4 InplaceThenQuantizableOpModel/squeeze__0" [id=4, type=squeeze_];
+"5 InplaceThenQuantizableOpModel/unsqueeze__1" [id=5, type=unsqueeze_];
+"6 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" [id=6, type=symmetric_quantize];
+"7 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/SymmetricQuantizer/symmetric_quantize_0" [id=7, type=symmetric_quantize];
+"8 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/conv2d_0" [id=8, type=conv2d];
+"9 /nncf_model_output_0" [id=9, type=nncf_model_output];
 "0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
 "1 SymmetricQuantizer/symmetric_quantize_0" -> "2 InplaceThenQuantizableOpModel/__mul___0";
 "2 InplaceThenQuantizableOpModel/__mul___0" -> "3 InplaceThenQuantizableOpModel/unsqueeze__0";
-"3 InplaceThenQuantizableOpModel/unsqueeze__0" -> "4 InplaceThenQuantizableOpModel/SymmetricQuantizer/symmetric_quantize_0";
-"3 InplaceThenQuantizableOpModel/unsqueeze__0" -> "6 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/conv2d_0";
-"5 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" -> "6 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/conv2d_0";
-"6 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/conv2d_0" -> "7 /nncf_model_output_0";
+"3 InplaceThenQuantizableOpModel/unsqueeze__0" -> "4 InplaceThenQuantizableOpModel/squeeze__0";
+"4 InplaceThenQuantizableOpModel/squeeze__0" -> "5 InplaceThenQuantizableOpModel/unsqueeze__1";
+"5 InplaceThenQuantizableOpModel/unsqueeze__1" -> "7 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/SymmetricQuantizer/symmetric_quantize_0";
+"6 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" -> "8 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/conv2d_0";
+"7 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/SymmetricQuantizer/symmetric_quantize_0" -> "8 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/conv2d_0";
+"8 InplaceThenQuantizableOpModel/NNCFConv2d[conv]/conv2d_0" -> "9 /nncf_model_output_0";
 }

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/logical_not_.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/logical_not_.dot
@@ -1,9 +1,7 @@
 strict digraph  {
 "0 /nncf_model_input_0" [id=0, type=nncf_model_input];
-"1 SymmetricQuantizer/symmetric_quantize_0" [id=1, type=symmetric_quantize];
-"2 TestModel/logical_not__0" [id=2, type=logical_not_];
-"3 /nncf_model_output_0" [id=3, type=nncf_model_output];
-"0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
-"1 SymmetricQuantizer/symmetric_quantize_0" -> "2 TestModel/logical_not__0";
-"2 TestModel/logical_not__0" -> "3 /nncf_model_output_0";
+"1 TestModel/logical_not__0" [id=1, type=logical_not_];
+"2 /nncf_model_output_0" [id=2, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "1 TestModel/logical_not__0";
+"1 TestModel/logical_not__0" -> "2 /nncf_model_output_0";
 }

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -29,6 +29,7 @@ from tests.torch.test_models.synthetic import ConvRelu6HSwishHSigmoid
 from tests.torch.test_models.synthetic import FC_ConstMul
 from tests.torch.test_models.synthetic import MMDivConv
 from tests.torch.test_models.synthetic import MatMulDivConv
+from tests.torch.test_models.synthetic import InplaceThenQuantizableOpModel
 from torch import nn
 import torch.nn.functional as F
 
@@ -706,7 +707,8 @@ SYNTHETIC_MODEL_DESC_LIST = [
     GeneralModelDesc(model_builder=ConvRelu6HSwishHSigmoid, input_sample_sizes=([1, 1, 5, 5],)),
     GeneralModelDesc(model_builder=ConvBNLeakyReLU, input_sample_sizes=([1, 1, 5, 5],)),
     GeneralModelDesc(model_builder=FC_ConstMul, input_sample_sizes=[1, 3, 6]),
-    GeneralModelDesc(model_builder=ConvGeluGetItem, input_sample_sizes=([1, 6, 6],))
+    GeneralModelDesc(model_builder=ConvGeluGetItem, input_sample_sizes=([1, 6, 6],)),
+    GeneralModelDesc(model_builder=InplaceThenQuantizableOpModel, input_sample_sizes=[1, 8, 8])
 ]
 
 

--- a/tests/torch/test_models/synthetic.py
+++ b/tests/torch/test_models/synthetic.py
@@ -325,5 +325,6 @@ class InplaceThenQuantizableOpModel(nn.Module):
     def forward(self, x: torch.Tensor):
         y = x * 1.0
         y.unsqueeze_(0)
+        y.squeeze_(0).unsqueeze_(0)
         z = self.conv(y)
         return z

--- a/tests/torch/test_models/synthetic.py
+++ b/tests/torch/test_models/synthetic.py
@@ -316,3 +316,14 @@ class FC_ConstMul(torch.nn.Module):
         x1 = self.fc1(x)
         x1 = x1 * 2
         return x + x1
+
+class InplaceThenQuantizableOpModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = create_conv(1, 2, 2, 2)
+
+    def forward(self, x: torch.Tensor):
+        y = x * 1.0
+        y.unsqueeze_(0)
+        z = self.conv(y)
+        return z


### PR DESCRIPTION
### Changes
In-place ops in PyTorch will not allow setting up pre- and post-hooks for themselves. The detection of the in-place op is done via naming convention.

### Reason for changes
Quantizers cannot end up on pre- and post-hooks of in-place ops, because quantizers themselves are currently not in-place and therefore a) the result of quantization is never used, and b) the compressed graph breaks down.

### Related tickets
76386

### Tests
tests/torch/test_compressed_graph.py::test_synthetic_model_quantization[InplaceThenQuantizableOpModel]
