### PR TITLE
Extend fixtures in tests/torch/conftest.py

### DIFF
--- a/nncf/torch/quantization/adjust_padding.py
+++ b/nncf/torch/quantization/adjust_padding.py
@@ -17,11 +17,11 @@ import networkx as nx
 import torch
 
 from nncf.common.graph import NNCFNodeName
+from nncf.common.quantization.structs import QuantizationMode
 from nncf.torch.layers import NNCFConv2d
 from nncf.torch.module_operations import UpdatePaddingValue
 from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.quantization.layers import BaseQuantizer
-from nncf.torch.quantization.layers import QuantizationMode
 from nncf.torch.quantization.layers import QuantizerConfig
 from nncf.torch.quantization.layers import SymmetricQuantizer
 

--- a/tests/torch/autograd_functions/test_autograd_functions.py
+++ b/tests/torch/autograd_functions/test_autograd_functions.py
@@ -10,8 +10,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from dataclasses import dataclass
 import math
+from dataclasses import dataclass
 
 import pytest
 import torch
@@ -33,7 +33,6 @@ class STThresholdTestCase:
     ref_output_tensor: torch.Tensor
 
 
-@pytest.mark.parametrize("use_cuda", [True, False])
 @pytest.mark.parametrize("requires_grad", [True, False])
 class TestAutogradFunction:
     @pytest.fixture(autouse=True)

--- a/tests/torch/binarization/test_functions.py
+++ b/tests/torch/binarization/test_functions.py
@@ -16,14 +16,15 @@ import pytest
 import torch
 from torch.autograd import Variable
 
-from nncf.torch.binarization.layers import xnor_binarize_op, dorefa_binarize_op, activation_bin_scale_threshold_op
+from nncf.torch.binarization.layers import activation_bin_scale_threshold_op
+from nncf.torch.binarization.layers import dorefa_binarize_op
+from nncf.torch.binarization.layers import xnor_binarize_op
 from nncf.torch.binarization.reference import ReferenceActivationBinarize
 from nncf.torch.binarization.reference import ReferenceBackendType
 from nncf.torch.binarization.reference import ReferenceDOREFABinarize
 from nncf.torch.binarization.reference import ReferenceXNORBinarize
-from tests.torch.helpers import get_grads
 from tests.torch.helpers import PTTensorListComparator
-
+from tests.torch.helpers import get_grads
 
 # reference impl
 
@@ -68,7 +69,6 @@ RACT = ReferenceActivationBinarize(backend_type=ReferenceBackendType.NUMPY)
                           [32, 192, 28, 28],
                           [32, 576, 14, 14]],
                          ids=idfn)
-@pytest.mark.parametrize("use_cuda", [False, True], ids=['cpu', 'cuda'])
 class TestParametrized:
     @pytest.mark.parametrize('weight_bin_type', ["xnor", "dorefa"])
     class TestWeightBinarization:

--- a/tests/torch/conftest.py
+++ b/tests/torch/conftest.py
@@ -15,17 +15,15 @@ import random
 
 import pytest
 
-
 try:
     import torch
 except: #pylint: disable=bare-except
     torch = None
-
-from tests.shared.install_fixtures import tmp_venv_with_nncf #pylint:disable=unused-import
-from tests.shared.logging import nncf_caplog #pylint:disable=unused-import
-from tests.shared.case_collection import skip_marked_cases_if_options_not_specified
+from nncf.torch.quantization.layers import QuantizationMode
 from tests.shared.case_collection import COMMON_SCOPE_MARKS_VS_OPTIONS
-
+from tests.shared.case_collection import skip_marked_cases_if_options_not_specified
+from tests.shared.install_fixtures import tmp_venv_with_nncf  # pylint:disable=unused-import
+from tests.shared.logging import nncf_caplog  # pylint:disable=unused-import
 
 pytest.register_assert_rewrite('tests.torch.helpers')
 
@@ -200,6 +198,29 @@ def ov_config_dir(request):
 def pip_cache_dir(request):
     return request.config.getoption("--pip-cache-dir")
 
+@pytest.fixture(params=[True, False], ids=["per_channel", "per_tensor"])
+def is_per_channel(request):
+    return request.param
+
+@pytest.fixture(params=[True, False], ids=["signed", "unsigned"])
+def is_signed(request):
+    return request.param
+
+@pytest.fixture(params=[True, False], ids=["weights", "activation"])
+def is_weights(request):
+    return request.param
+
+@pytest.fixture(params=[True, False], ids=["cuda", "cpu"])
+def use_cuda(request):
+    return request.param
+
+@pytest.fixture(params=[True, False], ids=["half_range", "full_range"])
+def is_half_range(request):
+    return request.param
+
+@pytest.fixture(params=[QuantizationMode.SYMMETRIC, QuantizationMode.ASYMMETRIC])
+def quantization_mode(request):
+    return request.param
 
 
 @pytest.fixture

