### PR TITLE
Automating Code Formatting in PyGuide.md

### DIFF
--- a/docs/styleguide/PyGuide.md
+++ b/docs/styleguide/PyGuide.md
@@ -62,7 +62,7 @@ Also recommend configuring your IDE to run Black and isort tools automatically w
 Automatic code formatting is mandatory for all Python files, but you can disable it for specific cases if required:
   - if you need a specialized order of importing modules;
   - for large data structures for which autoformatting unnecessarily breaks into lines,
-    e.g. reference data in tests or a list of classes;
+    e.g. reference data in tests, class lists or arguments for subprocess;
   - for structures for which formatting helps understanding, such as matrix.
 
 Example for 'isort':

--- a/docs/styleguide/PyGuide.md
+++ b/docs/styleguide/PyGuide.md
@@ -54,7 +54,7 @@ it's important to run a pre-commit command to ensure that the code is properly f
 You can use the following commands for this:
 
 ```bash
-make code-style
+make pre-commit
 ```
 
 Also recommend configuring your IDE to run Black and isort tools automatically when saving files.

--- a/docs/styleguide/PyGuide.md
+++ b/docs/styleguide/PyGuide.md
@@ -54,8 +54,7 @@ it's important to run a pre-commit command to ensure that the code is properly f
 You can use the following commands for this:
 
 ```bash
-pre-commit run     # Check and format only staged files
-pre-commit run -a  # Check and format all files
+make code-style
 ```
 
 Also recommend configuring your IDE to run Black and isort tools automatically when saving files.

