### PR TITLE
Bump pandas 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ INSTALL_REQUIRES = ["ninja>=1.10.0.post2, <1.11",
                     "jstyleson>=0.0.2",
                     "tqdm>=4.54.1",
                     "natsort>=7.1.0",
-                    "pandas>=1.1.5,<=1.5.2",
+                    "pandas>=1.1.5,<=2.0",
                     "scikit-learn>=0.24.0",
                     "openvino-telemetry"]
 


### PR DESCRIPTION
### Changes

Allow for `pandas<=2.0`

### Reason for changes

Current pandas version is causing conflicts in OpenVINO CI jobs on https://github.com/openvinotoolkit/openvino/pull/17117

### Related tickets

NA
