### PR TITLE
Skip BN adaptation in some cases to enable shorter compression configs

### DIFF
--- a/nncf/config/extractors.py
+++ b/nncf/config/extractors.py
@@ -148,6 +148,15 @@ def extract_bn_adaptation_init_params(config: NNCFConfig, algo_name: str) -> Opt
     return get_bn_adapt_algo_kwargs(config, params)
 
 
+def has_bn_section(config: NNCFConfig, algo_name: str) -> bool:
+    algo_config = extract_algo_specific_config(config, algo_name)
+    return algo_config.get('initializer', {}).get('batchnorm_adaptation') is not None
+
+
+class BNAdaptDataLoaderNotFoundError(RuntimeError):
+    pass
+
+
 def get_bn_adapt_algo_kwargs(nncf_config: NNCFConfig, params: Dict[str, Any]) -> Dict[str, Any]:
     num_bn_adaptation_samples = params.get('num_bn_adaptation_samples', NUM_BN_ADAPTATION_SAMPLES)
 
@@ -157,7 +166,7 @@ def get_bn_adapt_algo_kwargs(nncf_config: NNCFConfig, params: Dict[str, Any]) ->
     try:
         args = nncf_config.get_extra_struct(BNAdaptationInitArgs)
     except KeyError:
-        raise RuntimeError(
+        raise BNAdaptDataLoaderNotFoundError(
             'Unable to create the batch-norm statistics adaptation algorithm '
             'because the data loader is not provided as an extra struct. Refer to the '
             '`NNCFConfig.register_extra_structs` method and the `BNAdaptationInitArgs` class.') from None

--- a/nncf/tensorflow/sparsity/magnitude/algorithm.py
+++ b/nncf/tensorflow/sparsity/magnitude/algorithm.py
@@ -265,5 +265,5 @@ class MagnitudeSparsityController(BaseSparsityController):
         if self._bn_adaptation is None:
             self._bn_adaptation = BatchnormAdaptationAlgorithm(
                 **extract_bn_adaptation_init_params(self._config,
-                                                    'magnitude_sparsity'))
+                                                    self.name))
         self._bn_adaptation.run(self.model)

--- a/tests/tensorflow/pruning/test_strip.py
+++ b/tests/tensorflow/pruning/test_strip.py
@@ -33,12 +33,7 @@ def test_strip(enable_quantization):
         config["compression"].append(
             {
                 "algorithm": "quantization",
-                "preset": "mixed",
-                "initializer": {
-                    "batchnorm_adaptation": {
-                        "num_bn_adaptation_samples": 0,
-                    }
-                },
+                "preset": "mixed"
             }
         )
 

--- a/tests/tensorflow/quantization/test_strip.py
+++ b/tests/tensorflow/quantization/test_strip.py
@@ -26,11 +26,6 @@ def test_strip():
     config["compression"] = {
         "algorithm": "quantization",
         "preset": "mixed",
-        "initializer": {
-            "batchnorm_adaptation": {
-                "num_bn_adaptation_samples": 0,
-            }
-        }
     }
 
     compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)

--- a/tests/tensorflow/test_ignored_scopes.py
+++ b/tests/tensorflow/test_ignored_scopes.py
@@ -69,8 +69,6 @@ def test_raise_runtimeerror_for_not_matched_scope_names(algo_name):
     model = get_mock_model()
     config = get_empty_config()
     config['compression'] = {'algorithm': algo_name, 'ignored_scopes': ['unknown']}
-    if algo_name == "quantization":
-        config['compression']["initializer"] = {"batchnorm_adaptation": {"num_bn_adaptation_samples": 0}}
 
     with pytest.raises(RuntimeError) as exc_info:
         create_compressed_model_and_algo_for_test(model, config)

--- a/tests/torch/test_compression_lr_multiplier.py
+++ b/tests/torch/test_compression_lr_multiplier.py
@@ -49,9 +49,6 @@ def get_quantization_config() -> NNCFConfig:
     config['compression']['initializer'] = {
         'range': {
             'num_init_samples': 10
-        },
-        'batchnorm_adaptation': {
-            'num_bn_adaptation_samples': 0,
         }
     }
     return config


### PR DESCRIPTION
### Changes
Now `create_compressed_model` won't fail no BN adaptation data loader is given, but there was nothing in the NNCFConfig about BN adaptation anyway. If we skip BN adaptation in this way, log a corresponding message at `INFO` level.

### Reason for changes
This allows using shorter configs such as `"compression": { "quantization" }` without calling `register_default_init_args`. Examples would be test cases where we don't need BN adaptation mostly, but need a model with quantizers at proper places and do not want to define a dummy dataloader or to explicitly specify 0 BN adaptation samples in config. Also might make it easier for the user to quickly evaluate NNCF even if they missed the `register_default_init_args` call. 

### Related tickets
N/A

### Tests
tests.torch.test_algo_common.test_can_apply_algo_with_single_line, also some tests that couldn't pass without setting `"num_bn_adaptation_samples": 0` were adjusted and are now passing without it.
