### PR TITLE
Fix prune shape

### DIFF
--- a/examples/experimental/torch/classification/bootstrap_nas.py
+++ b/examples/experimental/torch/classification/bootstrap_nas.py
@@ -193,21 +193,21 @@ def main_worker(current_gpu, config: SampleConfig):
 
         # Maximal subnet
         elasticity_ctrl.multi_elasticity_handler.activate_maximum_subnet()
-        search_algo.bn_adaptation.run(model)
-        top1_acc = validate_model_fn_top1(model, val_loader)
+        search_algo.bn_adaptation.run(nncf_network)
+        top1_acc = validate_model_fn_top1(nncf_network, val_loader)
         logger.info("Maximal subnet Top1 acc: {top1_acc}, Macs: {macs}".format(top1_acc=top1_acc, macs=
                     elasticity_ctrl.multi_elasticity_handler.count_flops_and_weights_for_active_subnet()[0] / 2000000))
 
         # Best found subnet
         elasticity_ctrl.multi_elasticity_handler.activate_subnet_for_config(best_config)
-        search_algo.bn_adaptation.run(model)
-        top1_acc = validate_model_fn_top1(model, val_loader)
+        search_algo.bn_adaptation.run(nncf_network)
+        top1_acc = validate_model_fn_top1(nncf_network, val_loader)
         logger.info("Best found subnet Top1 acc: {top1_acc}, Macs: {macs}".format(top1_acc=top1_acc, macs=
         elasticity_ctrl.multi_elasticity_handler.count_flops_and_weights_for_active_subnet()[0] / 2000000))
         elasticity_ctrl.export_model(osp.join(config.log_dir, "best_subnet.onnx"))
 
     if 'test' in config.mode:
-        validate(val_loader, model, criterion, config)
+        validate(val_loader, nncf_network, criterion, config)
 
 
 if __name__ == '__main__':

--- a/examples/experimental/torch/classification/bootstrap_nas_search.py
+++ b/examples/experimental/torch/classification/bootstrap_nas_search.py
@@ -164,15 +164,15 @@ def main_worker(current_gpu, config: SampleConfig):
 
         # Maximal subnet
         elasticity_ctrl.multi_elasticity_handler.activate_maximum_subnet()
-        search_algo.bn_adaptation.run(model)
-        top1_acc = validate_model_fn_top1(model, val_loader)
+        search_algo.bn_adaptation.run(nncf_network)
+        top1_acc = validate_model_fn_top1(nncf_network, val_loader)
         logger.info("Maximal subnet Top1 acc: {top1_acc}, Macs: {macs}".format(top1_acc=top1_acc, macs=
                     elasticity_ctrl.multi_elasticity_handler.count_flops_and_weights_for_active_subnet()[0] / 2000000))
 
         # Best found subnet
         elasticity_ctrl.multi_elasticity_handler.activate_subnet_for_config(best_config)
-        search_algo.bn_adaptation.run(model)
-        top1_acc = validate_model_fn_top1(model, val_loader)
+        search_algo.bn_adaptation.run(nncf_network)
+        top1_acc = validate_model_fn_top1(nncf_network, val_loader)
         logger.info("Best found subnet Top1 acc: {top1_acc}, Macs: {macs}".format(top1_acc=top1_acc, macs=
         elasticity_ctrl.multi_elasticity_handler.count_flops_and_weights_for_active_subnet()[0] / 2000000))
         elasticity_ctrl.export_model(osp.join(config.log_dir, "best_subnet.onnx"))
@@ -183,7 +183,7 @@ def main_worker(current_gpu, config: SampleConfig):
         assert best_config == elasticity_ctrl.multi_elasticity_handler.get_active_config()
 
     if 'test' in config.mode:
-        validate(val_loader, model, criterion, config)
+        validate(val_loader, nncf_network, criterion, config)
 
 
 if __name__ == '__main__':

--- a/nncf/common/pruning/shape_pruning_processor.py
+++ b/nncf/common/pruning/shape_pruning_processor.py
@@ -126,8 +126,6 @@ class ShapePruningProcessor:
 
         for node in cluster.elements:
             output_channels[node.node_name] -= pruned_elems
-            if node.is_depthwise:
-                input_channels[node.node_name] -= pruned_elems
 
         # Prune in channels in all next nodes
         next_nodes_info = pruning_groups_next_nodes[cluster.id]