--- a/tests/torch/conftest.py
+++ b/tests/torch/conftest.py
@@ -19,7 +19,7 @@ try:
     import torch
 except: #pylint: disable=bare-except
     torch = None
-from nncf.torch.quantization.layers import QuantizationMode
+from nncf.common.quantization.structs import QuantizationMode
 from tests.shared.case_collection import COMMON_SCOPE_MARKS_VS_OPTIONS
 from tests.shared.case_collection import skip_marked_cases_if_options_not_specified
 from tests.shared.install_fixtures import tmp_venv_with_nncf  # pylint:disable=unused-import

--- a/tests/torch/modules/test_rnn.py
+++ b/tests/torch/modules/test_rnn.py
@@ -10,32 +10,37 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+import copy
 import logging
+import os
 import sys
 from collections import namedtuple
-from typing import List, Tuple
+from functools import partial
+from typing import List
+from typing import Tuple
 
-import copy
 import onnx
-import os
 import pytest
 import torch
 import torch.nn.functional as F
-from functools import partial
 from torch import nn
 from torch.autograd import Variable
 from torch.nn.utils.rnn import PackedSequence
 
 from nncf.torch import nncf_model_input
-from nncf.torch.dynamic_graph.io_handling import wrap_nncf_model_outputs_with_objwalk
 from nncf.torch.dynamic_graph.context import TracingContext
-from nncf.torch.layers import LSTMCellNNCF, NNCF_RNN, ITERATION_MODULES
+from nncf.torch.dynamic_graph.io_handling import wrap_nncf_model_outputs_with_objwalk
+from nncf.torch.layers import ITERATION_MODULES
+from nncf.torch.layers import NNCF_RNN
+from nncf.torch.layers import LSTMCellNNCF
 from nncf.torch.model_creation import create_compressed_model
 from nncf.torch.nncf_module_replacement import collect_modules_and_scopes_by_predicate
 from nncf.torch.utils import get_model_device
-from tests.torch.modules.seq2seq.gnmt import GNMT
-from tests.torch.helpers import get_empty_config, get_grads, create_compressed_model_and_algo_for_test
+from tests.torch.helpers import create_compressed_model_and_algo_for_test
+from tests.torch.helpers import get_empty_config
+from tests.torch.helpers import get_grads
 from tests.torch.helpers import register_bn_adaptation_init_args
+from tests.torch.modules.seq2seq.gnmt import GNMT
 
 
 def replace_lstm(model):
@@ -107,7 +112,7 @@ LSTMTestData = namedtuple('LSTMTestData', ['x', 'h0', 'c0', 'weight_ih', 'weight
 class TestLSTMCell:
     @staticmethod
     def generate_lstm_data(p, num_layers=1, num_directions=1, variable_length=False, sorted_=True, batch_first=True,
-                           is_cuda=False, bias=True, empty_initial=False, is_backward=False):
+                           use_cuda=False, bias=True, empty_initial=False, is_backward=False):
         # type: (LSTMTestSizes, int, int, bool, bool, bool, bool, bool, bool, bool) -> LSTMTestData
         num_chunks = 4
         seq_list = []
@@ -129,13 +134,13 @@ class TestLSTMCell:
 
         def wrap_tensor(tensor):
             wrapped = tensor
-            if is_cuda:
+            if use_cuda:
                 wrapped = wrapped.cuda()
             if is_backward:
                 wrapped = Variable(wrapped, requires_grad=True)
             return wrapped
 
-        if is_cuda:
+        if use_cuda:
             x_data = x_data.cuda()
         h0, c0, wih, whh, bih, bhh = ([] for _ in range(6))
         for layer_ in range(num_layers):
@@ -234,21 +239,20 @@ def test_export_lstm_cell(tmp_path):
                          ([True, True],
                           [True, False],
                           [False, False]), ids=['packed_sorted', 'packed_unsorted', 'not_packed'])
