### PR TITLE
Remove debuggable forward decorator

### DIFF
--- a/nncf/torch/debug.py
+++ b/nncf/torch/debug.py
@@ -10,6 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+import functools
 from typing import List, Dict
 
 from torch.nn import Module
@@ -62,6 +63,7 @@ class DebugInterface:
 
 
 def debuggable_forward(forward_func):
+    @functools.wraps(forward_func)
     def decorated(self: 'NNCFNetwork', *args, **kwargs):
         if hasattr(self, 'nncf') and self.nncf.debug_interface is not None:
             self.nncf.debug_interface.pre_forward_actions(module=self)

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -771,6 +771,8 @@ class NNCFNetworkMeta(type):
                                          fn.__defaults__, fn.__closure__)
         new_forward.__dict__.update(fn.__dict__)
         new_forward.__signature__ = inspect.signature(original_class.forward)
+        if is_debug():
+            new_forward = debuggable_forward(new_forward)
         new_class.forward = new_forward
 
         # Make resulting class keep __module__ attributes of the original class,
@@ -835,7 +837,6 @@ class NNCFNetwork(torch.nn.Module, metaclass=NNCFNetworkMeta):
         """
         return self.forward(*args, **kwargs)
 
-    @debuggable_forward
     def forward(self, *args, **kwargs):
         """
         Wraps the original forward call, doing additional actions before and after the call to facilitate model


### PR DESCRIPTION
### Changes
The `@debuggable_forward` decorator was removed from the `NNCFNetwork.forward` function and applied elsewhere.

### Reason for changes
Removing extra layers of decoration from the original method.

### Related tickets
N/A

### Tests
`tests.torch.quantization.test_algo_quantization.test_debug_mode`
