### PR TITLE
Added patching of torch.jit.script_if_tracing

### DIFF
--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -128,17 +128,17 @@ def torch_jit_script_wrapper(*args, **kwargs):
 
 
 def torch_jit_script_if_tracing(fn):
+    # pylint: disable=protected-access
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         if not is_tracing():
-            # Not tracing, don't do anything
             return fn(*args, **kwargs)
 
-        compiled_fn = torch.jit.script(wrapper.__original_fn)  # type: ignore[attr-defined]
+        compiled_fn = torch.jit.script(wrapper.__original_fn)
         return compiled_fn(*args, **kwargs)
 
-    wrapper.__original_fn = fn  # type: ignore[attr-defined]
-    wrapper.__script_if_tracing_wrapper = True  # type: ignore[attr-defined]
+    wrapper.__original_fn = fn
+    wrapper.__script_if_tracing_wrapper = True
 
     return wrapper
 

--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -11,12 +11,14 @@
  limitations under the License.
 """
 
+import functools
 from enum import Enum
 
 from typing import List
 
 import torch
 import torch.utils.cpp_extension
+from torch.jit import is_tracing
 from torch.nn import DataParallel
 from torch.nn.parallel import DistributedDataParallel
 
@@ -125,6 +127,22 @@ def torch_jit_script_wrapper(*args, **kwargs):
     return retval
 
 
+def torch_jit_script_if_tracing(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        if not is_tracing():
+            # Not tracing, don't do anything
+            return fn(*args, **kwargs)
+
+        compiled_fn = torch.jit.script(wrapper.__original_fn)  # type: ignore[attr-defined]
+        return compiled_fn(*args, **kwargs)
+
+    wrapper.__original_fn = fn  # type: ignore[attr-defined]
+    wrapper.__script_if_tracing_wrapper = True  # type: ignore[attr-defined]
+
+    return wrapper
+
+
 class OriginalOpInfo:
     def __init__(self, name: str, namespace, op):
         self.name = name
@@ -148,6 +166,11 @@ def patch_torch_jit_script():
     global _ORIG_JIT_SCRIPT
     _ORIG_JIT_SCRIPT = orig
     setattr(torch.jit, "script", torch_jit_script_wrapper)
+
+    # Patch torch.jit._script_if_tracing because during torch import inside it
+    # references an original unpatched torch.jit.script and the patching above
+    # does not affect it
+    setattr(torch.jit, "_script_if_tracing", torch_jit_script_if_tracing)
 
 
 def patch_namespace_opname(namespace, op_info: PatchedOperatorInfo):

--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -167,9 +167,8 @@ def patch_torch_jit_script():
     _ORIG_JIT_SCRIPT = orig
     setattr(torch.jit, "script", torch_jit_script_wrapper)
 
-    # Patch torch.jit._script_if_tracing because during torch import inside it
-    # references an original unpatched torch.jit.script and the patching above
-    # does not affect it
+    # Patch torch.jit._script_if_tracing because it references an original
+    # unpatched torch.jit.script and the patching above does not affect it
     setattr(torch.jit, "_script_if_tracing", torch_jit_script_if_tracing)
 
 

--- a/tests/torch/pytorch_patch_isolated.py
+++ b/tests/torch/pytorch_patch_isolated.py
@@ -14,7 +14,6 @@
 import inspect
 import os
 import pytest
-import re
 
 import torch
 

--- a/tests/torch/pytorch_patch_isolated.py
+++ b/tests/torch/pytorch_patch_isolated.py
@@ -1,0 +1,35 @@
+"""
+ Copyright (c) 2022 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import inspect
+import os
+import pytest
+
+import torch
+
+from tests.shared.isolation_runner import ISOLATION_RUN_ENV_VAR
+
+
+@pytest.mark.skipif(ISOLATION_RUN_ENV_VAR not in os.environ, reason="Should be run via isolation proxy")
+def test_jit_if_tracing_script_source_equals():
+    # Get original torch.jit._script_if_tracing source
+    torch_source = inspect.getsource(torch.jit._script_if_tracing)
+
+    import nncf.torch
+    # Get torch.jit._script_if_tracing source after patching was performed
+    nncf_source = inspect.getsource(torch.jit._script_if_tracing)
+
+    # Check that the two versions are essentially the same
+    nncf_source_corrected = nncf_source.replace("torch_jit_script_if_tracing", "_script_if_tracing").\
+        replace("torch.jit.script", "script")
+    assert torch_source == nncf_source_corrected

--- a/tests/torch/test_pytorch_patch.py
+++ b/tests/torch/test_pytorch_patch.py
@@ -6,6 +6,9 @@ from nncf.torch.dynamic_graph.context import TracingContext
 from nncf.torch.dynamic_graph.trace_tensor import TracedTensor
 from nncf.torch.dynamic_graph.trace_tensor import TensorMeta
 
+from tests.shared.isolation_runner import run_pytest_case_function_in_separate_process
+from tests.torch.pytorch_patch_isolated import test_jit_if_tracing_script_source_equals
+
 
 def test_get_all_aliases_is_valid():
     operator_names_to_function_name = {}
@@ -46,3 +49,21 @@ def test_tensor_printing_does_not_inflate_graph():
             str(tensor)
             tensor.__repr__()
     assert _ctx.graph.get_nodes_count() == 0
+
+
+def test_jit_if_tracing_script_patching(tmp_path):
+    @torch.jit.script_if_tracing
+    def test_fn(x: torch.Tensor):
+        return torch.empty(x.shape)
+
+    class TestModel(torch.nn.Module):
+        def forward(self, x: torch.Tensor):
+            return test_fn(x)
+
+    # ONNX export should work correctly because torch.jit.script_if_tracing is patched
+    torch.onnx.export(TestModel(), (torch.zeros((1,)),), str(tmp_path / "jit_if_tracing_test_model.onnx"))
+
+
+def test_jit_if_tracing_script_source():
+    # Run test case in a separate process to track patching of torch by NNCF
+    _, stdout, _ = run_pytest_case_function_in_separate_process(test_jit_if_tracing_script_source_equals)

--- a/tests/torch/test_pytorch_patch.py
+++ b/tests/torch/test_pytorch_patch.py
@@ -66,4 +66,4 @@ def test_jit_if_tracing_script_patching(tmp_path):
 
 def test_jit_if_tracing_script_source():
     # Run test case in a separate process to track patching of torch by NNCF
-    _, stdout, _ = run_pytest_case_function_in_separate_process(test_jit_if_tracing_script_source_equals)
+    run_pytest_case_function_in_separate_process(test_jit_if_tracing_script_source_equals)


### PR DESCRIPTION
The fact of importing of `nncf.torch` can lead to `torch.onnx.export` failing if the model being exported internally relies on [torch.jit.script_if_tracing](https://pytorch.org/docs/stable/generated/torch.jit.script_if_tracing.html). This is due to patching issues.

### Changes

- Added patching of torch.jit._script_if_tracing
- Added a couple of tests
