### PR TITLE
Remove scikit pre-install step

### DIFF
--- a/tests/tensorflow/test_sota_checkpoints.py
+++ b/tests/tensorflow/test_sota_checkpoints.py
@@ -569,12 +569,6 @@ class TestSotaCheckpoints(RunTest):
 
 Tsc = TestSotaCheckpoints
 
-
-@pytest.fixture(autouse=True, scope='class')
-def openvino_preinstall(openvino):
-    if openvino:
-        subprocess.run('pip install scikit-image!=0.18.2rc1', cwd=PROJECT_ROOT, check=True, shell=True)
-
 # pylint:disable=line-too-long
 @pytest.fixture(autouse=True, scope='class')
 def make_metrics_dump_path(metrics_dump_dir):


### PR DESCRIPTION
### Changes
Removed an autouse fixture that led to a scikit-images pre-installation step before TF E2E tests were being run.

### Reason for changes
The scikit-images now pulls with itself an incompatible numpy version and TF E2E are failing. The workaround might be no longer relevant for the latest OV anyway.

### Related tickets
N/A

### Tests
TF E2E + compat
