### PR TITLE
Added average pool 3d -like ops to pruning mask forwarding ops

### DIFF
--- a/nncf/tensorflow/pruning/operations.py
+++ b/nncf/tensorflow/pruning/operations.py
@@ -61,9 +61,15 @@ class TFIdentityMaskForwardPruningOp(IdentityMaskForwardPruningOp):
                        + layer_metatypes.TFGlobalAveragePooling2DLayerMetatype.get_all_aliases() \
                        + layer_metatypes.TFMaxPooling2DLayerMetatype.get_all_aliases() \
                        + layer_metatypes.TFGlobalMaxPooling2DLayerMetatype.get_all_aliases() \
-                       + layer_metatypes.TFDropoutLayerMetatype.get_all_aliases() \
                        + layer_metatypes.TFZeroPadding2DLayerMetatype.get_all_aliases() \
                        + layer_metatypes.TFUpSampling2DLayerMetatype.get_all_aliases() \
+                       + layer_metatypes.TFAveragePooling3DLayerMetatype.get_all_aliases() \
+                       + layer_metatypes.TFGlobalAveragePooling3DLayerMetatype.get_all_aliases() \
+                       + layer_metatypes.TFMaxPooling3DLayerMetatype.get_all_aliases() \
+                       + layer_metatypes.TFGlobalMaxPooling3DLayerMetatype.get_all_aliases() \
+                       + layer_metatypes.TFZeroPadding3DLayerMetatype.get_all_aliases() \
+                       + layer_metatypes.TFUpSampling3DLayerMetatype.get_all_aliases() \
+                       + layer_metatypes.TFDropoutLayerMetatype.get_all_aliases() \
                        + op_metatypes.TFIdentityOpMetatype.get_all_aliases() \
                        + op_metatypes.TFPadOpMetatype.get_all_aliases()
 

--- a/nncf/torch/pruning/operations.py
+++ b/nncf/torch/pruning/operations.py
@@ -21,6 +21,7 @@ from nncf.common.pruning.utils import get_input_masks
 from nncf.torch.graph.operator_metatypes import (
     PTAddMetatype,
     PTAvgPool2dMetatype,
+    PTAvgPool3dMetatype,
     PTBatchNormMetatype,
     PTCatMetatype,
     PTConv1dMetatype,
@@ -45,6 +46,7 @@ from nncf.torch.graph.operator_metatypes import (
     PTMatMulMetatype,
     PTMaxMetatype,
     PTMaxPool2dMetatype,
+    PTMaxPool3dMetatype,
     PTMeanMetatype,
     PTMinMetatype,
     PTMulMetatype,
@@ -147,7 +149,8 @@ class PTOutputPruningOp(OutputPruningOp, PTPruner):
 class PTIdentityMaskForwardPruningOp(IdentityMaskForwardPruningOp, PTPruner):
     subtypes = [PTHardTanhMetatype, PTTanhMetatype, PTRELUMetatype, PTRELU6Metatype, PTLeakyRELUMetatype,
                 PTPRELUMetatype, PTELUMetatype, PTGELUMetatype, PTSigmoidMetatype, PTSoftmaxMetatype,
-                PTAvgPool2dMetatype, PTMaxPool2dMetatype, PTDropoutMetatype, PTSILUMetatype, PTPowerMetatype,
+                PTAvgPool2dMetatype, PTMaxPool2dMetatype, PTAvgPool3dMetatype, PTMaxPool3dMetatype,
+                PTDropoutMetatype, PTSILUMetatype, PTPowerMetatype,
                 PTHardSwishMetatype, PTHardSigmoidMetatype, PTNoopMetatype, PTInterpolateMetatype]
     additional_types = ['h_sigmoid', 'h_swish', 'RELU']
 


### PR DESCRIPTION
`PTAvgPool2dMetatype` and `PTMaxPool2dMetatype` were in `PTIdentityMaskForwardPruningOp` but `PTAvgPool3dMetatype` and `PTMaxPool3dMetatype` not. Added.

Similarly for TF.