-@pytest.mark.parametrize('is_cuda', [True, False], ids=['cuda', 'cpu'])
 @pytest.mark.parametrize('empty_initial', [True, False], ids=['no_initial', 'with_initial'])
 # TODO: dropout gives different result. Looks like different random seed on CPU
 # @pytest.mark.parametrize('dropout', [0, 0.9], ids=['no_dropout', 'with_dropout'])
 @pytest.mark.parametrize('dropout', [0], ids=['no_dropout'])
 class TestLSTM:
-    def test_forward_lstm(self, sizes, bidirectional, num_layers, bias, batch_first, variable_length, sorted_, is_cuda,
+    def test_forward_lstm(self, sizes, bidirectional, num_layers, bias, batch_first, variable_length, sorted_, use_cuda,
                           empty_initial, dropout, _seed):
-        if not torch.cuda.is_available() and is_cuda is True:
+        if not torch.cuda.is_available() and use_cuda is True:
             pytest.skip("Skipping CUDA test cases for CPU only setups")
         num_directions = 2 if bidirectional else 1
         p = sizes
 
         ref_data = TestLSTMCell.generate_lstm_data(p, num_layers, num_directions, variable_length, sorted_, batch_first,
-                                                   is_cuda, bias, empty_initial)
+                                                   use_cuda, bias, empty_initial)
 
         ref_rnn = nn.LSTM(input_size=p.input_size, hidden_size=p.hidden_size, num_layers=num_layers,
                           bidirectional=bidirectional, batch_first=batch_first, bias=bias, dropout=dropout)
@@ -270,7 +274,7 @@ class TestLSTM:
         test_rnn = wrapped_test_rnn.lstm
         test_hidden = None if empty_initial else self.get_test_lstm_hidden(test_data)
 
-        if is_cuda:
+        if use_cuda:
             ref_rnn.cuda()
             test_rnn.cuda()
         ref_output, (ref_hn, ref_cn) = ref_rnn(ref_data.x, ref_hidden)
@@ -287,16 +291,16 @@ class TestLSTM:
         else:
             torch.testing.assert_allclose(test_output, ref_output, rtol=9e-2, atol=15e-4)
 
-    def test_backward_lstm(self, sizes, bidirectional, num_layers, bias, batch_first, variable_length, sorted_, is_cuda,
+    def test_backward_lstm(self, sizes, bidirectional, num_layers, bias, batch_first, variable_length, sorted_, use_cuda,
                            empty_initial, dropout, _seed):
-        if not torch.cuda.is_available() and is_cuda is True:
+        if not torch.cuda.is_available() and use_cuda is True:
             pytest.skip("Skipping CUDA test cases for CPU only setups")
         num_directions = 2 if bidirectional else 1
 
         p = sizes
 
         ref_data = TestLSTMCell.generate_lstm_data(p, num_layers, num_directions, variable_length, sorted_, batch_first,
-                                                   is_cuda, bias, empty_initial, True)
+                                                   use_cuda, bias, empty_initial, True)
 
         ref_rnn = nn.LSTM(input_size=p.input_size, hidden_size=p.hidden_size, num_layers=num_layers,
                           bidirectional=bidirectional, batch_first=batch_first, bias=bias, dropout=dropout)
@@ -307,7 +311,7 @@ class TestLSTM:
         test_rnn = replace_lstm(copy.deepcopy(ref_rnn))
         test_hidden = None if empty_initial else self.get_test_lstm_hidden(test_data)
 
-        if is_cuda:
+        if use_cuda:
             ref_rnn.cuda()
             test_rnn.cuda()
 

--- a/tests/torch/quantization/test_functions.py
+++ b/tests/torch/quantization/test_functions.py
@@ -20,6 +20,7 @@ import torch
 from torch.autograd import Variable
 from torch.distributions.uniform import Uniform
 
+from nncf.common.quantization.structs import QuantizationMode
 from nncf.torch.quantization.quantize_functions import asymmetric_quantize
 from nncf.torch.quantization.quantize_functions import get_scale_zp_from_input_low_input_high
 from nncf.torch.quantization.quantize_functions import symmetric_quantize
@@ -220,12 +221,9 @@ def check_outputs_for_quantization_functions(test_val: torch.Tensor, ref_val: np
                           [16, 576, 14, 14]],
                          ids=idfn)
 @pytest.mark.parametrize('bits', (8, 4), ids=('8bit', '4bit'))
-@pytest.mark.parametrize("use_cuda", [False, True], ids=['cpu', 'cuda'])
 @pytest.mark.parametrize('scale_mode', ["single_scale", "per_channel_scale"])
