### PR TITLE
Common api prepare_for_inference for controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Website](https://img.shields.io/website?up_color=blue&up_message=docs&url=https%3A%2F%2Fdocs.openvino.ai%2Flatest%2Fopenvino_docs_model_optimization_guide.html)](https://docs.openvino.ai/latest/openvino_docs_model_optimization_guide.html)
 [![Apache License Version 2.0](https://img.shields.io/badge/license-Apache_2.0-green.svg)](LICENSE)
 [![PyPI Downloads](https://static.pepy.tech/badge/nncf)](https://pypi.org/project/nncf/)
-
+ 
 </div>
 
 _For the installation instructions, [click here](#installation)._
@@ -15,13 +15,13 @@ NNCF provides a suite of advanced algorithms for Neural Networks inference optim
 
 NNCF is designed to work with models from [PyTorch](https://pytorch.org/), [TensorFlow](https://www.tensorflow.org/), [ONNX](https://onnx.ai/) and [OpenVINO&trade;](https://docs.openvino.ai/latest/home.html).
 
-NNCF provides samples that demonstrate the usage of compression algorithms for three different use cases on public PyTorch and
-TensorFlow models and datasets: Image Classification, Object Detection and Semantic Segmentation.
-[Compression results](#nncf-compressed-model-zoo) achievable with the NNCF-powered samples can be found in a table at
+NNCF provides samples that demonstrate the usage of compression algorithms for three different use cases on public PyTorch and 
+TensorFlow models and datasets: Image Classification, Object Detection and Semantic Segmentation. 
+[Compression results](#nncf-compressed-model-zoo) achievable with the NNCF-powered samples can be found in a table at 
 the end of this document.
 
-The framework is organized as a Python\* package that can be built and used in a standalone mode. The framework
-architecture is unified to make it easy to add different compression algorithms for both PyTorch and TensorFlow deep
+The framework is organized as a Python\* package that can be built and used in a standalone mode. The framework 
+architecture is unified to make it easy to add different compression algorithms for both PyTorch and TensorFlow deep 
 learning frameworks.
 
 ## Key Features
@@ -61,7 +61,7 @@ The NNCF is organized as a regular Python package that can be imported in your t
 The basic workflow is loading a JSON configuration script containing NNCF-specific parameters determining the compression to be applied to your model, and then passing your model along with the configuration script to the `create_compressed_model` function.
 This function returns a model with additional modifications necessary to enable algorithm-specific compression during fine-tuning and handle to the object allowing you to control the compression during the training process:
 
-### Usage example with PyTorch
+### Usage example with PyTorch 
 
 ```python
 import torch
@@ -86,14 +86,10 @@ nncf_config = register_default_init_args(nncf_config, init_loader)
 # Apply the specified compression algorithms to the model
 compression_ctrl, compressed_model = create_compressed_model(model, nncf_config)
 
-# Now use compressed_model as a usual torch.nn.Module
+# Now use compressed_model as a usual torch.nn.Module 
 # to fine-tune compression parameters along with the model weights
 
 # ... the rest of the usual PyTorch-powered training pipeline
-
-# (Optional) Preparing the model to work in framework native format without NNCF specific operations to inference
-# or export the model.
-inference_model = compression_ctrl.prepare_for_inference(make_model_copy=True)
 
 # Export to ONNX or .pth when done fine-tuning
 compression_ctrl.export_model("compressed_model.onnx")
@@ -129,15 +125,11 @@ compression_ctrl, compressed_model = create_compressed_model(model, nncf_config)
 
 # ... the rest of the usual TensorFlow-powered training pipeline
 
-# (Optional) Preparing the model to work in framework native format without NNCF specific operations to inference
-# or export the model.
-inference_model = compression_ctrl.prepare_for_inference(make_model_copy=True)
-
-# Export to Frozen Graph, TensorFlow SavedModel or .h5  when done fine-tuning
+# Export to Frozen Graph, TensorFlow SavedModel or .h5  when done fine-tuning 
 compression_ctrl.export_model("compressed_model.pb", save_format='frozen_graph')
 ```
 
-For a more detailed description of NNCF usage in your training code, see [this tutorial](docs/Usage.md).
+For a more detailed description of NNCF usage in your training code, see [this tutorial](docs/Usage.md). 
 For in-depth examples of NNCF integration, browse the [sample scripts](#compression-aware-training-samples) code, or the [example patches](#third-party-repository-integration) to third-party repositories.
 For FAQ, visit this [link](./docs/FAQ.md).
 
@@ -148,7 +140,7 @@ NNCF provides [samples](#post-training-quantization-samples), which demonstrate 
 To start the algorithm, provide the following entities:
 * Original model.
 * Validation part of the dataset.
-* [Data transformation function](./docs/compression_algorithms/post_training/Quantization.md#data-transformation-function) transforming data items from the original dataset to the model input data.
+* [Data transformation function](./docs/compression_algorithms/post_training/Quantization.md#data-transformation-function) transforming data items from the original dataset to the model input data. 
 
 
 The basic workflow steps:
@@ -168,7 +160,7 @@ import torch
 from torchvision import datasets, models
 
 # Instantiate your uncompressed model
-model = models.mobilenet_v2()
+model = models.mobilenet_v2() 
 # Provide validation part of the dataset to collect statistics needed for the compression algorithm
 val_dataset = datasets.ImageFolder("/path")
 dataset_loader = torch.utils.data.DataLoader(val_dataset)
@@ -197,7 +189,7 @@ import tensorflow_datasets as tfds
 # Instantiate your uncompressed model
 model = tf.keras.applications.MobileNetV2()
 # Provide validation part of the dataset to collect statistics needed for the compression algorithm
-val_dataset = tfds.load('/path', split='validation',
+val_dataset = tfds.load('/path', split='validation', 
                         shuffle_files=False, as_supervised=True)
 
 # Step 1: Initialize transformation function
@@ -291,7 +283,7 @@ To run the samples please refer to the corresponding tutorials:
 - [ONNX Post-Training Quantization sample](examples/post_training_quantization/onnx/mobilenet_v2/README.md)
 - [OpenVINO Post-Training Quantization sample](examples/post_training_quantization/openvino/mobilenet_v2/README.md)
 
-## Model Compression Notebooks
+## Model Compression Notebooks 
 
 A collection of ready-to-run Jupyter* notebooks are also available to demonstrate how to use NNCF compression algorithms
 to optimize models for inference with the OpenVINO Toolkit.
@@ -305,7 +297,7 @@ NNCF may be straightforwardly integrated into training/evaluation pipelines of t
 ### Used by
 
 - [OpenVINO Training Extensions](https://github.com/openvinotoolkit/training_extensions)
-
+  
   NNCF is integrated into OpenVINO Training Extensions as model optimization backend. So you can train, optimize and export new models based on the available model templates as well as run exported models with OpenVINO.
 
 ### Git patches for third-party repository
@@ -324,7 +316,7 @@ This repository is tested on Python* 3.8.10, PyTorch* 1.12.1 (NVidia CUDA\* Tool
 ## Installation
 We suggest to install or use the package in the [Python virtual environment](https://docs.python.org/3/tutorial/venv.html).
 
-If you want to optimize a model from PyTorch, install PyTorch by following [PyTorch installation guide](https://pytorch.org/get-started/locally/#start-locally).
+If you want to optimize a model from PyTorch, install PyTorch by following [PyTorch installation guide](https://pytorch.org/get-started/locally/#start-locally). 
 If you want to optimize a model from TensorFlow, install TensorFlow by following [TensorFlow installation guide](https://www.tensorflow.org/install/).
 
 #### As a package built from a checked-out repository:
@@ -398,8 +390,8 @@ Refer to the [CONTRIBUTING.md](./CONTRIBUTING.md) file for guidelines on contrib
 
 ## NNCF Compressed Model Zoo
 
-Results achieved using sample scripts, example patches to third-party repositories and NNCF configuration files provided
-with this repository. See README.md files for [sample scripts](#model-compression-samples) and [example patches](#third-party-repository-integration)
+Results achieved using sample scripts, example patches to third-party repositories and NNCF configuration files provided 
+with this repository. See README.md files for [sample scripts](#model-compression-samples) and [example patches](#third-party-repository-integration) 
 to find instruction and links to exact configuration files and final checkpoints.
 - [PyTorch models](#pytorch-models)
   * [Classification](#pytorch_classification)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Website](https://img.shields.io/website?up_color=blue&up_message=docs&url=https%3A%2F%2Fdocs.openvino.ai%2Flatest%2Fopenvino_docs_model_optimization_guide.html)](https://docs.openvino.ai/latest/openvino_docs_model_optimization_guide.html)
 [![Apache License Version 2.0](https://img.shields.io/badge/license-Apache_2.0-green.svg)](LICENSE)
 [![PyPI Downloads](https://static.pepy.tech/badge/nncf)](https://pypi.org/project/nncf/)
- 
+
 </div>
 
 _For the installation instructions, [click here](#installation)._
@@ -15,13 +15,13 @@ NNCF provides a suite of advanced algorithms for Neural Networks inference optim
 
 NNCF is designed to work with models from [PyTorch](https://pytorch.org/), [TensorFlow](https://www.tensorflow.org/), [ONNX](https://onnx.ai/) and [OpenVINO&trade;](https://docs.openvino.ai/latest/home.html).
 
-NNCF provides samples that demonstrate the usage of compression algorithms for three different use cases on public PyTorch and 
-TensorFlow models and datasets: Image Classification, Object Detection and Semantic Segmentation. 
-[Compression results](#nncf-compressed-model-zoo) achievable with the NNCF-powered samples can be found in a table at 
+NNCF provides samples that demonstrate the usage of compression algorithms for three different use cases on public PyTorch and
+TensorFlow models and datasets: Image Classification, Object Detection and Semantic Segmentation.
+[Compression results](#nncf-compressed-model-zoo) achievable with the NNCF-powered samples can be found in a table at
 the end of this document.
 
-The framework is organized as a Python\* package that can be built and used in a standalone mode. The framework 
-architecture is unified to make it easy to add different compression algorithms for both PyTorch and TensorFlow deep 
+The framework is organized as a Python\* package that can be built and used in a standalone mode. The framework
+architecture is unified to make it easy to add different compression algorithms for both PyTorch and TensorFlow deep
 learning frameworks.
 
 ## Key Features
@@ -61,7 +61,7 @@ The NNCF is organized as a regular Python package that can be imported in your t
 The basic workflow is loading a JSON configuration script containing NNCF-specific parameters determining the compression to be applied to your model, and then passing your model along with the configuration script to the `create_compressed_model` function.
 This function returns a model with additional modifications necessary to enable algorithm-specific compression during fine-tuning and handle to the object allowing you to control the compression during the training process:
 
-### Usage example with PyTorch 
+### Usage example with PyTorch
 
 ```python
 import torch
@@ -86,10 +86,14 @@ nncf_config = register_default_init_args(nncf_config, init_loader)
 # Apply the specified compression algorithms to the model
 compression_ctrl, compressed_model = create_compressed_model(model, nncf_config)
 
-# Now use compressed_model as a usual torch.nn.Module 
+# Now use compressed_model as a usual torch.nn.Module
 # to fine-tune compression parameters along with the model weights
 
 # ... the rest of the usual PyTorch-powered training pipeline
+
+# (Optional) Preparing the model to work in framework native format without NNCF specific operations to inference
+# or export the model.
+inference_model = compression_ctrl.prepare_for_inference(make_model_copy=True)
 
 # Export to ONNX or .pth when done fine-tuning
 compression_ctrl.export_model("compressed_model.onnx")
@@ -125,11 +129,15 @@ compression_ctrl, compressed_model = create_compressed_model(model, nncf_config)
 
 # ... the rest of the usual TensorFlow-powered training pipeline
 
-# Export to Frozen Graph, TensorFlow SavedModel or .h5  when done fine-tuning 
+# (Optional) Preparing the model to work in framework native format without NNCF specific operations to inference
+# or export the model.
+inference_model = compression_ctrl.prepare_for_inference(make_model_copy=True)
+
+# Export to Frozen Graph, TensorFlow SavedModel or .h5  when done fine-tuning
 compression_ctrl.export_model("compressed_model.pb", save_format='frozen_graph')
 ```
 
-For a more detailed description of NNCF usage in your training code, see [this tutorial](docs/Usage.md). 
+For a more detailed description of NNCF usage in your training code, see [this tutorial](docs/Usage.md).
 For in-depth examples of NNCF integration, browse the [sample scripts](#compression-aware-training-samples) code, or the [example patches](#third-party-repository-integration) to third-party repositories.
 For FAQ, visit this [link](./docs/FAQ.md).
 
@@ -140,7 +148,7 @@ NNCF provides [samples](#post-training-quantization-samples), which demonstrate 
 To start the algorithm, provide the following entities:
 * Original model.
 * Validation part of the dataset.
-* [Data transformation function](./docs/compression_algorithms/post_training/Quantization.md#data-transformation-function) transforming data items from the original dataset to the model input data. 
+* [Data transformation function](./docs/compression_algorithms/post_training/Quantization.md#data-transformation-function) transforming data items from the original dataset to the model input data.
 
 
 The basic workflow steps:
@@ -160,7 +168,7 @@ import torch
 from torchvision import datasets, models
 
 # Instantiate your uncompressed model
-model = models.mobilenet_v2() 
+model = models.mobilenet_v2()
 # Provide validation part of the dataset to collect statistics needed for the compression algorithm
 val_dataset = datasets.ImageFolder("/path")
 dataset_loader = torch.utils.data.DataLoader(val_dataset)
@@ -189,7 +197,7 @@ import tensorflow_datasets as tfds
 # Instantiate your uncompressed model
 model = tf.keras.applications.MobileNetV2()
 # Provide validation part of the dataset to collect statistics needed for the compression algorithm
-val_dataset = tfds.load('/path', split='validation', 
+val_dataset = tfds.load('/path', split='validation',
                         shuffle_files=False, as_supervised=True)
 
 # Step 1: Initialize transformation function
@@ -283,7 +291,7 @@ To run the samples please refer to the corresponding tutorials:
 - [ONNX Post-Training Quantization sample](examples/post_training_quantization/onnx/mobilenet_v2/README.md)
 - [OpenVINO Post-Training Quantization sample](examples/post_training_quantization/openvino/mobilenet_v2/README.md)
 
-## Model Compression Notebooks 
+## Model Compression Notebooks
 
 A collection of ready-to-run Jupyter* notebooks are also available to demonstrate how to use NNCF compression algorithms
 to optimize models for inference with the OpenVINO Toolkit.
@@ -297,7 +305,7 @@ NNCF may be straightforwardly integrated into training/evaluation pipelines of t
 ### Used by
 
 - [OpenVINO Training Extensions](https://github.com/openvinotoolkit/training_extensions)
-  
+
   NNCF is integrated into OpenVINO Training Extensions as model optimization backend. So you can train, optimize and export new models based on the available model templates as well as run exported models with OpenVINO.
 
 ### Git patches for third-party repository
@@ -316,7 +324,7 @@ This repository is tested on Python* 3.8.10, PyTorch* 1.12.1 (NVidia CUDA\* Tool
 ## Installation
 We suggest to install or use the package in the [Python virtual environment](https://docs.python.org/3/tutorial/venv.html).
 
-If you want to optimize a model from PyTorch, install PyTorch by following [PyTorch installation guide](https://pytorch.org/get-started/locally/#start-locally). 
+If you want to optimize a model from PyTorch, install PyTorch by following [PyTorch installation guide](https://pytorch.org/get-started/locally/#start-locally).
 If you want to optimize a model from TensorFlow, install TensorFlow by following [TensorFlow installation guide](https://www.tensorflow.org/install/).
 
 #### As a package built from a checked-out repository:
@@ -390,8 +398,8 @@ Refer to the [CONTRIBUTING.md](./CONTRIBUTING.md) file for guidelines on contrib
 
 ## NNCF Compressed Model Zoo
 
-Results achieved using sample scripts, example patches to third-party repositories and NNCF configuration files provided 
-with this repository. See README.md files for [sample scripts](#model-compression-samples) and [example patches](#third-party-repository-integration) 
+Results achieved using sample scripts, example patches to third-party repositories and NNCF configuration files provided
+with this repository. See README.md files for [sample scripts](#model-compression-samples) and [example patches](#third-party-repository-integration)
 to find instruction and links to exact configuration files and final checkpoints.
 - [PyTorch models](#pytorch-models)
   * [Classification](#pytorch_classification)

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -88,7 +88,7 @@ Important points you should consider when training your networks with compressio
 #### Step 4: Export the compressed model
 After the compressed model has been fine-tuned to acceptable accuracy and compression stages, you can export it. There are two ways to export a model:
 
-1. Call the compression controller's `export_model` method to properly export the model with compression specifics into ONNX:
+1. Call the compression controller's `export_model` method to properly export the model with compression specifics into ONNX.
 
     ```python
     compression_ctrl.export_model("./compressed_model.onnx")
@@ -98,7 +98,10 @@ After the compressed model has been fine-tuned to acceptable accuracy and compre
     Refer to [compression algorithm documentation](./compression_algorithms) for details.
     Also, this method is limited to the supported formats for export.
 
-2. Call the compression controller's `prepare_for_inference` method, to properly get the model without NNCF specific nodes for training compressed model, then use the standard export options. As well as this method also allows you to connect third-party inference solutions, like OpenVINO. By defaults, a copy of the compressed model will be modified, use `do_copy=False' to avoid creating additional copy of the model.
+2. Call the compression controller's `prepare_for_inference` method, to properly get the model without NNCF specific
+    nodes for training compressed model, after that you can trace the model via inference in framework operations.
+    It gives more flexibility to deploy model after optimization. As well as this method also allows you to connect
+    third-party inference solutions, like OpenVINO.
 
     ```python
     inference_model = compression_ctrl.prepare_for_inference()

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -86,30 +86,29 @@ Important points you should consider when training your networks with compressio
   - It is better to turn off additional regularization in the loss function (for example, L2 regularization via `weight_decay`) when training the network with RB sparsity, since it already imposes an L0 regularization term.
 
 #### Step 4: Export the compressed model
-After the compressed model has been fine-tuned to acceptable accuracy and compression stages, you can export it. There are two ways to export a model.
+After the compressed model has been fine-tuned to acceptable accuracy and compression stages, you can export it. There are two ways to export a model:
 
-First, you have to call the compression controller's `export_model` method to properly export the model with compression specifics into ONNX:
+1. Call the compression controller's `export_model` method to properly export the model with compression specifics into ONNX:
 
-```python
-compression_ctrl.export_model("./compressed_model.onnx")
-```
-The exported ONNX file may contain special, non-ONNX-standard operations and layers to leverage full compressed/low-precision potential of the OpenVINO toolkit.
-In some cases it is possible to export a compressed model with ONNX standard operations only (so that it can be run using `onnxruntime`, for example) - this is the case for the 8-bit symmetric quantization and sparsity/filter pruning algorithms.
-Refer to [compression algorithm documentation](./compression_algorithms) for details.
+    ```python
+    compression_ctrl.export_model("./compressed_model.onnx")
+    ```
+    The exported ONNX file may contain special, non-ONNX-standard operations and layers to leverage full compressed/low-precision potential of the OpenVINO toolkit.
+    In some cases it is possible to export a compressed model with ONNX standard operations only (so that it can be run using `onnxruntime`, for example) - this is the case for the 8-bit symmetric quantization and sparsity/filter pruning algorithms.
+    Refer to [compression algorithm documentation](./compression_algorithms) for details.
+    Also, this method is limited to the supported formats for export.
 
-Second, you have to call the compression controller's `prepare_for_inference` method, supports only for PyTorch, to properly get the model without NNCF specific nodes for training compressed model.
-The model can then be exported or converted as a conventional PyTorch model.
-If the `make_model_copy` arguments are set to `True`, a copy of the `compression_ctrl.model` will be modified.
+2. Call the compression controller's `prepare_for_inference` method, to properly get the model without NNCF specific nodes for training compressed model. The model can then be exported or converted as a conventional model. If the `make_model_copy` arguments are set to `True`, a copy of the `compression_ctrl.model` will be modified.
 
-```python
-inference_model = compression_ctrl.prepare_for_inference()
-# To ONNX format
-import torch
-torch.onnx.export(inference_model, dummy_input, './compressed_model.onnx')
-# To OpenVINO format
-from openvino.tools import mo
-ov_model = mo.convert_model(inference_model, example_input=example_input)
-```
+    ```python
+    inference_model = compression_ctrl.prepare_for_inference()
+    # To ONNX format
+    import torch
+    torch.onnx.export(inference_model, dummy_input, './compressed_model.onnx')
+    # To OpenVINO format
+    from openvino.tools import mo
+    ov_model = mo.convert_model(inference_model, example_input=example_input)
+    ```
 
 ## Saving and loading compressed models
 The complete information about compression is defined by a compressed model and a compression state.

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -85,7 +85,15 @@ Important points you should consider when training your networks with compressio
   - Turn off the `Dropout` layers (and similar ones like `DropConnect`) when training a network with quantization or sparsity
   - It is better to turn off additional regularization in the loss function (for example, L2 regularization via `weight_decay`) when training the network with RB sparsity, since it already imposes an L0 regularization term.
 
-#### Step 4 (optional): Export the compressed model to ONNX
+#### Step 4 (optional): Prepare for inference model.
+During training or after the training phases have been completed, you can obtain a ready-to-use model in framework native form by removing NNCF-specific features that used during the fine-training modules.
+```
+inference_model = compression_ctrl.prepare_for_inference(make_model_copy=True)
+```
+If you set `make_model_copy=False`, the original model in the controller will be changed and further training will not be possible.
+
+
+#### Step 5 (optional): Export the compressed model to ONNX
 After the compressed model has been fine-tuned to acceptable accuracy and compression stages, you can export it to ONNX format.
 Since export process is in general algorithm-specific, you have to call the compression controller's `export_model` method to properly export the model with compression specifics into ONNX:
 ```python
@@ -97,24 +105,24 @@ Refer to [compression algorithm documentation](./compression_algorithms) for det
 
 ## Saving and loading compressed models
 The complete information about compression is defined by a compressed model and a compression state.
-The model characterizes the weights and topology of the network. The compression state - how to restore the setting of 
+The model characterizes the weights and topology of the network. The compression state - how to restore the setting of
 compression layers in the model and how to restore the compression schedule and the compression loss.
-The latter can be obtained by `compression_ctrl.get_compression_state()` on saving and passed to the 
-`create_compressed_model` helper function by the optional `compression_state` argument on loading. 
+The latter can be obtained by `compression_ctrl.get_compression_state()` on saving and passed to the
+`create_compressed_model` helper function by the optional `compression_state` argument on loading.
 The compressed model should be loaded once it's created.
 
-Saving and loading of the compressed model and compression state is framework-specific and can be done in an arbitrary 
+Saving and loading of the compressed model and compression state is framework-specific and can be done in an arbitrary
 way. NNCF provides one possible way of doing it with helper functions in samples.
 
 To save the best compressed checkpoint use `compression_ctrl.compression_stage()` to distinguish between 3 possible
-levels of compression: `UNCOMPRESSED`, `PARTIALLY_COMPRESSED` and `FULLY_COMPRESSED`. It is useful in case of `staged` 
-compression. Model may achieve the best accuracy on earlier stages of compression - tuning without compression or with 
-intermediate compression rate, but still fully compressed model with lower accuracy should be considered as the best 
-compressed one. `UNCOMPRESSED` means that no compression is applied for the model, for instance, in case of stage 
-quantization - when all quantization are disabled, or in case of sparsity - when current sparsity rate is zero. 
+levels of compression: `UNCOMPRESSED`, `PARTIALLY_COMPRESSED` and `FULLY_COMPRESSED`. It is useful in case of `staged`
+compression. Model may achieve the best accuracy on earlier stages of compression - tuning without compression or with
+intermediate compression rate, but still fully compressed model with lower accuracy should be considered as the best
+compressed one. `UNCOMPRESSED` means that no compression is applied for the model, for instance, in case of stage
+quantization - when all quantization are disabled, or in case of sparsity - when current sparsity rate is zero.
 `PARTIALLY_COMPRESSED` stands for the compressed model which haven't reached final compression ratio yet, e.g. magnitude
-sparsity algorithm has learnt masking of 30% weights out of 51% of target rate. The controller returns 
-`FULLY_COMPRESSED` compression stage when it finished scheduling and tuning hyper parameters of the compression 
+sparsity algorithm has learnt masking of 30% weights out of 51% of target rate. The controller returns
+`FULLY_COMPRESSED` compression stage when it finished scheduling and tuning hyper parameters of the compression
 algorithm, for example when rb-sparsity method sets final target sparsity rate for the loss.
 
 ### Saving and loading compressed models in TensorFlow
@@ -147,8 +155,8 @@ checkpoint = tf.train.Checkpoint(model=compress_model,
 checkpoint.restore(path_to_checkpoint)
 ```
 
-Since the compression state is a dictionary of Python JSON-serializable objects, we convert it to JSON 
-string within `tf.train.Checkpoint`. There are 2 helper classes: `TFCompressionState` - for saving compression state and 
+Since the compression state is a dictionary of Python JSON-serializable objects, we convert it to JSON
+string within `tf.train.Checkpoint`. There are 2 helper classes: `TFCompressionState` - for saving compression state and
 `TFCompressionStateLoader` - for loading.
 
 ### Saving and loading compressed models in PyTorch
@@ -167,7 +175,7 @@ torch.save(checkpoint, path)
 
 # load part
 resuming_checkpoint = torch.load(path)
-state_dict = resuming_checkpoint['state_dict'] 
+state_dict = resuming_checkpoint['state_dict']
 compression_ctrl, compressed_model = create_compressed_model(model, nncf_config, resuming_state_dict=state_dict)
 compression_ctrl.scheduler.load_state(resuming_checkpoint['scheduler_state'])
 ```
@@ -185,39 +193,39 @@ torch.save(checkpoint, path)
 
 # load part
 resuming_checkpoint = torch.load(path)
-compression_state = resuming_checkpoint['compression_state'] 
+compression_state = resuming_checkpoint['compression_state']
 compression_ctrl, compressed_model = create_compressed_model(model, nncf_config, compression_state=compression_state)
-state_dict = resuming_checkpoint['state_dict'] 
+state_dict = resuming_checkpoint['state_dict']
 
 # load model in a preferable way
-    load_state(compressed_model, state_dict, is_resume=True)     
-    # or when execution mode on loading is the same as on saving: 
-    # save and load in a single GPU mode or save and load in the (Distributed)DataParallel one, not in a mixed way  
+    load_state(compressed_model, state_dict, is_resume=True)
+    # or when execution mode on loading is the same as on saving:
+    # save and load in a single GPU mode or save and load in the (Distributed)DataParallel one, not in a mixed way
     compressed_model.load_state_dict(state_dict)
 ```
 
-You can save the `compressed_model` object `torch.save` as usual: via `state_dict` and `load_state_dict` methods. 
-Alternatively, you can use the `nncf.load_state` function on loading. It will attempt to load a PyTorch state dict into 
-a model by first stripping the irrelevant prefixes, such as `module.` or `nncf_module.`, from both the checkpoint and 
+You can save the `compressed_model` object `torch.save` as usual: via `state_dict` and `load_state_dict` methods.
+Alternatively, you can use the `nncf.load_state` function on loading. It will attempt to load a PyTorch state dict into
+a model by first stripping the irrelevant prefixes, such as `module.` or `nncf_module.`, from both the checkpoint and
 the model layer identifiers, and then do the matching between the layers.
-Depending on the value of the `is_resume` argument, it will then fail if an exact match could not be made 
-(when `is_resume == True`), or load the matching layer parameters and print a warning listing the mismatches 
-(when `is_resume == False`). `is_resume=False` is most commonly used if you want to load the starting weights from an 
-uncompressed model into a compressed model and `is_resume=True` is used when you want to evaluate a compressed 
+Depending on the value of the `is_resume` argument, it will then fail if an exact match could not be made
+(when `is_resume == True`), or load the matching layer parameters and print a warning listing the mismatches
+(when `is_resume == False`). `is_resume=False` is most commonly used if you want to load the starting weights from an
+uncompressed model into a compressed model and `is_resume=True` is used when you want to evaluate a compressed
 checkpoint or resume compressed checkpoint training without changing the compression algorithm parameters.
 
 The compression state can be directly pickled by `torch.save` as well, since it is a dictionary of Python objects.
 
-In the previous releases of the NNCF, model can be loaded without compression state information 
-by saving the model state dictionary `compressed_model.state_dict` and loading it via `nncf.load_state` and  
-`compressed_model.load_state_dict` methods or using optional `resuming_state_dict` argument of the 
+In the previous releases of the NNCF, model can be loaded without compression state information
+by saving the model state dictionary `compressed_model.state_dict` and loading it via `nncf.load_state` and
+`compressed_model.load_state_dict` methods or using optional `resuming_state_dict` argument of the
 `create_compressed_model`.
 This way of loading is deprecated, and we highly recommend to not use this way as it does not guarantee the exact loading
-of compression model state for algorithms with sophisticated initialization - e.g. HAWQ and AutoQ. 
+of compression model state for algorithms with sophisticated initialization - e.g. HAWQ and AutoQ.
 Also in this case, keep in mind that in order to load the resulting checkpoint file the `compressed_model` object should
 have the same structure with regard to PyTorch module and parameters as it was when the checkpoint was saved.
-In practice this means that you should use the same compression algorithms (i.e. the same NNCF configuration file) when 
-loading a compressed model checkpoint. 
+In practice this means that you should use the same compression algorithms (i.e. the same NNCF configuration file) when
+loading a compressed model checkpoint.
 
 
 ## Exploring the compressed model
@@ -271,8 +279,8 @@ from nncf.common.accuracy_aware_training import create_accuracy_aware_training_l
 training_loop = create_accuracy_aware_training_loop(nncf_config, compression_ctrl)
 ```
 
-In order to properly instantiate the accuracy-aware training loop, the user has to specify the 'accuracy_aware_training' section. 
-This section fully depends on what Accuracy-Aware Training loop is being used. 
+In order to properly instantiate the accuracy-aware training loop, the user has to specify the 'accuracy_aware_training' section.
+This section fully depends on what Accuracy-Aware Training loop is being used.
 For more details about config of Adaptive Compression Level Training refer to [Adaptive Compression Level Training documentation](./accuracy_aware_model_training/AdaptiveCompressionTraining.md) and Early Exit Training refer to [Early Exit Training documentation](./accuracy_aware_model_training/EarlyExitTraining.md).
 
 The training loop is launched by calling its `run` method. Before the start of the training loop, the user is expected to define several functions related to the training of the model and pass them as arguments to the `run` method of the training loop instance:
@@ -318,9 +326,9 @@ def configure_optimizers_fn():
 def dump_checkpoint_fn(model, compression_controller, accuracy_aware_runner, save_dir):
     '''
     An (optional) function that allows a user to define how to save the model's checkpoint.
-    Training loop will call this function instead own dump_checkpoint function and pass 
+    Training loop will call this function instead own dump_checkpoint function and pass
     `model`, `compression_controller`, `accuracy_aware_runner` and `save_dir` to it as arguments.
-    The user can save the states of the objects according to their own needs. 
+    The user can save the states of the objects according to their own needs.
     `save_dir` is a directory that Accuracy-Aware pipeline created to store log information.
     '''
 ```

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -85,23 +85,31 @@ Important points you should consider when training your networks with compressio
   - Turn off the `Dropout` layers (and similar ones like `DropConnect`) when training a network with quantization or sparsity
   - It is better to turn off additional regularization in the loss function (for example, L2 regularization via `weight_decay`) when training the network with RB sparsity, since it already imposes an L0 regularization term.
 
-#### Step 4 (optional): Prepare for inference model.
-During training or after the training phases have been completed, you can obtain a ready-to-use model in framework native form by removing NNCF-specific features that used during the fine-training modules.
-```
-inference_model = compression_ctrl.prepare_for_inference(make_model_copy=True)
-```
-If you set `make_model_copy=False`, the original model in the controller will be changed and further training will not be possible.
+#### Step 4: Export the compressed model
+After the compressed model has been fine-tuned to acceptable accuracy and compression stages, you can export it. There are two ways to export a model.
 
+First, you have to call the compression controller's `export_model` method to properly export the model with compression specifics into ONNX:
 
-#### Step 5 (optional): Export the compressed model to ONNX
-After the compressed model has been fine-tuned to acceptable accuracy and compression stages, you can export it to ONNX format.
-Since export process is in general algorithm-specific, you have to call the compression controller's `export_model` method to properly export the model with compression specifics into ONNX:
 ```python
 compression_ctrl.export_model("./compressed_model.onnx")
 ```
 The exported ONNX file may contain special, non-ONNX-standard operations and layers to leverage full compressed/low-precision potential of the OpenVINO toolkit.
 In some cases it is possible to export a compressed model with ONNX standard operations only (so that it can be run using `onnxruntime`, for example) - this is the case for the 8-bit symmetric quantization and sparsity/filter pruning algorithms.
 Refer to [compression algorithm documentation](./compression_algorithms) for details.
+
+Second, you have to call the compression controller's `prepare_for_inference` method, supports only for PyTorch, to properly get the model without NNCF specific nodes for training compressed model.
+The model can then be exported or converted as a conventional PyTorch model.
+If the `make_model_copy` arguments are set to `True`, a copy of the `compression_ctrl.model` will be modified.
+
+```python
+inference_model = compression_ctrl.prepare_for_inference(make_model_copy=True)
+# To ONNX format
+import torch
+torch.onnx.export(inference_model, dummy_input, './compressed_model.onnx')
+# To OpenVINO format
+from openvino.tools import mo
+ov_model = mo.convert_model(inference_model, example_input=example_input)
+```
 
 ## Saving and loading compressed models
 The complete information about compression is defined by a compressed model and a compression state.
@@ -342,4 +350,4 @@ model = training_loop.run(model,
                           configure_optimizers_fn=configure_optimizers_fn,
                           dump_checkpoint_fn=dump_checkpoint_fn)
 ```
-The above call executes the acccuracy-aware training loop and return the compressed model. For more details on how to use the accuracy-aware training loop functionality of NNCF, please refer to its [documentation](./accuracy_aware_model_training/AdaptiveCompressionTraining.md).
+The above call executes the accuracy-aware training loop and return the compressed model. For more details on how to use the accuracy-aware training loop functionality of NNCF, please refer to its [documentation](./accuracy_aware_model_training/AdaptiveCompressionTraining.md).

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -102,7 +102,7 @@ The model can then be exported or converted as a conventional PyTorch model.
 If the `make_model_copy` arguments are set to `True`, a copy of the `compression_ctrl.model` will be modified.
 
 ```python
-inference_model = compression_ctrl.prepare_for_inference(make_model_copy=True)
+inference_model = compression_ctrl.prepare_for_inference()
 # To ONNX format
 import torch
 torch.onnx.export(inference_model, dummy_input, './compressed_model.onnx')

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -98,7 +98,7 @@ After the compressed model has been fine-tuned to acceptable accuracy and compre
     Refer to [compression algorithm documentation](./compression_algorithms) for details.
     Also, this method is limited to the supported formats for export.
 
-2. Call the compression controller's `prepare_for_inference` method, to properly get the model without NNCF specific nodes for training compressed model. The model can then be exported or converted as a conventional model. By defaults, a copy of the compressed model will be modified, use `do_copy=False' to avoid creating additional copy of the model.
+2. Call the compression controller's `prepare_for_inference` method, to properly get the model without NNCF specific nodes for training compressed model, then use the standard export options. As well as this method also allows you to connect third-party inference solutions, like OpenVINO. By defaults, a copy of the compressed model will be modified, use `do_copy=False' to avoid creating additional copy of the model.
 
     ```python
     inference_model = compression_ctrl.prepare_for_inference()

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -98,7 +98,7 @@ After the compressed model has been fine-tuned to acceptable accuracy and compre
     Refer to [compression algorithm documentation](./compression_algorithms) for details.
     Also, this method is limited to the supported formats for export.
 
-2. Call the compression controller's `prepare_for_inference` method, to properly get the model without NNCF specific nodes for training compressed model. The model can then be exported or converted as a conventional model. If the `make_model_copy` arguments are set to `True`, a copy of the `compression_ctrl.model` will be modified.
+2. Call the compression controller's `prepare_for_inference` method, to properly get the model without NNCF specific nodes for training compressed model. The model can then be exported or converted as a conventional model. By defaults, a copy of the compressed model will be modified, use `do_copy=False' to avoid creating additional copy of the model.
 
     ```python
     inference_model = compression_ctrl.prepare_for_inference()

--- a/examples/tensorflow/classification/README.md
+++ b/examples/tensorflow/classification/README.md
@@ -11,7 +11,7 @@ This sample demonstrates a DL model compression in case of the Image Classificat
 
 ## Installation
 
-At this point it is assumed that you have already installed nncf. You can find information on downloading nncf [here](https://github.com/openvinotoolkit/nncf#user-content-installation).  
+At this point it is assumed that you have already installed nncf. You can find information on downloading nncf [here](https://github.com/openvinotoolkit/nncf#user-content-installation).
 
 To work with the sample you should install the corresponding Python package dependencies:
 
@@ -55,7 +55,7 @@ The ImageNet dataset in TFRecords format should be specified in the configuratio
 
 #### Test Pretrained Model
 
-Before compressing a model, it is highly recommended checking the accuracy of the pretrained model. All models which are supported in the sample has pretrained weights for ImageNet. 
+Before compressing a model, it is highly recommended checking the accuracy of the pretrained model. All models which are supported in the sample has pretrained weights for ImageNet.
 
 To load pretrained weights into a model and then evaluate the accuracy of that model, make sure that the pretrained=True option is set in the configuration file and use the following command:
 ```bash
@@ -63,7 +63,7 @@ python main.py \
 --mode=test \
 --config=configs/quantization/mobilenet_v2_imagenet_int8.json \
 --data=<path_to_imagenet_dataset> \
---disable-compression 
+--disable-compression
 ```
 
 #### Compress Pretrained Model
@@ -79,6 +79,7 @@ Run the following command to start compression with fine-tuning on all available
 It may take a few epochs to get the baseline accuracy results.
 
 Use the `--resume` flag with the path to the checkpoint to resume training from the defined checkpoint or folder with checkpoints to resume training from the last checkpoint.
+- Use `--prepare-for-inference` argument to convert model to tensorflow native format without NNCF-specific operations before `test` and `export` steps.
 
 ### Validate Your Model Checkpoint
 

--- a/examples/tensorflow/classification/README.md
+++ b/examples/tensorflow/classification/README.md
@@ -79,7 +79,6 @@ Run the following command to start compression with fine-tuning on all available
 It may take a few epochs to get the baseline accuracy results.
 
 Use the `--resume` flag with the path to the checkpoint to resume training from the defined checkpoint or folder with checkpoints to resume training from the last checkpoint.
-- Use `--prepare-for-inference` argument to convert model to tensorflow native format without NNCF-specific operations before `test` and `export` steps.
 
 ### Validate Your Model Checkpoint
 

--- a/examples/tensorflow/classification/main.py
+++ b/examples/tensorflow/classification/main.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 import tensorflow as tf
 import tensorflow_addons as tfa
-from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
 
 from examples.common.sample_config import create_sample_config
 from examples.tensorflow.classification.datasets.builder import DatasetBuilder
@@ -26,16 +25,15 @@ from examples.tensorflow.common.callbacks import get_callbacks
 from examples.tensorflow.common.callbacks import get_progress_bar
 from examples.tensorflow.common.distributed import get_distribution_strategy
 from examples.tensorflow.common.experimental_patcher import patch_if_experimental_quantization
+from examples.tensorflow.common.export import export_model
 from examples.tensorflow.common.logger import logger
 from examples.tensorflow.common.model_loader import get_model
 from examples.tensorflow.common.optimizer import build_optimizer
 from examples.tensorflow.common.scheduler import build_scheduler
-from examples.tensorflow.common.utils import FROZEN_GRAPH_FORMAT
 from examples.tensorflow.common.utils import SummaryWriter
 from examples.tensorflow.common.utils import close_strategy_threadpool
 from examples.tensorflow.common.utils import configure_paths
 from examples.tensorflow.common.utils import create_code_snapshot
-from examples.tensorflow.common.utils import get_saving_parameters
 from examples.tensorflow.common.utils import print_args
 from examples.tensorflow.common.utils import serialize_cli_args
 from examples.tensorflow.common.utils import serialize_config

--- a/examples/tensorflow/classification/main.py
+++ b/examples/tensorflow/classification/main.py
@@ -34,6 +34,7 @@ from examples.tensorflow.common.utils import SummaryWriter
 from examples.tensorflow.common.utils import close_strategy_threadpool
 from examples.tensorflow.common.utils import configure_paths
 from examples.tensorflow.common.utils import create_code_snapshot
+from examples.tensorflow.common.utils import get_saving_parameters
 from examples.tensorflow.common.utils import print_args
 from examples.tensorflow.common.utils import serialize_cli_args
 from examples.tensorflow.common.utils import serialize_config
@@ -300,7 +301,9 @@ def run(config):
         write_metrics(results[1], config.metrics_dump)
 
     if 'export' in config.mode:
-        export_model(compression_ctrl, config)
+        save_path, save_format = get_saving_parameters(config)
+        export_model(compression_ctrl.prepare_for_inference(), save_path, save_format)
+        logger.info('Saved to {}'.format(save_path))
 
     close_strategy_threadpool(strategy)
 
@@ -336,7 +339,9 @@ def export(config):
         load_checkpoint(checkpoint=checkpoint,
                         ckpt_path=config.ckpt_path)
 
-    export_model(compression_ctrl, config)
+    save_path, save_format = get_saving_parameters(config)
+    export_model(compression_ctrl.prepare_for_inference(), save_path, save_format)
+    logger.info('Saved to {}'.format(save_path))
 
 
 def main(argv):

--- a/examples/tensorflow/common/argparser.py
+++ b/examples/tensorflow/common/argparser.py
@@ -229,9 +229,14 @@ def get_common_argument_parser(**flags):
 
     parser.add_argument(
         '--disable_tensor_float_32_execution',
-        help="Disable exection in TensorFloat-32",
+        help="Disable execution in TensorFloat-32",
         action="store_true"
     )
+
+    parser.add_argument(
+        "--prepare-for-inference",
+        action='store_true',
+        help="Convert model to framework native format without NNCF-specific operation for export and test steps.")
 
     return parser
 

--- a/examples/tensorflow/common/argparser.py
+++ b/examples/tensorflow/common/argparser.py
@@ -233,11 +233,6 @@ def get_common_argument_parser(**flags):
         action="store_true"
     )
 
-    parser.add_argument(
-        "--prepare-for-inference",
-        action='store_true',
-        help="Convert model to framework native format without NNCF-specific operation for export and test steps.")
-
     return parser
 
 

--- a/examples/tensorflow/common/export.py
+++ b/examples/tensorflow/common/export.py
@@ -1,0 +1,48 @@
+"""
+ Copyright (c) 2023 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+import os.path as osp
+
+import tensorflow as tf
+from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
+
+from examples.common.sample_config import SampleConfig
+from examples.tensorflow.common.logger import logger
+from examples.tensorflow.common.utils import FROZEN_GRAPH_FORMAT
+from examples.tensorflow.common.utils import get_saving_parameters
+from nncf.api.compression import CompressionAlgorithmController
+
+
+def export_model(compression_ctrl: CompressionAlgorithmController, config: SampleConfig) -> None:
+    """
+    Export compressed model. Supported types 'tf', 'h5', 'frozen_graph'.
+
+    :param compression_ctrl: The controller of the compression algorithm.
+    :param config: Config of examples.
+    """
+    save_path, save_format = get_saving_parameters(config)
+    model = compression_ctrl.prepare_for_inference()
+
+    if save_format == FROZEN_GRAPH_FORMAT:
+        input_signature = []
+        for item in model.inputs:
+            input_signature.append(tf.TensorSpec(item.shape, item.dtype, item.name))
+        concrete_function = tf.function(model).get_concrete_function(input_signature)
+        frozen_func = convert_variables_to_constants_v2(concrete_function, lower_control_flow=False)
+        frozen_graph = frozen_func.graph.as_graph_def(add_shapes=True)
+
+        save_dir, name = osp.split(save_path)
+        tf.io.write_graph(frozen_graph, save_dir, name, as_text=False)
+    else:
+        model.save(save_path, save_format=save_format)
+
+    logger.info('Saved to {}'.format(save_path))

--- a/examples/tensorflow/common/export.py
+++ b/examples/tensorflow/common/export.py
@@ -15,22 +15,17 @@ import os.path as osp
 import tensorflow as tf
 from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
 
-from examples.common.sample_config import SampleConfig
-from examples.tensorflow.common.logger import logger
 from examples.tensorflow.common.utils import FROZEN_GRAPH_FORMAT
-from examples.tensorflow.common.utils import get_saving_parameters
-from nncf.api.compression import CompressionAlgorithmController
 
 
-def export_model(compression_ctrl: CompressionAlgorithmController, config: SampleConfig) -> None:
+def export_model(model: tf.keras.Model, save_path: str, save_format: str) -> None:
     """
     Export compressed model. Supported types 'tf', 'h5', 'frozen_graph'.
 
-    :param compression_ctrl: The controller of the compression algorithm.
-    :param config: Config of examples.
+    :param model: Target model.
+    :param save_path: Path to save.
+    :param save_format: Model format used to save model.
     """
-    save_path, save_format = get_saving_parameters(config)
-    model = compression_ctrl.prepare_for_inference()
 
     if save_format == FROZEN_GRAPH_FORMAT:
         input_signature = []
@@ -44,5 +39,3 @@ def export_model(compression_ctrl: CompressionAlgorithmController, config: Sampl
         tf.io.write_graph(frozen_graph, save_dir, name, as_text=False)
     else:
         model.save(save_path, save_format=save_format)
-
-    logger.info('Saved to {}'.format(save_path))

--- a/examples/tensorflow/object_detection/README.md
+++ b/examples/tensorflow/object_detection/README.md
@@ -89,7 +89,6 @@ FP32 model, without applying any compression algorithms.
     --log-dir=../../results/quantization/retinanet_coco_int8
     ```
 - Use the `--resume` flag with the path to the checkpoint to resume training from the defined checkpoint or folder with checkpoints to resume training from the last checkpoint.
-- Use `--prepare-for-inference` argument to convert model to tensorflow native format without NNCF-specific operations before `test` and `export` steps.
 
 ### Validate Your Model Checkpoint
 

--- a/examples/tensorflow/object_detection/README.md
+++ b/examples/tensorflow/object_detection/README.md
@@ -14,7 +14,7 @@ The sample receives a configuration file where the training schedule, hyper-para
 
 ## Installation
 
-At this point it is assumed that you have already installed nncf. You can find information on downloading nncf [here](https://github.com/openvinotoolkit/nncf#user-content-installation).  
+At this point it is assumed that you have already installed nncf. You can find information on downloading nncf [here](https://github.com/openvinotoolkit/nncf#user-content-installation).
 
 To work with the sample you should install the corresponding Python package dependencies:
 
@@ -66,18 +66,18 @@ The [COCO2017](https://cocodataset.org/) dataset in TFRecords format should be s
 
 - If you did not install the package, add the repository root folder to the `PYTHONPATH` environment variable.
 - Go to the `examples/tensorflow/object_detection` folder.
-- Download the pre-trained weights in H5 format and provide the path to them using `--weights` flag. The link to the 
-archive with pre-trained weights can be found in the `TensorFlow checkpoint` column of the [results](#results) table. 
-Select the checkpoint corresponding to the `None` compression algorithm, which includes the pre-trained weights for the 
+- Download the pre-trained weights in H5 format and provide the path to them using `--weights` flag. The link to the
+archive with pre-trained weights can be found in the `TensorFlow checkpoint` column of the [results](#results) table.
+Select the checkpoint corresponding to the `None` compression algorithm, which includes the pre-trained weights for the
 FP32 model, without applying any compression algorithms.
-- (Optional) Before compressing a model, it is highly recommended checking the accuracy of the pretrained model, use the following command: 
+- (Optional) Before compressing a model, it is highly recommended checking the accuracy of the pretrained model, use the following command:
   ```bash
   python main.py \
   --mode=test \
   --config=configs/quantization/retinanet_coco_int8.json \
   --weights=<path_to_H5_file_with_pretrained_weights>
   --data=<path_to_dataset> \
-  --disable-compression 
+  --disable-compression
   ```
 - Run the following command to start compression with fine-tuning on all available GPUs on the machine:
     ```bash
@@ -89,6 +89,7 @@ FP32 model, without applying any compression algorithms.
     --log-dir=../../results/quantization/retinanet_coco_int8
     ```
 - Use the `--resume` flag with the path to the checkpoint to resume training from the defined checkpoint or folder with checkpoints to resume training from the last checkpoint.
+- Use `--prepare-for-inference` argument to convert model to tensorflow native format without NNCF-specific operations before `test` and `export` steps.
 
 ### Validate Your Model Checkpoint
 
@@ -177,4 +178,3 @@ To export a model to the OpenVINO IR and run it using the Intel® Deep Learning 
 |RetinaNet|None|COCO 2017|33.43|[retinanet_coco.json](configs/retinanet_coco.json)|[Link](https://storage.openvinotoolkit.org/repositories/nncf/models/develop/tensorflow/retinanet_coco.tar.gz)|
 |RetinaNet|Filter pruning, 40%|COCO 2017|32.72 (0.71)|[retinanet_coco_pruning_geometric_median.json](configs/pruning/retinanet_coco_pruning_geometric_median.json)|[Link](https://storage.openvinotoolkit.org/repositories/nncf/models/develop/tensorflow/retinanet_coco_pruning_geometric_median.tar.gz)|
 |RetinaNet|INT8 (per-tensor symmetric for weights, per-tensor asymmetric half-range for activations) + filter pruning 40%|COCO 2017|32.67 (0.76)|[retinanet_coco_pruning_geometric_median_int8.json](configs/pruning_quantization/retinanet_coco_pruning_geometric_median_int8.json)|[Link](https://storage.openvinotoolkit.org/repositories/nncf/models/develop/tensorflow/retinanet_coco_pruning_geometric_median_int8.tar.gz)|
-

--- a/examples/tensorflow/object_detection/main.py
+++ b/examples/tensorflow/object_detection/main.py
@@ -17,23 +17,21 @@ from pathlib import Path
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
 
 from examples.common.sample_config import create_sample_config
 from examples.tensorflow.common.argparser import get_common_argument_parser
 from examples.tensorflow.common.distributed import get_distribution_strategy
 from examples.tensorflow.common.experimental_patcher import patch_if_experimental_quantization
+from examples.tensorflow.common.export import export_model
 from examples.tensorflow.common.logger import logger
 from examples.tensorflow.common.object_detection.datasets.builder import COCODatasetBuilder
 from examples.tensorflow.common.optimizer import build_optimizer
 from examples.tensorflow.common.scheduler import build_scheduler
-from examples.tensorflow.common.utils import FROZEN_GRAPH_FORMAT
 from examples.tensorflow.common.utils import SummaryWriter
 from examples.tensorflow.common.utils import Timer
 from examples.tensorflow.common.utils import close_strategy_threadpool
 from examples.tensorflow.common.utils import configure_paths
 from examples.tensorflow.common.utils import create_code_snapshot
-from examples.tensorflow.common.utils import get_saving_parameters
 from examples.tensorflow.common.utils import print_args
 from examples.tensorflow.common.utils import serialize_cli_args
 from examples.tensorflow.common.utils import serialize_config
@@ -392,27 +390,6 @@ def run(config):
         export_model(compression_ctrl, config)
 
     close_strategy_threadpool(strategy)
-
-
-def export_model(compression_ctrl, config):
-    save_path, save_format = get_saving_parameters(config)
-    if config.prepare_for_inference:
-        model = compression_ctrl.prepare_for_inference()
-        if save_format == FROZEN_GRAPH_FORMAT:
-            input_signature = []
-            for item in model.inputs:
-                input_signature.append(tf.TensorSpec(item.shape, item.dtype, item.name))
-            concrete_function = tf.function(model).get_concrete_function(input_signature)
-            frozen_func = convert_variables_to_constants_v2(concrete_function, lower_control_flow=False)
-            frozen_graph = frozen_func.graph.as_graph_def(add_shapes=True)
-
-            save_dir, name = os.path.split(save_path)
-            tf.io.write_graph(frozen_graph, save_dir, name, as_text=False)
-        else:
-            model.save(save_path, save_format=save_format)
-    else:
-        compression_ctrl.export_model(save_path, save_format)
-    logger.info('Saved to {}'.format(save_path))
 
 
 def export(config):

--- a/examples/tensorflow/object_detection/main.py
+++ b/examples/tensorflow/object_detection/main.py
@@ -32,6 +32,7 @@ from examples.tensorflow.common.utils import Timer
 from examples.tensorflow.common.utils import close_strategy_threadpool
 from examples.tensorflow.common.utils import configure_paths
 from examples.tensorflow.common.utils import create_code_snapshot
+from examples.tensorflow.common.utils import get_saving_parameters
 from examples.tensorflow.common.utils import print_args
 from examples.tensorflow.common.utils import serialize_cli_args
 from examples.tensorflow.common.utils import serialize_config
@@ -387,7 +388,9 @@ def run(config):
         write_metrics(metric_result['AP'], config.metrics_dump)
 
     if 'export' in config.mode:
-        export_model(compression_ctrl, config)
+        save_path, save_format = get_saving_parameters(config)
+        export_model(compression_ctrl.prepare_for_inference(), save_path, save_format)
+        logger.info('Saved to {}'.format(save_path))
 
     close_strategy_threadpool(strategy)
 
@@ -407,7 +410,9 @@ def export(config):
                                          compression_state=TFCompressionState(compression_ctrl))
         load_checkpoint(checkpoint, config.ckpt_path)
 
-    export_model(compression_ctrl, config)
+    save_path, save_format = get_saving_parameters(config)
+    export_model(compression_ctrl.prepare_for_inference(), save_path, save_format)
+    logger.info('Saved to {}'.format(save_path))
 
 
 def main(argv):

--- a/examples/tensorflow/segmentation/README.md
+++ b/examples/tensorflow/segmentation/README.md
@@ -14,7 +14,7 @@ The sample receives a configuration file where the training schedule, hyper-para
 
 ## Installation
 
-At this point it is assumed that you have already installed nncf. You can find information on downloading nncf [here](https://github.com/openvinotoolkit/nncf#user-content-installation).  
+At this point it is assumed that you have already installed nncf. You can find information on downloading nncf [here](https://github.com/openvinotoolkit/nncf#user-content-installation).
 
 To work with the sample you should install the corresponding Python package dependencies:
 
@@ -52,8 +52,8 @@ We can run the sample after data preparation. For this follow these steps:
 - If you did not install the package, add the repository root folder to the `PYTHONPATH` environment variable.
 - Go to the `examples/tensorflow/segmentation` folder.
 - Download the pre-trained weights in checkpoint format and provide the path to them using `--weights` flag. The link to the
-archive with pre-trained weights can be found in the `TensorFlow checkpoint` column of the [results](#results) table. 
-Select the checkpoint corresponding to the `None` compression algorithm, which includes the pre-trained weights for the 
+archive with pre-trained weights can be found in the `TensorFlow checkpoint` column of the [results](#results) table.
+Select the checkpoint corresponding to the `None` compression algorithm, which includes the pre-trained weights for the
 FP32 model, without applying any compression algorithms.
 - Specify the GPUs to be used for training by setting the environment variable [`CUDA_VISIBLE_DEVICES`](https://developer.nvidia.com/blog/cuda-pro-tip-control-gpu-visibility-cuda_visible_devices/). This is necessary because training and validation during training must be performed on different GPU devices. Please note that usually only one GPU is required for validation during training.
 - (Optional) Before compressing a model, it is highly recommended checking the accuracy of the pretrained model, use the following command:
@@ -75,6 +75,7 @@ FP32 model, without applying any compression algorithms.
     --log-dir=../../results/quantization/maskrcnn_coco_int8
     ```
 - Use the `--resume` flag with the path to the checkpoint to resume training from the defined checkpoint or folder with checkpoints to resume training from the last checkpoint.
+- Use `--prepare-for-inference` argument to convert model to tensorflow native format without NNCF-specific operations before `test` and `export` steps.
 
 To start checkpoints validation during training follow these steps:
 - If you did not install the package, add the repository root folder to the `PYTHONPATH` environment variable.

--- a/examples/tensorflow/segmentation/README.md
+++ b/examples/tensorflow/segmentation/README.md
@@ -75,7 +75,6 @@ FP32 model, without applying any compression algorithms.
     --log-dir=../../results/quantization/maskrcnn_coco_int8
     ```
 - Use the `--resume` flag with the path to the checkpoint to resume training from the defined checkpoint or folder with checkpoints to resume training from the last checkpoint.
-- Use `--prepare-for-inference` argument to convert model to tensorflow native format without NNCF-specific operations before `test` and `export` steps.
 
 To start checkpoints validation during training follow these steps:
 - If you did not install the package, add the repository root folder to the `PYTHONPATH` environment variable.

--- a/examples/tensorflow/segmentation/evaluation.py
+++ b/examples/tensorflow/segmentation/evaluation.py
@@ -27,6 +27,7 @@ from examples.tensorflow.common.utils import SummaryWriter
 from examples.tensorflow.common.utils import Timer
 from examples.tensorflow.common.utils import close_strategy_threadpool
 from examples.tensorflow.common.utils import configure_paths
+from examples.tensorflow.common.utils import get_saving_parameters
 from examples.tensorflow.common.utils import print_args
 from examples.tensorflow.common.utils import write_metrics
 from examples.tensorflow.segmentation.models.model_selector import get_model_builder
@@ -242,7 +243,9 @@ def run_evaluation(config, eval_timeout=None):
         logger.info('Test metric = {}'.format(metric_result))
 
         if 'export' in config.mode:
-            export_model(compression_ctrl, config)
+            save_path, save_format = get_saving_parameters(config)
+            export_model(compression_ctrl.prepare_for_inference(), save_path, save_format)
+            logger.info('Saved to {}'.format(save_path))
 
     elif 'train' in config.mode:
         validation_summary_writer = SummaryWriter(config.log_dir, 'validation')
@@ -281,7 +284,9 @@ def export(config):
     strategy = tf.distribute.get_strategy()
     compression_ctrl, _, _ = restore_compressed_model(config, strategy, model_builder, config.ckpt_path)
 
-    export_model(compression_ctrl, config)
+    save_path, save_format = get_saving_parameters(config)
+    export_model(compression_ctrl.prepare_for_inference(), save_path, save_format)
+    logger.info('Saved to {}'.format(save_path))
 
 
 def main(argv):

--- a/examples/tensorflow/segmentation/evaluation.py
+++ b/examples/tensorflow/segmentation/evaluation.py
@@ -11,6 +11,7 @@
  limitations under the License.
 """
 
+import os
 import sys
 
 import tensorflow as tf
@@ -290,7 +291,7 @@ def export_model(compression_ctrl, config):
             frozen_func = convert_variables_to_constants_v2(concrete_function, lower_control_flow=False)
             frozen_graph = frozen_func.graph.as_graph_def(add_shapes=True)
 
-            save_dir, name = osp.split(save_path)
+            save_dir, name = os.path.split(save_path)
             tf.io.write_graph(frozen_graph, save_dir, name, as_text=False)
         else:
             model.save(save_path, save_format=save_format)

--- a/examples/torch/classification/README.md
+++ b/examples/torch/classification/README.md
@@ -60,7 +60,6 @@ python main.py \
 - Use the `--resume` flag with the path to a previously saved model to resume training.
 - For Torchvision-supported image classification models, set `"pretrained": true` inside the NNCF config JSON file supplied via `--config` to initialize the model to be compressed with Torchvision-supplied pretrained weights, or, alternatively:
 - Use the `--weights` flag with the path to a compatible PyTorch checkpoint in order to load all matching weights from the checkpoint into the model - useful if you need to start compression-aware training from a previously trained uncompressed (FP32) checkpoint instead of performing compression-aware training from scratch.
-- Use `--prepare-for-inference` argument to convert model to torch native format before `test` and `export` steps.
 
 #### Validate Your Model Checkpoint
 

--- a/examples/torch/classification/main.py
+++ b/examples/torch/classification/main.py
@@ -224,7 +224,8 @@ def main_worker(current_gpu, config: SampleConfig):
         load_state(model, model_state_dict, is_resume=True)
 
     if is_export_only:
-        export_model(compression_ctrl, config)
+        export_model(compression_ctrl.prepare_for_inference(), config.to_onnx)
+        logger.info(f'Saved to {config.to_onnx}')
         return
 
     model, _ = prepare_model_for_execution(model, config)
@@ -296,7 +297,8 @@ def main_worker(current_gpu, config: SampleConfig):
     config.mlflow.end_run()
 
     if 'export' in config.mode:
-        export_model(compression_ctrl, config)
+        export_model(compression_ctrl.prepare_for_inference(), config.to_onnx)
+        logger.info(f'Saved to {config.to_onnx}')
 
 
 def train(config, compression_ctrl, model, criterion, criterion_fn, lr_scheduler, model_name, optimizer,

--- a/examples/torch/classification/main.py
+++ b/examples/torch/classification/main.py
@@ -359,15 +359,6 @@ def train(config, compression_ctrl, model, criterion, criterion_fn, lr_scheduler
                 config.mlflow.safe_call('log_metric', 'compression/statistics/{0}'.format(key), value, epoch)
                 config.tb.add_scalar("compression/statistics/{0}".format(key), value, len(train_loader) * epoch)
 
-def export_model(compression_ctrl: PTCompressionAlgorithmController, config: SampleConfig) -> None:
-    if config.prepare_for_inference:
-        inference_model = compression_ctrl.prepare_for_inference()
-        inference_model = inference_model.eval().cpu()
-        input_size = config.get('input_info').get('sample_size')
-        torch.onnx.export(inference_model, torch.randn(input_size), config.to_onnx, input_names=['input.0'])
-    else:
-        compression_ctrl.export_model(config.to_onnx)
-    logger.info(f'Saved to {config.to_onnx}')
 
 def get_dataset(dataset_config, config, transform, is_train):
     if dataset_config == 'imagenet':

--- a/examples/torch/classification/staged_quantization_worker.py
+++ b/examples/torch/classification/staged_quantization_worker.py
@@ -16,12 +16,12 @@ import os.path as osp
 import time
 
 import torch
-from torch.backends import cudnn
-from torch import nn
 import torch.nn.parallel
 import torch.optim
 import torch.utils.data
 import torch.utils.data.distributed
+from torch import nn
+from torch.backends import cudnn
 from torchvision.models import InceptionOutputs
 
 from examples.torch.classification.main import AverageMeter
@@ -35,6 +35,7 @@ from examples.torch.common.example_logger import logger
 from examples.torch.common.execution import ExecutionMode
 from examples.torch.common.execution import prepare_model_for_execution
 from examples.torch.common.execution import set_seed
+from examples.torch.common.export import export_model
 from examples.torch.common.model_loader import COMPRESSION_STATE_ATTR
 from examples.torch.common.model_loader import MODEL_STATE_ATTR
 from examples.torch.common.model_loader import extract_model_and_compression_states
@@ -53,11 +54,11 @@ from nncf.common.utils.tensorboard import prepare_for_tensorboard
 from nncf.config.schemata.defaults import LR_POLY_DURATION_EPOCHS
 from nncf.config.schemata.defaults import STAGED_QUANTIZATION_BASE_LR
 from nncf.config.schemata.defaults import STAGED_QUANTIZATION_BASE_WD
+from nncf.torch import create_compressed_model
 from nncf.torch.binarization.algo import BinarizationController
 from nncf.torch.checkpoint_loading import load_state
 from nncf.torch.initialization import default_criterion_fn
 from nncf.torch.initialization import register_default_init_args
-from nncf.torch import create_compressed_model
 from nncf.torch.quantization.algo import QuantizationController
 from nncf.torch.utils import is_main_process
 
@@ -219,8 +220,7 @@ def staged_quantization_main_worker(current_gpu, config):
     log_common_mlflow_params(config)
 
     if is_export_only:
-        compression_ctrl.export_model(config.to_onnx)
-        logger.info("Saved to {}".format(config.to_onnx))
+        export_model(compression_ctrl, config)
         return
 
     if config.execution_mode != ExecutionMode.CPU_ONLY:
@@ -240,8 +240,7 @@ def staged_quantization_main_worker(current_gpu, config):
         validate(val_loader, model, criterion, config)
 
     if 'export' in config.mode:
-        compression_ctrl.export_model(config.to_onnx)
-        logger.info("Saved to {}".format(config.to_onnx))
+        export_model(compression_ctrl, config)
 
 
 

--- a/examples/torch/classification/staged_quantization_worker.py
+++ b/examples/torch/classification/staged_quantization_worker.py
@@ -220,7 +220,8 @@ def staged_quantization_main_worker(current_gpu, config):
     log_common_mlflow_params(config)
 
     if is_export_only:
-        export_model(compression_ctrl, config)
+        export_model(compression_ctrl.prepare_for_inference(), config.to_onnx)
+        logger.info(f'Saved to {config.to_onnx}')
         return
 
     if config.execution_mode != ExecutionMode.CPU_ONLY:
@@ -240,7 +241,8 @@ def staged_quantization_main_worker(current_gpu, config):
         validate(val_loader, model, criterion, config)
 
     if 'export' in config.mode:
-        export_model(compression_ctrl, config)
+        export_model(compression_ctrl.prepare_for_inference(), config.to_onnx)
+        logger.info(f'Saved to {config.to_onnx}')
 
 
 

--- a/examples/torch/common/argparser.py
+++ b/examples/torch/common/argparser.py
@@ -177,7 +177,7 @@ def get_common_argument_parser():
     parser.add_argument(
         "--prepare-for-inference",
         action='store_true',
-        help="Convert model to torch native format for export and test steps.")
+        help="Convert model to framework native format without NNCF-specific operation for export and test steps.")
 
     # Display
     parser.add_argument('-p', '--print-freq', default=10, type=int,

--- a/examples/torch/common/argparser.py
+++ b/examples/torch/common/argparser.py
@@ -174,11 +174,6 @@ def get_common_argument_parser():
     parser.add_argument('--to-onnx', type=str, metavar='PATH', default=None,
                         help='Export to ONNX model by given path')
 
-    parser.add_argument(
-        "--prepare-for-inference",
-        action='store_true',
-        help="Convert model to framework native format without NNCF-specific operation for export and test steps.")
-
     # Display
     parser.add_argument('-p', '--print-freq', default=10, type=int,
                         metavar='N', help='Print frequency (batch iterations). '

--- a/examples/torch/common/export.py
+++ b/examples/torch/common/export.py
@@ -34,6 +34,7 @@ def export_model(compression_ctrl: PTCompressionAlgorithmController, config: Sam
         input_shape = tuple([1] + list(info.shape)[1:])
         input_tensor_list.append(torch.rand(input_shape))
 
-    torch.onnx.export(inference_model, tuple(input_tensor_list), save_path, input_names=input_names)
+    with torch.no_grad():
+        torch.onnx.export(inference_model, tuple(input_tensor_list), save_path, input_names=input_names)
 
     logger.info(f'Saved to {save_path}')

--- a/examples/torch/common/export.py
+++ b/examples/torch/common/export.py
@@ -1,0 +1,39 @@
+"""
+ Copyright (c) 2023 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+import torch
+
+from examples.common.sample_config import SampleConfig
+from examples.tensorflow.common.logger import logger
+from nncf.torch.compression_method_api import PTCompressionAlgorithmController
+from nncf.torch.exporter import generate_input_names_list
+
+
+def export_model(compression_ctrl: PTCompressionAlgorithmController, config: SampleConfig) -> None:
+    """
+    Export compressed model. Supported only 'onnx' format.
+
+    :param compression_ctrl: The controller of the compression algorithm.
+    :param config: Config of examples.
+    """
+    save_path = config.to_onnx
+    inference_model = compression_ctrl.prepare_for_inference()
+    inference_model = inference_model.eval().cpu()
+    input_names = generate_input_names_list(len(inference_model.input_infos))
+    input_tensor_list = []
+    for info in inference_model.input_infos:
+        input_shape = tuple([1] + list(info.shape)[1:])
+        input_tensor_list.append(torch.rand(input_shape))
+
+    torch.onnx.export(inference_model, tuple(input_tensor_list), save_path, input_names=input_names)
+
+    logger.info(f'Saved to {save_path}')

--- a/examples/torch/object_detection/README.md
+++ b/examples/torch/object_detection/README.md
@@ -47,7 +47,6 @@ This scenario demonstrates quantization with fine-tuning of SSD300 on VOC datase
 - Use `--weights` flag with the path to a compatible PyTorch checkpoint in order to load all matching weights from the checkpoint into the model - useful if you need to start compression-aware training from a previously trained uncompressed (FP32) checkpoint instead of performing compression-aware training from scratch. This flag is optional, but highly recommended to use.
 - Use `--multiprocessing-distributed` flag to run in the distributed mode.
 - Use `--resume` flag with the path to a previously saved model to resume training.
-- Use `--prepare-for-inference` argument to convert model to torch native format before `test` and `export` steps.
 
 #### Validate your model checkpoint
 

--- a/examples/torch/object_detection/main.py
+++ b/examples/torch/object_detection/main.py
@@ -210,7 +210,8 @@ def main_worker(current_gpu, config):
     log_common_mlflow_params(config)
 
     if is_export_only:
-        export_model(compression_ctrl, config)
+        export_model(compression_ctrl.prepare_for_inference(), config.to_onnx)
+        logger.info(f'Saved to {config.to_onnx}')
         return
 
     if is_main_process():
@@ -268,7 +269,8 @@ def main_worker(current_gpu, config):
                     write_metrics(mAp, config.metrics_dump)
 
     if 'export' in config.mode:
-        export_model(compression_ctrl, config)
+        export_model(compression_ctrl.prepare_for_inference(), config.to_onnx)
+        logger.info(f'Saved to {config.to_onnx}')
 
 
 def create_dataloaders(config):

--- a/examples/torch/semantic_segmentation/README.md
+++ b/examples/torch/semantic_segmentation/README.md
@@ -45,7 +45,6 @@ This scenario demonstrates quantization with fine-tuning of UNet on Mapillary Vi
   ```
 - Run the following command to start compression with fine-tuning on GPUs:
   `python main.py -m train --config configs/unet_mapillary_int8.json --data <path_to_dataset> --weights <path_to_fp32_model_checkpoint>`
-- Use `--prepare-for-inference` argument to convert model to torch native format before `test` and `export` steps.
 
 It may take a few epochs to get the baseline accuracy results.
 

--- a/examples/torch/semantic_segmentation/main.py
+++ b/examples/torch/semantic_segmentation/main.py
@@ -10,12 +10,11 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-
-import functools
-import os
 # Major parts of this sample reuse code from:
 # https://github.com/davidtvs/PyTorch-ENet
 # https://github.com/pytorch/vision/tree/master/references/segmentation
+import functools
+import os
 import sys
 from copy import deepcopy
 from os import path as osp
@@ -540,7 +539,8 @@ def main_worker(current_gpu, config):
     log_common_mlflow_params(config)
 
     if is_export_only:
-        export_model(compression_ctrl, config)
+        export_model(compression_ctrl.prepare_for_inference(), config.to_onnx)
+        logger.info(f'Saved to {config.to_onnx}')
         return
 
     if is_main_process():
@@ -596,7 +596,8 @@ def main_worker(current_gpu, config):
         test(val_model, val_loader, criterion, color_encoding, config)
 
     if 'export' in config.mode:
-        export_model(compression_ctrl, config)
+        export_model(compression_ctrl.prepare_for_inference(), config.to_onnx)
+        logger.info(f'Saved to {config.to_onnx}')
 
 
 def main(argv):

--- a/nncf/api/compression.py
+++ b/nncf/api/compression.py
@@ -250,17 +250,17 @@ class CompressionAlgorithmController(ABC):
         :return: A `Statistics` class instance that contains compression algorithm statistics.
         """
 
-    def strip_model(self, model: TModel, make_model_copy: bool = False) -> TModel:
+    def strip_model(self, model: TModel, do_copy: bool = False) -> TModel:
         """
         Strips auxiliary layers that were used for the model compression, as it's
         only needed for training. The method is used before exporting the model
         in the target format.
 
         :param model: The compressed model.
-        :param make_model_copy: Modify copy of the model, defaults to False.
+        :param do_copy: Modify copy of the model, defaults to False.
         :return: The stripped model.
         """
-        if make_model_copy:
+        if do_copy:
             model = copy_model(model)
         return model
 
@@ -270,17 +270,17 @@ class CompressionAlgorithmController(ABC):
         """
         self._model = self.strip_model(self._model)
 
-    def prepare_for_inference(self, make_model_copy: bool = True) -> TModel:
+    def prepare_for_inference(self, do_copy: bool = True) -> TModel:
         """
         Prepare the compressed model for inference and export by removing NNCF-specific operations, as it's
         only needed for training.
 
-        :param make_model_copy: `True` means that a copy of the model will be modified.
+        :param do_copy: `True` means that a copy of the model will be modified.
             `False` means that the original model will be modify. Defaults to True.
 
         :return: Modified model.
         """
-        return self.strip_model(self.model, make_model_copy)
+        return self.strip_model(self.model, do_copy)
 
     @abstractmethod
     def export_model(self,

--- a/nncf/api/compression.py
+++ b/nncf/api/compression.py
@@ -14,7 +14,12 @@
 from abc import ABC
 from abc import abstractmethod
 from enum import IntEnum
-from typing import Any, Dict, List, Optional, Tuple, TypeVar
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import TypeVar
 
 from nncf.api.statistics import Statistics
 from nncf.common.graph.transformations.layout import TransformationLayout
@@ -249,6 +254,18 @@ class CompressionAlgorithmController(ABC):
         Prepare the compressed model for deployment.
         """
         self._model = self.strip_model(self._model)
+
+    def prepare_for_inference(self, make_model_copy: bool = True) -> TModel:
+        """
+        Prepare NNCFNetwork for inference by converting NNCF modules to torch native format.
+
+        :param make_model_copy: `True` means that a copy of the model will be modified.
+            `False` means that the original model in the controller will be changed and
+            no further compression actions will be available. Defaults to True.
+
+        :return: Modified model.
+        """
+        raise NotImplementedError(f"Method `prepare_for_inference` not implemented for {type(self)}.")
 
     @abstractmethod
     def export_model(self,

--- a/nncf/api/compression.py
+++ b/nncf/api/compression.py
@@ -272,7 +272,8 @@ class CompressionAlgorithmController(ABC):
 
     def prepare_for_inference(self, make_model_copy: bool = True) -> TModel:
         """
-        Prepare NNCFNetwork for inference by converting NNCF modules to torch native format.
+        Prepare the compressed model for inference and export by removing nncf specific operations, as it's
+        only needed for training.
 
         :param make_model_copy: `True` means that a copy of the model will be modified.
             `False` means that the original model will be modify. Defaults to True.

--- a/nncf/api/compression.py
+++ b/nncf/api/compression.py
@@ -272,7 +272,7 @@ class CompressionAlgorithmController(ABC):
 
     def prepare_for_inference(self, make_model_copy: bool = True) -> TModel:
         """
-        Prepare the compressed model for inference and export by removing nncf specific operations, as it's
+        Prepare the compressed model for inference and export by removing NNCF-specific operations, as it's
         only needed for training.
 
         :param make_model_copy: `True` means that a copy of the model will be modified.

--- a/nncf/common/accuracy_aware_training/runner_factory.py
+++ b/nncf/common/accuracy_aware_training/runner_factory.py
@@ -19,8 +19,8 @@ from nncf.api.compression import CompressionAlgorithmController
 from nncf.common.accuracy_aware_training.runner import BaseAccuracyAwareTrainingRunner
 from nncf.common.accuracy_aware_training.runner import BaseAdaptiveCompressionLevelTrainingRunner
 from nncf.common.accuracy_aware_training.runner import TrainingRunner
-from nncf.common.utils.backend import infer_backend_from_compression_controller
 from nncf.common.utils.backend import BackendType
+from nncf.common.utils.backend import get_backend
 
 
 class TrainingRunnerCreator(ABC):
@@ -53,7 +53,7 @@ class EarlyExitTrainingRunnerCreator(TrainingRunnerCreator):
 
         :return: AccuracyAwareTrainingRunner object
         """
-        nncf_backend = infer_backend_from_compression_controller(self.compression_controller)
+        nncf_backend = get_backend(self.compression_controller.model)
         if nncf_backend is BackendType.TORCH:
             from nncf.torch.accuracy_aware_training.runner import PTAccuracyAwareTrainingRunner
             return PTAccuracyAwareTrainingRunner(self.accuracy_aware_training_params, self.verbose,
@@ -88,7 +88,7 @@ class AdaptiveCompressionLevelTrainingRunnerCreator(TrainingRunnerCreator):
 
         :return: AdaptiveCompressionLevelTrainingRunner object
         """
-        nncf_backend = infer_backend_from_compression_controller(self.compression_controller)
+        nncf_backend = get_backend(self.compression_controller.model)
 
         if nncf_backend is BackendType.TORCH:
             from nncf.torch.accuracy_aware_training.runner import PTAdaptiveCompressionLevelTrainingRunner

--- a/nncf/common/composite_compression.py
+++ b/nncf/common/composite_compression.py
@@ -281,12 +281,12 @@ class CompositeCompressionAlgorithmController(CompressionAlgorithmController):
             stripped_model = ctrl.strip_model(stripped_model)
         self._model = stripped_model
 
-    def prepare_for_inference(self, make_model_copy: bool = True) -> TModel:
+    def prepare_for_inference(self, do_copy: bool = True) -> TModel:
         model = self.model
-        if make_model_copy:
+        if do_copy:
             model = copy_model(model)
         for ctrl in self.child_ctrls:
-            model = ctrl.strip_model(model, make_model_copy=False)
+            model = ctrl.strip_model(model, do_copy=False)
         return model
 
     @property

--- a/nncf/common/composite_compression.py
+++ b/nncf/common/composite_compression.py
@@ -291,19 +291,49 @@ class CompositeCompressionAlgorithmController(CompressionAlgorithmController):
 
         :return: Modified model.
         """
-        model = self.model
-        if make_model_copy:
-            model = copy.deepcopy(self.model)
+        # Because of the differences in model preparation for Torch and TF backends, it is not possible to use
+        # the same pipeline. TF transformations (expect quantization) creates copy of the model,
+        # torch transformations can modify existed instance of the model.
 
-        for ctrl in self.child_ctrls:
-            if make_model_copy:
+        model = self.model
+
+        backend = get_backend(model)
+        if backend is BackendType.TENSORFLOW:
+            from nncf.tensorflow.quantization.algorithm import QuantizationController
+
+            # Step 1: Prepare call prepare_for_inference for not QuantizationController,
+            #         that return new instance of the model.
+            for ctrl in self.child_ctrls:
+                if not isinstance(ctrl, QuantizationController):
+                    model = ctrl.prepare_for_inference(make_model_copy=False)
+
+            # Step 2: Prepare call prepare_for_inference for QuantizationController
+            for ctrl in self.child_ctrls:
+                if isinstance(ctrl, QuantizationController):
+                    # pylint: disable=protected-access
+                    ctrl._model = model
+                    model = ctrl.prepare_for_inference(make_model_copy=False)
+
+            # Step 3: Set model in controllers
+            self._model = self.model if make_model_copy else model
+            for ctrl in self.child_ctrls:
                 # pylint: disable=protected-access
-                saved_model = ctrl.model
-                ctrl._model = model
-                model = ctrl.prepare_for_inference(make_model_copy=False)
-                ctrl._model = saved_model
-            else:
-                model = ctrl.prepare_for_inference(make_model_copy=False)
+                ctrl._model = self.model
+        else:
+            assert backend is BackendType.TORCH
+
+            if make_model_copy:
+                model = copy.deepcopy(self.model)
+
+            for ctrl in self.child_ctrls:
+                if make_model_copy:
+                    # pylint: disable=protected-access
+                    saved_model = ctrl.model
+                    ctrl._model = model
+                    model = ctrl.prepare_for_inference(make_model_copy=False)
+                    ctrl._model = saved_model
+                else:
+                    model = ctrl.prepare_for_inference(make_model_copy=False)
 
         return model
 

--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -85,7 +85,7 @@ def copy_model(model: TModel) -> TModel:
         # TODO(l-bat): Remove after fixing ticket: 100919
         return model.clone()
     if model_backend == BackendType.TENSORFLOW:
-        # deepcopy and tensorflow.keras.models.clone_model does not works
+        # deepcopy and tensorflow.keras.models.clone_model does not work correctly on 2.8.4 version
         from nncf.tensorflow.graph.model_transformer import TFModelTransformer
         from nncf.tensorflow.graph.transformations.layout import TFTransformationLayout
         model = TFModelTransformer(model).transform(TFTransformationLayout())

--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -10,11 +10,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from typing import TypeVar
-from enum import Enum
 from copy import deepcopy
-
-from nncf.api.compression import CompressionAlgorithmController
+from enum import Enum
+from typing import TypeVar
 
 TModel = TypeVar('TModel')
 
@@ -75,19 +73,6 @@ def get_backend(model) -> BackendType:
                        'The available frameworks found: {}.'.format(', '.join(available_frameworks)))
 
 
-def infer_backend_from_compression_controller(compression_controller: CompressionAlgorithmController) -> BackendType:
-    """
-    Returns the NNCF backend name string inferred from the type of the model
-    stored in the passed compression controller.
-
-    :param compression_controller: Passed compression controller
-    (of CompressionAlgorithmController type).
-    :return: A BackendType representing the NNCF backend.
-    """
-    return get_backend(compression_controller.model)
-
-
-# TODO(l-bat): Remove after fixing ticket: 100919
 def copy_model(model: TModel) -> TModel:
     """
     Function to create copy of the backend-specific model.
@@ -97,5 +82,12 @@ def copy_model(model: TModel) -> TModel:
     """
     model_backend = get_backend(model)
     if model_backend == BackendType.OPENVINO:
+        # TODO(l-bat): Remove after fixing ticket: 100919
         return model.clone()
+    if model_backend == BackendType.TENSORFLOW:
+        # deepcopy and tensorflow.keras.models.clone_model does not works
+        from nncf.tensorflow.graph.model_transformer import TFModelTransformer
+        from nncf.tensorflow.graph.transformations.layout import TFTransformationLayout
+        model = TFModelTransformer(model).transform(TFTransformationLayout())
+        return model
     return deepcopy(model)

--- a/nncf/experimental/tensorflow/quantization/algorithm.py
+++ b/nncf/experimental/tensorflow/quantization/algorithm.py
@@ -11,39 +11,42 @@
  limitations under the License.
 """
 
-from typing import List, Optional, Dict, Any
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
 
-from nncf.common.logging import nncf_logger
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode
-from nncf.common.graph.utils import get_first_nodes_of_type
 from nncf.common.graph.transformations.commands import TargetPoint
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.transformations.commands import TransformationPriority
-from nncf.common.quantization.structs import QuantizerConfig
-from nncf.common.quantization.quantizer_setup import QuantizationPointId
+from nncf.common.graph.utils import get_first_nodes_of_type
+from nncf.common.logging import nncf_logger
 from nncf.common.quantization.quantizer_setup import ActivationQuantizationInsertionPoint
+from nncf.common.quantization.quantizer_setup import QuantizationPointId
+from nncf.common.quantization.structs import QuantizerConfig
 from nncf.common.stateful_classes_registry import TF_STATEFUL_CLASSES
 from nncf.common.statistics import NNCFStatistics
+from nncf.common.utils.backend import copy_model
 from nncf.config.extractors import extract_range_init_params
-from nncf.tensorflow.algorithm_selector import TF_COMPRESSION_ALGORITHMS
-from nncf.tensorflow.graph.transformations.commands import TFInsertionCommand
-from nncf.tensorflow.graph.metatypes.tf_ops import TFOpWithWeightsMetatype
-from nncf.tensorflow.quantization.quantizers import TFQuantizerSpec
-from nncf.tensorflow.quantization.algorithm import QuantizationController
-from nncf.tensorflow.quantization.algorithm import TFQuantizationPointStateNames
-from nncf.tensorflow.quantization.algorithm import TFQuantizationPoint
-from nncf.tensorflow.quantization.algorithm import TFQuantizationSetup
-from nncf.tensorflow.quantization.algorithm import QuantizationBuilder
-from nncf.experimental.tensorflow.nncf_network import NNCFNetwork
 from nncf.experimental.tensorflow.graph.converter import SubclassedConverter
 from nncf.experimental.tensorflow.graph.model_transformer import TFModelTransformerV2
-from nncf.experimental.tensorflow.graph.transformations.layout import TFTransformationLayoutV2
-from nncf.experimental.tensorflow.quantization.init_range import TFRangeInitParamsV2
-from nncf.experimental.tensorflow.quantization.init_range import RangeInitializerV2
-from nncf.experimental.tensorflow.quantization.quantizers import create_quantizer
 from nncf.experimental.tensorflow.graph.transformations.commands import TFTargetPoint
-
+from nncf.experimental.tensorflow.graph.transformations.layout import TFTransformationLayoutV2
+from nncf.experimental.tensorflow.nncf_network import NNCFNetwork
+from nncf.experimental.tensorflow.quantization.init_range import RangeInitializerV2
+from nncf.experimental.tensorflow.quantization.init_range import TFRangeInitParamsV2
+from nncf.experimental.tensorflow.quantization.quantizers import create_quantizer
+from nncf.tensorflow.algorithm_selector import TF_COMPRESSION_ALGORITHMS
+from nncf.tensorflow.graph.metatypes.tf_ops import TFOpWithWeightsMetatype
+from nncf.tensorflow.graph.transformations.commands import TFInsertionCommand
+from nncf.tensorflow.quantization.algorithm import QuantizationBuilder
+from nncf.tensorflow.quantization.algorithm import QuantizationController
+from nncf.tensorflow.quantization.algorithm import TFQuantizationPoint
+from nncf.tensorflow.quantization.algorithm import TFQuantizationPointStateNames
+from nncf.tensorflow.quantization.algorithm import TFQuantizationSetup
+from nncf.tensorflow.quantization.quantizers import TFQuantizerSpec
 
 UNSUPPORTED_TF_OP_METATYPES = [
 ]
@@ -364,7 +367,9 @@ class QuantizationBuilderV2(QuantizationBuilder):
 
 
 class QuantizationControllerV2(QuantizationController):
-    def strip_model(self, model: NNCFNetwork) -> NNCFNetwork:
+    def strip_model(self, model: NNCFNetwork, make_model_copy: bool = False) -> NNCFNetwork:
+        if make_model_copy:
+            model = copy_model(model)
         return model
 
     def statistics(self, quickly_collected_only: bool = False) -> NNCFStatistics:

--- a/nncf/experimental/tensorflow/quantization/algorithm.py
+++ b/nncf/experimental/tensorflow/quantization/algorithm.py
@@ -367,8 +367,8 @@ class QuantizationBuilderV2(QuantizationBuilder):
 
 
 class QuantizationControllerV2(QuantizationController):
-    def strip_model(self, model: NNCFNetwork, make_model_copy: bool = False) -> NNCFNetwork:
-        if make_model_copy:
+    def strip_model(self, model: NNCFNetwork, do_copy: bool = False) -> NNCFNetwork:
+        if do_copy:
             model = copy_model(model)
         return model
 

--- a/nncf/tensorflow/algorithm_selector.py
+++ b/nncf/tensorflow/algorithm_selector.py
@@ -10,6 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+import copy
 from typing import Dict
 from typing import Type
 
@@ -17,12 +18,12 @@ import tensorflow as tf
 
 from nncf.api.compression import CompressionAlgorithmController
 from nncf.common.compression import NO_COMPRESSION_ALGORITHM_NAME
-from nncf.common.graph.transformations.layout import TransformationLayout
-from nncf.common.schedulers import StubCompressionScheduler
-from nncf.common.logging import nncf_logger
-from nncf.common.utils.registry import Registry
-from nncf.common.statistics import NNCFStatistics
 from nncf.common.compression import BaseCompressionAlgorithmController
+from nncf.common.graph.transformations.layout import TransformationLayout
+from nncf.common.logging import nncf_logger
+from nncf.common.schedulers import StubCompressionScheduler
+from nncf.common.statistics import NNCFStatistics
+from nncf.common.utils.registry import Registry
 from nncf.tensorflow.api.compression import TFCompressionAlgorithmBuilder
 from nncf.tensorflow.loss import TFZeroCompressionLoss
 
@@ -60,6 +61,12 @@ class NoCompressionAlgorithmController(BaseCompressionAlgorithmController):
 
     def statistics(self, quickly_collected_only: bool = False) -> NNCFStatistics:
         return NNCFStatistics()
+
+    def prepare_for_inference(self, make_model_copy: bool = True) -> tf.keras.Model:
+        model = self.model
+        if make_model_copy:
+            model = copy.deepcopy(self.model)
+        return model
 
 
 def get_compression_algorithm_builder(algo_name: str) -> Type[TFCompressionAlgorithmBuilder]:

--- a/nncf/tensorflow/algorithm_selector.py
+++ b/nncf/tensorflow/algorithm_selector.py
@@ -10,7 +10,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-import copy
 from typing import Dict
 from typing import Type
 

--- a/nncf/tensorflow/algorithm_selector.py
+++ b/nncf/tensorflow/algorithm_selector.py
@@ -23,6 +23,7 @@ from nncf.common.graph.transformations.layout import TransformationLayout
 from nncf.common.logging import nncf_logger
 from nncf.common.schedulers import StubCompressionScheduler
 from nncf.common.statistics import NNCFStatistics
+from nncf.common.utils.backend import copy_model
 from nncf.common.utils.registry import Registry
 from nncf.tensorflow.api.compression import TFCompressionAlgorithmBuilder
 from nncf.tensorflow.loss import TFZeroCompressionLoss
@@ -65,7 +66,7 @@ class NoCompressionAlgorithmController(BaseCompressionAlgorithmController):
     def prepare_for_inference(self, make_model_copy: bool = True) -> tf.keras.Model:
         model = self.model
         if make_model_copy:
-            model = copy.deepcopy(self.model)
+            model = copy_model(self.model)
         return model
 
 

--- a/nncf/tensorflow/algorithm_selector.py
+++ b/nncf/tensorflow/algorithm_selector.py
@@ -62,9 +62,9 @@ class NoCompressionAlgorithmController(BaseCompressionAlgorithmController):
     def statistics(self, quickly_collected_only: bool = False) -> NNCFStatistics:
         return NNCFStatistics()
 
-    def prepare_for_inference(self, make_model_copy: bool = True) -> tf.keras.Model:
+    def prepare_for_inference(self, do_copy: bool = True) -> tf.keras.Model:
         model = self.model
-        if make_model_copy:
+        if do_copy:
             model = copy_model(self.model)
         return model
 

--- a/nncf/tensorflow/pruning/base_algorithm.py
+++ b/nncf/tensorflow/pruning/base_algorithm.py
@@ -11,6 +11,7 @@
  limitations under the License.
 """
 
+import copy
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -356,3 +357,10 @@ class BasePruningAlgoController(BaseCompressionAlgorithmController):
 
     def strip_model(self, model: tf.keras.Model) -> tf.keras.Model:
         return strip_model_from_masks(model, self._op_names)
+
+    def prepare_for_inference(self, make_model_copy: bool = True) -> tf.keras.Model:
+        model = self.model
+        if make_model_copy:
+            model = copy.deepcopy(self.model)
+        model = self.strip_model(model)
+        return model

--- a/nncf/tensorflow/pruning/base_algorithm.py
+++ b/nncf/tensorflow/pruning/base_algorithm.py
@@ -354,12 +354,6 @@ class BasePruningAlgoController(BaseCompressionAlgorithmController):
 
         return pruned_layers_summary
 
-    def strip_model(self, model: tf.keras.Model) -> tf.keras.Model:
+    def strip_model(self, model: tf.keras.Model, make_model_copy: bool = False) -> tf.keras.Model:
+        # Transform model for pruning creates copy of the model.
         return strip_model_from_masks(model, self._op_names)
-
-    def prepare_for_inference(self, make_model_copy: bool = True) -> tf.keras.Model:
-        # Pruning transformer create new copy of the model.
-        model = strip_model_from_masks(self.model, self._op_names)
-        if not make_model_copy:
-            self._model = model
-        return model

--- a/nncf/tensorflow/pruning/base_algorithm.py
+++ b/nncf/tensorflow/pruning/base_algorithm.py
@@ -11,7 +11,6 @@
  limitations under the License.
 """
 
-import copy
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -359,8 +358,8 @@ class BasePruningAlgoController(BaseCompressionAlgorithmController):
         return strip_model_from_masks(model, self._op_names)
 
     def prepare_for_inference(self, make_model_copy: bool = True) -> tf.keras.Model:
-        model = self.model
-        if make_model_copy:
-            model = copy.deepcopy(self.model)
-        model = self.strip_model(model)
+        # Pruning transformer create new copy of the model.
+        model = strip_model_from_masks(self.model, self._op_names)
+        if not make_model_copy:
+            self._model = model
         return model

--- a/nncf/tensorflow/pruning/base_algorithm.py
+++ b/nncf/tensorflow/pruning/base_algorithm.py
@@ -354,6 +354,6 @@ class BasePruningAlgoController(BaseCompressionAlgorithmController):
 
         return pruned_layers_summary
 
-    def strip_model(self, model: tf.keras.Model, make_model_copy: bool = False) -> tf.keras.Model:
+    def strip_model(self, model: tf.keras.Model, do_copy: bool = False) -> tf.keras.Model:
         # Transform model for pruning creates copy of the model.
         return strip_model_from_masks(model, self._op_names)

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -699,8 +699,8 @@ class QuantizationController(BaseCompressionAlgorithmController):
     def loss(self) -> CompressionLoss:
         return self._loss
 
-    def strip_model(self, model: tf.keras.Model, make_model_copy: bool = False) -> tf.keras.Model:
-        if make_model_copy:
+    def strip_model(self, model: tf.keras.Model, do_copy: bool = False) -> tf.keras.Model:
+        if do_copy:
             model = copy_model(model)
         apply_overflow_fix(model, self._op_names)
         return model

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -718,5 +718,5 @@ class QuantizationController(BaseCompressionAlgorithmController):
         model = self.model
         if make_model_copy:
             model = copy.deepcopy(self.model)
-        model = self.strip_model(model)
+        apply_overflow_fix(model, self._op_names)
         return model

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -10,6 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+import copy
 from copy import deepcopy
 from typing import Any
 from typing import Dict
@@ -712,3 +713,10 @@ class QuantizationController(BaseCompressionAlgorithmController):
 
     def compression_stage(self) -> CompressionStage:
         return CompressionStage.FULLY_COMPRESSED
+
+    def prepare_for_inference(self, make_model_copy: bool = True) -> tf.keras.Model:
+        model = self.model
+        if make_model_copy:
+            model = copy.deepcopy(self.model)
+        model = self.strip_model(model)
+        return model

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -52,6 +52,7 @@ from nncf.common.scopes import check_scopes_in_graph
 from nncf.common.scopes import should_consider_scope
 from nncf.common.stateful_classes_registry import TF_STATEFUL_CLASSES
 from nncf.common.statistics import NNCFStatistics
+from nncf.common.utils.backend import copy_model
 from nncf.config.extractors import extract_range_init_params
 from nncf.config.schemata.defaults import QUANTIZATION_OVERFLOW_FIX
 from nncf.config.schemata.defaults import QUANTIZE_INPUTS
@@ -699,7 +700,9 @@ class QuantizationController(BaseCompressionAlgorithmController):
     def loss(self) -> CompressionLoss:
         return self._loss
 
-    def strip_model(self, model: tf.keras.Model) -> tf.keras.Model:
+    def strip_model(self, model: tf.keras.Model, make_model_copy: bool = False) -> tf.keras.Model:
+        if make_model_copy:
+            model = copy_model(model)
         apply_overflow_fix(model, self._op_names)
         return model
 
@@ -713,10 +716,3 @@ class QuantizationController(BaseCompressionAlgorithmController):
 
     def compression_stage(self) -> CompressionStage:
         return CompressionStage.FULLY_COMPRESSED
-
-    def prepare_for_inference(self, make_model_copy: bool = True) -> tf.keras.Model:
-        model = self.model
-        if make_model_copy:
-            model = copy.deepcopy(self.model)
-        apply_overflow_fix(model, self._op_names)
-        return model

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -10,7 +10,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-import copy
 from copy import deepcopy
 from typing import Any
 from typing import Dict

--- a/nncf/tensorflow/sparsity/base_algorithm.py
+++ b/nncf/tensorflow/sparsity/base_algorithm.py
@@ -10,8 +10,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-import copy
-
 import tensorflow as tf
 
 from nncf.common.compression import BaseCompressionAlgorithmController

--- a/nncf/tensorflow/sparsity/base_algorithm.py
+++ b/nncf/tensorflow/sparsity/base_algorithm.py
@@ -55,8 +55,8 @@ class BaseSparsityController(BaseCompressionAlgorithmController, SparsityControl
         return strip_model_from_masks(model, self._op_names)
 
     def prepare_for_inference(self, make_model_copy: bool = True) -> tf.keras.Model:
-        model = self.model
-        if make_model_copy:
-            model = copy.deepcopy(self.model)
-        model = self.strip_model(model)
+        # Sparsity transformer create new copy of the model.
+        model = strip_model_from_masks(self.model, self._op_names)
+        if not make_model_copy:
+            self._model = model
         return model

--- a/nncf/tensorflow/sparsity/base_algorithm.py
+++ b/nncf/tensorflow/sparsity/base_algorithm.py
@@ -49,12 +49,6 @@ class BaseSparsityController(BaseCompressionAlgorithmController, SparsityControl
         super().__init__(target_model)
         self._op_names = op_names
 
-    def strip_model(self, model) -> tf.keras.Model:
+    def strip_model(self, model: tf.keras.Model, make_model_copy: bool = False) -> tf.keras.Model:
+        # Transform model for sparsity creates copy of the model.
         return strip_model_from_masks(model, self._op_names)
-
-    def prepare_for_inference(self, make_model_copy: bool = True) -> tf.keras.Model:
-        # Sparsity transformer create new copy of the model.
-        model = strip_model_from_masks(self.model, self._op_names)
-        if not make_model_copy:
-            self._model = model
-        return model

--- a/nncf/tensorflow/sparsity/base_algorithm.py
+++ b/nncf/tensorflow/sparsity/base_algorithm.py
@@ -10,9 +10,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+import copy
 
-from nncf.common.sparsity.controller import SparsityController
+import tensorflow as tf
+
 from nncf.common.compression import BaseCompressionAlgorithmController
+from nncf.common.sparsity.controller import SparsityController
 from nncf.tensorflow.graph.metatypes import keras_layers as layer_metatypes
 from nncf.tensorflow.sparsity.utils import strip_model_from_masks
 
@@ -48,5 +51,12 @@ class BaseSparsityController(BaseCompressionAlgorithmController, SparsityControl
         super().__init__(target_model)
         self._op_names = op_names
 
-    def strip_model(self, model):
+    def strip_model(self, model) -> tf.keras.Model:
         return strip_model_from_masks(model, self._op_names)
+
+    def prepare_for_inference(self, make_model_copy: bool = True) -> tf.keras.Model:
+        model = self.model
+        if make_model_copy:
+            model = copy.deepcopy(self.model)
+        model = self.strip_model(model)
+        return model

--- a/nncf/tensorflow/sparsity/base_algorithm.py
+++ b/nncf/tensorflow/sparsity/base_algorithm.py
@@ -49,6 +49,6 @@ class BaseSparsityController(BaseCompressionAlgorithmController, SparsityControl
         super().__init__(target_model)
         self._op_names = op_names
 
-    def strip_model(self, model: tf.keras.Model, make_model_copy: bool = False) -> tf.keras.Model:
+    def strip_model(self, model: tf.keras.Model, do_copy: bool = False) -> tf.keras.Model:
         # Transform model for sparsity creates copy of the model.
         return strip_model_from_masks(model, self._op_names)

--- a/nncf/torch/algo_selector.py
+++ b/nncf/torch/algo_selector.py
@@ -21,6 +21,7 @@ from nncf.api.compression import CompressionStage
 from nncf.common.compression import NO_COMPRESSION_ALGORITHM_NAME
 from nncf.common.schedulers import StubCompressionScheduler
 from nncf.common.statistics import NNCFStatistics
+from nncf.common.utils.backend import copy_model
 from nncf.common.utils.registry import Registry
 from nncf.torch.compression_method_api import PTCompressionAlgorithmBuilder
 from nncf.torch.compression_method_api import PTCompressionAlgorithmController
@@ -88,5 +89,5 @@ class NoCompressionAlgorithmController(PTCompressionAlgorithmController):
     def prepare_for_inference(self, make_model_copy: bool = True) -> NNCFNetwork:
         model = self.model
         if make_model_copy:
-            model = copy.deepcopy(self.model)
+            model = copy_model(self.model)
         return model

--- a/nncf/torch/algo_selector.py
+++ b/nncf/torch/algo_selector.py
@@ -10,25 +10,23 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-
 # pylint:disable=relative-beyond-top-level
+import copy
 from typing import Dict
 
 import torch
 
-from nncf.torch.graph.transformations.layout import PTTransformationLayout
-from nncf.torch.nncf_network import NNCFNetwork
-
-from nncf.api.compression import CompressionStage
 from nncf.api.compression import CompressionScheduler
-from nncf.torch.compression_method_api import PTCompressionAlgorithmBuilder
-from nncf.torch.compression_method_api import PTCompressionAlgorithmController
-
-from nncf.torch.compression_method_api import PTCompressionLoss
+from nncf.api.compression import CompressionStage
 from nncf.common.compression import NO_COMPRESSION_ALGORITHM_NAME
 from nncf.common.schedulers import StubCompressionScheduler
-from nncf.common.utils.registry import Registry
 from nncf.common.statistics import NNCFStatistics
+from nncf.common.utils.registry import Registry
+from nncf.torch.compression_method_api import PTCompressionAlgorithmBuilder
+from nncf.torch.compression_method_api import PTCompressionAlgorithmController
+from nncf.torch.compression_method_api import PTCompressionLoss
+from nncf.torch.graph.transformations.layout import PTTransformationLayout
+from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.utils import get_model_device
 
 PT_COMPRESSION_ALGORITHMS = Registry('compression algorithm', add_name_as_attr=True)
@@ -86,3 +84,9 @@ class NoCompressionAlgorithmController(PTCompressionAlgorithmController):
 
     def statistics(self, quickly_collected_only: bool = False) -> NNCFStatistics:
         return NNCFStatistics()
+
+    def prepare_for_inference(self, make_model_copy: bool = True) -> NNCFNetwork:
+        model = self.model
+        if make_model_copy:
+            model = copy.deepcopy(self.model)
+        return model

--- a/nncf/torch/algo_selector.py
+++ b/nncf/torch/algo_selector.py
@@ -10,8 +10,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-# pylint:disable=relative-beyond-top-level
-import copy
 from typing import Dict
 
 import torch

--- a/nncf/torch/algo_selector.py
+++ b/nncf/torch/algo_selector.py
@@ -84,8 +84,8 @@ class NoCompressionAlgorithmController(PTCompressionAlgorithmController):
     def statistics(self, quickly_collected_only: bool = False) -> NNCFStatistics:
         return NNCFStatistics()
 
-    def prepare_for_inference(self, make_model_copy: bool = True) -> NNCFNetwork:
+    def prepare_for_inference(self, do_copy: bool = True) -> NNCFNetwork:
         model = self.model
-        if make_model_copy:
+        if do_copy:
             model = copy_model(self.model)
         return model

--- a/nncf/torch/composite_compression.py
+++ b/nncf/torch/composite_compression.py
@@ -10,7 +10,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-import copy
 from typing import TypeVar
 
 import torch.nn

--- a/nncf/torch/composite_compression.py
+++ b/nncf/torch/composite_compression.py
@@ -133,29 +133,3 @@ class PTCompositeCompressionAlgorithmController(
                 sum_compression_rate += sum_compression_rate
                 not_none_compression_rate_cnt += 1
         return sum_compression_rate / max(not_none_compression_rate_cnt, 1)
-
-    def prepare_for_inference(self, make_model_copy: bool = True) -> NNCFNetwork:
-        """
-        Prepare NNCFNetwork for inference by converting NNCF modules to torch native format.
-
-        :param make_model_copy: `True` means that a copy of the model will be modified.
-            `False` means that the original model in the controller will be changed and
-            no further compression actions will be available. Defaults to True.
-
-        :return NNCFNetwork: Converted model.
-        """
-        model = self.model
-        if make_model_copy:
-            model = copy.deepcopy(self.model)
-
-        for ctrl in self.child_ctrls:
-            if make_model_copy:
-                # pylint: disable=protected-access
-                saved_model = ctrl.model
-                ctrl._model = model
-                model = ctrl.prepare_for_inference(make_model_copy=False)
-                ctrl._model = saved_model
-            else:
-                model = ctrl.prepare_for_inference(make_model_copy=False)
-
-        return model

--- a/nncf/torch/compression_method_api.py
+++ b/nncf/torch/compression_method_api.py
@@ -101,6 +101,10 @@ class PTCompressionAlgorithmController(BaseCompressionAlgorithmController):
         should be made inside this function.
         """
 
+    def prepare_for_export(self) -> None:
+        # For Torch models no need to call strip_model
+        pass
+
 
 class PTCompressionAlgorithmBuilder(BaseCompressionAlgorithmBuilder):
     """

--- a/nncf/torch/compression_method_api.py
+++ b/nncf/torch/compression_method_api.py
@@ -101,18 +101,6 @@ class PTCompressionAlgorithmController(BaseCompressionAlgorithmController):
         should be made inside this function.
         """
 
-    def prepare_for_inference(self, make_model_copy: bool = True) -> NNCFNetwork:
-        """
-        Prepare NNCFNetwork for inference by converting NNCF modules to torch native format.
-
-        :param make_model_copy: `True` means that a copy of the model will be modified.
-            `False` means that the original model in the controller will be changed and
-            no further compression actions will be available. Defaults to True.
-
-        :return NNCFNetwork: Converted model.
-        """
-        raise NotImplementedError(f"Method `prepare_for_inference` not implemented for {type(self)}.")
-
 
 class PTCompressionAlgorithmBuilder(BaseCompressionAlgorithmBuilder):
     """

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -27,6 +27,7 @@ from typing import TypeVar
 import torch
 from torch import nn
 
+from nncf import nncf_logger
 from nncf.common.graph import NNCFNode
 from nncf.common.graph import NNCFNodeName
 from nncf.common.graph.definitions import MODEL_INPUT_OP_NAME
@@ -38,7 +39,6 @@ from nncf.common.insertion_point_graph import InsertionPointGraph
 from nncf.common.insertion_point_graph import PostHookInsertionPoint
 from nncf.common.insertion_point_graph import PreHookInsertionPoint
 from nncf.common.utils.debug import is_debug
-from nncf import nncf_logger
 from nncf.torch.debug import CombinedDebugInterface
 from nncf.torch.debug import debuggable_forward
 from nncf.torch.dynamic_graph.context import TracingContext
@@ -56,7 +56,6 @@ from nncf.torch.dynamic_graph.patch_pytorch import ignore_scope
 from nncf.torch.dynamic_graph.scope import Scope
 from nncf.torch.dynamic_graph.scope_access import get_module_by_scope
 from nncf.torch.dynamic_graph.trace_tensor import TracedTensor
-from nncf.torch.nncf_module_replacement import replace_modules_by_nncf_modules
 from nncf.torch.graph.graph import PTNNCFGraph
 from nncf.torch.graph.graph_builder import GraphBuilder
 from nncf.torch.graph.graph_builder import GraphConverter
@@ -68,6 +67,7 @@ from nncf.torch.knowledge_distillation.knowledge_distillation_handler import Kno
 from nncf.torch.layer_utils import _NNCFModuleMixin
 from nncf.torch.module_operations import UpdateWeight
 from nncf.torch.nested_objects_traversal import objwalk
+from nncf.torch.nncf_module_replacement import replace_modules_by_nncf_modules
 from nncf.torch.quantization.layers import QUANTIZATION_MODULES
 from nncf.torch.utils import compute_FLOPs_hook
 from nncf.torch.utils import get_all_modules_by_type
@@ -312,7 +312,8 @@ class NNCFNetwork(nn.Module, PostGraphBuildActing):
     def get_clean_shallow_copy(self) -> 'NNCFNetwork':
         # WARNING: Will reset pre- and post-ops of the underlying model. Use save_nncf_module_additions
         # and load_nncf_module_additions to preserve these, or temporary_clean_view().
-        from nncf.torch.utils import save_module_state, load_module_state #pylint: disable=cyclic-import
+        from nncf.torch.utils import load_module_state  # pylint: disable=cyclic-import
+        from nncf.torch.utils import save_module_state  # pylint: disable=cyclic-import
         saved_state = save_module_state(self)
         model_copy = NNCFNetwork(self.get_nncf_wrapped_model(), self.input_infos,
                                  self._user_dummy_forward_fn, self._wrap_inputs_fn,

--- a/nncf/torch/pruning/filter_pruning/algo.py
+++ b/nncf/torch/pruning/filter_pruning/algo.py
@@ -45,6 +45,7 @@ from nncf.common.pruning.utils import get_rounded_pruned_element_number
 from nncf.common.pruning.weights_flops_calculator import WeightsFlopsCalculator
 from nncf.common.schedulers import StubCompressionScheduler
 from nncf.common.statistics import NNCFStatistics
+from nncf.common.utils.backend import copy_model
 from nncf.common.utils.debug import is_debug
 from nncf.common.utils.os import safe_open
 from nncf.config.extractors import extract_bn_adaptation_init_params
@@ -658,10 +659,9 @@ class FilterPruningController(BasePruningAlgoController):
                                                                                                    'filter_pruning'))
         self._bn_adaptation.run(self.model)
 
-    def prepare_for_inference(self, make_model_copy: bool = True) -> NNCFNetwork:
-        model = self.model
+    def strip_model(self, model: NNCFNetwork, make_model_copy: bool = False) -> NNCFNetwork:
         if make_model_copy:
-            model = copy.deepcopy(self.model)
+            model = copy_model(model)
 
         graph = model.get_original_graph()
         ModelPruner(model, graph, PT_PRUNING_OPERATOR_METATYPES, PrunType.FILL_ZEROS).prune_model()

--- a/nncf/torch/pruning/filter_pruning/algo.py
+++ b/nncf/torch/pruning/filter_pruning/algo.py
@@ -11,7 +11,6 @@
  limitations under the License.
 """
 
-import copy
 import json
 from math import isclose
 from pathlib import Path

--- a/nncf/torch/pruning/filter_pruning/algo.py
+++ b/nncf/torch/pruning/filter_pruning/algo.py
@@ -658,8 +658,8 @@ class FilterPruningController(BasePruningAlgoController):
                                                                                                    'filter_pruning'))
         self._bn_adaptation.run(self.model)
 
-    def strip_model(self, model: NNCFNetwork, make_model_copy: bool = False) -> NNCFNetwork:
-        if make_model_copy:
+    def strip_model(self, model: NNCFNetwork, do_copy: bool = False) -> NNCFNetwork:
+        if do_copy:
             model = copy_model(model)
 
         graph = model.get_original_graph()

--- a/nncf/torch/pruning/filter_pruning/algo.py
+++ b/nncf/torch/pruning/filter_pruning/algo.py
@@ -659,15 +659,6 @@ class FilterPruningController(BasePruningAlgoController):
         self._bn_adaptation.run(self.model)
 
     def prepare_for_inference(self, make_model_copy: bool = True) -> NNCFNetwork:
-        """
-        Prepare NNCFNetwork for inference by converting NNCF modules to torch native format.
-
-        :param make_model_copy: `True` means that a copy of the model will be modified.
-            `False` means that the original model in the controller will be changed and
-            no further compression actions will be available. Defaults to True.
-
-        :return NNCFNetwork: Converted model.
-        """
         model = self.model
         if make_model_copy:
             model = copy.deepcopy(self.model)

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -12,7 +12,6 @@
 """
 # pylint:disable=too-many-lines
 
-import copy
 import shutil
 from collections import Counter
 from collections import OrderedDict

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -1459,8 +1459,8 @@ class QuantizationController(QuantizationControllerBase):
         nncf_stats.register('quantization', stats)
         return nncf_stats
 
-    def strip_model(self, model: NNCFNetwork, make_model_copy: bool = False) -> NNCFNetwork:
-        if make_model_copy:
+    def strip_model(self, model: NNCFNetwork, do_copy: bool = False) -> NNCFNetwork:
+        if do_copy:
             model = copy_model(model)
         model = replace_quantizer_to_torch_native_module(model)
         model = remove_disabled_quantizers(model)

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -72,6 +72,7 @@ from nncf.common.schedulers import BaseCompressionScheduler
 from nncf.common.scopes import matches_any
 from nncf.common.statistics import NNCFStatistics
 from nncf.common.utils.backend import BackendType
+from nncf.common.utils.backend import copy_model
 from nncf.common.utils.debug import is_debug
 from nncf.common.utils.dot_file_rw import write_dot_graph
 from nncf.common.utils.os import safe_open
@@ -1459,14 +1460,11 @@ class QuantizationController(QuantizationControllerBase):
         nncf_stats.register('quantization', stats)
         return nncf_stats
 
-    def prepare_for_inference(self, make_model_copy: bool = True) -> NNCFNetwork:
-        model = self.model
+    def strip_model(self, model: NNCFNetwork, make_model_copy: bool = False) -> NNCFNetwork:
         if make_model_copy:
-            model = copy.deepcopy(self.model)
-
+            model = copy_model(model)
         model = replace_quantizer_to_torch_native_module(model)
         model = remove_disabled_quantizers(model)
-
         return model
 
 

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -42,10 +42,10 @@ from nncf.common.graph import NNCFNodeName
 from nncf.common.graph.definitions import MODEL_INPUT_OP_NAME
 from nncf.common.graph.layer_attributes import ConvolutionLayerAttributes
 from nncf.common.graph.layer_attributes import WeightedLayerAttributes
-from nncf.common.graph.transformations.commands import TargetPoint
-from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.patterns.manager import PatternsManager
 from nncf.common.graph.patterns.manager import TargetDevice
+from nncf.common.graph.transformations.commands import TargetPoint
+from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.utils import get_first_nodes_of_type
 from nncf.common.hardware.config import HWConfig
 from nncf.common.hardware.config import HWConfigType
@@ -71,10 +71,10 @@ from nncf.common.quantization.structs import WeightQuantizerId
 from nncf.common.schedulers import BaseCompressionScheduler
 from nncf.common.scopes import matches_any
 from nncf.common.statistics import NNCFStatistics
+from nncf.common.utils.backend import BackendType
 from nncf.common.utils.debug import is_debug
 from nncf.common.utils.dot_file_rw import write_dot_graph
 from nncf.common.utils.os import safe_open
-from nncf.common.utils.backend import BackendType
 from nncf.config import NNCFConfig
 from nncf.config.extractors import extract_algo_specific_config
 from nncf.config.extractors import extract_bn_adaptation_init_params
@@ -1460,15 +1460,6 @@ class QuantizationController(QuantizationControllerBase):
         return nncf_stats
 
     def prepare_for_inference(self, make_model_copy: bool = True) -> NNCFNetwork:
-        """
-        Prepare NNCFNetwork for inference by converting NNCF modules to torch native format.
-
-        :param make_model_copy: `True` means that a copy of the model will be modified.
-            `False` means that the original model in the controller will be changed and
-            no further compression actions will be available. Defaults to True.
-
-        :return NNCFNetwork: Converted model.
-        """
         model = self.model
         if make_model_copy:
             model = copy.deepcopy(self.model)

--- a/nncf/torch/sparsity/base_algo.py
+++ b/nncf/torch/sparsity/base_algo.py
@@ -117,15 +117,6 @@ class BaseSparsityAlgoController(PTCompressionAlgorithmController, SparsityContr
         return CompressionStage.FULLY_COMPRESSED
 
     def prepare_for_inference(self, make_model_copy: bool = True) -> NNCFNetwork:
-        """
-        Prepare NNCFNetwork for inference by converting NNCF modules to torch native format.
-
-        :param make_model_copy: `True` means that a copy of the model will be modified.
-            `False` means that the original model in the controller will be changed and
-            no further compression actions will be available. Defaults to True.
-
-        :return NNCFNetwork: Converted model.
-        """
         model = self.model
         if make_model_copy:
             model = copy.deepcopy(self.model)

--- a/nncf/torch/sparsity/base_algo.py
+++ b/nncf/torch/sparsity/base_algo.py
@@ -10,7 +10,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-import copy
 from typing import List
 
 import torch

--- a/nncf/torch/sparsity/base_algo.py
+++ b/nncf/torch/sparsity/base_algo.py
@@ -116,8 +116,8 @@ class BaseSparsityAlgoController(PTCompressionAlgorithmController, SparsityContr
     def compression_stage(self) -> CompressionStage:
         return CompressionStage.FULLY_COMPRESSED
 
-    def strip_model(self, model: NNCFNetwork, make_model_copy: bool = False) -> NNCFNetwork:
-        if make_model_copy:
+    def strip_model(self, model: NNCFNetwork, do_copy: bool = False) -> NNCFNetwork:
+        if do_copy:
             model = copy_model(model)
 
         for node in model.get_original_graph().get_all_nodes():

--- a/tests/tensorflow/pruning/test_prepare_for_inference.py
+++ b/tests/tensorflow/pruning/test_prepare_for_inference.py
@@ -1,0 +1,34 @@
+"""
+ Copyright (c) 2023 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import pytest
+
+from tests.tensorflow.helpers import create_compressed_model_and_algo_for_test
+from tests.tensorflow.pruning.helpers import get_basic_pruning_config
+from tests.tensorflow.pruning.helpers import get_concat_test_model
+
+
+@pytest.mark.parametrize("make_model_copy", (True, False))
+def test_make_model_copy(make_model_copy):
+    config = get_basic_pruning_config(8)
+    sample_size = [1, 8, 8, 3]
+    model = get_concat_test_model(sample_size)
+    compression_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config, force_no_init=True)
+    inference_model = compression_ctrl.prepare_for_inference(make_model_copy=make_model_copy)
+
+    if make_model_copy:
+        assert id(inference_model) != id(compression_model)
+    else:
+        assert id(inference_model) == id(compression_model)
+
+    assert id(compression_model) == id(compression_ctrl.model)

--- a/tests/tensorflow/pruning/test_prepare_for_inference.py
+++ b/tests/tensorflow/pruning/test_prepare_for_inference.py
@@ -15,7 +15,6 @@ import pytest
 
 from tests.tensorflow.helpers import create_compressed_model_and_algo_for_test
 from tests.tensorflow.helpers import get_empty_config
-from tests.tensorflow.pruning.helpers import get_basic_pruning_config
 from tests.tensorflow.pruning.helpers import get_concat_test_model
 
 

--- a/tests/tensorflow/pruning/test_prepare_for_inference.py
+++ b/tests/tensorflow/pruning/test_prepare_for_inference.py
@@ -12,16 +12,49 @@
 """
 
 import pytest
+import tensorflow as tf
 
+from tests.tensorflow.helpers import TFTensorListComparator
 from tests.tensorflow.helpers import create_compressed_model_and_algo_for_test
 from tests.tensorflow.helpers import get_empty_config
 from tests.tensorflow.pruning.helpers import get_concat_test_model
 
 
+@pytest.mark.parametrize("enable_quantization", (True, False), ids=("with_quantization", "no_quantization"))
+def test_prepare_for_inference(enable_quantization):
+    input_shape = (1, 8, 8, 3)
+    model = get_concat_test_model(input_shape)
+
+    config = get_empty_config(input_sample_sizes=input_shape)
+    config.update(
+        {"compression": [{"algorithm": "filter_pruning", "pruning_init": 0.5, "params": {"prune_first_conv": True}}]}
+    )
+    if enable_quantization:
+        config["compression"].append(
+            {
+                "algorithm": "quantization",
+                "preset": "mixed",
+                "initializer": {
+                    "batchnorm_adaptation": {
+                        "num_bn_adaptation_samples": 0,
+                    }
+                },
+            }
+        )
+
+    compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
+    input_tensor = tf.ones(input_shape)
+    x_nncf = compressed_model(input_tensor)
+
+    inference_model = compression_ctrl.prepare_for_inference()
+    x_tf = inference_model(input_tensor)
+
+    TFTensorListComparator.check_equal(x_nncf, x_tf)
+
 @pytest.mark.parametrize("make_model_copy", (True, False))
 @pytest.mark.parametrize("enable_quantization", (True, False), ids=("with_quantization", "no_quantization"))
 def test_make_model_copy(make_model_copy, enable_quantization):
-    input_shape = [1, 8, 8, 3]
+    input_shape = (1, 8, 8, 3)
     model = get_concat_test_model(input_shape)
 
     config = get_empty_config(input_sample_sizes=input_shape)
@@ -34,11 +67,5 @@ def test_make_model_copy(make_model_copy, enable_quantization):
     compression_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config, force_no_init=True)
     inference_model = compression_ctrl.prepare_for_inference(make_model_copy=make_model_copy)
 
-    if make_model_copy:
-        assert id(inference_model) != id(compression_model)
-    else:
-        assert id(inference_model) == id(compression_ctrl.model)
-
-    if enable_quantization:
-        for ctrl in compression_ctrl.child_ctrls:
-            assert id(compression_ctrl.model) == id(ctrl.model)
+    # Transform model for pruning creates copy of the model in both cases
+    assert id(inference_model) != id(compression_model)

--- a/tests/tensorflow/pruning/test_prepare_for_inference.py
+++ b/tests/tensorflow/pruning/test_prepare_for_inference.py
@@ -14,21 +14,32 @@
 import pytest
 
 from tests.tensorflow.helpers import create_compressed_model_and_algo_for_test
+from tests.tensorflow.helpers import get_empty_config
 from tests.tensorflow.pruning.helpers import get_basic_pruning_config
 from tests.tensorflow.pruning.helpers import get_concat_test_model
 
 
 @pytest.mark.parametrize("make_model_copy", (True, False))
-def test_make_model_copy(make_model_copy):
-    config = get_basic_pruning_config(8)
-    sample_size = [1, 8, 8, 3]
-    model = get_concat_test_model(sample_size)
+@pytest.mark.parametrize("enable_quantization", (True, False), ids=("with_quantization", "no_quantization"))
+def test_make_model_copy(make_model_copy, enable_quantization):
+    input_shape = [1, 8, 8, 3]
+    model = get_concat_test_model(input_shape)
+
+    config = get_empty_config(input_sample_sizes=input_shape)
+    config.update(
+        {"compression": [{"algorithm": "filter_pruning", "pruning_init": 0.5, "params": {"prune_first_conv": True}}]}
+    )
+    if enable_quantization:
+        config["compression"].append({"algorithm": "quantization", "preset": "mixed"})
+
     compression_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config, force_no_init=True)
     inference_model = compression_ctrl.prepare_for_inference(make_model_copy=make_model_copy)
 
     if make_model_copy:
         assert id(inference_model) != id(compression_model)
     else:
-        assert id(inference_model) == id(compression_model)
+        assert id(inference_model) == id(compression_ctrl.model)
 
-    assert id(compression_model) == id(compression_ctrl.model)
+    if enable_quantization:
+        for ctrl in compression_ctrl.child_ctrls:
+            assert id(compression_ctrl.model) == id(ctrl.model)

--- a/tests/tensorflow/pruning/test_prepare_for_inference.py
+++ b/tests/tensorflow/pruning/test_prepare_for_inference.py
@@ -51,9 +51,9 @@ def test_prepare_for_inference(enable_quantization):
 
     TFTensorListComparator.check_equal(x_nncf, x_tf)
 
-@pytest.mark.parametrize("make_model_copy", (True, False))
+@pytest.mark.parametrize("do_copy", (True, False))
 @pytest.mark.parametrize("enable_quantization", (True, False), ids=("with_quantization", "no_quantization"))
-def test_make_model_copy(make_model_copy, enable_quantization):
+def test_do_copy(do_copy, enable_quantization):
     input_shape = (1, 8, 8, 3)
     model = get_concat_test_model(input_shape)
 
@@ -65,7 +65,7 @@ def test_make_model_copy(make_model_copy, enable_quantization):
         config["compression"].append({"algorithm": "quantization", "preset": "mixed"})
 
     compression_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config, force_no_init=True)
-    inference_model = compression_ctrl.prepare_for_inference(make_model_copy=make_model_copy)
+    inference_model = compression_ctrl.prepare_for_inference(do_copy=do_copy)
 
     # Transform model for pruning creates copy of the model in both cases
     assert id(inference_model) != id(compression_model)

--- a/tests/tensorflow/quantization/test_prepare_for_inference.py
+++ b/tests/tensorflow/quantization/test_prepare_for_inference.py
@@ -12,17 +12,42 @@
 """
 
 import pytest
+import tensorflow as tf
 
+from tests.tensorflow.helpers import TFTensorListComparator
 from tests.tensorflow.helpers import create_compressed_model_and_algo_for_test
 from tests.tensorflow.helpers import get_basic_two_conv_test_model
 from tests.tensorflow.quantization.utils import get_basic_quantization_config
+
+
+def test_prepare_for_inference():
+    model = get_basic_two_conv_test_model()
+    config = get_basic_quantization_config()
+    config["compression"] = {
+        "algorithm": "quantization",
+        "preset": "mixed",
+        "initializer": {
+            "batchnorm_adaptation": {
+                "num_bn_adaptation_samples": 0,
+            }
+        }
+    }
+
+    compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
+
+    input_tensor = tf.ones([1, 4, 4, 1])
+    x_nncf = compressed_model(input_tensor)
+
+    inference_model = compression_ctrl.prepare_for_inference()
+    x_tf = inference_model(input_tensor)
+
+    TFTensorListComparator.check_equal(x_nncf, x_tf)
 
 
 @pytest.mark.parametrize("make_model_copy", (True, False))
 def test_make_model_copy(make_model_copy):
     model = get_basic_two_conv_test_model()
     config = get_basic_quantization_config()
-    config["target_device"] = "TRIAL"
     config["compression"] = {
         "algorithm": "quantization",
         "preset": "mixed",
@@ -34,5 +59,3 @@ def test_make_model_copy(make_model_copy):
         assert id(inference_model) != id(compression_model)
     else:
         assert id(inference_model) == id(compression_model)
-
-    assert id(compression_model) == id(compression_ctrl.model)

--- a/tests/tensorflow/quantization/test_prepare_for_inference.py
+++ b/tests/tensorflow/quantization/test_prepare_for_inference.py
@@ -44,8 +44,8 @@ def test_prepare_for_inference():
     TFTensorListComparator.check_equal(x_nncf, x_tf)
 
 
-@pytest.mark.parametrize("make_model_copy", (True, False))
-def test_make_model_copy(make_model_copy):
+@pytest.mark.parametrize("do_copy", (True, False))
+def test_do_copy(do_copy):
     model = get_basic_two_conv_test_model()
     config = get_basic_quantization_config()
     config["compression"] = {
@@ -53,9 +53,9 @@ def test_make_model_copy(make_model_copy):
         "preset": "mixed",
     }
     compression_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config, force_no_init=True)
-    inference_model = compression_ctrl.prepare_for_inference(make_model_copy=make_model_copy)
+    inference_model = compression_ctrl.prepare_for_inference(do_copy=do_copy)
 
-    if make_model_copy:
+    if do_copy:
         assert id(inference_model) != id(compression_model)
     else:
         assert id(inference_model) == id(compression_model)

--- a/tests/tensorflow/quantization/test_prepare_for_inference.py
+++ b/tests/tensorflow/quantization/test_prepare_for_inference.py
@@ -1,0 +1,38 @@
+"""
+ Copyright (c) 2023 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import pytest
+
+from tests.tensorflow.helpers import create_compressed_model_and_algo_for_test
+from tests.tensorflow.helpers import get_basic_two_conv_test_model
+from tests.tensorflow.quantization.utils import get_basic_quantization_config
+
+
+@pytest.mark.parametrize("make_model_copy", (True, False))
+def test_make_model_copy(make_model_copy):
+    model = get_basic_two_conv_test_model()
+    config = get_basic_quantization_config()
+    config["target_device"] = "TRIAL"
+    config["compression"] = {
+        "algorithm": "quantization",
+        "preset": "mixed",
+    }
+    compression_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config, force_no_init=True)
+    inference_model = compression_ctrl.prepare_for_inference(make_model_copy=make_model_copy)
+
+    if make_model_copy:
+        assert id(inference_model) != id(compression_model)
+    else:
+        assert id(inference_model) == id(compression_model)
+
+    assert id(compression_model) == id(compression_ctrl.model)

--- a/tests/tensorflow/sparsity/test_prepare_for_inference.py
+++ b/tests/tensorflow/sparsity/test_prepare_for_inference.py
@@ -51,9 +51,9 @@ def test_prepare_for_inference(enable_quantization):
     TFTensorListComparator.check_equal(x_nncf, x_tf)
 
 
-@pytest.mark.parametrize("make_model_copy", (True, False))
+@pytest.mark.parametrize("do_copy", (True, False))
 @pytest.mark.parametrize("enable_quantization", (True, False), ids=("with_quantization", "no_quantization"))
-def test_make_model_copy(make_model_copy, enable_quantization):
+def test_do_copy(do_copy, enable_quantization):
     input_shape = (1, 4, 4, 1)
     model = get_basic_conv_test_model(input_shape=input_shape[1:])
 
@@ -63,7 +63,7 @@ def test_make_model_copy(make_model_copy, enable_quantization):
         config["compression"].append({"algorithm": "quantization", "preset": "mixed"})
 
     compression_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config, force_no_init=True)
-    inference_model = compression_ctrl.prepare_for_inference(make_model_copy=make_model_copy)
+    inference_model = compression_ctrl.prepare_for_inference(do_copy=do_copy)
 
     # Transform model for sparsity creates copy of the model in both cases
     assert id(inference_model) != id(compression_model)

--- a/tests/tensorflow/sparsity/test_prepare_for_inference.py
+++ b/tests/tensorflow/sparsity/test_prepare_for_inference.py
@@ -13,7 +13,6 @@
 
 import pytest
 
-from nncf.config.config import NNCFConfig
 from tests.tensorflow.helpers import create_compressed_model_and_algo_for_test
 from tests.tensorflow.helpers import get_basic_conv_test_model
 from tests.tensorflow.helpers import get_empty_config

--- a/tests/tensorflow/sparsity/test_prepare_for_inference.py
+++ b/tests/tensorflow/sparsity/test_prepare_for_inference.py
@@ -1,0 +1,36 @@
+"""
+ Copyright (c) 2023 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import pytest
+
+from tests.tensorflow.helpers import create_compressed_model_and_algo_for_test
+from tests.tensorflow.helpers import get_basic_conv_test_model
+from tests.tensorflow.helpers import get_empty_config
+
+
+@pytest.mark.parametrize("make_model_copy", (True, False))
+def test_make_model_copy(make_model_copy):
+    input_shape = (1, 5, 5, 1)
+    model = get_basic_conv_test_model(input_shape=input_shape[1:])
+    config = get_empty_config(input_sample_sizes=input_shape)
+    config.update({'compression': {'algorithm': "magnitude_sparsity"}})
+
+    compression_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config, force_no_init=True)
+    inference_model = compression_ctrl.prepare_for_inference(make_model_copy=make_model_copy)
+
+    if make_model_copy:
+        assert id(inference_model) != id(compression_model)
+    else:
+        assert id(inference_model) == id(compression_model)
+
+    assert id(compression_model) == id(compression_ctrl.model)

--- a/tests/torch/pruning/filter_pruning/test_prepare_for_inference.py
+++ b/tests/torch/pruning/filter_pruning/test_prepare_for_inference.py
@@ -67,16 +67,16 @@ def test_prepare_for_inference_pruning(enable_quantization):
     assert torch.equal(x_nncf, x_torch), f"{x_nncf=} != {x_torch}"
 
 
-@pytest.mark.parametrize("make_model_copy", (True, False))
+@pytest.mark.parametrize("do_copy", (True, False))
 @pytest.mark.parametrize("enable_quantization", (True, False), ids=("with_quantization", "no_quantization"))
-def test_make_model_copy(make_model_copy, enable_quantization):
+def test_do_copy(do_copy, enable_quantization):
     model = BasicConvTestModel()
     config = _get_config_for_algo(model.INPUT_SIZE, enable_quantization)
     compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
 
-    inference_model = compression_ctrl.prepare_for_inference(make_model_copy=make_model_copy)
+    inference_model = compression_ctrl.prepare_for_inference(do_copy=do_copy)
 
-    if make_model_copy:
+    if do_copy:
         assert id(inference_model) != id(compressed_model)
     else:
         assert id(inference_model) == id(compressed_model)

--- a/tests/torch/quantization/test_prepare_for_inference.py
+++ b/tests/torch/quantization/test_prepare_for_inference.py
@@ -269,16 +269,16 @@ def test_prepare_for_inference_quantization(mode, overflow_fix, num_bits):
     assert torch.all(torch.isclose(x_nncf, x_torch)), f"{x_nncf.view(-1)} != {x_torch.view(-1)}"
 
 
-@pytest.mark.parametrize("make_model_copy", (True, False))
-def test_make_model_copy(make_model_copy):
+@pytest.mark.parametrize("do_copy", (True, False))
+def test_do_copy(do_copy):
     model = BasicConvTestModel()
     config = _get_config_for_algo(model.INPUT_SIZE)
     register_bn_adaptation_init_args(config)
     compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
 
-    inference_model = compression_ctrl.prepare_for_inference(make_model_copy=make_model_copy)
+    inference_model = compression_ctrl.prepare_for_inference(do_copy=do_copy)
 
-    if make_model_copy:
+    if do_copy:
         assert id(inference_model) != id(compressed_model)
     else:
         assert id(inference_model) == id(compressed_model)

--- a/tests/torch/quantization/test_sanity_sample.py
+++ b/tests/torch/quantization/test_sanity_sample.py
@@ -275,6 +275,8 @@ class ExportSampleValidator(PrecisionSampleValidator):
         create_model_location = sample_location + '.create_compressed_model'
         create_model_patch = mocker.patch(create_model_location)
 
+        self._torch_onn_export_mock = mocker.patch('torch.onnx.export')
+
         if self._desc.sample_type_ == SampleType.CLASSIFICATION_STAGED:
             mocker.patch(sample_location + '.get_quantization_optimizer')
 
@@ -287,10 +289,11 @@ class ExportSampleValidator(PrecisionSampleValidator):
     def validate_spy(self):
         super().validate_spy()
         self._reg_init_args_patch.assert_called()
+
         if self.is_export_called:
-            self._ctrl_mock.export_model.assert_called_once()
+            self._torch_onn_export_mock.assert_called_once()
         else:
-            self._ctrl_mock.export_model.assert_not_called()
+            self._torch_onn_export_mock.assert_not_called()
 
 
 EXPORT_TEST_CASE_DESCRIPTORS = [

--- a/tests/torch/sparsity/test_prepare_for_inference.py
+++ b/tests/torch/sparsity/test_prepare_for_inference.py
@@ -81,16 +81,16 @@ def test_prepare_for_inference_sparsity(enable_quantization):
     assert torch.all(torch.isclose(x_nncf, x_torch)), f"{x_nncf.view(-1)} != {x_torch.view(-1)}"
 
 
-@pytest.mark.parametrize("make_model_copy", (True, False))
+@pytest.mark.parametrize("do_copy", (True, False))
 @pytest.mark.parametrize("enable_quantization", (True, False), ids=("with_quantization", "no_quantization"))
-def test_make_model_copy(make_model_copy, enable_quantization):
+def test_do_copy(do_copy, enable_quantization):
     model = BasicConvTestModel()
     config = _get_config_for_algo(model.INPUT_SIZE, enable_quantization)
     compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
 
-    inference_model = compression_ctrl.prepare_for_inference(make_model_copy=make_model_copy)
+    inference_model = compression_ctrl.prepare_for_inference(do_copy=do_copy)
 
-    if make_model_copy:
+    if do_copy:
         assert id(inference_model) != id(compressed_model)
     else:
         assert id(inference_model) == id(compressed_model)
@@ -108,7 +108,7 @@ def test_corruption_binary_masks():
     ref_mask_1 = torch.clone(compression_ctrl.sparsified_module_info[0].operand.binary_mask)
     ref_mask_2 = torch.clone(compression_ctrl.sparsified_module_info[1].operand.binary_mask)
 
-    compression_ctrl.prepare_for_inference(make_model_copy=False)
+    compression_ctrl.prepare_for_inference(do_copy=False)
 
     after_mask_1 = compression_ctrl.sparsified_module_info[0].operand.binary_mask
     after_mask_2 = compression_ctrl.sparsified_module_info[1].operand.binary_mask
@@ -137,7 +137,7 @@ def tests_weights_after_onnx_export(tmp_path):
             weights_sparse.append(data)
 
     onnx_sparse_model_prepare_path = f"{tmp_path}/sparse_model_prepare.onnx"
-    compression_ctrl.prepare_for_inference(make_model_copy=False)
+    compression_ctrl.prepare_for_inference(do_copy=False)
     compression_ctrl.export_model(onnx_sparse_model_prepare_path, "onnx")
 
     onnx_prepare_model = onnx.load(onnx_sparse_model_prepare_path)


### PR DESCRIPTION
### Changes

Add `prepare_for_inference` to common api for PyTorch orch and TF Controllers.
PyTorch implementation: https://github.com/openvinotoolkit/nncf/pull/1526

1. Move `prepare_for_inference` logics to `strip_model` method for PT. (before strip_model do nothing, get model and return same model)
2. Add make_model_copy argument to `strip_model`, defaults value is False.
3. Add to `copy_model` from `nncf/common/utils/backend.py` logic to copy TF model via TFModelTransformer. (deepcopy, tf.keras.model_copy do not work as expected)
4. Removed `infer_backend_from_compression_controller` function because was import cycle and   `infer_backend_from_compression_controller` is longer than use `get_backend`.
    ```python
    infer_backend_from_compression_controller(compression_ctrl)
    # Changed to 
    get_bakend(compression_ctrl.model)
    ```
5. In torch examples for `--prepare_for_inference` used export via `torch.onnx.export`
6. Add TF examples with export models without using `ctrl.export_model` method. 

### Related tickets

92247

