### PR TITLE
[Torch] Set narrow_range=False for bits != 8

### DIFF
--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -771,7 +771,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
 
             if qp.is_weight_quantization_point():
                 use_logarithm_scale = self._use_logarithm_scale_per_group[QuantizerGroup.WEIGHTS]
-                narrow_range = not half_range
+                narrow_range = qconfig.num_bits == 8 and not half_range
             else:
                 use_logarithm_scale = self._use_logarithm_scale_per_group[QuantizerGroup.ACTIVATIONS]
                 narrow_range = False

--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -134,7 +134,7 @@ def test_quantization_configs__custom():
                                        mode=QuantizationMode.ASYMMETRIC,
                                        signedness_to_force=None,
                                        scale_shape=model.wq_scale_shape_per_channel,
-                                       narrow_range=True,
+                                       narrow_range=False,
                                        half_range=False,
                                        logarithm_scale=False)
     for wq_info in weight_quantizers.values():

--- a/tests/torch/quantization/test_prepare_for_inference.py
+++ b/tests/torch/quantization/test_prepare_for_inference.py
@@ -78,7 +78,7 @@ def check_quantizer_operators(model, levels=255, overflow_fix=True):
                 op = nncf_module.get_pre_op(key).op
                 assert isinstance(op, FakeQuantize)
                 is_symmetric = op.qscheme in [torch.per_tensor_symmetric, torch.per_channel_symmetric]
-                narrow_range = not overflow_fix
+                narrow_range = levels in [255, 256] and not overflow_fix
                 ref_levels = levels - 1 if is_symmetric and narrow_range else levels
                 assert op.quant_max - op.quant_min == ref_levels
 


### PR DESCRIPTION
### Changes

* Fix narrow_range for weighted symmetric quantizers in case of num_bits != 8

### Reason for changes

* Fix torch sota eval

### Related tickets

* 106861

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->

Build: 279
