### PR TITLE
Do not fail outright if cannot trace tensors

### DIFF
--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -78,7 +78,7 @@ class FunctionsToPatchWithoutTracing:
                                 'q_per_channel_axis', 'q_per_channel_scales', 'q_per_channel_zero_points', 'q_scale',
                                 'q_zero_point', 'qr', 'qscheme', 'random_', 'record_stream', 'refine_names',
                                 'register_hook', 'rename', 'rename_', 'shape', 'size', 'sort', 'storage',
-                                'storage_offset', 'stride', 'to']
+                                'storage_offset', 'stride', 'to', 'get_device']
 
     FUNCTIONS_TO_PATCH_WITHOUT_TRACING = TENSOR_CREATING_FUNCTIONS + TENSOR_UTILITY_FUNCTIONS
 

--- a/nncf/torch/dynamic_graph/trace_tensor.py
+++ b/nncf/torch/dynamic_graph/trace_tensor.py
@@ -10,7 +10,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-
 from typing import Iterable
 from typing import List
 from typing import Optional
@@ -21,6 +20,7 @@ from typing import Union
 import numpy as np
 import torch
 
+from nncf import nncf_logger
 from nncf.common.graph import Dtype
 
 
@@ -154,7 +154,8 @@ def trace_tensors(operator_output: TensorOrTupleOrList,
         if ctx is not None:
             ctx.register_traced_tensor(tt)
         return tt
-    raise ValueError("Unknown return type. Can not trace function call")
+    nncf_logger.debug(f"Could not find tensors to trace in operator output: {operator_output}")
+    return operator_output
 
 
 def make_tensor_metas(inputs: 'OperatorInput') -> List[Optional[TensorMeta]]:

--- a/tests/torch/test_graph_building.py
+++ b/tests/torch/test_graph_building.py
@@ -12,6 +12,7 @@
 """
 from typing import List
 from typing import Tuple
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -38,6 +39,7 @@ from nncf.torch.dynamic_graph.graph_tracer import GraphTracer
 from nncf.torch.dynamic_graph.graph_tracer import ModelInputInfo
 from nncf.torch.dynamic_graph.graph_tracer import create_dummy_forward_fn
 from nncf.torch.dynamic_graph.io_handling import wrap_nncf_model_outputs_with_objwalk
+from nncf.torch.dynamic_graph.trace_tensor import trace_tensors
 from nncf.torch.graph.graph_builder import GraphBuilder
 from nncf.torch.graph.operator_metatypes import PTCatMetatype
 from nncf.torch.graph.operator_metatypes import PTGatherMetatype
@@ -667,3 +669,8 @@ def test_integer_path_marking():
     # cat -> __floordiv__,  __floordiv__ -> __getitem__0 (to get single_idx),
     # __getitem__0 -> __getitem__1 (first indexing by tensor), __getitem__0 -> __getitem__2 (second indexing by tensor)
     assert num_integer_edges == 4
+
+
+def test_trace_output_with_no_tensors():
+    output = None
+    trace_tensors(output, MagicMock())


### PR DESCRIPTION
### Changes
Modified the `trace_tensors` function in order for it not to fail if it cannot find tensors to trace in the operator output. Also added a `torch.Tensor.get_device` function to the list of non-patched functions because it is irrelevant for DNN control flow.

### Reason for changes
Increased robustness of NNCF PT.

### Related tickets
N/A

### Tests
tests.torch.test_graph_building.test_trace_output_with_no_tensors
