### PR TITLE
Tracing of in-place slice multiplication

### DIFF
--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -97,7 +97,7 @@ class MagicFunctionsToPatch:
                                        "__rsub__", "__mul__", "__matmul__", "__rmatmul__",
                                        "__imul__", "__rmul__", "__div__", "__idiv__",
                                        "__truediv__", "__floordiv__",
-                                       "__ifloordiv__", "__rfloordiv__", "__getitem__",
+                                       "__ifloordiv__", "__rfloordiv__", "__getitem__", "__setitem__",
                                        "__lt__", "__le__", "__gt__",
                                        "__ge__", "__mod__", "__eq__", "__ne__", "__or__",
                                        "__xor__", "__and__", "__pow__"]

--- a/nncf/torch/dynamic_graph/trace_tensor.py
+++ b/nncf/torch/dynamic_graph/trace_tensor.py
@@ -154,6 +154,7 @@ def trace_tensors(operator_output: TensorOrTupleOrList,
         if ctx is not None:
             ctx.register_traced_tensor(tt)
         return tt
+    return None
     raise ValueError("Unknown return type. Can not trace function call")
 
 

--- a/nncf/torch/dynamic_graph/wrappers.py
+++ b/nncf/torch/dynamic_graph/wrappers.py
@@ -198,7 +198,12 @@ def _execute_op(op_address: 'OperationAddress',
         if is_debug() and node is not None:
             ctx.register_node_call(node)
 
-    result = trace_tensors(result, node, ctx)
+    if not op_name == '__setitem__':
+        result = trace_tensors(result, node, ctx)
+    else:
+        result = args[0]
+        result = trace_tensors(result, node, ctx)
+        result = None
     result = ctx.execute_post_hooks(op_address, result)
     return result
 

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -577,7 +577,7 @@ class NNCFNetwork(nn.Module, PostGraphBuildActing):
                                                     input_port_id=port_id)
                 pre_hooks.append(pre_hook_ip)
 
-            if issubclass(node.metatype, PTSplitMetatype):
+            if issubclass(node.metatype, PTSplitMetatype) or node.node_type == '__setitem__':
                 # chunk returns a tuple of tensors, which can only be handled in NNCF
                 # once post-hook ports are enabled. Work around it for now by disallowing post-hook
                 # insertion for chunks

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -634,9 +634,11 @@ class SymmetricQuantizer(BaseQuantizer):
         scaled_num_bits = 1 if self._half_range else 0
         self.level_low, self.level_high, self.levels = self.calculate_level_ranges(self.num_bits - scaled_num_bits,
                                                                                    self.signed)
+        self.level_low = 0
 
     @staticmethod
     def calculate_level_ranges(num_bits, signed):
+        # return calculate_asymmetric_level_ranges(num_bits, signed)
         return calculate_symmetric_level_ranges(num_bits, signed)
 
     @property

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -634,11 +634,9 @@ class SymmetricQuantizer(BaseQuantizer):
         scaled_num_bits = 1 if self._half_range else 0
         self.level_low, self.level_high, self.levels = self.calculate_level_ranges(self.num_bits - scaled_num_bits,
                                                                                    self.signed)
-        self.level_low = 0
 
     @staticmethod
     def calculate_level_ranges(num_bits, signed):
-        # return calculate_asymmetric_level_ranges(num_bits, signed)
         return calculate_symmetric_level_ranges(num_bits, signed)
 
     @property


### PR DESCRIPTION
# Draft

### Changes

<!--- What was changed (briefly), how to reproduce (if applicable), what the reviewers should focus on -->

### Reason for changes

An operation of the following form is not traced by NNCF properly.
 

For example

```
class Model(torch.nn.Module):
    def forward(self, x):
        x[..., -1] *= 2.0
        return x
```
 results in the wrong graph:

  
![image](https://user-images.githubusercontent.com/23343961/225284197-a0c9b140-1132-4099-b27e-b9503a3fa2fe.png)


### Related tickets

105954

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
