### PR TITLE
Add NNCF cache directory

### DIFF
--- a/examples/post_training_quantization/openvino/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/openvino/mobilenet_v2/main.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from typing import List, Optional
 
 import nncf
+from nncf.definitions import CACHE_DATASET_PATH
+from nncf.definitions import CACHE_MODELS_PATH
 import numpy as np
 import openvino.runtime as ov
 import torch
@@ -28,16 +30,14 @@ from tqdm import tqdm
 
 ROOT = Path(__file__).parent.resolve()
 MODEL_URL = 'https://huggingface.co/alexsu52/mobilenet_v2_imagenette/resolve/main/openvino_model.tgz'
-MODEL_PATH = '~/.cache/nncf/models'
 DATASET_URL = 'https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz'
-DATASET_PATH = '~/.cache/nncf/datasets'
 DATASET_CLASSES = 10
 
 
 def download(url: str, path: str) -> Path:
     downloader = FastDownload(base=path, 
                               archive='downloaded', 
-                              data='extracted')
+                              data='imagenette2-320')
     return downloader.get(url)
 
 
@@ -90,7 +90,7 @@ def get_model_size(ir_path: str, m_type: str = 'Mb',
 ###############################################################################
 # Create an OpenVINO model and dataset
 
-dataset_path = download(DATASET_URL, DATASET_PATH)
+dataset_path = download(DATASET_URL, CACHE_DATASET_PATH)
 
 normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                  std=[0.229, 0.224, 0.225])