-@pytest.mark.parametrize("is_weights", (True, False), ids=('weights', 'activation'))
 @pytest.mark.parametrize("is_fp16", (True, False), ids=('fp16', 'fp32'))
 class TestParametrized:
-    @pytest.mark.parametrize("is_signed", (True, False), ids=('signed', 'unsigned'))
     class TestSymmetric:
         @staticmethod
         def generate_scale(input_size, scale_mode, is_weights, is_fp16, fixed=None):
@@ -555,7 +553,6 @@ class TestParametrized:
                                                      rtol=1e-2 if is_fp16 else 1e-3)
 
 
-@pytest.mark.parametrize('quantization_mode', ['symmetric', 'asymmetric'])
 @pytest.mark.parametrize('device', ['cuda', 'cpu'])
 def test_mapping_to_zero(quantization_mode, device):
     torch.manual_seed(42)
@@ -567,7 +564,7 @@ def test_mapping_to_zero(quantization_mode, device):
     eps = 1e-6
     number_of_samples = 100
 
-    if quantization_mode == 'symmetric':
+    if quantization_mode == QuantizationMode.SYMMETRIC:
         level_low = -128
         level_high = 127
 

--- a/tests/torch/quantization/test_onnx_export.py
+++ b/tests/torch/quantization/test_onnx_export.py
@@ -21,11 +21,11 @@ import torch
 from torch import nn
 
 from nncf import NNCFConfig
+from nncf.common.quantization.structs import QuantizationMode
 from nncf.torch.quantization.layers import QUANTIZATION_MODULES
 from nncf.torch.quantization.layers import AsymmetricQuantizer
 from nncf.torch.quantization.layers import BaseQuantizer
 from nncf.torch.quantization.layers import PTQuantizerSpec
-from nncf.torch.quantization.layers import QuantizationMode
 from nncf.torch.quantization.layers import QuantizerExportMode
 from nncf.torch.quantization.layers import SymmetricQuantizer
 from tests.torch.helpers import TwoConvTestModel

--- a/tests/torch/quantization/test_onnx_export.py
+++ b/tests/torch/quantization/test_onnx_export.py
@@ -10,30 +10,31 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from itertools import product
-from typing import Tuple, Dict, List
+from typing import Dict
+from typing import List
+from typing import Tuple
 
+import numpy as np
 import onnx
 import pytest
 import torch
 from torch import nn
-import numpy as np
 
 from nncf import NNCFConfig
-from nncf.torch.quantization.layers import PTQuantizerSpec
-from nncf.torch.quantization.layers import BaseQuantizer
-from nncf.torch.quantization.layers import SymmetricQuantizer
-from nncf.torch.quantization.layers import AsymmetricQuantizer
 from nncf.torch.quantization.layers import QUANTIZATION_MODULES
+from nncf.torch.quantization.layers import AsymmetricQuantizer
+from nncf.torch.quantization.layers import BaseQuantizer
+from nncf.torch.quantization.layers import PTQuantizerSpec
 from nncf.torch.quantization.layers import QuantizationMode
 from nncf.torch.quantization.layers import QuantizerExportMode
-from tests.torch.helpers import get_nodes_by_type
+from nncf.torch.quantization.layers import SymmetricQuantizer
+from tests.torch.helpers import TwoConvTestModel
+from tests.torch.helpers import create_compressed_model_and_algo_for_test
 from tests.torch.helpers import get_all_inputs_for_graph_node
+from tests.torch.helpers import get_nodes_by_type
+from tests.torch.helpers import load_exported_onnx_version
 from tests.torch.helpers import register_bn_adaptation_init_args
 from tests.torch.helpers import resolve_constant_node_inputs_to_values
-from tests.torch.helpers import TwoConvTestModel
-from tests.torch.helpers import load_exported_onnx_version
-from tests.torch.helpers import create_compressed_model_and_algo_for_test
 
 
 def get_config_for_export_mode(should_be_onnx_standard: bool) -> NNCFConfig:
@@ -104,21 +105,17 @@ def test_onnx_export_to_quantize_dequantize(tmp_path):
 INPUT_TENSOR_SHAPE = (2, 64, 15, 10)
 PER_CHANNEL_AQ_SCALE_SHAPE = (1, INPUT_TENSOR_SHAPE[1], 1, 1)
 
