### PR TITLE
Register controller in NNCFNetwork at create_compressed_model

### DIFF
--- a/nncf/torch/compression_method_api.py
+++ b/nncf/torch/compression_method_api.py
@@ -161,7 +161,7 @@ class PTCompressionAlgorithmBuilder(BaseCompressionAlgorithmBuilder):
         """
         Builds `PTCompressionAlgorithmController` to handle the additional modules,
         parameters, and hooks inserted into the model to enable algorithm-specific
-        compression.
+        compression. Registers the built controller in the model's NNCFNetworkInterface.
 
         :param model: The model with additional modifications necessary to enable
             algorithm-specific compression during fine-tuning.

--- a/nncf/torch/model_creation.py
+++ b/nncf/torch/model_creation.py
@@ -108,8 +108,11 @@ def create_compressed_model(model: Module,
         builder.load_state(compression_state[BaseController.BUILDER_STATE])
     compressed_model = builder.apply_to(nncf_network)
     compression_ctrl = builder.build_controller(compressed_model)
+
     if is_state_loadable:
         compression_ctrl.load_state(compression_state[BaseController.CONTROLLER_STATE])
+
+    compressed_model.nncf.set_compression_controller(compression_ctrl)
 
     # Required to ensure that the model leaving create_compressed_model has correct compressed graph.
     # In particular, this is currently required for correct functioning of RNNs.

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -288,8 +288,7 @@ class NNCFNetworkInterface(torch.nn.Module):
                                                           ShapeIgnoringTensorMetaComparator())
         self._load_listener = None
 
-
-
+        self.compression_controller = None  # type: PTCompressionAlgorithmController
 
     @property
     def _model_ref(self) -> 'NNCFNetwork':
@@ -698,6 +697,9 @@ class NNCFNetworkInterface(torch.nn.Module):
             nncf_node = self._original_graph.get_node_by_id(node_id)
             retval[nncf_node.node_name] = op_address
         return retval
+
+    def set_compression_controller(self, ctrl: 'PTCompressionAlgorithmController'):
+        self.compression_controller = ctrl
 
 
 class NNCFNetworkMeta(type):

--- a/tests/torch/test_algo_common.py
+++ b/tests/torch/test_algo_common.py
@@ -398,3 +398,16 @@ def test_raise_runtimeerror_for_not_matched_scope_names(algo_name):
     with pytest.raises(RuntimeError) as exc_info:
         create_compressed_model_and_algo_for_test(model, config)
     assert "No match has been found among the model" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("algos", (["quantization", ],
+                                   ["magnitude_sparsity", "filter_pruning"]))
+def test_compressed_model_has_controller_references(algos: List[str]):
+    model = BasicLinearTestModel()
+    cc = ConfigCreator()
+    for algo_name in algos:
+        cc.add_algo(algo_name)
+    config = cc.create()
+    register_bn_adaptation_init_args(config)
+    model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
+    assert compression_ctrl is model.nncf.compression_controller


### PR DESCRIPTION
### Changes
NNCFNetwork objects leaving `create_compressed_model` now have a controller reference available in them.

### Reason for changes
Much ore convenient to access the controller through the model object in certain cases.

### Related tickets
N/A

### Tests
tests.torch.test_algo_common.test_compressed_model_has_controller_references
