### PR TITLE
[OV] Align FQ params data type with target node  precision

### DIFF
--- a/nncf/experimental/openvino_native/graph/model_transformer.py
+++ b/nncf/experimental/openvino_native/graph/model_transformer.py
@@ -231,7 +231,7 @@ class OVModelTransformer(ModelTransformer):
             inp_node = target_node.input(port_id)
             input_node_output = inp_node.get_source_output()
             data_type = inp_node.get_element_type()
-            if data_type == np.float16:
+            if data_type == ov.Type(np.float16):
                 input_low, input_high, output_low, output_high = OVModelTransformer.convert_params_to_fp16(fq_params)
             name = 'fq_weights' if transform_type == TargetType.OPERATION_WITH_WEIGHTS else 'fq_input'
             fq_name = f'{node_name}/{name}_{port_id}'
@@ -241,7 +241,7 @@ class OVModelTransformer(ModelTransformer):
         elif transform_type == TargetType.POST_LAYER_OPERATION:
             output = target_node.output(port_id)
             data_type = output.get_element_type()
-            if data_type == np.float16:
+            if data_type == ov.Type(np.float16):
                 input_low, input_high, output_low, output_high = OVModelTransformer.convert_params_to_fp16(fq_params)
             target_inputs = output.get_target_inputs()
             fq_name = f'{node_name}/fq_output_{port_id}'

--- a/nncf/experimental/openvino_native/graph/model_transformer.py
+++ b/nncf/experimental/openvino_native/graph/model_transformer.py
@@ -12,8 +12,6 @@
 """
 
 from typing import List, Tuple, Dict
-from enum import Enum
-
 import openvino.runtime as ov
 import numpy as np
 from openvino.runtime import opset9 as opset
@@ -176,18 +174,12 @@ class OVModelTransformer(ModelTransformer):
         :param transformations: List of the OVQuantizerInsertionCommand transformations.
         :return: Model with inserted FakeQuantize nodes.
         """
-        model_precision = ModelPrecision.FP32
-        for op in model.get_ops():
-            if op.get_type_name() == 'Constant':
-                if op.get_element_type().is_real():
-                    if op.get_element_type() == ov.Type(np.float16):
-                        model_precision = ModelPrecision.FP16
-                        break
         name_to_node_mapping = OVModelTransformer._get_name_to_node_mapping(model)
         for transformation in transformations:
-            OVModelTransformer._insert_fake_quantize_op(transformation, name_to_node_mapping, model_precision)
+            OVModelTransformer._insert_fake_quantize_op(transformation, name_to_node_mapping)
         return model
 
