### PR TITLE
Minor fix for calibrate tool

### DIFF
--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -389,7 +389,7 @@ def quantize_model_with_accuracy_control(xml_path: str,
                                          quantization_parameters):
     ov_model = ov.Core().read_model(xml_path, bin_path)
     model_evaluator = create_model_evaluator(accuracy_checcker_config)
-    model_evaluator.load_network([{'model': ov_model}])
+    model_evaluator.load_network_from_ir([{'model': xml_path, 'weights': bin_path}])
     model_evaluator.select_dataset('')
 
     def transform_fn(data_item):


### PR DESCRIPTION
### Changes

The initialization of the model evaluator was fixed.

### Reason for changes

Some models failed.

### Related tickets

N/A

### Tests

N/A
