### PR TITLE
[OV] Add Clamp to ATOMIC_ACTIVATIONS_OPERATIONS

### DIFF
--- a/nncf/experimental/openvino_native/hardware/pattern_operations.py
+++ b/nncf/experimental/openvino_native/hardware/pattern_operations.py
@@ -27,6 +27,7 @@ BATCH_NORMALIZATION_OPERATIONS = {GraphPattern.METATYPE_ATTR: [ov_metatypes.OVBa
                                   GraphPattern.LABEL_ATTR: 'BATCH_NORMALIZATION'}
 
 ATOMIC_ACTIVATIONS_OPERATIONS = {GraphPattern.METATYPE_ATTR: [ov_metatypes.OVReluMetatype,
+                                                              ov_metatypes.OVClampMetatype,
                                                               ov_metatypes.OVEluMetatype,
                                                               ov_metatypes.OVPReluMetatype,
                                                               ov_metatypes.OVSigmoidMetatype,


### PR DESCRIPTION
### Changes

Add OVClmapMetatype to ATOMIC_ACTIVATIONS_OPERATIONS

### Reason for changes

Fix bug with quantization scheme for mobilenetv2_050
![MicrosoftTeams-image](https://user-images.githubusercontent.com/32935044/221573452-5d28002b-c7f7-4ad6-b1e3-d5cef1c68739.png)


### Related tickets

No

### Tests

No
