### PR TITLE
Fix: out of sync level_ranges and signed parameter

### DIFF
--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -333,7 +333,7 @@ class BaseQuantizer(nn.Module):
         # TODO: refactor to get rid of extra if's and calls on each forward
         if not self.is_enabled_quantization():
             return x
-        self.set_level_ranges()
+
         is_exporting = is_tracing_state()
         if is_exporting:
             with no_nncf_trace():

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -333,7 +333,7 @@ class BaseQuantizer(nn.Module):
         # TODO: refactor to get rid of extra if's and calls on each forward
         if not self.is_enabled_quantization():
             return x
-
+        self.set_level_ranges()
         is_exporting = is_tracing_state()
         if is_exporting:
             with no_nncf_trace():

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -404,6 +404,7 @@ class BaseQuantizer(nn.Module):
     @num_bits.setter
     def num_bits(self, num_bits: int):
         self._num_bits.fill_(num_bits)
+        self.set_level_ranges()
 
     @property
     def narrow_range(self) -> bool:

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -567,7 +567,7 @@ class SymmetricQuantizer(BaseQuantizer):
         else:
             self.eps = 1e-16
         if qspec.signedness_to_force is not None:
-            self.signed = int(qspec.signedness_to_force)
+            self.signed = bool(qspec.signedness_to_force)
         self.set_level_ranges()
 
         self._register_load_state_dict_pre_hook(StorageRedirectingLoadStateDictHook(
@@ -581,6 +581,9 @@ class SymmetricQuantizer(BaseQuantizer):
             name_in_state_dict=self.SCALE_PARAM_NAME,
             use_log_storage_in_module=self._is_using_log_scale_storage
         ))
+
+        # Values of level_low, level_high must be recalculated for load new signed parameter.
+        self.register_load_state_dict_post_hook(lambda module, _: module.set_level_ranges())
 
     @property
     def scale(self):
@@ -625,7 +628,8 @@ class SymmetricQuantizer(BaseQuantizer):
 
     @signed.setter
     def signed(self, signed: bool):
-        self.signed_tensor.fill_(signed)
+        self.signed_tensor.fill_(int(signed))
+        self.set_level_ranges()
 
     def quantize(self, x, execute_traced_op_as_identity: bool = False):
         return symmetric_quantize(x, self.levels, self.level_low, self.level_high, self.scale, self.eps,
@@ -639,7 +643,7 @@ class SymmetricQuantizer(BaseQuantizer):
         if self._signedness_to_force is not None and sign != self._signedness_to_force:
             nncf_logger.debug(f"Forcing signed to {self._signedness_to_force} for module {log_module_name}")
             sign = self._signedness_to_force
-        self.signed = int(sign)
+        self.signed = sign
 
         abs_max = torch.max(torch.abs(max_values), torch.abs(min_values))
         SCALE_LOWER_THRESHOLD = 0.1

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -333,7 +333,6 @@ class BaseQuantizer(nn.Module):
         # TODO: refactor to get rid of extra if's and calls on each forward
         if not self.is_enabled_quantization():
             return x
-        self.set_level_ranges()
         is_exporting = is_tracing_state()
         if is_exporting:
             with no_nncf_trace():

--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -866,14 +866,14 @@ def test_sync_of_level_ranges_and_signed_parameter():
 
     sq = SymmetricQuantizer(qspec)
     # Check if the default values are different from the values to be loaded.
-    assert sq.signed == False
+    assert sq.signed is False
     assert sq.level_low == 0
 
     sq.signed = True
-    assert sq.signed == True
+    assert sq.signed is True
     assert sq.level_low == -8
 
     loaded_sq = SymmetricQuantizer(qspec)
     loaded_sq.load_state_dict(sq.state_dict())
-    assert loaded_sq.signed == True
+    assert loaded_sq.signed is True
     assert loaded_sq.level_low == -8

--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -45,10 +45,10 @@ from nncf.torch.module_operations import UpdateWeight
 from nncf.torch.nncf_network import ExtraCompressionModuleType
 from nncf.torch.quantization.algo import QuantizationBuilder
 from nncf.torch.quantization.algo import QuantizationController
+from nncf.torch.quantization.layers import QUANTIZATION_MODULES
 from nncf.torch.quantization.layers import AsymmetricQuantizer
 from nncf.torch.quantization.layers import BaseQuantizer
 from nncf.torch.quantization.layers import PTQuantizerSpec
-from nncf.torch.quantization.layers import QUANTIZATION_MODULES
 from nncf.torch.quantization.layers import SymmetricQuantizer
 from nncf.torch.utils import get_all_modules_by_type
 from nncf.torch.utils import get_model_device
@@ -850,3 +850,30 @@ def test_activation_ignored_scope(update_config_info, should_ignore_quantizers):
     ctrl, _ = create_compressed_model(model, config)
     assert Counter([item.target_node_name for item in ctrl.all_quantizations.keys()]) == \
            Counter(ref_quantization_names)
+
+
+def test_sync_of_level_ranges_and_signed_parameter():
+    qspec = PTQuantizerSpec(
+        num_bits=4,
+        mode=QuantizationMode.SYMMETRIC,
+        signedness_to_force=None,
+        scale_shape=(1, ),
+        narrow_range=False,
+        half_range=False,
+        logarithm_scale=False
+    )
+
+
+    sq = SymmetricQuantizer(qspec)
+    # Check if the default values are different from the values to be loaded.
+    assert sq.signed == False
+    assert sq.level_low == 0
+
+    sq.signed = True
+    assert sq.signed == True
+    assert sq.level_low == -8
+
+    loaded_sq = SymmetricQuantizer(qspec)
+    loaded_sq.load_state_dict(sq.state_dict())
+    assert loaded_sq.signed == True
+    assert loaded_sq.level_low == -8


### PR DESCRIPTION
### Changes

1. Add post_hook on `load_state_dict` to update `level_low` and `level_hight` for `SymmetrciQuantizer`.
2. Setter for signed got boolean value and cast to `int` inside function. To work with same type for getter and setter. (now type hint is actual.
3.  Add in setter of `signed` and `num_bits` parameters call `set_level_range` function. To have actual values of levels in all time.

### Reason for changes
```python
qspec = PTQuantizerSpec(
    num_bits=4,
    mode=QuantizationMode.SYMMETRIC,
    signedness_to_force=None,
    scale_shape=(1, ),
    narrow_range=False,
    half_range=False,
    logarithm_scale=False
)

sq = SymmetricQuantizer(qspec)
# sq.signed == False
# sq.level_low == 0

sq.apply_minmax_init(torch.Tensor([-11]), torch.Tensor([11]))
# sq.signed == True
# sq.level_low == 0, but expected -8

loaded_sq = SymmetricQuantizer(qspec)
loaded_sq.load_state_dict(sq.state_dict())
# loaded_sq.signed == True
# loaded_sq.level_low == 0, but expected -8

```

This does not affect the behaviour of the models, as the function `set_level_ranges` calls in `forward`.
https://github.com/openvinotoolkit/nncf/blob/7a1de11e3b9c9d641b7f44faa271ac059700f252/nncf/torch/quantization/layers.py#L330-L337

### Related tickets

103667

### Tests

- test_sync_of_level_ranges_and_signed_parameter