### PR TITLE
Add baddbmm as a matmul alias for PT

### DIFF
--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -516,7 +516,7 @@ class PTMatMulMetatype(PTOperatorMetatype):
     name = "MatMulOp"
     module_to_function_names = {
         NamespaceTarget.TORCH_TENSOR: ["matmul"],
-        NamespaceTarget.TORCH: ["matmul", "bmm", "mm"],
+        NamespaceTarget.TORCH: ["matmul", "bmm", "mm", "baddbmm"],
     }
     hw_config_names = [HWConfigOpName.MATMUL]
 

--- a/nncf/torch/graph/pattern_operations.py
+++ b/nncf/torch/graph/pattern_operations.py
@@ -23,7 +23,8 @@ LINEAR_OPERATIONS = {GraphPattern.METATYPE_ATTR: ['linear',
                                                   'addmm',
                                                   'bmm',
                                                   'matmul',
-                                                  'mm'
+                                                  'mm',
+                                                  'baddbmm'
                                                   ],
                      GraphPattern.LABEL_ATTR: 'LINEAR'}
 

--- a/nncf/torch/hardware/fused_patterns.py
+++ b/nncf/torch/hardware/fused_patterns.py
@@ -52,10 +52,11 @@ def create_l2_norm_operations():
 
 @PT_HW_FUSED_PATTERNS.register(PatternNames.MATMUL_SOFTMAX_MATMUL)
 def create_matmul_softmax_matmul():
+    matmul_aliases = ['linear', 'addmm', 'matmul', 'bmm', 'mm', 'baddbmm']
     pattern = GraphPattern()
     softmax_1 = pattern.add_node(label='SOFTMAX', type='softmax')
-    mat_mul_1_1 = pattern.add_node(label='MATMUL_1', type=['linear', 'addmm', 'matmul', 'bmm', 'mm'])
-    mat_mul_2_1 = pattern.add_node(label='MATMUL_2', type=['linear', 'addmm', 'matmul', 'bmm', 'mm'])
+    mat_mul_1_1 = pattern.add_node(label='MATMUL_1', type=matmul_aliases)
+    mat_mul_2_1 = pattern.add_node(label='MATMUL_2', type=matmul_aliases)
 
     any_1 = pattern.add_node(label='ANY', type=GraphPattern.NON_PATTERN_NODE_TYPE)
 
@@ -65,8 +66,8 @@ def create_matmul_softmax_matmul():
 
     softmax_2 = pattern.add_node(label='SOFTMAX', type='softmax')
     add_2 = pattern.add_node(label='ADD', type=["add", "__add__", "__iadd__", "__radd__"])
-    mat_mul_1_2 = pattern.add_node(label='MATMUL_1', type=['linear', 'addmm', 'matmul', 'bmm', 'mm'])
-    mat_mul_2_2 = pattern.add_node(label='MATMUL_2', type=['linear', 'addmm', 'matmul', 'bmm', 'mm'])
+    mat_mul_1_2 = pattern.add_node(label='MATMUL_1', type=matmul_aliases)
+    mat_mul_2_2 = pattern.add_node(label='MATMUL_2', type=matmul_aliases)
 
     any_2 = pattern.add_node(label='ANY', type=GraphPattern.NON_PATTERN_NODE_TYPE)
 

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/Baddbmm.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/Baddbmm.dot
@@ -1,0 +1,17 @@
+strict digraph  {
+"0 /nncf_model_input_0" [id=0, type=nncf_model_input];
+"1 SymmetricQuantizer/symmetric_quantize_0" [id=1, type=symmetric_quantize];
+"2 /nncf_model_input_1" [id=2, type=nncf_model_input];
+"3 SymmetricQuantizer/symmetric_quantize_1" [id=3, type=symmetric_quantize];
+"4 /nncf_model_input_2" [id=4, type=nncf_model_input];
+"5 SymmetricQuantizer/symmetric_quantize_2" [id=5, type=symmetric_quantize];
+"6 Baddbmm/baddbmm_0" [id=6, type=baddbmm];
+"7 /nncf_model_output_0" [id=7, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
+"1 SymmetricQuantizer/symmetric_quantize_0" -> "6 Baddbmm/baddbmm_0";
+"2 /nncf_model_input_1" -> "3 SymmetricQuantizer/symmetric_quantize_1";
+"3 SymmetricQuantizer/symmetric_quantize_1" -> "6 Baddbmm/baddbmm_0";
+"4 /nncf_model_input_2" -> "5 SymmetricQuantizer/symmetric_quantize_2";
+"5 SymmetricQuantizer/symmetric_quantize_2" -> "6 Baddbmm/baddbmm_0";
+"6 Baddbmm/baddbmm_0" -> "7 /nncf_model_output_0";
+}

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -23,6 +23,7 @@ import pytest
 import torch
 
 from nncf.torch.utils import get_model_device
+from tests.torch.test_models.synthetic import Baddbmm
 from tests.torch.test_models.synthetic import ConvBNLeakyReLU
 from tests.torch.test_models.synthetic import ConvGeluGetItem
 from tests.torch.test_models.synthetic import ConvRelu6HSwishHSigmoid
@@ -603,6 +604,8 @@ SYNTHETIC_MODEL_DESC_LIST = [
     TorchBinaryMethodDesc(model_name='MatMul', torch_method=torch.matmul),
     SingleLayerModelDesc(model_name='BMM', layer=torch.bmm, input_sample_sizes=([1, 1, 1], [1, 1, 1]),
                          wrap_inputs_fn=n_inputs_fn),
+    GeneralModelDesc(model_builder=Baddbmm,
+                     input_sample_sizes=([1, 1, 1], [1, 1, 1], [1, 1, 1])),
     TensorBinaryMethodsDesc(model_name='MatMul', tensor_method='matmul'),
 
     SingleLayerModelDesc(model_name='Mean', layer=torch.mean),

--- a/tests/torch/test_models/synthetic.py
+++ b/tests/torch/test_models/synthetic.py
@@ -316,3 +316,7 @@ class FC_ConstMul(torch.nn.Module):
         x1 = self.fc1(x)
         x1 = x1 * 2
         return x + x1
+
+class Baddbmm(torch.nn.Module):
+    def forward(self, x, y, z):
+        return torch.baddbmm(x, y, z)


### PR DESCRIPTION
### Changes
`torch.baddbmm` has been added as an alias for the matmul metatype for quantization purposes.

### Reason for changes
Wouldn't be quantized otherwise.

### Related tickets
N/A

### Tests
test_synthetic_model_quantization