+    @staticmethod
     def convert_params_to_fp16(fq_params: OVQuantizerLayerParameters) -> \
                                Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """

--- a/nncf/experimental/openvino_native/graph/model_transformer.py
+++ b/nncf/experimental/openvino_native/graph/model_transformer.py
@@ -21,23 +21,12 @@ from openvino.runtime import opset9 as opset
 from nncf.common.graph.model_transformer import ModelTransformer
 from nncf.common.graph.transformations.layout import TransformationLayout
 from nncf.common.graph.transformations.commands import TargetType
+from nncf.experimental.openvino_native.quantization.quantizer_parameters import OVQuantizerLayerParameters
 from nncf.experimental.openvino_native.graph.transformations.commands import OVQuantizerInsertionCommand
 from nncf.experimental.openvino_native.graph.transformations.commands import OVOutputInsertionCommand
 from nncf.experimental.openvino_native.graph.transformations.commands import OVModelExtractionCommand
 from nncf.experimental.openvino_native.graph.transformations.commands import OVBiasCorrectionCommand
 from nncf.experimental.openvino_native.graph.transformations.commands import OVFQNodeRemovingCommand
-
-
-class ModelPrecision(Enum):
-    """
-    Describes the model precision based on the precision of floating point constants.
-
-    :param FP32:
-    :param FP16:
-    """
-
-    FP32 = 'FP32'
-    FP16 = 'FP16'
 
 
 class OVModelTransformer(ModelTransformer):
@@ -199,16 +188,32 @@ class OVModelTransformer(ModelTransformer):
             OVModelTransformer._insert_fake_quantize_op(transformation, name_to_node_mapping, model_precision)
         return model
 
+    def convert_params_to_fp16(fq_params: OVQuantizerLayerParameters) -> \
+                               Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Converts FakeQuantize parameters to FP16 precision.
+
+        :param fq_params: FakeQuantize node attributes.
+        :return: FakeQuantize parameters in FP16 precision.
+        """
+        def _convert_to_fp16(data):
+            clip_data = np.clip(data, np.finfo(np.float16).min, np.finfo(np.float16).max)
+            return clip_data.astype(np.float16)
+
+        input_low = _convert_to_fp16(fq_params.input_low)
+        input_high = _convert_to_fp16(fq_params.input_high)
+        output_low = _convert_to_fp16(fq_params.output_low)
+        output_high = _convert_to_fp16(fq_params.output_high)
+        return input_low, input_high, output_low, output_high
+
     @staticmethod
     def _insert_fake_quantize_op(transformation: OVQuantizerInsertionCommand,
-                                 name_to_node_mapping: Dict[str, ov.Node],
-                                 model_precision: ModelPrecision) -> None:
+                                 name_to_node_mapping: Dict[str, ov.Node]) -> None:
         """
         Inserts FakeQuantize Operation to a model which name_to_node_mapping is passed.
 
         :param transformation: FakeQuantize insertion command.
         :param name_to_node_mapping: Mapping from node name to node instance.
-        :param model_precision: Precision of the Model.
         :return: None
         """
         fq_params = transformation.quantizer_parameters
@@ -218,15 +223,6 @@ class OVModelTransformer(ModelTransformer):
         output_high = fq_params.output_high
         levels = fq_params.levels
 
-        def _convert_to_fp16(data):
-            return opset.convert(data.astype(np.float16), np.float32)
-
-        if model_precision == ModelPrecision.FP16:
-            input_low = _convert_to_fp16(input_low)
-            input_high = _convert_to_fp16(input_high)
-            output_low = _convert_to_fp16(output_low)
-            output_high = _convert_to_fp16(output_high)
-
         node_name = transformation.target_point.target_node_name
         target_node = name_to_node_mapping[node_name]
         port_id = transformation.target_point.port_id
@@ -234,6 +230,9 @@ class OVModelTransformer(ModelTransformer):
         if transform_type in [TargetType.PRE_LAYER_OPERATION, TargetType.OPERATION_WITH_WEIGHTS]:
             inp_node = target_node.input(port_id)
             input_node_output = inp_node.get_source_output()
