### PR TITLE
Add a visualization function for debugging quantization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,17 +34,18 @@
 # installs.
 
 
+import codecs
 import glob
+import os
+import re
 import stat
 import sys
 import sysconfig
 
-import codecs
-import os
-import re
 import setuptools
-from setuptools import setup, find_packages
 from pkg_resources import parse_version
+from setuptools import find_packages
+from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 BKC_SETUPTOOLS_VERSION = '59.5.0'
@@ -140,8 +141,12 @@ OPENVINO_EXTRAS = [
 
 
 EXTRAS_REQUIRE = {
-    "dev": ["matplotlib>=3.3.4, <3.6",
-            "pillow>=9.0.0"],
+    "dev": [
+        "kaleido>=0.2.1"
+        "matplotlib>=3.3.4, <3.6",
+        "pillow>=9.0.0",
+        "plotly-express>=0.4.1",
+    ],
     "tests": ["pytest"],
     "docs": [],
 

--- a/tests/common/quantization/data_generators.py
+++ b/tests/common/quantization/data_generators.py
@@ -10,6 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from typing import Dict
 from typing import Tuple
 
 import numpy as np
@@ -395,3 +396,52 @@ def check_outputs(arr_a: np.array, arr_b: np.array, is_near_mid_point: np.array,
             f"Points: {num_fail_points} / {len(isclose_points)} | max_d={arr_diff_points.max():.8f} "
             f"Mid_points: {num_fail_spec_points} / {len(isclose_spec_points)} | max_d={arr_diff_spec_points.max():.8f}"
         )
+
+
+def visualization(
+    data: Dict[str, np.array], x_column: str = None, vertical_lines: np.array = None, save_to_file: str = None
+) -> None:
+    """
+    Function to render test data on scatter plot.
+    If save_to_file is None, scatter plot will be rendered in interactive mode with enable zooming.
+
+    Example of using:
+    ```
+    visualization(
+        data={
+            "input": test_input.detach().numpy(),
+            "x_nncf":  x_nncf.detach().numpy(),
+            "x_torch":  x_torch.detach().numpy(),
+        },
+        x_column="input",
+        vertical_lines=mid_quant_points,
+        save_to_file="plot.png"
+    )
+    ```
+
+    :param data: Dict with data.
+    :param x_column: Column name that will used as x-axis, defaults is 1st column.
+    :param vertical_lines: Array to render vertical lines, defaults to None.
+    :param save_to_file: Save plot to file as image, defaults to None.
+    """
+    import pandas as pd
+    import plotly.express as px
+
+    column_names = list(data.keys())
+    for column in column_names:
+        data[column] = data[column].reshape(-1)
+
+    df = pd.DataFrame.from_dict(data)
+    df["X"] = df[x_column if x_column else column_names[0]]
+
+    fig = px.scatter(data_frame=df, x='X', y=column_names)
+    fig.update_traces(marker={'size': 2})
+
+    if vertical_lines:
+        for x_line in vertical_lines:
+            fig.add_vline(x=x_line, line_width=1)
+
+    if save_to_file:
+        fig.write_image(save_to_file, scale=2)
+    else:
+        fig.show(config={'scrollZoom': True})

--- a/tests/common/quantization/data_generators.py
+++ b/tests/common/quantization/data_generators.py
@@ -13,7 +13,6 @@
 from typing import Tuple
 
 import numpy as np
-import torch
 
 
 def get_quant_len_by_range(input_range: np.array, bits: int) -> np.array:
@@ -221,16 +220,18 @@ def get_points_near_of_mid_points(input_data: np.array, mid_points: np.array, at
     return is_near_mid_point
 
 
-def generate_lazy_sweep_data(shape: Tuple[int]):
+def generate_lazy_sweep_data(shape: Tuple[int], min: float = -1.0, max: float = 1.0):
     """
     Generate tensor that contains sweep values from -1.0 to 1.0.
 
     :param shape: Shape of generate tensor.
+    :param min: Min value of generated data.
+    :param max: Max value of generated data.
 
     :return torch.Tensor: Generated tensor.
     """
     n = np.prod(list(shape))
-    res = torch.Tensor(range(n)) / torch.Tensor([n - 1]) * torch.Tensor([2]) - torch.Tensor([1.0])
+    res = np.array(range(n)) / (n - 1) * (max - min) + min
     res[n // 2] = 0.0
     return res.reshape(shape)
 

--- a/tests/torch/pruning/filter_pruning/test_prepare_for_inference.py
+++ b/tests/torch/pruning/filter_pruning/test_prepare_for_inference.py
@@ -53,7 +53,7 @@ def test_prepare_for_inference_pruning(enable_quantization):
     config = _get_config_for_algo(input_size, enable_quantization)
     compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
 
-    input_tensor = generate_lazy_sweep_data(input_size)
+    input_tensor = torch.Tensor(generate_lazy_sweep_data(input_size))
     x_nncf = compressed_model(input_tensor)
 
     inference_model = compression_ctrl.prepare_for_inference()

--- a/tests/torch/quantization/test_prepare_for_inference.py
+++ b/tests/torch/quantization/test_prepare_for_inference.py
@@ -258,7 +258,7 @@ def test_prepare_for_inference_quantization(mode, overflow_fix, num_bits):
     register_bn_adaptation_init_args(config)
     compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
 
-    input_tensor = generate_lazy_sweep_data(model.INPUT_SIZE)
+    input_tensor = torch.Tensor(generate_lazy_sweep_data(model.INPUT_SIZE))
     x_nncf = compressed_model(input_tensor)
 
     inference_model = compression_ctrl.prepare_for_inference()

--- a/tests/torch/sparsity/test_prepare_for_inference.py
+++ b/tests/torch/sparsity/test_prepare_for_inference.py
@@ -65,7 +65,7 @@ def test_prepare_for_inference_sparsity(enable_quantization):
     assert sparsity_ctrl.sparsified_module_info[0].operand.binary_mask.shape[0] == 2
     sparsity_ctrl.sparsified_module_info[0].operand.binary_mask[0] = 0
 
-    input_tensor = generate_lazy_sweep_data(input_size)
+    input_tensor = torch.Tensor(generate_lazy_sweep_data(input_size))
     x_nncf = compressed_model(input_tensor)
 
     inference_model = compression_ctrl.prepare_for_inference()


### PR DESCRIPTION
### Changes

Added function for visualization data with feature of zooming and working with remote developing.
```python
visualisation(
    data={
        "input": test_input.detach().numpy(),
        "nncf_output":  x_nncf.detach().numpy(),
        "torch_output":  x_torch.detach().numpy(),
    }
)
```

Example of output:
![newplot (5)](https://user-images.githubusercontent.com/48012821/226190058-6ce6585c-cb5a-423e-ab5e-7ced16863c5e.png)


### Related tickets

CVS-104072


