### PR TITLE
[PTQ][OV] Fix rank zero output tensor for inplace statistics

### DIFF
--- a/nncf/experimental/openvino_native/graph/node_utils.py
+++ b/nncf/experimental/openvino_native/graph/node_utils.py
@@ -138,7 +138,7 @@ def get_reduce_node_name(output_name: str, node_type: str, port_id: int) -> str:
     return f'{output_name}_{node_type}.{port_id}'
 
 
-def get_inplace_reduce_op(op: Type[ov.Node], node_type: str, reduction_axes: Tuple[int, ...],
+def get_inplace_reduce_op(op: Type[ov.Node], node_type: str, reduction_axes: Optional[Tuple[int, ...]],
                           use_abs: bool) -> InplaceInsertionFnType:
     """
     Returns inplace insertion function that adds reduce node to a passed node.
@@ -155,7 +155,7 @@ def get_inplace_reduce_op(op: Type[ov.Node], node_type: str, reduction_axes: Tup
         name_output_port_id = output_port_id
         if reduction_axes_ is None:
             partial_shape = get_partial_shape_safe(node, output_port_id)
-            reduction_axes_ = np.array(range(partial_shape.rank.get_length()))
+            reduction_axes_ = np.arange(partial_shape.rank.get_length()).astype(np.int64)
 
         if use_abs:
             op_input = opset.abs(node.output(output_port_id),

--- a/nncf/experimental/openvino_native/statistics/collectors.py
+++ b/nncf/experimental/openvino_native/statistics/collectors.py
@@ -97,8 +97,6 @@ class OVNNCFCollectorTensorProcessor(NNCFCollectorTensorProcessor):
         return np.sum(tensor.tensor)
 
 
-
-
 class OVNoopReducer(NoopReducer):
     def get_output_name(self, target_node_name: str, port_id: int) -> str:
         return get_result_node_name(target_node_name, port_id)

--- a/tests/openvino/native/models.py
+++ b/tests/openvino/native/models.py
@@ -599,3 +599,14 @@ class SeBlockModel(OVReferenceModel):
         result_1 = opset.result(matmul, name="Result")
         model = ov.Model([result_1], [input_1])
         return model
+
+
+class ZeroRankEltwiseModel(OVReferenceModel):
+    def _create_ov_model(self):
+        input_shape = [1, 3, 5, 6]
+
+        input_1 = opset.parameter(input_shape, name="Input")
+        add = opset.add(input_1, np.array(1., dtype=np.float32), name="Add")
+        result_1 = opset.result(add, name="Result")
+        model = ov.Model([result_1], [input_1])
+        return model

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -41,6 +41,7 @@ from tests.openvino.native.models import ConvModel
 from tests.openvino.native.models import FPModel
 from tests.openvino.native.models import QuantizedModel
 from tests.openvino.native.models import SimpleSplitModel
+from tests.openvino.native.models import ZeroRankEltwiseModel
 from tests.openvino.native.common import compare_nncf_graphs
 from tests.openvino.conftest import OPENVINO_NATIVE_TEST_ROOT
 
@@ -160,6 +161,9 @@ def check_inplace_op(target_node, ref_types, ref_vals, inplace_branches_num,
         assert node.type_info.name == t
         if ref_val is not None:
             const = get_prev_node(node, 1)
+            if not len(ref_val):
+                assert const.get_data().shape == (0,)
+                continue
             res = np.equal(const.get_data(), np.array(ref_val))
             assert all(res)
 
@@ -252,6 +256,24 @@ def test_inplace_reduce_fn_dynamic_shapes(input_shape, raise_error):
     # check_const
     ref_const = np.array([0, 1, 2, 3])
     assert all(np.equal(get_prev_node(op, 1).get_data(), ref_const))
+
+
+@pytest.mark.parametrize('reduction_shape', [None, np.array([], dtype=np.int64)])
+def test_inplace_reduce_fn_zero_rank_output(reduction_shape):
+    model = ZeroRankEltwiseModel().ov_model
+    target_layer = 'Add'
+    port_id = 1
+    name = 'min'
+    transformed_model = create_transformed_model(
+        model, [target_layer], TargetType.OPERATION_WITH_WEIGHTS, OVInplaceFnInsertionCommand,
+        port_id=port_id, inplace_op_fn=get_inplace_min_op(name, reduction_shape=reduction_shape),
+        fn_output_port_id=0)
+    target_node = get_prev_node(get_node_by_name(transformed_model, target_layer), 1)
+    check_inplace_op(target_node, ['ReduceMin'], [[]], 1, 0)
+    extra_outputs = get_extra_outputs(model, transformed_model)
+    ref_output_name = get_result_node_name(get_reduce_node_name(target_node.get_friendly_name(), name, 0), 0)
+    assert len(extra_outputs) == 1
+    assert extra_outputs.pop() == ref_output_name
 
 
 DYNAMIC_SHAPE_TEST_CASES = [

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -161,11 +161,11 @@ def check_inplace_op(target_node, ref_types, ref_vals, inplace_branches_num,
         assert node.type_info.name == t
         if ref_val is not None:
             const = get_prev_node(node, 1)
-            if not len(ref_val):
+            if ref_val == []:
                 assert const.get_data().shape == (0,)
-                continue
-            res = np.equal(const.get_data(), np.array(ref_val))
-            assert all(res)
+            else:
+                res = np.equal(const.get_data(), np.array(ref_val))
+                assert all(res)
 
         nodes = get_next_nodes(node, 0)
         assert len(nodes) == 1

--- a/tests/post_training/test_quantize_conformance.py
+++ b/tests/post_training/test_quantize_conformance.py
@@ -371,7 +371,6 @@ def ov_runner(model, calibration_dataset,
         return images.numpy()
 
     ov_calibration_dataset = nncf.Dataset(batch_one_dataloader, ov_transform_fn)
-
     ov_model_path = output_folder / (model_name + '.xml')
     core = ov.Core()
     ov_model = core.read_model(ov_model_path)


### PR DESCRIPTION
### Changes

Nodes with zero output ranks raised runtime error because empty `np.array` has `np.float` type and openvino reduction operations require `np.int64`. Now case `rank==0` works as expected.

### Reason for changes

To fix runtime error during statistic collection for models with nodes with target quantize nodes that have `rank==0` output.

### Related tickets

108784

### Tests

New test in openvino `test_model_transformer.py` that checks corner case with a target point node that has `rank==0` output.
