### PR TITLE
Fix incorrect work of `is_quantized_weights` in ONNX backend of PTQ

### DIFF
--- a/nncf/quantization/algorithms/bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/onnx_backend.py
@@ -117,7 +117,7 @@ class ONNXBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
 
     @staticmethod
     def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
-        input_nodes = nncf_graph.get_previous_nodes(node)
+        input_nodes = [edge.from_node for edge in nncf_graph.get_input_edges(node)]
         weight_port_id = node.metatype.weight_definitions.weight_port_id
         weight_node = input_nodes[weight_port_id]
         return weight_node.metatype == ONNXDequantizeLinearMetatype

--- a/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
@@ -97,7 +97,7 @@ class ONNXFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
 
     @staticmethod
     def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
-        input_nodes = nncf_graph.get_previous_nodes(node)
+        input_nodes = [edge.from_node for edge in nncf_graph.get_input_edges(node)]
         weight_port_id = node.metatype.weight_definitions.weight_port_id
         weight_node = input_nodes[weight_port_id]
         return weight_node.metatype == ONNXDequantizeLinearMetatype


### PR DESCRIPTION
### Changes

Use `get_input_edges` that return sorted edges by port_id instead of `get_previous_nodes`

### Reason for changes

`get_previous_nodes` returns unsorted nodes, in result `is_quantized_weights` can return false negative result.


