### PR TITLE
[PTQ][Tests] Add model reshape to calibrate.py

### DIFF
--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -281,7 +281,7 @@ def get_partial_shape_safe(node, port_id) -> int:
     partial_shape = node.get_output_partial_shape(port_id)
     if partial_shape.rank.is_dynamic or not partial_shape.all_non_negative:
         raise RuntimeError(
-            f"Could not collect statistics for the node {node}" f"because its output shape rank is dynamic or negative"
+            f"Could not collect statistics for the node {node} because its output shape rank is dynamic or negative"
         )
     return partial_shape
 

--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -599,6 +599,7 @@ def get_allow_reshape_input(accuracy_checker_config) -> bool:
     return False
 
 
+# pylint:disable=too-many-branches
 def maybe_reshape_model(model, dataset, subset_size):
     dataset_inputs_shapes = defaultdict(set)
     for input_dict in islice(dataset.get_inference_data(), subset_size):


### PR DESCRIPTION
### Changes

`allow_reshape_input` Accuracy checker param now emulated in `calibrate.py`

### Reason for changes

To enable models that require reshape or dynamic shapes before inference on a calibration  dataset

### Related tickets

108977

### Tests
Checked locally on bert-base-cased, fbcnn and human-pose-estimation
TODO

- [x] Check on all models with `allow_reshape_input`  param in ACConfig