### PR TITLE
Corrected incorrect import to restore nightly tests

### DIFF
--- a/nncf/experimental/common/pruning/block_hierarchy.py
+++ b/nncf/experimental/common/pruning/block_hierarchy.py
@@ -17,7 +17,7 @@ from typing import List
 
 import networkx as nx
 from nncf.common.utils.dot_file_rw import write_dot_graph
-from nncf.experimental.common.pruning.nodes_grouping import PropagationGroup
+from nncf.experimental.common.pruning.propagation_data import PropagationGroup
 
 
 class BlockHierarchy:

--- a/nncf/experimental/common/pruning/operations.py
+++ b/nncf/experimental/common/pruning/operations.py
@@ -35,10 +35,10 @@ from nncf.common.logging import nncf_logger
 from nncf.common.pruning.tensor_processor import NNCFPruningBaseTensorProcessor
 from nncf.common.pruning.utils import get_input_masks
 from nncf.common.pruning.utils import identity_mask_propagation
-from nncf.experimental.common.pruning.nodes_grouping import PropagationGroup
 from nncf.experimental.common.pruning.nodes_grouping import PruningBlock
 from nncf.experimental.common.pruning.nodes_grouping import PropagationMask
 from nncf.experimental.common.pruning.propagation_data import ConsumerInfo
+from nncf.experimental.common.pruning.propagation_data import PropagationGroup
 
 
 class BasePruningOp:


### PR DESCRIPTION
### Changes

`PropagationGroup` is imported directly

### Reason for changes

degradation in ONNX install tests

### Related tickets

n/a

### Tests

install_tests
nightly onnx install build 87 - ✅ 