### PR TITLE
Added conv3d to first layer overflow fix check

### DIFF
--- a/nncf/experimental/tensorflow/quantization/algorithm.py
+++ b/nncf/experimental/tensorflow/quantization/algorithm.py
@@ -278,7 +278,7 @@ class QuantizationBuilderV2(QuantizationBuilder):
         quantization_setup = TFQuantizationSetupV2()
         node_name_to_qconfig_map = {}  # type: Dict[str, QuantizerConfig]
         qp_id_to_setup_index_map = {}  # type: Dict[QuantizationPointId, int]
-        first_conv_nodes = get_first_nodes_of_type(nncf_graph, ['Conv2D'])
+        first_conv_nodes = get_first_nodes_of_type(nncf_graph, ['Conv2D', 'Conv3D'])
 
         for idx, (qp_id, qp) in enumerate(qp_solution.quantization_points.items()):
             qp_id_to_setup_index_map[qp_id] = idx

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -451,7 +451,7 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
         qp_id_to_index = {}  # type: Dict[QuantizationPointId, int]
         tf_setup_qp_index = 0
         applied_overflow_fix = False
-        first_conv_nodes = get_first_nodes_of_type(nncf_graph, ['Conv2D'])
+        first_conv_nodes = get_first_nodes_of_type(nncf_graph, ['Conv2D', 'Conv3D'])
         for qp_id, qp in quantizer_setup.quantization_points.items():
             if qp.is_weight_quantization_point():
                 target_node = nncf_graph.get_node_by_name(qp.insertion_point.target_node_name)

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -763,7 +763,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
                         half_range = True
                         quantizers_with_overflow_fix_str = 'all weight quantizers'
                     elif self._overflow_fix == 'first_layer_only':
-                        if target_node in get_first_nodes_of_type(target_model_graph, ['conv2d']):
+                        if target_node in get_first_nodes_of_type(target_model_graph, ['conv2d', 'conv3d']):
                             half_range = True
                             quantizers_with_overflow_fix_str = 'first convolution weight quantizers'
                     elif self._overflow_fix != 'disable':


### PR DESCRIPTION
Overflow fix for a first layer check should consider `conv3d` besides `conv2d`.

In general, all weighted ops should be considered, but this requires some refactoring, see ticket [104645]