@@ -201,7 +199,6 @@ class ShapePruningProcessor:
                 curr_next_nodes = get_next_nodes_of_types(graph, nncf_cluster_node, self._prunable_types)
 
                 next_nodes_cluster = next_nodes_cluster.union(curr_next_nodes)
-            next_nodes_cluster = next_nodes_cluster - cluster_nodes
             next_nodes[cluster.id] = []
             for next_node in next_nodes_cluster:
                 sparse_multiplier = self._get_next_node_sparse_multiplier(graph, next_node, cluster)

--- a/tests/torch/nas/test_flops.py
+++ b/tests/torch/nas/test_flops.py
@@ -51,6 +51,26 @@ LIST_OF_ME_DESCS = [
         blocks_to_skip=RESNET50_BLOCK_TO_SKIP,
     ),
     MultiElasticityTestDesc(
+        name='resnet50_width_overwrite_groups',
+        model_creator=resnet50_cifar10,
+        ref_model_stats=RefModelStats(
+            supernet=ModelStats(651_599_872, 23_467_712),
+            kernel_stage=ModelStats(651_599_872, 23_467_712),
+            depth_stage=ModelStats(615_948_288, 23_398_080),
+            width_stage=ModelStats(589_209_600, 23_238_336)
+        ),
+        blocks_to_skip=RESNET50_BLOCK_TO_SKIP,
+        algo_params={'width': {
+            "overwrite_groups": [
+                [
+                    "ResNet/Sequential[layer2]/Bottleneck[0]/NNCFConv2d[conv1]/conv2d_0",
+                    "ResNet/Sequential[layer2]/Bottleneck[0]/NNCFConv2d[conv2]/conv2d_0"
+                ],
+            ],
+            "overwrite_groups_widths":[[128, 96, 64]]
+        }},
+    ),
+    MultiElasticityTestDesc(
         name='resnet50_tv',
         model_creator=partial(resnet50, num_classes=10),
         ref_model_stats=RefModelStats(

--- a/tests/torch/pruning/filter_pruning/test_algo.py
+++ b/tests/torch/pruning/filter_pruning/test_algo.py
@@ -457,7 +457,8 @@ def test_collect_output_shapes(model, ref_output_shapes):
 
 
 BigPruningTestModelNextNodesRef = {
-    0: [{'node_name': 'BigPruningTestModel/NNCFConv2d[conv2]/conv2d_0', 'sparse_multiplier': 1}],
+    0: [{'node_name': 'BigPruningTestModel/NNCFConv2d[conv2]/conv2d_0', 'sparse_multiplier': 1},
+        {'node_name': 'BigPruningTestModel/NNCFConv2d[conv_depthwise]/conv2d_0', 'sparse_multiplier': 1}],
     1: [{'node_name': 'BigPruningTestModel/NNCFConvTranspose2d[up]/conv_transpose2d_0', 'sparse_multiplier': 1}],
     2: [{'node_name': 'BigPruningTestModel/NNCFLinear[linear]/linear_0', 'sparse_multiplier': 49}],
     3: [{'node_name': 'BigPruningTestModel/NNCFConv2d[conv3]/conv2d_0', 'sparse_multiplier': 1}],


### PR DESCRIPTION
### Changes

Allow next_nodes_cluster to include nodes in clusters.

### Reason for changes

1. Code is simpler.
2. Current flops count function is incorrect when dealing with some specific designs of 'overwrite_groups' in elastic width.

For example:

```
"overwrite_groups": [[
        "ResNet/Sequential[layer2]/Bottleneck[0]/NNCFConv2d[conv1]/conv2d_0",
        "ResNet/Sequential[layer2]/Bottleneck[0]/NNCFConv2d[conv2]/conv2d_0"
 ]],
"overwrite_groups_widths":[[128, 96, 64]]
```

conv1 and conv2 are connected, conv2 is not a depthwise conv.

When we activate the minimum subnet:

output_channel[conv1] = 64, output_channel[conv2] = 64
input_channel[conv2] = 64

However, if we use the current flops count function, input_channel[conv2]=128. This is because conv2 is excluded from next_nodes_cluster and conv2 is not a depthwise conv.

### Related tickets

N/A

### Tests

Added a test in test_flops.py to check the flops count when using 'overwrite_groups' in elastic width.