### PR TITLE
Fail informatively when compressing Torch models twice

### DIFF
--- a/nncf/torch/model_creation.py
+++ b/nncf/torch/model_creation.py
@@ -93,6 +93,18 @@ def create_compressed_model(
         is an instance of CompositeCompressionController) and the model ready for compression parameter training wrapped
         as an object of NNCFNetwork.
     """
+    if isinstance(model, NNCFNetwork):
+        raise RuntimeError(
+            "The model object has already been compressed.\n"
+            "NNCF for PyTorch modifies the model object in-place, and repeat calls to "
+            "`nncf.torch.create_compressed_model` with the same model object passed as argument "
+            "will lead to an incorrect attempt to compress the model twice.\n"
+            "Make sure that the model object you are passing has not already been compressed (for "
+            "instance, by testing `if isinstance(model, nncf.torch.nncf_network.NNCFNetwork)`).\n"
+            "If you are encountering this in a Jupyter notebook context - make sure that when "
+            "re-running cells involving `nncf.torch.create_compressed_model` the original model object "
+            "is also re-created (via constructor call)."
+        )
 
     set_debug_log_dir(config.get("log_dir", "."))
 

--- a/tests/torch/test_api_behavior.py
+++ b/tests/torch/test_api_behavior.py
@@ -15,6 +15,7 @@ from torch.utils.data import DataLoader
 
 from nncf import NNCFConfig
 from nncf.common.quantization.quantizer_setup import SingleConfigQuantizerSetup
+from nncf.torch import create_compressed_model
 from nncf.torch import register_default_init_args
 from nncf.torch.tensor_statistics.algo import TensorStatisticsCollectionBuilder
 from nncf.torch.tensor_statistics.algo import TensorStatisticsCollectionController
@@ -22,6 +23,7 @@ from tests.torch.helpers import BasicConvTestModel
 from tests.torch.helpers import OnesDatasetMock
 from tests.torch.helpers import TwoConvTestModel
 from tests.torch.helpers import create_compressed_model_and_algo_for_test
+from tests.torch.test_nncf_network import SimplestModel
 
 INPUT_SAMPLE_SIZE = [1, 1, 4, 4]
 CONFIG_WITH_ALL_INIT_TYPES = {
@@ -126,3 +128,11 @@ def test_model_is_inited_with_own_device_by_default(nncf_config_with_default_ini
         pytest.skip("Skipping for CPU-only setups")
     model = DeviceCheckingModel(original_device)
     create_compressed_model_and_algo_for_test(model, nncf_config_with_default_init_args)
+
+
+def test_repeat_compression_fails():
+    model = SimplestModel()
+    nncf_config = NNCFConfig.from_dict({"input_info": {"sample_size": SimplestModel.INPUT_SIZE}})
+    _ = create_compressed_model(model, nncf_config)
+    with pytest.raises(RuntimeError, match="The model object has already been compressed."):
+        _ = create_compressed_model(model, nncf_config)


### PR DESCRIPTION
### Changes
When running `nncf.torch.create_compressed_model` on one and the same object more than once (deliberately or not), raise an exception with an informative explanation of the situation.

### Reason for changes
Jupyter notebook users who re-run cells out of order may end up compressing models twice without knowing it. This functionality will prevent that outcome.

### Related tickets

109958

### Tests
tests.torch.test_api_behavior.test_repeat_compression_fails
