### PR TITLE
[Pruning] Fixed statistics computation for pruned layers

### DIFF
--- a/nncf/torch/pruning/base_algo.py
+++ b/nncf/torch/pruning/base_algo.py
@@ -245,10 +245,10 @@ class BasePruningAlgoController(PTCompressionAlgorithmController):
         """
         Calculates sparsity level for all weight nodes.
         """
-        weight = minfo.module.weight
-        mask = self.get_mask(minfo)
-        expanded_mask = mask[(...,) + (None,) * (len(weight.shape) - 1)]
-        pruning_level = 1 - (weight * expanded_mask).nonzero().size(0) / weight.view(-1).size(0)
+        dim = minfo.module.target_weight_dim_for_compression
+        weight = minfo.module.weight.transpose(0, dim).contiguous()
+        mask = self.get_mask(minfo)[(...,) + (None,) * (len(weight.shape) - 1)]
+        pruning_level = 1 - (weight * mask).nonzero().size(0) / weight.view(-1).size(0)
         return pruning_level
 
     def pruning_level_for_filters(self, minfo: PrunedModuleInfo):

--- a/nncf/torch/pruning/base_algo.py
+++ b/nncf/torch/pruning/base_algo.py
@@ -241,27 +241,6 @@ class BasePruningAlgoController(PTCompressionAlgorithmController):
         """
         raise NotImplementedError
 
-    def pruning_level_for_weight(self, minfo: PrunedModuleInfo):
-        """
-        Calculates sparsity level for all weight nodes.
-        """
-        dim = minfo.module.target_weight_dim_for_compression
-        weight = minfo.module.weight.transpose(0, dim).contiguous()
-        mask = self.get_mask(minfo)[(...,) + (None,) * (len(weight.shape) - 1)]
-        pruning_level = 1 - (weight * mask).nonzero().size(0) / weight.view(-1).size(0)
-        return pruning_level
-
-    def pruning_level_for_filters(self, minfo: PrunedModuleInfo):
-        """
-        Calculates sparsity level for weight filter-wise.
-        """
-        dim = minfo.module.target_weight_dim_for_compression
-        mask = self.get_mask(minfo)
-        weight = minfo.module.weight.transpose(0, dim).contiguous()
-        filters_sum = (weight.view(weight.size(0), -1) * mask[..., None]).sum(axis=1)
-        pruning_level = 1 - len(filters_sum.nonzero()) / filters_sum.size(0)
-        return pruning_level
-
     def pruning_level_for_mask(self, minfo: PrunedModuleInfo):
         mask = self.get_mask(minfo)
         pruning_level = 1 - mask.nonzero().size(0) / max(mask.view(-1).size(0), 1)
@@ -284,7 +263,7 @@ class BasePruningAlgoController(PTCompressionAlgorithmController):
             drow["Name"] = str(minfo.module_scope)
             drow["Weight's shape"] = list(minfo.module.weight.size())
             drow["Bias shape"] = list(minfo.module.bias.size()) if minfo.module.bias is not None else []
-            drow["Layer PR"] = self.pruning_level_for_filters(minfo)
+            drow["Layer PR"] = self.pruning_level_for_mask(minfo)
             row = [drow[h] for h in header]
             data.append(row)
         table.add_rows(data)


### PR DESCRIPTION
### Summary
For PT filter pruning, before `compression_ctrl.export_model()` call the pruned layer statistics are printed. They however are currently empty and do not reflect the actual pruned state of the model.

### Reason
This is due the fact that `pruning_level_for_filters()` method used to retrieve statistics returns incorrect values. This in turn is due the fact that it relies on the number of zeros in the model weights. But weights are zeroed (pruned) only during model export and actual model weights are not zeroed during runtime.

### What's changed
Removed `pruning_level_for_weight()` and `pruning_level_for_filters()` altogether. Now `pruning_level_for_mask()` is the only method to compute the statistic.


#### Before
![image](https://user-images.githubusercontent.com/23343961/220954948-8498ea47-cf15-4801-a014-7852b08914bd.png)
#### After
![image](https://user-images.githubusercontent.com/23343961/220955021-72a98967-fa8b-4f4d-a5f0-d2a1d09afb88.png)

