### PR TITLE
Replaced openvino-dev to openvino in required dependencies of nncf[openvino]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,11 @@ test-install-onnx:
 install-openvino-test:
 	pip install -U pip
 	pip install -e .[openvino]
-	pip install git+https://github.com/openvinotoolkit/open_model_zoo.git#subdirectory=tools/model_tools
 	pip install -r tests/openvino/requirements.txt
 	pip install -r tests/cross_fw/install/requirements.txt
 	pip install -r examples/experimental/openvino/bert/requirements.txt
 	pip install -r examples/experimental/openvino/yolo_v5/requirements.txt
+	pip install git+https://github.com/openvinotoolkit/open_model_zoo.git#subdirectory=tools/model_tools
 
 install-openvino-dev: install-openvino-test
 	pip install pylint==$(PYLINT_VERSION)

--- a/nncf/__init__.py
+++ b/nncf/__init__.py
@@ -39,7 +39,6 @@ except ImportError:
 
 try:
     import openvino.runtime as ov_runtime
-    import openvino.tools.pot as ov_pot
 except ImportError:
     _LOADED_FRAMEWORKS["openvino"] = False
 

--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 from copy import deepcopy
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
@@ -20,10 +21,6 @@ from nncf.common.quantization.structs import QuantizationPreset
 from nncf.common.utils.backend import get_backend
 from nncf.common.utils.timer import timer
 from nncf.data import Dataset
-from nncf.openvino.pot.quantization.quantize_model import quantize_impl as pot_quantize_impl
-from nncf.openvino.pot.quantization.quantize_model import (
-    quantize_with_accuracy_control_impl as pot_quantize_with_accuracy_control_impl,
-)
 from nncf.openvino.quantization.backend_parameters import BackendParameters
 from nncf.openvino.quantization.backend_parameters import is_weight_compression_needed
 from nncf.parameters import ModelType
@@ -48,10 +45,24 @@ def should_use_pot(advanced_parameters: Optional[AdvancedQuantizationParameters]
 
     :param advanced_parameters: Advanced quantization parameters.
     :return: True if POT should be used, False otherwise.
+    :raises ImportError if POT is not found in the Python environment.
     """
-    if advanced_parameters is None:
-        return USE_POT_AS_DEFAULT
-    return advanced_parameters.backend_params.get(BackendParameters.USE_POT, USE_POT_AS_DEFAULT)
+    use_pot = USE_POT_AS_DEFAULT
+    if advanced_parameters is not None:
+        use_pot = advanced_parameters.backend_params.get(BackendParameters.USE_POT, USE_POT_AS_DEFAULT)
+
+    if not use_pot:
+        return False
+
+    try:
+        importlib.import_module("openvino.tools.pot")
+    except ImportError:
+        nncf_logger.error(
+            "OpenVINO POT was not found in your Python environment.\n"
+            "Please install the openvino-dev package, e.g. via pypi: pip install openvino-dev.\n"
+        )
+
+    return True
 
 
 def dump_parameters(model: ov.Model, parameters: Dict, path: Optional[List] = None) -> None:
@@ -238,6 +249,8 @@ def quantize_impl(
     Implementation of the `quantize()` method for the OpenVINO backend.
     """
     if should_use_pot(advanced_parameters):
+        from nncf.openvino.pot.quantization.quantize_model import quantize_impl as pot_quantize_impl
+
         quantize_fn = pot_quantize_impl
     else:
         quantize_fn = native_quantize_impl
@@ -274,6 +287,10 @@ def quantize_with_accuracy_control_impl(
     Implementation of the `quantize_with_accuracy_control()` method for the OpenVINO backend.
     """
     if should_use_pot(advanced_quantization_parameters):
+        from nncf.openvino.pot.quantization.quantize_model import (
+            quantize_with_accuracy_control_impl as pot_quantize_with_accuracy_control_impl,
+        )
+
         quantize_with_accuracy_control_fn = pot_quantize_with_accuracy_control_impl
     else:
         quantize_with_accuracy_control_fn = native_quantize_with_accuracy_control_impl

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ TORCH_EXTRAS = [
 
 ONNX_EXTRAS = ["onnx~=1.13.1", "onnxruntime~=1.14.1;python_version < '3.11'"]
 
-OPENVINO_EXTRAS = ["openvino-dev"]
+OPENVINO_EXTRAS = ["openvino"]
 
 
 EXTRAS_REQUIRE = {

--- a/tests/cross_fw/install/install_checks_openvino.py
+++ b/tests/cross_fw/install/install_checks_openvino.py
@@ -21,6 +21,7 @@ EXCLUDED_MODULES_PATTERNS = (
     ".*?onnx_[^\\.]*",
     ".*?torch_[^\\.]*",
     ".*?tf_[^\\.]*",
+    "nncf\\.openvino\\.pot.*",
 )
 
 load_nncf_modules(EXCLUDED_MODULES_PATTERNS)


### PR DESCRIPTION
### Changes

Replaced openvino-dev to openvino in required dependencies of nncf[openvino]

### Reason for changes

The OpenVINO backend migrated to the NGraph implementation that requires only openvino as dependency.

### Related tickets

N/A

### Tests
install_ov: 140