@@ -106,7 +106,7 @@ val_dataset = datasets.ImageFolder(
 val_loader = torch.utils.data.DataLoader(
     val_dataset, batch_size=1, shuffle=False)
 
-model_path = download(MODEL_URL, MODEL_PATH)
+model_path = download(MODEL_URL, CACHE_MODELS_PATH)
 model = ov.Core().read_model(model_path / 'mobilenet_v2_fp32.xml')
 
 ###############################################################################

--- a/examples/post_training_quantization/openvino/quantize_with_accuracy_control/main.py
+++ b/examples/post_training_quantization/openvino/quantize_with_accuracy_control/main.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
 import nncf
+from nncf.definitions import CACHE_MODELS_PATH
+from nncf.definitions import CACHE_DATASET_PATH
 import numpy as np
 import openvino.runtime as ov
 import torch
@@ -36,13 +38,11 @@ MODEL_INFO = download.DownloadInfo(
     name="stfpm_mvtec_capsule",
     url='https://huggingface.co/alexsu52/stfpm_mvtec_capsule/resolve/main/openvino_model.tar',
     hash='0d15817bc56af80793de38c8a0b3fd9e')
-MODEL_PATH = HOME_PATH / '.cache/nncf/models/stfpm_mvtec_capsule'
 
 DATASET_INFO = download.DownloadInfo(
     name="mvtec_capsule",
     url='https://www.mydrive.ch/shares/38536/3830184030e49fe74747669442f0f282/download/420937454-1629951595/capsule.tar.xz',
     hash='380afc46701c99cb7b9a928edbe16eb5')
-DATASET_PATH = HOME_PATH / '.cache/nncf/datasets/mvtec_capsule'
 
 max_accuracy_drop = 0.005 if len(sys.argv) < 2 else sys.argv[1]
 
@@ -114,9 +114,9 @@ def get_model_size(ir_path: str, m_type: str = 'Mb',
 ###############################################################################
 # Create an OpenVINO model and dataset
 
-download_and_extract(DATASET_PATH, DATASET_INFO)
+download_and_extract(CACHE_DATASET_PATH, DATASET_INFO)
 
-datamodule = MVTec(root=DATASET_PATH,
+datamodule = MVTec(root=CACHE_DATASET_PATH,
                    category="capsule",
                    image_size=(256, 256),
                    train_batch_size=1,
@@ -125,10 +125,10 @@ datamodule = MVTec(root=DATASET_PATH,
 datamodule.setup()
 test_loader = datamodule.test_dataloader()
 
-download_and_extract(MODEL_PATH, MODEL_INFO)
-model = ov.Core().read_model(MODEL_PATH / 'stfpm_capsule.xml')
+download_and_extract(CACHE_MODELS_PATH, MODEL_INFO)
+model = ov.Core().read_model(CACHE_MODELS_PATH / 'stfpm_capsule.xml')
 
-with open(MODEL_PATH / 'meta_data_stfpm_capsule.json', 'r') as f:
+with open(CACHE_MODELS_PATH / 'meta_data_stfpm_capsule.json', 'r') as f:
     validation_params = json.load(f)
 
 ###############################################################################

--- a/examples/post_training_quantization/torch/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/torch/mobilenet_v2/main.py
@@ -31,7 +31,7 @@ from tqdm import tqdm
 ROOT = Path(__file__).parent.resolve()
 CHECKPOINT_URL = 'https://huggingface.co/alexsu52/mobilenet_v2_imagenette/resolve/main/pytorch_model.bin'
 DATASET_URL = 'https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz'
-mDATASET_CLASSES = 10
+DATASET_CLASSES = 10
 
 
 def download_dataset() -> Path:

--- a/examples/post_training_quantization/torch/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/torch/mobilenet_v2/main.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import List, Optional
 
 import nncf
+from nncf.definitions import CACHE_DATASET_PATH
 import numpy as np
 import openvino.runtime as ov
 import torch
@@ -30,14 +31,13 @@ from tqdm import tqdm
 ROOT = Path(__file__).parent.resolve()
 CHECKPOINT_URL = 'https://huggingface.co/alexsu52/mobilenet_v2_imagenette/resolve/main/pytorch_model.bin'
 DATASET_URL = 'https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz'
-DATASET_PATH = '~/.cache/nncf/datasets'
-DATASET_CLASSES = 10
+mDATASET_CLASSES = 10
 
 
 def download_dataset() -> Path:
-    downloader = FastDownload(base=DATASET_PATH, 
+    downloader = FastDownload(base=CACHE_DATASET_PATH,
                               archive='downloaded', 
-                              data='extracted')
+                              data='imagenette2-320')
     return downloader.get(DATASET_URL)
 
 

--- a/nncf/definitions.py
+++ b/nncf/definitions.py
@@ -12,8 +12,13 @@
 """
 
 import os
+from pathlib import Path
 NNCF_PACKAGE_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 HW_CONFIG_RELATIVE_DIR = "common/hardware/configs"
+
+NNCF_CACHE_PATH = Path.home() / Path('.cache/nncf/')
+CACHE_DATASET_PATH = NNCF_CACHE_PATH / Path('datasets')
+CACHE_MODELS_PATH = NNCF_CACHE_PATH / Path('models')
 
 # Environment variables below, if set, mark the execution environment
 # so that certain actions within NNCF proper, such as telemetry event collection or

--- a/tests/onnx/quantization/test_ptq_regression.py
+++ b/tests/onnx/quantization/test_ptq_regression.py
@@ -23,15 +23,17 @@ from fastdownload import FastDownload
 from sklearn.metrics import accuracy_score
 from torchvision import datasets, transforms
 from tqdm import tqdm
+from nncf.definitions import CACHE_DATASET_PATH
+from nncf.definitions import CACHE_MODELS_PATH
 
 MODELS = [
     ('https://github.com/onnx/models/raw/main/vision/classification/mobilenet/model/mobilenetv2-12.onnx',
-     'mobilenetv2-12', 0.7875159235668789),
+     'mobilenetv2-12', 0.7875),
     ('https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet50-v1-7.onnx',
-     'resnet50-v1-7', 0.8119745222929936),
+     'resnet50-v1-7', 0.8119),
     (
     'https://github.com/onnx/models/raw/main/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11.onnx',
-    'efficientnet-lite4-11', 0.8015286624203821)
+    'efficientnet-lite4-11', 0.8015)
 ]
 
 DATASET_URL = 'https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz'
@@ -41,7 +43,7 @@ DATASET_URL = 'https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz'
 def data(request):
     option = request.config.getoption("--data")
     if option is None:
-        return Path('~/.cache/nncf/datasets')
+        return CACHE_DATASET_PATH
     return Path(option)
 
 
@@ -49,14 +51,14 @@ def data(request):
 def models(request, tmp_path):
     option = request.config.getoption("--data")
     if option is None:
-        return Path(tmp_path)
+        return CACHE_MODELS_PATH
     return Path(option)
 
 
 def download_dataset(dataset_path: Path) -> Path:
     downloader = FastDownload(base=dataset_path,
                               archive='downloaded',
-                              data='extracted')
+                              data='imagenette2-320')
     return downloader.get(DATASET_URL)
 
 

--- a/tests/onnx/quantization/test_ptq_regression.py
+++ b/tests/onnx/quantization/test_ptq_regression.py
@@ -27,13 +27,15 @@ from nncf.definitions import CACHE_DATASET_PATH
 from nncf.definitions import CACHE_MODELS_PATH
 
 MODELS = [
-    ('https://github.com/onnx/models/raw/main/vision/classification/mobilenet/model/mobilenetv2-12.onnx',
+    ('https://github.com/onnx/models/raw/8e893eb39b131f6d3970be6ebd525327d3df34ea/vision/'
+     'classification/mobilenet/model/mobilenetv2-12.onnx',
      'mobilenetv2-12', 0.7875),
-    ('https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet50-v1-7.onnx',
+    ('https://github.com/onnx/models/raw/8e893eb39b131f6d3970be6ebd525327d3df34ea/vision/'
+     'classification/resnet/model/resnet50-v1-7.onnx',
      'resnet50-v1-7', 0.8119),
-    (
-    'https://github.com/onnx/models/raw/main/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11.onnx',
-    'efficientnet-lite4-11', 0.8015)
+    ('https://github.com/onnx/models/raw/8e893eb39b131f6d3970be6ebd525327d3df34ea/vision/'
+     'classification/efficientnet-lite4/model/efficientnet-lite4-11.onnx',
+     'efficientnet-lite4-11', 0.8015)
 ]
 
 DATASET_URL = 'https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz'


### PR DESCRIPTION
### Changes

Add directory is used to store cache to run tests or samples.

### Reason for changes

Speed up ONNX pre-commit by caching dataset and models.

### Related tickets

No

### Tests

No
