### PR TITLE
Bump up tensorflow_datasets version

### DIFF
--- a/examples/tensorflow/requirements.txt
+++ b/examples/tensorflow/requirements.txt
@@ -1,6 +1,6 @@
 addict
 absl-py==1.0.0
-tensorflow_datasets==4.2.0
+tensorflow_datasets==4.8.2
 tensorflow_hub
 tensorflow_addons~=0.20.0
 opencv-python


### PR DESCRIPTION
### Changes

Bump up to `tensorflow_datasets==4.8.2`

### Reason for changes

Regular update 

### Related tickets

100587

### Tests

Sota eval build: 299
