### PR TITLE
[PTQ] Add softmax_matmul pattern

### DIFF
--- a/nncf/common/graph/patterns/patterns.py
+++ b/nncf/common/graph/patterns/patterns.py
@@ -389,3 +389,4 @@ class PatternNames(Enum):
 
     # TRANSFORMERS
     MATMUL_SOFTMAX_MATMUL = PatternDesc('matmul_softmax_matmul')
+    SOFTMAX_MATMUL = PatternDesc('softmax_matmul')

--- a/nncf/experimental/openvino_native/hardware/fused_patterns.py
+++ b/nncf/experimental/openvino_native/hardware/fused_patterns.py
@@ -326,6 +326,21 @@ def create_matmul_softmax_matmul():
     return pattern
 
 
+@OPENVINO_HW_FUSED_PATTERNS.register(PatternNames.SOFTMAX_MATMUL)
+def create_softmax_matmul():
+    pattern = GraphPattern()
+    softmax = pattern.add_node(**{GraphPattern.LABEL_ATTR: 'SOFTMAX',
+                                  GraphPattern.METATYPE_ATTR: om.OVSoftmaxMetatype})
+    mat_mul = pattern.add_node(**{GraphPattern.LABEL_ATTR: 'MATMUL',
+                                  GraphPattern.METATYPE_ATTR: om.OVMatMulMetatype})
+    any = pattern.add_node(**{GraphPattern.LABEL_ATTR: 'ANY',
+                              GraphPattern.METATYPE_ATTR: GraphPattern.NON_PATTERN_NODE_TYPE})
+
+    pattern.add_edge(softmax, mat_mul)
+    pattern.add_edge(any, mat_mul)
+
+    return pattern
+
 # ACTIVATIONS
 
 

--- a/nncf/onnx/hardware/fused_patterns.py
+++ b/nncf/onnx/hardware/fused_patterns.py
@@ -110,6 +110,21 @@ def create_matmul_softmax_matmul():
     return pattern
 
 
+@ONNX_HW_FUSED_PATTERNS.register(PatternNames.SOFTMAX_MATMUL)
+def create_softmax_matmul():
+    pattern = GraphPattern()
+    softmax = pattern.add_node(**{GraphPattern.LABEL_ATTR: 'SOFTMAX',
+                                  GraphPattern.METATYPE_ATTR: om.ONNXSoftmaxMetatype})
+    mat_mul = pattern.add_node(**{GraphPattern.LABEL_ATTR: 'MATMUL',
+                                  GraphPattern.METATYPE_ATTR: om.ONNXLinearMetatype})
+    any = pattern.add_node(**{GraphPattern.LABEL_ATTR: 'ANY',
+                              GraphPattern.METATYPE_ATTR: GraphPattern.NON_PATTERN_NODE_TYPE})
+
+    pattern.add_edge(softmax, mat_mul)
+    pattern.add_edge(any, mat_mul)
+
+    return pattern
+
 # INPUT PROCESSING
 
 

--- a/nncf/torch/hardware/fused_patterns.py
+++ b/nncf/torch/hardware/fused_patterns.py
@@ -77,6 +77,19 @@ def create_matmul_softmax_matmul():
 
     return pattern
 
+
+@PT_HW_FUSED_PATTERNS.register(PatternNames.MATMUL_SOFTMAX_MATMUL)
+def create_matmul_softmax_matmul():
+    pattern = GraphPattern()
+    softmax = pattern.add_node(label='SOFTMAX', type='softmax')
+    mat_mul = pattern.add_node(label='MATMUL', type=['linear', 'addmm', 'matmul', 'bmm', 'mm'])
+    any = pattern.add_node(label='ANY', type=GraphPattern.NON_PATTERN_NODE_TYPE)
+
+    pattern.add_edge(softmax, mat_mul)
+    pattern.add_edge(any, mat_mul)
+
+    return pattern
+
 # COMBINATIONS
 
 


### PR DESCRIPTION
### Changes

Add pattern Softmax -> MatMul <- Non_Pattern_Node

### Reason for changes

To align the quantization scheme with POT - don't insert FQ into these red areas.

![image](https://user-images.githubusercontent.com/32935044/228480798-7026d355-e078-4e11-a2c7-baf1d550d5fd.png)

### Related tickets

106873

### Tests

Tested manually