-
-@pytest.mark.parametrize('per_channel, qmode, export_mode',
-                         product(
-                             [True, False],
-                             [QuantizationMode.SYMMETRIC, QuantizationMode.ASYMMETRIC],
-                             [QuantizerExportMode.FAKE_QUANTIZE, QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS]
-                         ))
-def test_onnx_export_to_quantize_dequantize_per_channel(per_channel: bool,
-                                                        qmode: QuantizationMode,
+@pytest.mark.parametrize(
+    "export_mode", (QuantizerExportMode.FAKE_QUANTIZE, QuantizerExportMode.ONNX_QUANTIZE_DEQUANTIZE_PAIRS)
+)
+def test_onnx_export_to_quantize_dequantize_per_channel(is_per_channel: bool,
+                                                        quantization_mode: QuantizationMode,
                                                         export_mode: QuantizerExportMode):
-    scale_shape = PER_CHANNEL_AQ_SCALE_SHAPE if per_channel else (1,)
+    scale_shape = PER_CHANNEL_AQ_SCALE_SHAPE if is_per_channel else (1,)
     qspec = PTQuantizerSpec(
         scale_shape=scale_shape,
         num_bits=8,
-        mode=qmode,
+        mode=quantization_mode,
         signedness_to_force=None,
         logarithm_scale=False,
         narrow_range=False,
@@ -126,9 +123,9 @@ def test_onnx_export_to_quantize_dequantize_per_channel(per_channel: bool,
         is_quantized_on_export=False
     )
 
-    q_cls = QUANTIZATION_MODULES.get(qmode)
+    q_cls = QUANTIZATION_MODULES.get(quantization_mode)
     quantizer = q_cls(qspec)
-    if qmode is QuantizationMode.SYMMETRIC:
+    if quantization_mode is QuantizationMode.SYMMETRIC:
         quantizer.scale = torch.nn.Parameter(torch.rand_like(quantizer.scale))
     else:
         quantizer.input_low = torch.nn.Parameter(torch.rand_like(quantizer.input_low))
@@ -304,17 +301,19 @@ def generate_middle_quants(size: List[int], input_low: np.ndarray, quant_len: np
     return torch.from_numpy(ref_weights.astype(np.single))
 
 
-@pytest.mark.parametrize("half_range, quantization_mode, parameters_to_set",
-                         [(True, "symmetric", {"scale": 1.}),
-                          (True, "asymmetric", {"input_low": -1., "input_range": 3.}),
-                          (False, "symmetric", {"scale": 1.}),
-                          (False, "asymmetric", {"input_low": -1., "input_range": 3.})])
-def test_export_quantized_weights_with_middle_quants(tmp_path, half_range, quantization_mode, parameters_to_set):
+@pytest.mark.parametrize(
+    "quantization_mode, parameters_to_set",
+    [
+        ("symmetric", {"scale": 1.0}),
+        ("asymmetric", {"input_low": -1.0, "input_range": 3.0})
+    ]
+)
+def test_export_quantized_weights_with_middle_quants(tmp_path, is_half_range, quantization_mode, parameters_to_set):
     model = TwoConvTestModel()
     sample_size = [1, 1, 20, 20]
     config = get_config_for_export_mode(False)
     config["compression"]["weights"] = {"mode": quantization_mode}
-    if not half_range:
+    if not is_half_range:
         config["compression"]["overflow_fix"] = 'disable'
     config["input_info"]["sample_size"] = sample_size
 

--- a/tests/torch/quantization/test_range_init.py
+++ b/tests/torch/quantization/test_range_init.py
@@ -19,10 +19,9 @@ from typing import Tuple
 
 import pytest
 import torch
-
-from torch import nn
 import torch.utils.data
 from pytest import approx
+from torch import nn
 from torch.utils.data import DataLoader
 from torchvision.models import squeezenet1_1
 
@@ -42,13 +41,13 @@ from nncf.torch.checkpoint_loading import load_state
 from nncf.torch.initialization import DefaultInitializingDataLoader
 from nncf.torch.initialization import wrap_dataloader_for_init
 from nncf.torch.nncf_network import EXTERNAL_QUANTIZERS_STORAGE_NAME
-from nncf.torch.quantization.init_range import PTRangeInitParams
 from nncf.torch.quantization.init_range import PTRangeInitCollectorParams
+from nncf.torch.quantization.init_range import PTRangeInitParams
 from nncf.torch.quantization.init_range import StatCollectorGenerator
+from nncf.torch.quantization.layers import QUANTIZATION_MODULES
 from nncf.torch.quantization.layers import AsymmetricQuantizer
 from nncf.torch.quantization.layers import BaseQuantizer
 from nncf.torch.quantization.layers import PTQuantizerSpec
-from nncf.torch.quantization.layers import QUANTIZATION_MODULES
 from nncf.torch.quantization.layers import SymmetricQuantizer
 from nncf.torch.tensor_statistics.collectors import PTMeanMinMaxStatisticCollector
 from nncf.torch.tensor_statistics.collectors import PTMedianMADStatisticCollector
@@ -501,16 +500,22 @@ def init_idfn(val):
     return val
 
 
-@pytest.mark.parametrize("quantization_mode, per_channel, range_init_type_vs_ref_vals",
-                         itertools.product(["symmetric", "asymmetric"],
-                                           [True, False],
-                                           [("min_max", 9999, 0, 9999),
-                                            ("mixed_min_max", 9999, 0, 9999),
-                                            ("mean_min_max", 9999, 0, 9999),
-                                            ("threesigma", 16119.5, -6119.5, 22239),
-                                            ("percentile", 6789, 3210, 3578)]), ids=init_idfn)
-def test_init_ranges_are_set(quantization_mode: str, per_channel: bool,
-                             range_init_type_vs_ref_vals: Tuple[str, float, float, float]):
+@pytest.mark.parametrize(
+    "range_init_type_vs_ref_vals",
+    (
+        [
+            ("min_max", 9999, 0, 9999),
+            ("mixed_min_max", 9999, 0, 9999),
+            ("mean_min_max", 9999, 0, 9999),
+            ("threesigma", 16119.5, -6119.5, 22239),
+            ("percentile", 6789, 3210, 3578),
+        ]
+    ),
+    ids=init_idfn,
+)
+def test_init_ranges_are_set(
+    quantization_mode: str, is_per_channel: bool, range_init_type_vs_ref_vals: Tuple[str, float, float, float]
+):
     class SyntheticDataset(torch.utils.data.Dataset):
         def __init__(self):
             super().__init__()
@@ -544,11 +549,11 @@ def test_init_ranges_are_set(quantization_mode: str, per_channel: bool,
                 "algorithm": "quantization",
                 "activations": {
                     "mode": quantization_mode,
-                    "per_channel": per_channel
+                    "per_channel": is_per_channel
                 },
                 "weights": {
                     "mode": quantization_mode,
-                    "per_channel": per_channel
+                    "per_channel": is_per_channel
                 },
                 "initializer": {
                     "range": {
@@ -597,14 +602,14 @@ def test_init_ranges_are_set(quantization_mode: str, per_channel: bool,
                 assert quantizer.input_low.numel() == 1
                 assert quantizer.input_range.numel() == 1
 
-    check_scales(act_quantizer_info.quantizer_module_ref, per_channel)
+    check_scales(act_quantizer_info.quantizer_module_ref, is_per_channel)
     # Weight init check
     synth_weight_model = SingleConv2dSyntheticWeightModel()
     _, compression_ctrl = create_compressed_model_and_algo_for_test(synth_weight_model,
                                                                     config_with_init)
 
     weight_quantizer_info = next(iter(compression_ctrl.weight_quantizers.values()))
-    check_scales(weight_quantizer_info.quantizer_module_ref, per_channel)
+    check_scales(weight_quantizer_info.quantizer_module_ref, is_per_channel)
 
 
 RangeInitCallCountTestStruct = namedtuple('RangeInitCallCountTestStruct',

--- a/tests/torch/sparsity/movement/test_components.py
+++ b/tests/torch/sparsity/movement/test_components.py
@@ -10,7 +10,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from typing import Any, Dict, Tuple
+from typing import Any
+from typing import Dict
+from typing import Tuple
 from unittest.mock import MagicMock
 
 import pytest
@@ -413,7 +415,6 @@ class TestImportanceLoss:
         )
     ])
     @pytest.mark.parametrize('requires_grad', [True, False])
-    @pytest.mark.parametrize('use_cuda', [True, False])
     def test_importance_loss_forward(self, desc, requires_grad: bool, use_cuda: bool):
         if (not torch.cuda.is_available()) and use_cuda:
             pytest.skip("Skipping CUDA test cases for CPU only setups")


### PR DESCRIPTION
### Changes
Extend list of fixtures which are often used to remove code duplicate and improve test names.

```
is_per_channel
is_signed
is_weights
use_cuda
is_half_range
quantization_mode
```

### Reason for changes

https://github.com/openvinotoolkit/nncf/pull/1526#discussion_r1108322175

### Related tickets

104706

