### PR TITLE
Tenserflow: use set_hard_limit_num_open_files() only on Linux platform

### DIFF
--- a/examples/tensorflow/common/utils.py
+++ b/examples/tensorflow/common/utils.py
@@ -16,10 +16,10 @@ import time
 import datetime
 import json
 import os
+import sys
 import tarfile
 
 import numpy as np
-import resource
 from os import path as osp
 from pathlib import Path
 import atexit
@@ -136,8 +136,10 @@ def get_saving_parameters(config):
 
 
 def set_hard_limit_num_open_files():
-    _, high = resource.getrlimit(resource.RLIMIT_NOFILE)
-    resource.setrlimit(resource.RLIMIT_NOFILE, (high, high))
+    if "linux" in sys.platform:
+        import resource
+        _, high = resource.getrlimit(resource.RLIMIT_NOFILE)
+        resource.setrlimit(resource.RLIMIT_NOFILE, (high, high))
 
 
 def set_memory_growth(devices):

--- a/examples/tensorflow/common/utils.py
+++ b/examples/tensorflow/common/utils.py
@@ -16,9 +16,7 @@ import time
 import datetime
 import json
 import os
-import sys
 import tarfile
-
 import numpy as np
 from os import path as osp
 from pathlib import Path
@@ -30,6 +28,7 @@ from tensorflow.python.distribute.mirrored_strategy import MirroredStrategy
 from examples.tensorflow.common.logger import logger as default_logger
 from examples.common.sample_config import CustomArgumentParser
 from nncf.config.schemata.defaults import QUANTIZATION_BITS
+from nncf.common.utils.os import is_linux
 
 GENERAL_LOG_FILE_NAME = "output.log"
 NNCF_LOG_FILE_NAME = "nncf_output.log"
@@ -136,7 +135,7 @@ def get_saving_parameters(config):
 
 
 def set_hard_limit_num_open_files():
-    if "linux" in sys.platform:
+    if is_linux():
         import resource
         _, high = resource.getrlimit(resource.RLIMIT_NOFILE)
         resource.setrlimit(resource.RLIMIT_NOFILE, (high, high))


### PR DESCRIPTION
### Changes

Tenserflow: use set_hard_limit_num_open_files() only on Linux platform

### Reason for changes

There is no "resource" package for Win32

### Related tickets

107218

### Tests

Windows and Linux precommits 
