### PR TITLE
Log file for calibrate tool

### DIFF
--- a/nncf/common/logging/logger.py
+++ b/nncf/common/logging/logger.py
@@ -41,6 +41,17 @@ def set_log_level(level: int):
         handler.setLevel(level)
 
 
+def set_log_file(filename: str):
+    """
+    Sets the log file for the NNCF logging.
+
+    :param filename: Path to the file to save the log.
+    """
+    file_handler = logging.FileHandler(filename)
+    file_handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
+    nncf_logger.addHandler(file_handler)
+
+
 def disable_logging():
     """
     Disables NNCF logging entirely. `FutureWarning`s are still shown.

--- a/tests/common/test_logging.py
+++ b/tests/common/test_logging.py
@@ -1,0 +1,58 @@
+"""
+ Copyright (c) 2023 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import tempfile
+
+import pytest
+
+from nncf.common.logging.logger import set_log_file
+from nncf.common.logging.logger import nncf_logger
+
+
+TEST_CASES = [
+    (
+        [
+            ('Test_Message_0', 'INFO'),
+            ('Test_Message_1', 'WARNING'),
+            ('Test_Message_2', 'ERROR'),
+        ],
+        [
+            'INFO:nncf:Test_Message_0',
+            'WARNING:nncf:Test_Message_1',
+            'ERROR:nncf:Test_Message_2',
+        ]
+    )
+]
+
+
+@pytest.mark.parametrize('messages,expected', TEST_CASES)
+def test_set_log_file(messages, expected):
+    level_to_fn_map = {
+        'INFO': nncf_logger.info,
+        'WARNING': nncf_logger.warning,
+        'ERROR': nncf_logger.error,
+    }
+
+    with tempfile.TemporaryDirectory(dir=tempfile.gettempdir()) as tmp_dir:
+        log_file = f'{tmp_dir}/log.txt'
+        set_log_file(log_file)
+
+        for message, message_level in messages:
+            wirter = level_to_fn_map[message_level]
+            wirter(message)
+
+        with open(log_file, 'r') as f:
+            lines = f.readlines()
+
+        for actual_line, expected_line in  zip(lines, expected):
+            assert actual_line.rstrip('\n') == expected_line

--- a/tests/common/test_logging.py
+++ b/tests/common/test_logging.py
@@ -51,7 +51,7 @@ def test_set_log_file(messages, expected):
             wirter = level_to_fn_map[message_level]
             wirter(message)
 
-        with open(log_file, 'r') as f:
+        with open(log_file, 'r', encoding='utf8') as f:
             lines = f.readlines()
 
         for actual_line, expected_line in  zip(lines, expected):

--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -22,6 +22,7 @@ from openvino.tools.accuracy_checker.evaluators.quantization_model_evaluator imp
 from openvino.tools.pot.configs.config import Config
 
 import nncf
+from nncf.common.logging.logger import set_log_file
 from nncf.common.quantization.structs import QuantizationPreset
 from nncf.data.dataset import Dataset
 from nncf.experimental.openvino_native.quantization.quantize import \
@@ -259,6 +260,7 @@ def main():
     accuracy_checcker_config = get_accuracy_checker_config(config.engine)
     nncf_algorithms_config = get_nncf_algorithms_config(config.compression)
 
+    set_log_file(f'{args.output_dir}/log.txt')
     output_dir = os.path.join(args.output_dir, 'optimized')
     os.makedirs(output_dir, exist_ok=True)
 


### PR DESCRIPTION
### Changes

- `set_log_file()` method was added for nncf logger.

### Reason for changes

Calibrate tool should save logs to analyze

### Related tickets

N/A

### Tests

- tests/common/test_logging.py
