### PR TITLE
[ReleaseV250] Remove redundant warning

### DIFF
--- a/nncf/quantization/algorithms/post_training/algorithm.py
+++ b/nncf/quantization/algorithms/post_training/algorithm.py
@@ -16,7 +16,6 @@ from typing import Dict, Optional, TypeVar
 import numpy as np
 
 from nncf import Dataset
-from nncf.common.logging import nncf_logger
 from nncf.common.quantization.structs import QuantizationPreset
 from nncf.common.tensor_statistics.aggregator import StatisticsAggregator
 from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
@@ -178,9 +177,6 @@ class PostTrainingQuantization(Algorithm):
         modified_model = copy_model(model)
         if statistic_points is None:
             backend = get_backend(modified_model)
-            # TODO (l-bat): Remove after OpenVINO Native is removed from experimental
-            if backend == BackendType.OPENVINO:
-                nncf_logger.warning("You are using experimental OpenVINO backend for the Post-training quantization.")
 
             statistics_aggregator = self._create_statistics_aggregator(dataset, backend)
             for algorithm in self.algorithms:


### PR DESCRIPTION
### Changes

Remove warning "You are using experimental OpenVINO backend for the Post-training quantization."

### Reason for changes

OpenVINO backend was removed from experimental

### Related tickets

https://github.com/openvinotoolkit/nncf/pull/1761

### Tests

N/A