+            data_type = inp_node.get_element_type()
+            if data_type == np.float16:
+                input_low, input_high, output_low, output_high = OVModelTransformer.convert_params_to_fp16(fq_params)
             name = 'fq_weights' if transform_type == TargetType.OPERATION_WITH_WEIGHTS else 'fq_input'
             fq_name = f'{node_name}/{name}_{port_id}'
             fq = opset.fake_quantize(input_node_output, input_low, input_high,
@@ -241,6 +240,9 @@ class OVModelTransformer(ModelTransformer):
             inp_node.replace_source_output(fq.output(0))
         elif transform_type == TargetType.POST_LAYER_OPERATION:
             output = target_node.output(port_id)
+            data_type = output.get_element_type()
+            if data_type == np.float16:
+                input_low, input_high, output_low, output_high = OVModelTransformer.convert_params_to_fp16(fq_params)
             target_inputs = output.get_target_inputs()
             fq_name = f'{node_name}/fq_output_{port_id}'
             fq = opset.fake_quantize(output, input_low, input_high,

--- a/nncf/experimental/openvino_native/quantization/quantizer_parameters.py
+++ b/nncf/experimental/openvino_native/quantization/quantizer_parameters.py
@@ -204,8 +204,8 @@ def calculate_quantizer_parameters(statistics: MinMaxTensorStatistic,
     :param quantizer_group: Group of the quantizer.
     :return: Parameters of the FakeQuantize layer.
     """
-    min_values = np.array(statistics.min_values)
-    max_values = np.array(statistics.max_values)
+    min_values = np.array(statistics.min_values).astype(np.float32)
+    max_values = np.array(statistics.max_values).astype(np.float32)
 
     if quantizer_config.mode == QuantizationMode.SYMMETRIC:
         narrow_range = quant_group == QuantizerGroup.WEIGHTS

--- a/tests/openvino/native/models.py
+++ b/tests/openvino/native/models.py
@@ -196,7 +196,7 @@ class FPModel(OVReferenceModel):
 
     def _create_ov_model(self):
         input_shape = [1, 3, 4, 2]
-        input_1 = opset.parameter(input_shape, name="Input")
+        input_1 = opset.parameter(input_shape, name="Input", dtype=np.float32)
         data = self._rng.random((1, 3, 4, 5)).astype(self.precision)
         if self.precision == np.float16:
             data = opset.convert(data, np.float32)
@@ -204,6 +204,19 @@ class FPModel(OVReferenceModel):
         bias = self._rng.random((1, 3, 1, 1)).astype(self.precision)
         if self.precision == np.float16:
             bias = opset.convert(bias, np.float32)
+        add = opset.add(matmul, bias, name="Add")
+        r1 = opset.result(add, name="Result_Add")
+        model = ov.Model([r1], [input_1])
+        return model
+
+
+class FP16InputModel(OVReferenceModel):
+    def _create_ov_model(self):
+        input_shape = [1, 3, 4, 2]
+        input_1 = opset.parameter(input_shape, name="Input", dtype=np.float16)
+        data = self._rng.random((1, 3, 4, 5)).astype(np.float16)
+        matmul = opset.matmul(input_1, data, transpose_a=True, transpose_b=False, name="MatMul")
+        bias = self._rng.random((1, 3, 1, 1)).astype(np.float16)
         add = opset.add(matmul, bias, name="Add")
         r1 = opset.result(add, name="Result_Add")
         model = ov.Model([r1], [input_1])

--- a/tests/openvino/native/models.py
+++ b/tests/openvino/native/models.py
@@ -190,33 +190,21 @@ class MatMul2DModel(OVReferenceModel):
 
 
 class FPModel(OVReferenceModel):
-    def __init__(self, precision='FP32'):
-        self.precision = np.float32 if precision == 'FP32' else np.float16
+    def __init__(self, const_dtype='FP32', input_dtype='FP32'):
+        self.const_dtype = np.float32 if const_dtype == 'FP32' else np.float16
+        self.input_dtype = np.float32 if input_dtype == 'FP32' else np.float16
         super().__init__()
 
     def _create_ov_model(self):
         input_shape = [1, 3, 4, 2]
-        input_1 = opset.parameter(input_shape, name="Input", dtype=np.float32)
-        data = self._rng.random((1, 3, 4, 5)).astype(self.precision)
-        if self.precision == np.float16:
-            data = opset.convert(data, np.float32)
+        input_1 = opset.parameter(input_shape, name="Input", dtype=self.input_dtype)
+        data = self._rng.random((1, 3, 4, 5)).astype(self.const_dtype)
+        if self.const_dtype != self.input_dtype:
+            data = opset.convert(data, self.input_dtype)
         matmul = opset.matmul(input_1, data, transpose_a=True, transpose_b=False, name="MatMul")
-        bias = self._rng.random((1, 3, 1, 1)).astype(self.precision)
-        if self.precision == np.float16:
-            bias = opset.convert(bias, np.float32)
-        add = opset.add(matmul, bias, name="Add")
-        r1 = opset.result(add, name="Result_Add")
-        model = ov.Model([r1], [input_1])
-        return model
-
-
-class FP16InputModel(OVReferenceModel):
-    def _create_ov_model(self):
-        input_shape = [1, 3, 4, 2]
-        input_1 = opset.parameter(input_shape, name="Input", dtype=np.float16)
-        data = self._rng.random((1, 3, 4, 5)).astype(np.float16)
-        matmul = opset.matmul(input_1, data, transpose_a=True, transpose_b=False, name="MatMul")
-        bias = self._rng.random((1, 3, 1, 1)).astype(np.float16)
+        bias = self._rng.random((1, 3, 1, 1)).astype(self.const_dtype)
+        if self.const_dtype != self.input_dtype:
+            bias = opset.convert(bias, self.input_dtype)
         add = opset.add(matmul, bias, name="Add")
         r1 = opset.result(add, name="Result_Add")
         model = ov.Model([r1], [input_1])

--- a/tests/openvino/native/quantization/test_fq_params_calculation.py
+++ b/tests/openvino/native/quantization/test_fq_params_calculation.py
@@ -33,7 +33,6 @@ from tests.openvino.native.models import LinearModel
 from tests.openvino.native.models import ConvModel
 from tests.openvino.native.models import MatMul2DModel
 from tests.openvino.native.models import FPModel
-from tests.openvino.native.models import FP16InputModel
 
 REFERENCE_SCALES_DIR = OPENVINO_NATIVE_TEST_ROOT / 'data' / 'reference_scales'
 
@@ -148,27 +147,19 @@ def test_syntetic_models_fq_shapes(model_creator_func, ref_shapes):
         assert node['output_high'].shape == ref_shapes[node_name]
 
 
-@pytest.mark.parametrize('precision', ['FP16', 'FP32'])
-def test_fq_precision_orig_fp32model(precision):
-    model = FPModel(precision)
+@pytest.mark.parametrize('const_dtype', ['FP16', 'FP32'])
+@pytest.mark.parametrize('input_dtype', ['FP16', 'FP32'])
+def test_fq_precision_orig_fp32model(const_dtype, input_dtype):
+    model = FPModel(const_dtype, input_dtype)
     quantized_model = quantize_model(model.ov_model, QuantizationPreset.PERFORMANCE)
     for op in quantized_model.get_ops():
         if op.get_type_name() == 'FakeQuantize':
             inp_node = op.input(0)
             fq_input_node = inp_node.get_source_output().get_node()
             if fq_input_node.get_element_type() == 'Constant':
-                assert op.get_element_type() == ov.Type(np.float32)
+                assert op.get_element_type() == ov.Type(np.float32 if input_dtype == 'FP32' else np.float16)
         elif op.get_type_name() == 'Convert':
             inp_node = op.input(0)
             fq_input_node = inp_node.get_source_output().get_node()
             if fq_input_node.get_element_type() == 'Constant':
-                assert op.get_element_type() == ov.Type(np.float32 if precision == 'FP32' else np.float16)
-
-
-def test_fq_precision_orig_fp16model():
-    model = FP16InputModel()
-    quantized_model = quantize_model(model.ov_model, QuantizationPreset.PERFORMANCE)
-    for op in quantized_model.get_ops():
-        if op.get_type_name() == 'Constant':
-            if op.get_element_type().is_real():
-                assert op.get_element_type() == ov.Type(np.float16)
+                assert op.get_element_type() == ov.Type(np.float32 if const_dtype == 'FP32' else np.float16)

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -176,7 +176,7 @@ MODELS_WITH_PARAMETERS = [
         'refs': [2.0],
     },
     {
-        'model': FPModel(precision='FP16').ov_model,
+        'model': FPModel(const_dtype='FP16').ov_model,
         'layers': ['MatMul'],
         'values': [np.full((3,), 2)],
         'refs': [2.0],


### PR DESCRIPTION
### Changes

For models coming from a framework in FP16 precision, FakeQuantize parameters should be in FP16.
For models coming from a framework in FP32 precision and converted to FP16 via MO, FakeQuantize parameters should be in FP32.
FQ parameters precision aligned with model input precision.
Input FP32
![image](https://user-images.githubusercontent.com/22346860/221900280-a4e0746c-403d-4e36-8e1c-d3103f91ba58.png)
Input FP16
![image](https://user-images.githubusercontent.com/22346860/221900547-88280cfc-6afa-4625-b7ef-e76631d35ee5.png)


### Reason for changes

* To align NNCF PTQ with POT

### Related tickets

* 103926, 101738

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
