### PR TITLE
Align PT model names in AC configs

### DIFF
--- a/tests/torch/data/ac_configs/googlenet_imagenet_pruning_geometric_median.yml
+++ b/tests/torch/data/ac_configs/googlenet_imagenet_pruning_geometric_median.yml
@@ -1,5 +1,5 @@
 models:
-  - name: googlenet_imagenet_filter_pruning_geomedian
+  - name: googlenet_imagenet_pruning_geometric_median
 
     # list of launchers
     launchers:

--- a/tests/torch/data/ac_configs/resnet18_imagenet_pruning_geometric_median.yml
+++ b/tests/torch/data/ac_configs/resnet18_imagenet_pruning_geometric_median.yml
@@ -1,5 +1,5 @@
 models:
-  - name: resnet18_imagenet_filter_pruning_geomedian
+  - name: resnet18_imagenet_pruning_geometric_median
     launchers:
       - framework: dlsdk
         device: CPU

--- a/tests/torch/data/ac_configs/resnet18_imagenet_pruning_magnitude.yml
+++ b/tests/torch/data/ac_configs/resnet18_imagenet_pruning_magnitude.yml
@@ -1,5 +1,5 @@
 models:
-  - name: resnet18_imagenet_filter_pruning_magnitude
+  - name: resnet18_imagenet_pruning_magnitude
     launchers:
       - framework: dlsdk
         device: CPU

--- a/tests/torch/data/ac_configs/resnet34_imagenet_pruning_geometric_median_kd.yml
+++ b/tests/torch/data/ac_configs/resnet34_imagenet_pruning_geometric_median_kd.yml
@@ -1,5 +1,5 @@
 models:
-  - name: resnet34_imagenet_filter_pruning_geomedian_kd
+  - name: resnet34_imagenet_pruning_geometric_median_kd
     launchers:
       - framework: dlsdk
         device: CPU

--- a/tests/torch/data/ac_configs/resnet34_imagenet_pruning_magnitude.yml
+++ b/tests/torch/data/ac_configs/resnet34_imagenet_pruning_magnitude.yml
@@ -1,5 +1,5 @@
 models:
-  - name: resnet34_imagenet_filter_pruning_magnitude
+  - name: resnet34_imagenet_pruning_magnitude
     launchers:
       - framework: dlsdk
         device: CPU

--- a/tests/torch/data/ac_configs/resnet50_imagenet_pruning_geometric_median.yml
+++ b/tests/torch/data/ac_configs/resnet50_imagenet_pruning_geometric_median.yml
@@ -1,5 +1,5 @@
 models:
-  - name: resnet50_imagenet_filter_pruning_geomedian
+  - name: resnet50_imagenet_pruning_geometric_median
     launchers:
       - framework: dlsdk
         device: CPU

--- a/tests/torch/data/ac_configs/resnet50_imagenet_pruning_magnitude.yml
+++ b/tests/torch/data/ac_configs/resnet50_imagenet_pruning_magnitude.yml
@@ -1,5 +1,5 @@
 models:
-  - name: resnet50_imagenet_filter_pruning_magnitude
+  - name: resnet50_imagenet_pruning_magnitude
     launchers:
       - framework: dlsdk
         device: CPU


### PR DESCRIPTION
### Changes
Names in AC configs for PT E2E models were aligned with canonical names.

### Reason for changes
E2E test pipeline relies on AC config model names being the same as the model IDs in `sota_checkpoints_eval.json`, otherwise it can't find proper OV metrics to be displayed in the test report.

### Related tickets
N/A

### Tests
E2E PT