### PR TITLE
Use functools.wraps on NNCF wrappers

### DIFF
--- a/nncf/telemetry/decorator.py
+++ b/nncf/telemetry/decorator.py
@@ -10,7 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-
+import functools
 import inspect
 from typing import Callable
 from typing import List, Union
@@ -46,6 +46,7 @@ class tracked_function:
     def __call__(self, fn: Callable) -> Callable:
         fn_signature = inspect.signature(fn)
 
+        @functools.wraps(fn)
         def wrapped(*args, **kwargs):
             bound_args = fn_signature.bind(*args, **kwargs)
             bound_args.apply_defaults()
@@ -74,4 +75,3 @@ class tracked_function:
             return retval
 
         return wrapped
-

--- a/nncf/telemetry/wrapper.py
+++ b/nncf/telemetry/wrapper.py
@@ -10,6 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+import functools
 import os
 import sys
 from abc import ABC
@@ -38,7 +39,6 @@ class ITelemetry(ABC):
         :param category: the application code
         :return: None
         """
-        pass
 
     @abstractmethod
     def send_event(self, event_category: str, event_action: str, event_label: str, event_value: int = 1,
@@ -54,7 +54,6 @@ class ITelemetry(ABC):
         :param kwargs: additional parameters
         :return: None
         """
-        pass
 
     @abstractmethod
     def end_session(self, category: str, **kwargs):
@@ -65,7 +64,6 @@ class ITelemetry(ABC):
         :param category: the application code
         :return: None
         """
-        pass
 
 
 def skip_if_raised(func: Callable[..., None]) -> Callable[..., None]:
@@ -73,9 +71,11 @@ def skip_if_raised(func: Callable[..., None]) -> Callable[..., None]:
     For the calls on the decorated function the execution will continue from the statement after the function
     even if an exception was triggered inside the function. The function to be wrapped must return nothing or None.
     """
+    @functools.wraps(func)
     def wrapped(*args, **kwargs):
         try:
             func()
+        #pylint:disable=broad-except
         except Exception as e:
             nncf_logger.debug(f"Skipped calling {func.__name__} - internally triggered exception {e}")
     return wrapped
@@ -87,6 +87,7 @@ class NNCFTelemetry(ITelemetry):
     def __init__(self):
         try:
             self._impl = Telemetry(app_name='nncf', app_version=__version__, tid=self.MEASUREMENT_ID)
+        #pylint:disable=broad-except
         except Exception as e:
             nncf_logger.debug(f"Failed to instantiate telemetry object: exception {e}")
 

--- a/nncf/torch/dynamic_graph/wrappers.py
+++ b/nncf/torch/dynamic_graph/wrappers.py
@@ -10,7 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-
+import functools
 from copy import deepcopy
 from typing import Callable
 from typing import List
@@ -82,6 +82,7 @@ def wrap_operator(operator, operator_info: 'PatchedOperatorInfo'):
         nncf_logger.debug(f"Operator: {_orig_op.__name__} is already wrapped")
         return operator
 
+    @functools.wraps(operator)
     def wrapped(*args, **kwargs):
         ctx = get_current_context()
         if not ctx or getattr(ctx, 'in_operator', False) or not ctx.is_tracing:
@@ -134,6 +135,7 @@ def wrap_module_call(module_call):
     from nncf.torch.dynamic_graph.patch_pytorch import ORIGINAL_OPERATORS #pylint: disable=cyclic-import
     NAMES_ORIGINAL_OPERATORS = [op.name for op in ORIGINAL_OPERATORS]
 
+    @functools.wraps(module_call)
     def wrapped(self, *args, **kwargs):
         ctx = get_current_context()
         if not ctx or self.__class__ in _IGNORED_SCOPES:


### PR DESCRIPTION
### Changes
As stated in the title.

### Reason for changes
Makes NNCF-wrapped functions preserve original names and attributes, which will make NNCF patching less noticeable to external entities.

### Related tickets
N/A

### Tests
Existing PT precommit scope
