### PR TITLE
Typo was fixed

### DIFF
--- a/nncf/experimental/openvino_native/graph/node_utils.py
+++ b/nncf/experimental/openvino_native/graph/node_utils.py
@@ -75,7 +75,7 @@ def get_weight_value(node_with_weight: NNCFNode, nncf_graph: NNCFGraph, model: o
     attrs = node_with_weight.layer_attributes  # type: OVConstantLayerAttributes
     node = nncf_graph.get_input_edges(node_with_weight)[attrs.const_port_id].from_node
     if node.metatype == OVConvertMetatype:
-        node = nncf_graph.get_input_edges()[0].from_node
+        node = nncf_graph.get_input_edges(node)[0].from_node
 
     friendly_name_to_op_map = {op.get_friendly_name(): op for op in model.get_ops()}
     const_op = friendly_name_to_op_map[node.node_name]

--- a/tests/openvino/native/test_node_utils.py
+++ b/tests/openvino/native/test_node_utils.py
@@ -1,0 +1,27 @@
+"""
+ Copyright (c) 2023 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import numpy as np
+
+from nncf.experimental.openvino_native.graph.node_utils import get_weight_value
+from nncf.common.factory import NNCFGraphFactory
+from tests.openvino.native.models import FPModel
+
+
+def test_get_weight_value_const_with_convert():
+    model = FPModel(const_dtype='FP16').ov_model
+    nncf_graph = NNCFGraphFactory.create(model)
+    node_with_weight = nncf_graph.get_node_by_name('MatMul')
+
+    actual_value = get_weight_value(node_with_weight, nncf_graph, model)
+    assert actual_value.dtype == np.uint16


### PR DESCRIPTION
### Changes

The typo was fixed in the `get_weight_value()` method.

### Reason for changes

TypeError: get_input_edges() missing 1 required positional argument: 'node'

### Related tickets

N/A

### Tests

tests/openvino/native/test_node_utils.py
