### PR TITLE
Add support int4 for convert_to_torch_fakequantizer

### DIFF
--- a/nncf/torch/quantization/prepare_for_inference.py
+++ b/nncf/torch/quantization/prepare_for_inference.py
@@ -72,7 +72,6 @@ def convert_to_torch_fakequantizer(nncf_quantizer: BaseQuantizer) -> FakeQuantiz
 
     :return: Instance of FakeQuantize similar to the input quantizer.
     """
-    assert nncf_quantizer.num_bits == 8, "Support only 8bit quantization."
 
     # Call set_level_ranges to set actual values
     nncf_quantizer.set_level_ranges()

--- a/tests/torch/quantization/test_prepare_for_inference.py
+++ b/tests/torch/quantization/test_prepare_for_inference.py
@@ -188,7 +188,7 @@ def test_converting_asymmetric_quantizer(input_size, num_bits, is_per_channel, i
     input_low, input_range = generate_random_low_and_range_by_input_size(input_size, is_per_channel, is_weights)
 
     ######################################################################
-    # TODO: Workaround for CVS-105241 (remove after fix)
+    # TODO: Workaround for issue 105241 (remove after fix)
     get_quant_len = get_quant_len_by_range(input_range, real_num_bits)
     input_low[(input_low > -get_quant_len / 2) & (input_low < 0)] = 0
     ######################################################################

--- a/tests/torch/quantization/test_prepare_for_inference.py
+++ b/tests/torch/quantization/test_prepare_for_inference.py
@@ -38,7 +38,7 @@ from tests.torch.quantization.test_functions import get_test_data
 def _get_config_for_algo(input_size, quant_mode="symmetric", overflow_fix="enable", bits=8):
     config = NNCFConfig()
     config.update({"model": "model", "input_info": {"sample_size": input_size}, "compression": []})
-    config['target_device'] = 'TRIAL'
+    config["target_device"] = "TRIAL"
     config["compression"].append(
         {
             "algorithm": "quantization",
@@ -99,7 +99,9 @@ INPUT_TEST_SCALES = (
 @pytest.mark.parametrize("input_size", INPUT_TEST_SCALES, ids=_idfn)
 @pytest.mark.parametrize("is_per_channel", (True, False), ids=("per_channel", "per_tensor"))
 @pytest.mark.parametrize("num_bits", (4, 8), ids=("4-bits", "8-bits"))
-def test_converting_symmetric_quantizer(input_size, num_bits, is_per_channel, is_weights, half_range, is_signed, use_cuda):
+def test_converting_symmetric_quantizer(
+    input_size, num_bits, is_per_channel, is_weights, half_range, is_signed, use_cuda
+):
     if not torch.cuda.is_available() and use_cuda is True:
         pytest.skip("Skipping CUDA test cases for CPU only setups")
 
@@ -150,7 +152,7 @@ def test_converting_symmetric_quantizer(input_size, num_bits, is_per_channel, is
     fq = convert_to_torch_fakequantizer(quantizer)
 
     fq_levels = fq.quant_max - fq.quant_min
-    assert fq_levels == 2**num_bits-1, "Levels in converted FQ should be 2**num_bits-1"
+    assert fq_levels == 2**num_bits - 1, "Levels in converted FQ should be 2**num_bits-1"
 
     fq_test_input = test_input
     if half_range:
@@ -188,7 +190,7 @@ def test_converting_asymmetric_quantizer(input_size, num_bits, is_per_channel, i
     ######################################################################
     # TODO: Workaround for CVS-105241 (remove after fix)
     get_quant_len = get_quant_len_by_range(input_range, real_num_bits)
-    input_low[(input_low>-get_quant_len/2)&(input_low<0)] = 0
+    input_low[(input_low > -get_quant_len / 2) & (input_low < 0)] = 0
     ######################################################################
 
     tensor_input_low, tensor_input_range = get_test_data([input_low, input_range], use_cuda)
@@ -228,7 +230,7 @@ def test_converting_asymmetric_quantizer(input_size, num_bits, is_per_channel, i
     fq = convert_to_torch_fakequantizer(quantizer)
 
     fq_levels = fq.quant_max - fq.quant_min
-    assert fq_levels == 2**num_bits-1, "Levels in converted FQ should be 2**num_bits-1"
+    assert fq_levels == 2**num_bits - 1, "Levels in converted FQ should be 2**num_bits-1"
 
     fq_test_input = test_input
     if half_range:
@@ -262,7 +264,7 @@ def test_prepare_for_inference_quantization(mode, overflow_fix, num_bits):
     inference_model = compression_ctrl.prepare_for_inference()
     x_torch = inference_model(input_tensor)
 
-    check_quantizer_operators(inference_model, 2**num_bits-1)
+    check_quantizer_operators(inference_model, 2**num_bits - 1)
 
     assert torch.all(torch.isclose(x_nncf, x_torch)), f"{x_nncf.view(-1)} != {x_torch.view(-1)}"
 

--- a/tests/torch/quantization/test_prepare_for_inference.py
+++ b/tests/torch/quantization/test_prepare_for_inference.py
@@ -27,6 +27,7 @@ from tests.common.quantization.data_generators import generate_lazy_sweep_data
 from tests.common.quantization.data_generators import generate_random_low_and_range_by_input_size
 from tests.common.quantization.data_generators import generate_random_scale_by_input_size
 from tests.common.quantization.data_generators import generate_sweep_data
+from tests.common.quantization.data_generators import get_quant_len_by_range
 from tests.common.quantization.data_generators import get_symmetric_range_level
 from tests.torch.helpers import BasicConvTestModel
 from tests.torch.helpers import create_compressed_model_and_algo_for_test
@@ -34,16 +35,16 @@ from tests.torch.helpers import register_bn_adaptation_init_args
 from tests.torch.quantization.test_functions import get_test_data
 
 
-def _get_config_for_algo(input_size, quant_mode="symmetric", overflow_fix="enable"):
+def _get_config_for_algo(input_size, quant_mode="symmetric", overflow_fix="enable", bits=8):
     config = NNCFConfig()
     config.update({"model": "model", "input_info": {"sample_size": input_size}, "compression": []})
-
+    config['target_device'] = 'TRIAL'
     config["compression"].append(
         {
             "algorithm": "quantization",
             "initializer": {"range": {"num_init_samples": 0}},
-            "weights": {"mode": quant_mode},
-            "activations": {"mode": quant_mode},
+            "weights": {"mode": quant_mode, "bits": bits},
+            "activations": {"mode": quant_mode, "bits": bits},
             "overflow_fix": overflow_fix,
         }
     )
@@ -57,14 +58,14 @@ def _idfn(val):
     return None
 
 
-def check_quantizer_operators(model):
+def check_quantizer_operators(model, levels=255):
     """Check that model contains only 8bit FakeQuantize operators."""
 
     if hasattr(model, "external_quantizers"):
         for key in list(model.external_quantizers.keys()):
             op = model.external_quantizers[key]
             assert isinstance(model.external_quantizers[key], FakeQuantize)
-            assert op.quant_max - op.quant_min == 255
+            assert op.quant_max - op.quant_min == levels
 
     for node in model.get_original_graph().get_all_nodes():
         if node.node_type in ["nncf_model_input", "nncf_model_output"]:
@@ -76,13 +77,13 @@ def check_quantizer_operators(model):
             for key in list(nncf_module.pre_ops.keys()):
                 op = nncf_module.get_pre_op(key).op
                 assert isinstance(op, FakeQuantize)
-                assert op.quant_max - op.quant_min == 255
+                assert op.quant_max - op.quant_min == levels
 
         if hasattr(nncf_module, "post_ops"):
             for key in list(nncf_module.post_ops.keys()):
                 op = nncf_module.post_ops(key).op
                 assert isinstance(op, FakeQuantize)
-                assert op.quant_max - op.quant_min == 255
+                assert op.quant_max - op.quant_min == levels
 
 
 INPUT_TEST_SCALES = (
@@ -97,7 +98,8 @@ INPUT_TEST_SCALES = (
 @pytest.mark.parametrize("is_signed", (True, False), ids=("signed", "unsigned"))
 @pytest.mark.parametrize("input_size", INPUT_TEST_SCALES, ids=_idfn)
 @pytest.mark.parametrize("is_per_channel", (True, False), ids=("per_channel", "per_tensor"))
-def test_converting_symmetric_quantizer(input_size, is_per_channel, is_weights, half_range, is_signed, use_cuda):
+@pytest.mark.parametrize("num_bits", (4, 8), ids=("4-bits", "8-bits"))
+def test_converting_symmetric_quantizer(input_size, num_bits, is_per_channel, is_weights, half_range, is_signed, use_cuda):
     if not torch.cuda.is_available() and use_cuda is True:
         pytest.skip("Skipping CUDA test cases for CPU only setups")
 
@@ -105,11 +107,11 @@ def test_converting_symmetric_quantizer(input_size, is_per_channel, is_weights, 
         pytest.skip("Same case as for per_tensor case")
 
     np.random.seed(42)
-    bits = 7 if half_range else 8
+    real_num_bits = num_bits - 1 if half_range else num_bits
     np_scale = generate_random_scale_by_input_size(input_size, is_per_channel, is_weights)
     tensor_scale = get_test_data([np_scale], use_cuda)
 
-    level_low, level_high, _ = get_symmetric_range_level(is_signed, bits)
+    level_low, level_high, _ = get_symmetric_range_level(is_signed, real_num_bits)
 
     input_low = np_scale * (level_low / level_high)
     input_range = np_scale - input_low
@@ -118,7 +120,7 @@ def test_converting_symmetric_quantizer(input_size, is_per_channel, is_weights, 
     input_range = np.squeeze(input_range)
 
     qspec = PTQuantizerSpec(
-        num_bits=8,
+        num_bits=num_bits,
         mode=QuantizationMode.SYMMETRIC,
         signedness_to_force=is_signed,
         narrow_range=False,
@@ -139,7 +141,7 @@ def test_converting_symmetric_quantizer(input_size, is_per_channel, is_weights, 
     tuned_input_range = tuned_input_high - tuned_input_low
 
     np_input, np_is_near_mid_point, quant_lens = generate_sweep_data(
-        input_size, tuned_input_low, tuned_input_range, bits, is_per_channel, is_weights
+        input_size, tuned_input_low, tuned_input_range, real_num_bits, is_per_channel, is_weights
     )
     test_input = get_test_data([np_input], use_cuda)
 
@@ -148,7 +150,7 @@ def test_converting_symmetric_quantizer(input_size, is_per_channel, is_weights, 
     fq = convert_to_torch_fakequantizer(quantizer)
 
     fq_levels = fq.quant_max - fq.quant_min
-    assert fq_levels == 255, "Levels in converted FQ should be 255"
+    assert fq_levels == 2**num_bits-1, "Levels in converted FQ should be 2**num_bits-1"
 
     fq_test_input = test_input
     if half_range:
@@ -170,7 +172,8 @@ def test_converting_symmetric_quantizer(input_size, is_per_channel, is_weights, 
 @pytest.mark.parametrize("is_weights", (True, False), ids=("weights", "activation"))
 @pytest.mark.parametrize("input_size", INPUT_TEST_SCALES, ids=_idfn)
 @pytest.mark.parametrize("is_per_channel", (True, False), ids=("per_channel", "per_tensor"))
-def test_converting_asymmetric_quantizer(input_size, is_per_channel, is_weights, half_range, use_cuda):
+@pytest.mark.parametrize("num_bits", (4, 8), ids=("4-bits", "8-bits"))
+def test_converting_asymmetric_quantizer(input_size, num_bits, is_per_channel, is_weights, half_range, use_cuda):
     if not torch.cuda.is_available() and use_cuda is True:
         pytest.skip("Skipping CUDA test cases for CPU only setups")
 
@@ -178,16 +181,23 @@ def test_converting_asymmetric_quantizer(input_size, is_per_channel, is_weights,
         pytest.skip("Same case as for per_tensor case")
 
     np.random.seed(42)
-    bits = 7 if half_range else 8
+    real_num_bits = num_bits - 1 if half_range else num_bits
 
     input_low, input_range = generate_random_low_and_range_by_input_size(input_size, is_per_channel, is_weights)
+
+    ######################################################################
+    # TODO: Workaround for CVS-105241 (remove after fix)
+    get_quant_len = get_quant_len_by_range(input_range, real_num_bits)
+    input_low[(input_low>-get_quant_len/2)&(input_low<0)] = 0
+    ######################################################################
+
     tensor_input_low, tensor_input_range = get_test_data([input_low, input_range], use_cuda)
 
     input_low = np.squeeze(input_low)
     input_range = np.squeeze(input_range)
 
     qspec = PTQuantizerSpec(
-        num_bits=8,
+        num_bits=num_bits,
         mode=QuantizationMode.ASYMMETRIC,
         signedness_to_force=False,
         narrow_range=False,
@@ -209,7 +219,7 @@ def test_converting_asymmetric_quantizer(input_size, is_per_channel, is_weights,
     tuned_input_range = tuned_input_high - tuned_input_low
 
     np_input, np_is_near_mid_point, quant_lens = generate_sweep_data(
-        input_size, tuned_input_low, tuned_input_range, bits, is_per_channel, is_weights
+        input_size, tuned_input_low, tuned_input_range, real_num_bits, is_per_channel, is_weights
     )
     test_input = get_test_data([np_input], use_cuda)
 
@@ -218,7 +228,7 @@ def test_converting_asymmetric_quantizer(input_size, is_per_channel, is_weights,
     fq = convert_to_torch_fakequantizer(quantizer)
 
     fq_levels = fq.quant_max - fq.quant_min
-    assert fq_levels == 255, "Levels in converted FQ should be 255"
+    assert fq_levels == 2**num_bits-1, "Levels in converted FQ should be 2**num_bits-1"
 
     fq_test_input = test_input
     if half_range:
@@ -238,10 +248,11 @@ def test_converting_asymmetric_quantizer(input_size, is_per_channel, is_weights,
 
 @pytest.mark.parametrize("mode", ("asymmetric", "symmetric"))
 @pytest.mark.parametrize("overflow_fix", ("disable", "enable"), ids=("overflow_fix_enable", "overflow_fix_disable"))
-def test_prepare_for_inference_quantization(mode, overflow_fix):
+@pytest.mark.parametrize("num_bits", (4, 8), ids=("4-bits", "8-bits"))
+def test_prepare_for_inference_quantization(mode, overflow_fix, num_bits):
     model = BasicConvTestModel()
 
-    config = _get_config_for_algo(model.INPUT_SIZE, mode, overflow_fix)
+    config = _get_config_for_algo(model.INPUT_SIZE, mode, overflow_fix, bits=num_bits)
     register_bn_adaptation_init_args(config)
     compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
 
@@ -251,7 +262,7 @@ def test_prepare_for_inference_quantization(mode, overflow_fix):
     inference_model = compression_ctrl.prepare_for_inference()
     x_torch = inference_model(input_tensor)
 
-    check_quantizer_operators(inference_model)
+    check_quantizer_operators(inference_model, 2**num_bits-1)
 
     assert torch.all(torch.isclose(x_nncf, x_torch)), f"{x_nncf.view(-1)} != {x_torch.view(-1)}"
 


### PR DESCRIPTION
### Changes

Add support ad tests for convert 4bit fakequantizer.

### Reason for changes

https://github.com/openvinotoolkit/nncf/pull/1526

