### PR TITLE
Minor improvements

### DIFF
--- a/nncf/common/graph/patterns/patterns.py
+++ b/nncf/common/graph/patterns/patterns.py
@@ -267,8 +267,8 @@ class PatternDesc:
 
     :param name: Specific pattern name.
     :param devices: A field containing the list of devices
-    for which this pattern should be taken into account when quantizing.
-    None value means that this pattern is applicable to all devices.
+        for which this pattern should be taken into account when quantizing.
+        None value means that this pattern is applicable to all devices.
     """
 
     name: str

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -339,7 +339,7 @@ class MinMaxQuantization(Algorithm):
             return self._quantization_target_points_to_qconfig
         backend = get_backend(model)
         device = self._parameters.target_device
-        pattern = PatternsManager().get_full_pattern_graph(backend, device)
+        pattern = PatternsManager.get_full_pattern_graph(backend, device)
         quantizer_setup = self._get_quantizer_setup(nncf_graph, pattern)
         for quantization_point in quantizer_setup.quantization_points.values():
             if quantization_point.is_weight_quantization_point():

--- a/tests/openvino/native/quantization/test_ptq_params.py
+++ b/tests/openvino/native/quantization/test_ptq_params.py
@@ -34,8 +34,8 @@ from tests.openvino.native.models import DepthwiseConvModel
 
 def get_patterns_setup(model: OVReferenceModel, device: TargetDevice) -> GraphPattern:
     backend = get_backend(model)
-    patterns_manager = PatternsManager()
-    return patterns_manager.get_full_pattern_graph(backend, device)
+    return PatternsManager.get_full_pattern_graph(backend, device)
+
 
 # pylint: disable=protected-access
 @pytest.mark.parametrize('target_device', [TargetDevice.CPU, TargetDevice.GPU, TargetDevice.VPU])

--- a/tests/shared/patterns.py
+++ b/tests/shared/patterns.py
@@ -16,8 +16,9 @@ from nncf.common.utils.backend import BackendType
 from nncf.common.graph.patterns import PatternNames
 from nncf.common.graph.patterns.manager import PatternsManager
 
+
 def check_patterns(backend: BackendType, reasons: Dict[PatternNames, str]):
-    backend_patterns = PatternsManager().get_backend_patterns_map(backend)
+    backend_patterns = PatternsManager.get_backend_patterns_map(backend)
 
     all_base_apatterns = PatternNames
     for base_pattern in all_base_apatterns:


### PR DESCRIPTION
### Changes

Refactoring.

### Reason for changes

The `get_backend_patterns_map()` and `get_full_pattern_graph()` methods are decorated as `staticmethod` so we don't need to create an object to call them.

### Related tickets

N/A

### Tests

N/A