--- a/docs/styleguide/PyGuide.md
+++ b/docs/styleguide/PyGuide.md
@@ -15,21 +15,22 @@
     *   [3.7 Files and Sockets](#s3.7-files-and-sockets)
     *   [3.8 Abstract Classes](#s3.8-abstract-classes)
 -   [4 Python Style Rules](#s4-python-style-rules)
-    *   [4.1 Comments and Docstrings](#s4.1-comments-and-docstrings)
-        +   [4.1.1 Modules](#s4.1.1-modules)
-        +   [4.1.2 Functions and Methods](#s4.1.2-functions-and-methods)
-        +   [4.1.3 Classes](#s4.1.3-classes)
-        +   [4.1.4 Block and Inline Comments](#s4.1.4-block-and-inline-comments)
-    *   [4.2 Strings](#s4.2-strings)
-    *   [4.3 Logging](#s4.3-logging)
-    *   [4.4 Error Messages](#s4.4-error-messages)
-    *   [4.5 TODO Comments](#s4.5-todo-comments)
-    *   [4.6 Naming](#s4.6-naming)
-        +   [4.6.1 Names to Avoid](#s4.6.1-names-to-avoid)
-        +   [4.6.2 Naming Conventions](#s4.6.2-naming-conventions)
-        +   [4.6.3 Framework specific class naming](#s4.6.3-framework-specific-class-naming)
-        +   [4.6.4 File Naming](#s4.6.4-file-naming)
-    *   [4.7 Main](#s4.7-main)
+    *   [4.1 Line length](#s4.1-line-length)
+    *   [4.2 Comments and Docstrings](#s4.2-comments-and-docstrings)
+        +   [4.2.1 Modules](#s4.2.1-modules)
+        +   [4.2.2 Functions and Methods](#s4.2.2-functions-and-methods)
+        +   [4.2.3 Classes](#s4.2.3-classes)
+        +   [4.2.4 Block and Inline Comments](#s4.2.4-block-and-inline-comments)
+    *   [4.3 Strings](#s4.3-strings)
+    *   [4.4 Logging](#s4.4-logging)
+    *   [4.5 Error Messages](#s4.5-error-messages)
+    *   [4.6 TODO Comments](#s4.6-todo-comments)
+    *   [4.7 Naming](#s4.7-naming)
+        +   [4.7.1 Names to Avoid](#s4.7.1-names-to-avoid)
+        +   [4.7.2 Naming Conventions](#s4.7.2-naming-conventions)
+        +   [4.7.3 Framework specific class naming](#s4.7.3-framework-specific-class-naming)
+        +   [4.7.4 File Naming](#s4.7.4-file-naming)
+    *   [4.8 Main](#s4.8-main)
 </details>
 
 <a id="s1-introduction"></a>
@@ -279,18 +280,34 @@ class C(ABC):
 <a id="python-style-rules"></a>
 ## 4 Python Style Rules
 
-<a id="s4.1-comments-and-docstrings"></a>
-<a id="41-comments-and-docstrings"></a>
+<a id="s4.1-line-length"></a>
+<a id="41-line-length"></a>
+<a id="line-length"></a>
+### 4.1 Line length
+
+Maximum line length is *120 characters*.
+
+Explicit exceptions to the 120 character limit:
+
+-   Long import statements.
+-   URLs, pathnames, or long flags in comments.
+-   Long string module level constants not containing whitespace that would be
+    inconvenient to split across lines such as URLs or pathnames.
+    -   Pylint disable comments. (e.g.: `# pylint: disable=invalid-name`)
+
+
+<a id="s4.2-comments-and-docstrings"></a>
+<a id="42-comments-and-docstrings"></a>
 <a id="comments-and-docstrings"></a>
-### 4.1 Comments and Docstrings
+### 4.2 Comments and Docstrings
 
 Be sure to use the right style for module, function, method docstrings and
 inline comments.
 
-<a id="s4.1.1-modules"></a>
-<a id="411-modules"></a>
+<a id="s4.2.1-modules"></a>
+<a id="421-modules"></a>
 <a id="modules"></a>
-#### 4.1.1 Modules
+#### 4.2.1 Modules
 
 Every file should contain a license boilerplate.
 
@@ -309,10 +326,10 @@ Every file should contain a license boilerplate.
 """
 ```
 
-<a id="s4.1.2-functions-and-methods"></a>
-<a id="412-functions-and-methods"></a>
+<a id="s4.2.2-functions-and-methods"></a>
+<a id="422-functions-and-methods"></a>
 <a id="functions-and-methods"></a>
-#### 4.1.2 Functions and Methods
+#### 4.2.2 Functions and Methods
 
 In this section, "function" means a method, function, or generator.
 
@@ -345,10 +362,10 @@ def load_state(model: torch.nn.Module, state_dict_to_load: dict, is_resume: bool
     """
 ```
 
-<a id="s4.1.3-classes"></a>
-<a id="413-classes"></a>
+<a id="s4.2.3-classes"></a>
+<a id="423-classes"></a>
 <a id="classes"></a>
-#### 4.1.3 Classes
+#### 4.2.3 Classes
 
 Classes should have a docstring below the class definition describing the class. If your class
 has public attributes, they should be documented here follow the same formatting as a function's
@@ -429,10 +446,10 @@ class ComplexKlass(BaseClass):
         # ... potentially more code which is not understandable at a glance
 ```
 
-<a id="s4.1.4-block-and-inline-comments"></a>
-<a id="414-block-and-inline-comments"></a>
+<a id="s4.2.4-block-and-inline-comments"></a>
+<a id="424-block-and-inline-comments"></a>
 <a id="block-and-inline-comments"></a>
-#### 4.1.4 Block and Inline Comments
+#### 4.2.4 Block and Inline Comments
 
 The final place to have comments is in tricky parts of the code. If you're going to have to explain it
 in the future, you should comment it now. Complicated operations get a few lines of comments before
@@ -459,10 +476,10 @@ knows Python (though not what you're trying to do) better than you do.
 # the next element is i+1
 ```
 
-<a id="s4.2-strings"></a>
-<a id="42-strings"></a>
+<a id="s4.3-strings"></a>
+<a id="43-strings"></a>
 <a id="strings"></a>
-### 4.2 Strings
+### 4.3 Strings
 
 
 ```python
@@ -487,10 +504,10 @@ long_string = textwrap.dedent(
 )
 ```
 
-<a id="s4.3-logging"></a>
-<a id="43-logging"></a>
+<a id="s4.4-logging"></a>
+<a id="44-logging"></a>
 <a id="logging"></a>
-### 4.3 Logging
+### 4.4 Logging
 Use the logger object built into NNCF for all purposes of logging within the NNCF package code.
 Do not use `print(...)` or other ways of output.
 
@@ -549,10 +566,10 @@ At all log levels the log lines should not be duplicated during execution, if po
 For deprecation warnings, use `nncf.common.logging.logger.warning_deprecated` instead of the regular `nncf_logger.warning`.
 This ensures that the deprecation warning is seen to the user at all NNCF log levels.
 
-<a id="s4.4-error-messages"></a>
-<a id="44-error-messages"></a>
+<a id="s4.5-error-messages"></a>
+<a id="45-error-messages"></a>
 <a id="error-messages"></a>
-### 4.4 Error Messages
+### 4.5 Error Messages
 
 Error messages (such as: message strings on exceptions like `ValueError`, or
 messages shown to the user) should follow guidelines:
@@ -560,10 +577,10 @@ messages shown to the user) should follow guidelines:
 - Interpolated pieces need to always be clearly identifiable as such.
 - The message should start with a capital letter.
 
-<a id="s4.5-todo-comments"></a>
-<a id="45-todo-comments"></a>
+<a id="s4.6-todo-comments"></a>
+<a id="46-todo-comments"></a>
 <a id="todo-comments"></a>
-### 4.5 TODO Comments
+### 4.6 TODO Comments
 
 Use `TODO` comments for code that is temporary, a short-term solution, or
 good-enough but not perfect.
@@ -588,10 +605,10 @@ If your `TODO` is of the form "At a future date do something" make sure that you
 either include a very specific date ("Fix by November 2030") or a very specific
 event ("Remove this code when all clients can handle XML responses.").
 
-<a id="s4.6-naming"></a>
-<a id="46-naming"></a>
+<a id="s4.7-naming"></a>
+<a id="47-naming"></a>
 <a id="naming"></a>
-### 4.6 Naming
+### 4.7 Naming
 
 `module_name`, `package_name`, `ClassName`, `method_name`, `ExceptionName`,
 `function_name`, `GLOBAL_CONSTANT_NAME`, `global_var_name`, `instance_var_name`,
@@ -683,10 +700,10 @@ Always use a `.py` filename extension. Never use dashes.
 
 </table>
 
-<a id="s4.6.1-names-to-avoid"></a>
-<a id="461-names-to-avoid"></a>
+<a id="s4.7.1-names-to-avoid"></a>
+<a id="471-names-to-avoid"></a>
 <a id="names-to-avoid"></a>
-#### 4.6.1 Names to Avoid
+#### 4.7.1 Names to Avoid
 
 -   single character names, except for specifically allowed cases:
     -   counters or iterators (e.g. `i`, `j`, `k`, `v`, et al.)
@@ -702,10 +719,10 @@ Always use a `.py` filename extension. Never use dashes.
 -   names that needlessly include the type of the variable (for example:
     `id_to_name_dict`)
 
-<a id="s4.6.2-naming-conventions"></a>
-<a id="462-naming-convention"></a>
+<a id="s4.7.2-naming-conventions"></a>
+<a id="472-naming-convention"></a>
 <a id="naming-conventions"></a>
-#### 4.6.2 Naming Conventions
+#### 4.7.2 Naming Conventions
 
 -   "Internal" means internal to a module, or protected or private within a
     class.
@@ -721,26 +738,26 @@ Always use a `.py` filename extension. Never use dashes.
 -   Use the word "layer" (instead of "module") in the `nncf.common` module to
     refer to the building block of neural networks.
 
-<a id="s4.6.3-framework-specific-class-naming"></a>
-<a id="463-framework-specific-class-naming"></a>
+<a id="s4.7.3-framework-specific-class-naming"></a>
+<a id="473-framework-specific-class-naming"></a>
 <a id="framework-specific-class-naming"></a>
-#### 4.6.3 Framework specific class naming
+#### 4.7.3 Framework specific class naming
 
 - `PTClassName` for Torch
 - `TFClassName` for TensorFlow
 
-<a id="s4.6.4-file-naming"></a>
-<a id="464-file-naming"></a>
+<a id="s4.7.4-file-naming"></a>
+<a id="474-file-naming"></a>
 <a id="file-naming"></a>
-#### 4.6.4 File Naming
+#### 4.7.4 File Naming
 
 Python filenames must have a `.py` extension and must not contain dashes (`-`).
 This allows them to be imported and unit tested.
 
-<a id="s4.7-main"></a>
-<a id="4.7-main"></a>
+<a id="s4.8-main"></a>
+<a id="4.8-main"></a>
 <a id="main"></a>
-### 4.7 Main
+### 4.8 Main
 
 ```python
 def main():

--- a/docs/styleguide/PyGuide.md
+++ b/docs/styleguide/PyGuide.md
@@ -4,159 +4,134 @@
   <summary>Table of Contents</summary>
 
 -   [1 Introduction](#s1-introduction)
--   [2 Python Language Rules](#s2-python-language-rules)
-    *   [2.1 PyLint](#s2.1-pylint)
-    *   [2.2 Imports](#s2.2-imports)
-    *   [2.3 3rd party packages](#s2.3-3rd-party-packages)
-    *   [2.4 Global variables](#s2.4-global-variables)
-    *   [2.5 Nested/Local/Inner Classes and Functions](#s2.5-nested)
-    *   [2.6 Default Iterators and Operators](#s2.6-default-iterators-and-operators)
-    *   [2.7 Type Annotated Code](#s2.7-type-annotated-code)
-    *   [2.8 Files and Sockets](#2.8-files-and-sockets)
-    *   [2.9 Abstract Classes](#2.9-abstract-classes)
--   [3 Python Style Rules](#s3-python-style-rules)
-    *   [3.1 Line length](#s3.1-line-length)
-    *   [3.2 Indentation](#s3.2-indentation)
-    *   [3.3 Blank Lines](#s3.3-blank-lines)
-    *   [3.4 Whitespace](#s3.4-whitespace)
-    *   [3.5 Comments and Docstrings](#s3.5-comments-and-docstrings)
-        +   [3.5.1 Modules](#s3.5.1-modules)
-        +   [3.5.2 Functions and Methods](#s3.5.2-functions-and-methods)
-        +   [3.5.3 Classes](#s3.5.3-classes)
-        +   [3.5.4 Block and Inline Comments](#s3.5.4-block-and-inline-comments)
-    *   [3.6 Strings](#s3.6-strings)
-    *   [3.7 Logging](#s3.7-logging) 
-    *   [3.8 Error Messages](#s3.8-error-messages)
-    *   [3.9 TODO Comments](#s3.9-todo-comments)
-    *   [3.10 Naming](#s3.10-naming)
-        +   [3.10.1 Names to Avoid](#s3.10.1-names-to-avoid)
-        +   [3.10.2 Naming Conventions](#s3.10.2-naming-conventions)
-        +   [3.10.3 Framework specific class naming](#s3.10.3-framework-specific-class-naming)
-        +   [3.10.4 File Naming](#s3.10.4-file-naming)
-    *   [3.11 Main](#s3.11-main)
+-   [2 Automating Code Formatting](#s2-auto-code-formatting)
+-   [3 Python Language Rules](#s3-python-language-rules)
+    *   [3.1 PyLint](#s3.1-pylint)
+    *   [3.2 3rd party packages](#s3.2-3rd-party-packages)
+    *   [3.3 Global variables](#s3.3-global-variables)
+    *   [3.4 Nested/Local/Inner Classes and Functions](#s3.4-nested)
+    *   [3.6 Default Iterators and Operators](#s3.4-default-iterators-and-operators)
+    *   [3.7 Type Annotated Code](#s3.4-type-annotated-code)
+    *   [3.8 Files and Sockets](#3.4-files-and-sockets)
+    *   [3.9 Abstract Classes](#3.4-abstract-classes)
+-   [4 Python Style Rules](#s4-python-style-rules)
+    *   [4.1 Comments and Docstrings](#s4.1-comments-and-docstrings)
+        +   [4.1.1 Modules](#s4.1.1-modules)
+        +   [4.1.2 Functions and Methods](#s4.1.2-functions-and-methods)
+        +   [4.1.3 Classes](#s4.1.3-classes)
+        +   [4.1.4 Block and Inline Comments](#s4.1.4-block-and-inline-comments)
+    *   [4.2 Strings](#s4.2-strings)
+    *   [4.3 Logging](#s4.3-logging)
+    *   [4.4 Error Messages](#s4.4-error-messages)
+    *   [4.5 TODO Comments](#s4.5-todo-comments)
+    *   [4.6 Naming](#s4.6-naming)
+        +   [4.6.1 Names to Avoid](#s4.6.1-names-to-avoid)
+        +   [4.6.2 Naming Conventions](#s4.6.2-naming-conventions)
+        +   [4.6.3 Framework specific class naming](#s4.6.3-framework-specific-class-naming)
+        +   [4.6.4 File Naming](#s4.6.4-file-naming)
+    *   [4.7 Main](#s4.7-main)
 </details>
 
 <a id="s1-introduction"></a>
 <a id="1-introduction"></a>
 <a id="introduction"></a>
-## 1 Introduction 
+## 1 Introduction
 
-This document gives coding conventions for the Python code comprising [Neural Network Compression Framework (NNCF)](../../README.md). 
+This document gives coding conventions for the Python code comprising [Neural Network Compression Framework (NNCF)](../../README.md).
 
 This style guide supplements the [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/)
-with a list of *dos and don'ts* for Python code. If no guidelines were found in this style guide then 
-the [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/) should be followed.   
+with a list of *dos and don'ts* for Python code. If no guidelines were found in this style guide then
+the [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/) should be followed.
 
-<a id="s2-python-language-rules"></a>
-<a id="2-python-language-rules"></a>
+<a id="s2-auto-code-formatting"></a>
+<a id="2-auto-code-formatting"></a>
+<a id="auto-code-formatting"></a>
+## 2 Automating Code Formatting
+
+To maintain consistency and readability throughout the codebase, we use the [black](https://github.com/psf/black)
+and [isort](https://github.com/PyCQA/isort) tools for formatting. Before committing any changes,
+it's important to run a pre-commit command to ensure that the code is properly formatted.
+You can use the following commands for this:
+
+```bash
+pre-commit run     # Check and format only staged files
+pre-commit run -a  # Check and format all files
+```
+
+Also recommend configuring your IDE to run Black and isort tools automatically when saving files.
+
+Automatic code formatting is mandatory for all Python files, but you can disable it for specific cases if required.
+
+Example for 'black':
+
+```python
+arr1 = [
+  1, 0,
+  0, 1,
+]  # fmt: skip
+
+# fmt: off
+arr2 = [
+  1, 0,
+  0, 1,
+]
+# fmt: on
+```
+Example for 'isort':
+
+```python
+import c
+# isort: off
+import b
+import a
+```
+
+<a id="s3-python-language-rules"></a>
+<a id="3-python-language-rules"></a>
 <a id="python-language-rules"></a>
-## 2 Python Language Rules 
+## 3 Python Language Rules
 
-<a id="s2.1-pylint"></a>
-<a id="21-pylint"></a>
+<a id="s3.1-pylint"></a>
+<a id="31-pylint"></a>
 <a id="pylint"></a>
-### 2.1 PyLint 
+### 3.1 PyLint
 
 Run [pylint](https://github.com/PyCQA/pylint) over your code using this [pylintrc](../../.pylintrc).
 
 - Every warning reported by [pylint](https://github.com/PyCQA/pylint) must be resolved in one of the following way:
   - *Preferred solution*: Change the code to fix the warning.
-  - *Exception*: Suppress the warning if they are inappropriate so that other issues are not hidden. 
+  - *Exception*: Suppress the warning if they are inappropriate so that other issues are not hidden.
     To suppress warnings you can set a line-level comment
     ```python
     dict = 'something awful'  # Bad Idea... pylint: disable=redefined-builtin
     ```
-    or update [pylintrc](../../.pylintrc) if applicable for the whole project. If the reason for the suppression 
+    or update [pylintrc](../../.pylintrc) if applicable for the whole project. If the reason for the suppression
     is not clear from the symbolic name, add an explanation.
-      
 
-<a id="s2.2-imports"></a>
-<a id="22-imports"></a>
-<a id="imports"></a>
-### 2.2 Imports 
 
-- Use absolute imports, as they are usually more readable and tend to be better behaved
-  ```python
-  # Correct:
-  import mypkg.sibling
-  from mypkg import sibling
-  from mypkg.sibling import example
-  ```
-  ```python
-  # Wrong:
-  from . import sibling
-  from .sibling import example
-  ```
-- Imports should usually be on separate lines:
-  ```python
-  # Correct:
-  from nncf.api.compression import CompressionLoss
-  from nncf.api.compression import CompressionScheduler
-  from nncf.api.compression import CompressionAlgorithmBuilder
-  from nncf.api.compression import CompressionAlgorithmController
-  ```
-  ```python
-  # Wrong:
-  from nncf.api.compression import CompressionLoss, CompressionScheduler, CompressionAlgorithmBuilder, \
-      CompressionAlgorithmController
-  ```
-- Imports are always put at the top of the file, just after any module comments and docstrings, and before module 
-  globals and constants. Imports should be grouped in the following order:
-  - Standard library imports.
-  - Related third party imports. 
-  - Local application/library specific imports.
-  
-  You should put a blank line between each group of imports.
-- When importing a class from a class-containing module, the preferred behavior is as follows:
-  ```python
-  from myclass import MyClass
-  from foo.bar.yourclass import YourClass
-  ```
-  If this spelling causes local name clashes, then spell them explicitly:
-  ```python
-  import myclass
-  import foo.bar.yourclass
-  ```
-  and use `myclass.MyClass` and `foo.bar.yourclass.YourClass`.
-
-- Wildcard imports (`from module import *`) should be avoided, as they make it unclear which names are present 
-  in the namespace, confusing both readers and many automated tools.
-
-- For classes from the typing module. You are explicitly allowed to import multiple specific classes on one line from the typing module.
-  ```python
-  # Recommended:
-  from typing import Any, Dict, Optional
-  ```
-  ```python
-  # Try to avoid, but this is also applicable:
-  from typing import Any 
-  from typing import Dict
-  from typing import Optional
-  ```
-
-<a id="s2.3-3rd-party-packages"></a>
-<a id="23-3rd-party-packages"></a>
+<a id="s3.2-3rd-party-packages"></a>
+<a id="32-3rd-party-packages"></a>
 <a id="3rd-party-packages"></a>
-### 2.3 3rd party packages 
+### 3.2 3rd party packages
 
-Do not add new third-party dependencies unless absolutely necessary. All things being equal, give preference to built-in packages.  
+Do not add new third-party dependencies unless absolutely necessary. All things being equal, give preference to built-in packages.
 
-<a id="s2.4-global-variables"></a>
-<a id="24-global-variables"></a>
+<a id="s3.3-global-variables"></a>
+<a id="33-global-variables"></a>
 <a id="global-variables"></a>
-### 2.4 Global variables 
+### 3.3 Global variables
 
 Avoid global variables.
 
-- Module-level constants are permitted and encouraged. For example: `MAX_HOLY_HANDGRENADE_COUNT = 3`. Constants must be 
+- Module-level constants are permitted and encouraged. For example: `MAX_HOLY_HANDGRENADE_COUNT = 3`. Constants must be
   named using all caps with underscores.
-- If needed, globals should be declared at the module level and made internal to the module by prepending an `_` to the 
+- If needed, globals should be declared at the module level and made internal to the module by prepending an `_` to the
   name. External access must be done through public module-level functions.
 
-<a id="s2.5-nested"></a>
-<a id="25-nested"></a>
+<a id="s3.4-nested"></a>
+<a id="34-nested"></a>
 <a id="nested-classes-functions"></a>
-### 2.5 Nested/Local/Inner Classes and Functions 
+### 3.4 Nested/Local/Inner Classes and Functions
 
 No need to overuse nested local functions or classes and inner classes.
 
@@ -173,7 +148,7 @@ No need to overuse nested local functions or classes and inner classes.
 
 - Inner classes are fine when it creates more readable and simple code.
 
-- Do not nest a function just to hide it from users of a module. Instead, prefix its name with an `_` at the module 
+- Do not nest a function just to hide it from users of a module. Instead, prefix its name with an `_` at the module
   level so that it can still be accessed by tests.
   ```Python
   # Wrong:
@@ -197,10 +172,10 @@ No need to overuse nested local functions or classes and inner classes.
       return m/3
   ```
 
-<a id="s2.6-default-iterators-and-operators"></a>
-<a id="26-default-iterators-and-operators"></a>
+<a id="s3.5-default-iterators-and-operators"></a>
+<a id="35-default-iterators-and-operators"></a>
 <a id="default-iterators-operators"></a>
-### 2.6 Default Iterators and Operators 
+### 3.5 Default Iterators and Operators
 
 Use default iterators and operators for types that support them, like lists,
 dictionaries, and files. The built-in types define iterator methods, too. Prefer
@@ -223,10 +198,10 @@ for line in afile.readlines(): ...
 for k, v in dict.iteritems(): ...
 ```
 
-<a id="s2.7-type-annotated-code"></a>
-<a id="27-type-annotated-code"></a>
+<a id="s3.6-type-annotated-code"></a>
+<a id="36-type-annotated-code"></a>
 <a id="type-annotated-code"></a>
-### 2.7 Type Annotated Code 
+### 3.6 Type Annotated Code
 
 Code should be annotated with type hints according to
 [PEP-484](https://www.python.org/dev/peps/pep-0484/), and type-check the code at
@@ -236,10 +211,10 @@ build time with a type checking tool like [mypy](http://www.mypy-lang.org/).
 def func(a: int) -> List[int]:
 ```
 
-<a id="s2.8-files-and-sockets"></a>
-<a id="28-files-and-sockets"></a>
+<a id="s3.7-files-and-sockets"></a>
+<a id="37-files-and-sockets"></a>
 <a id="files-and-sockets"></a>
-### 2.8 Files and Sockets 
+### 3.7 Files and Sockets
 
 Explicitly close files and sockets when done with them.
 
@@ -250,10 +225,10 @@ with open("hello.txt") as hello_file:
 ```
 
 
-<a id="s2.9-abstract-classes"></a>
-<a id="29-abstract-classes"></a>
+<a id="s3.8-abstract-classes"></a>
+<a id="38-abstract-classes"></a>
 <a id="abstract-classes"></a>
-### 2.9 Abstract Classes 
+### 3.8 Abstract Classes
 
 When defining abstract classes, the following template should be used:
 
@@ -264,263 +239,54 @@ class C(ABC):
     @abstractmethod
     def my_abstract_method(self, ...):
         pass
-    
+
     @classmethod
     @abstractmethod
     def my_abstract_classmethod(cls, ...):
         pass
-    
+
     @staticmethod
     @abstractmethod
     def my_abstract_staticmethod(...):
         pass
-    
+
     @property
     @abstractmethod
     def my_abstract_property(self):
         pass
-    
+
     @my_abstract_property.setter
     @abstractmethod
     def my_abstract_property(self, val):
         pass
-    
+
     @abstractmethod
     def _get_x(self):
         pass
-    
+
     @abstractmethod
     def _set_x(self, val):
         pass
 ```
 
 
-<a id="s3-python-style-rules"></a>
-<a id="3-python-style-rules"></a>
+<a id="s4-python-style-rules"></a>
+<a id="4-python-style-rules"></a>
 <a id="python-style-rules"></a>
-## 3 Python Style Rules 
+## 4 Python Style Rules
 
-<a id="s3.1-line-length"></a>
-<a id="31-line-length"></a>
-<a id="line-length"></a>
-### 3.1 Line length 
-
-Maximum line length is *120 characters*.
-
-Explicit exceptions to the 120 character limit:
-
--   Long import statements.
--   URLs, pathnames, or long flags in comments.
--   Long string module level constants not containing whitespace that would be
-    inconvenient to split across lines such as URLs or pathnames.
-    -   Pylint disable comments. (e.g.: `# pylint: disable=invalid-name`)
-
-<a id="s3.2-indentation"></a>
-<a id="32-indentation"></a>
-<a id="indentation"></a>
-### 3.2 Indentation 
-
-Indent your code blocks with *4 spaces*.
-
-Never use tabs or mix tabs and spaces. In cases of implied line continuation,
-you should align wrapped elements either verticall; or using a hanging indent of 4 spaces,
-in which case there should be nothing after the open parenthesis or bracket on
-the first line.
-
-```python
-# Correct:   
-
-# Aligned with opening delimiter
-foo = long_function_name(var_one, var_two,
-                         var_three, var_four)
-meal = (spam,
-       beans)
-
-# Aligned with opening delimiter in a dictionary
-foo = {
-   long_dictionary_key: value1 +
-                        value2,
-   ...
-}
-
-# 4-space hanging indent; nothing on first line
-foo = long_function_name(
-   var_one, var_two, var_three,
-   var_four)
-meal = (
-   spam,
-   beans)
-
-# 4-space hanging indent in a dictionary
-foo = {
-   long_dictionary_key:
-       long_dictionary_value,
-   ...
-}
-```
-
-```python
-# Wrong:
-
-# Stuff on first line forbidden
-foo = long_function_name(var_one, var_two,
-   var_three, var_four)
-meal = (spam,
-   beans)
-
-# 2-space hanging indent forbidden
-foo = long_function_name(
- var_one, var_two, var_three,
- var_four)
-
-# No hanging indent in a dictionary
-foo = {
-   long_dictionary_key:
-   long_dictionary_value,
-   ...
-}
-```
-
-<a id="s3.3-blank-lines"></a>
-<a id="33-blank-lines"></a>
-<a id="blank-lines"></a>
-### 3.3 Blank Lines 
-
-Two blank lines between top-level definitions, be they function or class
-definitions. One blank line between method definitions and between the `class`
-line and the first method. No blank line following a `def` line. Use single
-blank lines as you judge appropriate within functions or methods.
-
-<a id="s3.4-whitespace"></a>
-<a id="34-whitespace"></a>
-<a id="whitespace"></a>
-### 3.4 Whitespace 
-
-Follow standard typographic rules for the use of spaces around punctuation.
-
-No whitespace inside parentheses, brackets or braces.
-
-```python
-# Correct: 
-spam(ham[1], {eggs: 2}, [])
-```
-
-```python
-# Wrong:
-spam( ham[ 1 ], { eggs: 2 }, [ ] )
-```
-
-No whitespace before a comma, semicolon, or colon. Do use whitespace after a
-comma, semicolon, or colon, except at the end of the line.
-
-```python
-# Correct: 
-if x == 4:
-     print(x, y)
- x, y = y, x
-```
-
-```python
-# Wrong:
-if x == 4 :
-     print(x , y)
- x , y = y , x
-```
-
-No whitespace before the open paren/bracket that starts an argument list,
-indexing or slicing.
-
-```python
-# Correct: 
-spam(1)
-```
-
-```python
-# Wrong:
-spam (1)
-```
-
-```python
-# Correct: 
-dict['key'] = list[index]
-```
-
-```python
-# Wrong:
-dict ['key'] = list [index]
-```
-
-No trailing whitespace.
-
-Surround binary operators with a single space on either side for assignment
-(`=`), comparisons (`==, <, >, !=, <>, <=, >=, in, not in, is, is not`), and
-Booleans (`and, or, not`). Use your better judgment for the insertion of spaces
-around arithmetic operators (`+`, `-`, `*`, `/`, `//`, `%`, `**`, `@`).
-
-```python
-# Correct: 
-x == 1
-```
-
-```python
-# Wrong:
-x<1
-```
-
-Never use spaces around `=` when passing keyword arguments or defining a default
-parameter value, with one exception:
-when a type annotation is present, _do_ use spaces
-around the `=` for the default parameter value.
-
-```python
-# Correct:
-def complex(real, imag=0.0): return Magic(r=real, i=imag)
-def complex(real, imag: float = 0.0): return Magic(r=real, i=imag)
-```
-
-```python
-# Wrong:
-def complex(real, imag = 0.0): return Magic(r = real, i = imag)
-def complex(real, imag: float=0.0): return Magic(r = real, i = imag)
-```
-
-Don't use spaces to vertically align tokens on consecutive lines, since it
-becomes a maintenance burden (applies to `:`, `#`, `=`, etc.):
-
-```python
-# Correct:
-foo = 1000  # comment
-long_name = 2  # comment that should not be aligned
-
-dictionary = {
-    'foo': 1,
-    'long_name': 2
-}
-```
-
-```python
-# Wrong:
-foo       = 1000  # comment
-long_name = 2     # comment that should not be aligned
-
-dictionary = {
-    'foo'      : 1,
-    'long_name': 2
-}
-```
-
-<a id="s3.5-comments-and-docstrings"></a>
-<a id="35-comments-and-docstrings"></a>
+<a id="s4.1-comments-and-docstrings"></a>
+<a id="41-comments-and-docstrings"></a>
 <a id="comments-and-docstrings"></a>
-### 3.5 Comments and Docstrings 
+### 4.1 Comments and Docstrings
 
 Be sure to use the right style for module, function, method docstrings and
 inline comments.
 
-<a id="s3.5.1-modules"></a>
-<a id="351-modules"></a>
+<a id="s4.1.1-modules"></a>
+<a id="411-modules"></a>
 <a id="modules"></a>
-#### 3.5.1 Modules 
+#### 1.1.1 Modules
 
 Every file should contain a license boilerplate.
 
@@ -539,10 +305,10 @@ Every file should contain a license boilerplate.
 """
 ```
 
-<a id="s3.5.2-functions-and-methods"></a>
-<a id="352-functions-and-methods"></a>
+<a id="s4.1.2-functions-and-methods"></a>
+<a id="412-functions-and-methods"></a>
 <a id="functions-and-methods"></a>
-#### 3.5.2 Functions and Methods 
+#### 4.1.2 Functions and Methods
 
 In this section, "function" means a method, function, or generator.
 
@@ -562,23 +328,23 @@ def load_state(model: torch.nn.Module, state_dict_to_load: dict, is_resume: bool
 
     :param model: The target module for the state_dict_to_load to be loaded to.
     :param state_dict_to_load: A state dict containing the parameters to be loaded into the model.
-    :param is_resume: Determines the behavior when the function cannot do a successful parameter 
-        match when loading. If True, the function will raise an exception if it cannot match 
-        the state_dict_to_load parameters to the model's parameters (i.e. if some parameters required 
-        by model are missing in state_dict_to_load, or if state_dict_to_load has parameters that 
-        could not be matched to model parameters, or if the shape of parameters is not matching). 
-        If False, the exception won't be raised. Usually is_resume is specified as False when loading 
-        uncompressed model's weights into the model with compression algorithms already applied, and 
-        as True when loading a compressed model's weights into the model with compression algorithms 
+    :param is_resume: Determines the behavior when the function cannot do a successful parameter
+        match when loading. If True, the function will raise an exception if it cannot match
+        the state_dict_to_load parameters to the model's parameters (i.e. if some parameters required
+        by model are missing in state_dict_to_load, or if state_dict_to_load has parameters that
+        could not be matched to model parameters, or if the shape of parameters is not matching).
+        If False, the exception won't be raised. Usually is_resume is specified as False when loading
+        uncompressed model's weights into the model with compression algorithms already applied, and
+        as True when loading a compressed model's weights into the model with compression algorithms
         applied to evaluate the model.
     :return: The number of state_dict_to_load entries successfully matched and loaded into model.
     """
 ```
 
-<a id="s3.5.3-classes"></a>
-<a id="353-classes"></a>
+<a id="s4.1.3-classes"></a>
+<a id="413-classes"></a>
 <a id="classes"></a>
-#### 3.5.3 Classes 
+#### 4.1.3 Classes
 
 Classes should have a docstring below the class definition describing the class. If your class
 has public attributes, they should be documented here follow the same formatting as a function's
@@ -612,8 +378,8 @@ class ModelTransformer:
 ```
 
 The `__init__` function and other magic methods in non-API classes may be left without a textual description,
-if there is nothing special about this exact implementation of the magic method 
-(i.e. the function has no notable side effects, the implementation is done in a conventional way such as 
+if there is nothing special about this exact implementation of the magic method
+(i.e. the function has no notable side effects, the implementation is done in a conventional way such as
 hashing all fields as a tuple in `__hash__` or concatenating string-like objects in `__add__` etc.)
 
 For instance, this simple `__init__` method may omit the method description in the docstring (the parameter description is, however, still required):
@@ -640,10 +406,10 @@ class ComplexKlass(BaseClass):
         Each instantiation of an object of this class leads to a side effect in ... (explain side effect)
         If *this* and *that*, the object creation will fail with a RuntimeError.
         *... and other noteworthy stuff happening in this method.*
-        
+
         :param param1: Description of param1
         :param param2: Description of param2
-        
+
         :raises RuntimeError if *this* and *that*
         """
         super().__init__(param1)
@@ -659,13 +425,13 @@ class ComplexKlass(BaseClass):
         # ... potentially more code which is not understandable at a glance
 ```
 
-<a id="s3.5.4-block-and-inline-comments"></a>
-<a id="354-block-and-inline-comments"></a>
+<a id="s4.1.4-block-and-inline-comments"></a>
+<a id="414-block-and-inline-comments"></a>
 <a id="block-and-inline-comments"></a>
-#### 3.5.4 Block and Inline Comments 
+#### 4.1.4 Block and Inline Comments
 
-The final place to have comments is in tricky parts of the code. If you're going to have to explain it 
-in the future, you should comment it now. Complicated operations get a few lines of comments before 
+The final place to have comments is in tricky parts of the code. If you're going to have to explain it
+in the future, you should comment it now. Complicated operations get a few lines of comments before
 the operations commence. Non-obvious ones get comments at the end of the line.
 
 ```python
@@ -689,36 +455,38 @@ knows Python (though not what you're trying to do) better than you do.
 # the next element is i+1
 ```
 
-<a id="s3.6-strings"></a>
-<a id="36-strings"></a>
+<a id="s4.2-strings"></a>
+<a id="42-strings"></a>
 <a id="strings"></a>
-### 3.6 Strings 
+### 4.2 Strings
 
-Use `'something'` instead of `"something"`
 
 ```python
 # Correct:
 
-long_string = '''This is fine if your use case can accept
-    extraneous leading spaces.'''
+long_string = """This is fine if your use case can accept
+    extraneous leading spaces."""
 
-long_string = ('And this is fine if you cannot accept\n' +
-               'extraneous leading spaces.')
+long_string = (
+    "And this too is fine if you cannot accept\n"
+    "extraneous leading spaces."
+)
 
-long_string = ('And this too is fine if you cannot accept\n'
-               'extraneous leading spaces.')
 
 import textwrap
 
-long_string = textwrap.dedent('''\
+long_string = textwrap.dedent(
+    """
     This is also fine, because textwrap.dedent()
-    will collapse common leading spaces in each line.''')
+    will collapse common leading spaces in each line.
+    """
+)
 ```
 
-<a id="s3.7-logging"></a>
-<a id="37-logging"></a>
+<a id="s4.3-logging"></a>
+<a id="43-logging"></a>
 <a id="logging"></a>
-### 3.7 Logging 
+### 4.3 Logging
 Use the logger object built into NNCF for all purposes of logging within the NNCF package code.
 Do not use `print(...)` or other ways of output.
 
@@ -777,10 +545,10 @@ At all log levels the log lines should not be duplicated during execution, if po
 For deprecation warnings, use `nncf.common.logging.logger.warning_deprecated` instead of the regular `nncf_logger.warning`.
 This ensures that the deprecation warning is seen to the user at all NNCF log levels.
 
-<a id="s3.8-error-messages"></a>
-<a id="38-error-messages"></a>
+<a id="s4.4-error-messages"></a>
+<a id="44-error-messages"></a>
 <a id="error-messages"></a>
-### 3.8 Error Messages 
+### 4.4 Error Messages
 
 Error messages (such as: message strings on exceptions like `ValueError`, or
 messages shown to the user) should follow guidelines:
@@ -788,10 +556,10 @@ messages shown to the user) should follow guidelines:
 - Interpolated pieces need to always be clearly identifiable as such.
 - The message should start with a capital letter.
 
-<a id="s3.9-todo-comments"></a>
-<a id="39-todo-comments"></a>
+<a id="s4.5-todo-comments"></a>
+<a id="45-todo-comments"></a>
 <a id="todo-comments"></a>
-### 3.9 TODO Comments 
+### 4.5 TODO Comments
 
 Use `TODO` comments for code that is temporary, a short-term solution, or
 good-enough but not perfect.
@@ -816,10 +584,10 @@ If your `TODO` is of the form "At a future date do something" make sure that you
 either include a very specific date ("Fix by November 2030") or a very specific
 event ("Remove this code when all clients can handle XML responses.").
 
-<a id="s3.10-naming"></a>
-<a id="310-naming"></a>
+<a id="s4.6-naming"></a>
+<a id="46-naming"></a>
 <a id="naming"></a>
-### 3.10 Naming 
+### 4.6 Naming
 
 `module_name`, `package_name`, `ClassName`, `method_name`, `ExceptionName`,
 `function_name`, `GLOBAL_CONSTANT_NAME`, `global_var_name`, `instance_var_name`,
@@ -911,10 +679,10 @@ Always use a `.py` filename extension. Never use dashes.
 
 </table>
 
-<a id="s3.10.1-names-to-avoid"></a>
-<a id="3101-names-to-avoid"></a>
+<a id="s4.6.1-names-to-avoid"></a>
+<a id="461-names-to-avoid"></a>
 <a id="names-to-avoid"></a>
-#### 3.10.1 Names to Avoid 
+#### 4.6.1 Names to Avoid
 
 -   single character names, except for specifically allowed cases:
     -   counters or iterators (e.g. `i`, `j`, `k`, `v`, et al.)
@@ -930,10 +698,10 @@ Always use a `.py` filename extension. Never use dashes.
 -   names that needlessly include the type of the variable (for example:
     `id_to_name_dict`)
 
-<a id="s3.10.2-naming-conventions"></a>
-<a id="3102-naming-convention"></a>
+<a id="s4.6.2-naming-conventions"></a>
+<a id="462-naming-convention"></a>
 <a id="naming-conventions"></a>
-#### 3.10.2 Naming Conventions 
+#### 4.6.2 Naming Conventions
 
 -   "Internal" means internal to a module, or protected or private within a
     class.
@@ -949,26 +717,26 @@ Always use a `.py` filename extension. Never use dashes.
 -   Use the word "layer" (instead of "module") in the `nncf.common` module to
     refer to the building block of neural networks.
 
-<a id="s3.10.3-framework-specific-class-naming"></a>
-<a id="3103-framework-specific-class-naming"></a>
+<a id="s4.6.3-framework-specific-class-naming"></a>
+<a id="463-framework-specific-class-naming"></a>
 <a id="framework-specific-class-naming"></a>
-#### 3.10.3 Framework specific class naming 
+#### 4.6.3 Framework specific class naming
 
 - `PTClassName` for Torch
 - `TFClassName` for TensorFlow
 
-<a id="s3.10.4-file-naming"></a>
-<a id="3104-file-naming"></a>
+<a id="s4.6.4-file-naming"></a>
+<a id="464-file-naming"></a>
 <a id="file-naming"></a>
-#### 3.10.4 File Naming 
+#### 4.6.4 File Naming
 
 Python filenames must have a `.py` extension and must not contain dashes (`-`).
 This allows them to be imported and unit tested.
 
-<a id="s3.11-main"></a>
-<a id="311-main"></a>
+<a id="s4.7-main"></a>
+<a id="4.7-main"></a>
 <a id="main"></a>
-### 3.11 Main 
+### 4.7 Main
 
 ```python
 def main():

--- a/docs/styleguide/PyGuide.md
+++ b/docs/styleguide/PyGuide.md
@@ -286,7 +286,7 @@ inline comments.
 <a id="s4.1.1-modules"></a>
 <a id="411-modules"></a>
 <a id="modules"></a>
-#### 1.1.1 Modules
+#### 4.1.1 Modules
 
 Every file should contain a license boilerplate.
 

--- a/docs/styleguide/PyGuide.md
+++ b/docs/styleguide/PyGuide.md
@@ -10,10 +10,10 @@
     *   [3.2 3rd party packages](#s3.2-3rd-party-packages)
     *   [3.3 Global variables](#s3.3-global-variables)
     *   [3.4 Nested/Local/Inner Classes and Functions](#s3.4-nested)
-    *   [3.6 Default Iterators and Operators](#s3.4-default-iterators-and-operators)
-    *   [3.7 Type Annotated Code](#s3.4-type-annotated-code)
-    *   [3.8 Files and Sockets](#3.4-files-and-sockets)
-    *   [3.9 Abstract Classes](#3.4-abstract-classes)
+    *   [3.5 Default Iterators and Operators](#s3.5-default-iterators-and-operators)
+    *   [3.6 Type Annotated Code](#s3.6-type-annotated-code)
+    *   [3.7 Files and Sockets](#s3.7-files-and-sockets)
+    *   [3.8 Abstract Classes](#s3.8-abstract-classes)
 -   [4 Python Style Rules](#s4-python-style-rules)
     *   [4.1 Comments and Docstrings](#s4.1-comments-and-docstrings)
         +   [4.1.1 Modules](#s4.1.1-modules)
@@ -103,7 +103,7 @@ Run [pylint](https://github.com/PyCQA/pylint) over your code using this [pylintr
   - *Exception*: Suppress the warning if they are inappropriate so that other issues are not hidden.
     To suppress warnings you can set a line-level comment
     ```python
-    dict = 'something awful'  # Bad Idea... pylint: disable=redefined-builtin
+    dict = "something awful"  # Bad Idea... pylint: disable=redefined-builtin
     ```
     or update [pylintrc](../../.pylintrc) if applicable for the whole project. If the reason for the suppression
     is not clear from the symbolic name, add an explanation.
@@ -513,14 +513,14 @@ import nncf
 from nncf.common.logging import nncf_logger
 
 # OK:
-nncf_logger.info('Test message: %s', nncf.__version__)
+nncf_logger.info("Test message: %s", nncf.__version__)
 
 # Also OK:
-nncf_logger.info(f'Test message: {nncf.__version__}')
+nncf_logger.info(f"Test message: {nncf.__version__}")
 
 # Probably not OK:
 for i in range(1000000):
-    nncf_logger.info(f'Test message: {sum(range(10000000))}')
+    nncf_logger.info(f"Test message: {sum(range(10000000))}")
 ```
 
 Use proper logging levels (https://docs.python.org/3/library/logging.html#logging-levels) when printing out a message to the logger.
@@ -742,6 +742,6 @@ This allows them to be imported and unit tested.
 def main():
     ...
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
 ```

--- a/docs/styleguide/PyGuide.md
+++ b/docs/styleguide/PyGuide.md
@@ -60,7 +60,20 @@ pre-commit run -a  # Check and format all files
 
 Also recommend configuring your IDE to run Black and isort tools automatically when saving files.
 
-Automatic code formatting is mandatory for all Python files, but you can disable it for specific cases if required.
+Automatic code formatting is mandatory for all Python files, but you can disable it for specific cases if required:
+  - if you need a specialized order of importing modules;
+  - for large data structures for which autoformatting unnecessarily breaks into lines,
+    e.g. reference data in tests or a list of classes;
+  - for structures for which formatting helps understanding, such as matrix.
+
+Example for 'isort':
+
+```python
+import c
+# isort: off
+import b
+import a
+```
 
 Example for 'black':
 
@@ -76,14 +89,6 @@ arr2 = [
   0, 1,
 ]
 # fmt: on
-```
-Example for 'isort':
-
-```python
-import c
-# isort: off
-import b
-import a
 ```
 
 <a id="s3-python-language-rules"></a>


### PR DESCRIPTION
### Changes

Update PyGuide.md
 - added `Automating Code Formatting` paragraph 
 - removed paragraphs about code style that will be auto-formatted by 'black' and 'isort'

 
### Reason for changes

https://github.com/openvinotoolkit/nncf/pull/1692

### Related tickets

CVS-74733


