### PR TITLE
[ReleaseV250] Speedup test_quantize_conformance.py

### DIFF
--- a/tests/post_training/conftest.py
+++ b/tests/post_training/conftest.py
@@ -15,18 +15,30 @@ from abc import abstractclassmethod
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Dict
+from typing import Callable, Dict, Optional
 
 import numpy as np
 import pytest
 
 from tests.shared.paths import TEST_ROOT
 
+NOT_AVAILABLE_MESSAGE = "N/A"
+
 
 def pytest_addoption(parser):
     parser.addoption("--data", action="store")
     parser.addoption("--output", action="store", default="./tmp/")
     parser.addoption("--backends", action="store", default="TORCH,TORCH_PTQ,ONNX,OV_NATIVE,OV")
+    parser.addoption(
+        "--eval_fp32",
+        action="store_true",
+        help="Evaluation fp32 model, by defaults used cached metric.",
+    )
+    parser.addoption(
+        "--skip_bench",
+        action="store_true",
+        help="Skip the collection of performance statistics.",
+    )
 
 
 def pytest_configure(config):
@@ -44,8 +56,8 @@ class PipelineType(Enum):
 
 @dataclass
 class RunInfo:
-    top_1: float
-    FPS: float
+    top_1: Optional[float]
+    fps: Optional[float]
     status: str = None
 
 
@@ -66,28 +78,46 @@ class TableColumn:
         Is statistic applicable for given pipeline type.
 
         :param pipeline_type: Given pipeline type.
-        :returns: Eather given pipeline type applicable or not.
+        :returns: Either given pipeline type applicable or not.
         """
 
     @classmethod
     @abstractclassmethod
     def get_value(cls, info: Dict[PipelineType, RunInfo], target_pipeline_type: PipelineType) -> str:
         """
-        Metod describes how to retrieve column info out of RunInfo.
+        Method describes how to retrieve column info out of RunInfo.
 
-        :param info: Runinfo to retrive column info.
+        :param info: Runinfo to retrieve column info.
         :param target_pipeline_type: Target type of the pipeline.
         :returns: Column info.
         """
 
     @staticmethod
-    def assign_default_value(func):
+    def assign_default_value(func: Callable):
+        """
+        Return '-' for pipeline types that does not runs.
+        """
+
         def wrapped_get_value(cls, info: Dict[PipelineType, RunInfo], target_pipeline_type: PipelineType):
             if target_pipeline_type not in info:
                 return "-"
             return func(cls, info, target_pipeline_type)
 
         return wrapped_get_value
+
+    @staticmethod
+    def na_msg(func: Callable):
+        """
+        Replace return value of function from None to NOT_AVAILABLE_MESSAGE.
+        """
+
+        def wrapped_na_msg(*args, **kwargs):
+            result = func(*args, **kwargs)
+            if result is None:
+                return NOT_AVAILABLE_MESSAGE
+            return result
+
+        return wrapped_na_msg
 
 
 class Top1Column(TableColumn):
@@ -101,6 +131,7 @@ class Top1Column(TableColumn):
 
     @classmethod
     @TableColumn.assign_default_value
+    @TableColumn.na_msg
     def get_value(cls, info: Dict[PipelineType, RunInfo], target_pipeline_type: PipelineType) -> str:
         return info[target_pipeline_type].top_1
 
@@ -116,8 +147,9 @@ class FPSColumn(TableColumn):
 
     @classmethod
     @TableColumn.assign_default_value
+    @TableColumn.na_msg
     def get_value(cls, info: Dict[PipelineType, RunInfo], target_pipeline_type: PipelineType) -> str:
-        return info[target_pipeline_type].FPS
+        return info[target_pipeline_type].fps
 
 
 class Top1DiffColumn(TableColumn):
@@ -131,7 +163,10 @@ class Top1DiffColumn(TableColumn):
 
     @classmethod
     @TableColumn.assign_default_value
+    @TableColumn.na_msg
     def get_value(cls, info: Dict[PipelineType, RunInfo], target_pipeline_type: PipelineType) -> str:
+        if info[target_pipeline_type].top_1 is None or info[PipelineType.FP32].top_1 is None:
+            return None
         return info[PipelineType.FP32].top_1 - info[target_pipeline_type].top_1
 
 
@@ -146,10 +181,13 @@ class FPSSpeedupColumn(TableColumn):
 
     @classmethod
     @TableColumn.assign_default_value
+    @TableColumn.na_msg
     def get_value(cls, info: Dict[PipelineType, RunInfo], target_pipeline_type: PipelineType) -> str:
-        if info[PipelineType.FP32].FPS > 1e-5:
-            return info[target_pipeline_type].FPS / info[PipelineType.FP32].FPS
-        return "inf"
+        if info[target_pipeline_type].fps is None or info[PipelineType.FP32].fps is None:
+            return None
+        if info[PipelineType.FP32].fps > 1e-5:
+            return info[target_pipeline_type].fps / info[PipelineType.FP32].fps
+        return None
 
 
 class StatusColumn(TableColumn):
@@ -176,6 +214,16 @@ class StatusColumn(TableColumn):
 @pytest.fixture
 def backends_list(request):
     return request.config.getoption("--backends")
+
+
+@pytest.fixture
+def eval_fp32(request):
+    return request.config.getoption("--eval_fp32")
+
+
+@pytest.fixture
+def skip_bench(request):
+    return request.config.getoption("--skip_bench")
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -213,3 +261,4 @@ def pytest_runtest_makereport(item, call):
 
 PTQ_TEST_ROOT = TEST_ROOT / "post_training"
 FQ_CALCULATED_PARAMETERS_PATH = PTQ_TEST_ROOT / "data" / "fq_params" / "fq_params.json"
+MODELS_SCOPE_PATH = PTQ_TEST_ROOT / "model_scope.json"

--- a/tests/post_training/model_scope.json
+++ b/tests/post_training/model_scope.json
@@ -1,0 +1,232 @@
+{
+    "vgg11": {
+        "model_name": "vgg11",
+        "quantization_params": {},
+        "metrics": {
+            "FP32 top 1": 0.61246
+        }
+    },
+    "resnet18": {
+        "model_name": "resnet18",
+        "quantization_params": {},
+        "metrics": {
+            "FP32 top 1": 0.62734
+        }
+    },
+    "mobilenetv2_050": {
+        "model_name": "mobilenetv2_050",
+        "quantization_params": {
+            "preset": "MIXED"
+        },
+        "metrics": {
+            "FP32 top 1": 0.59498
+        }
+    },
+    "mobilenetv2_050_BC": {
+        "model_name": "mobilenetv2_050",
+        "quantization_params": {
+            "preset": "MIXED",
+            "fast_bias_correction": false
+        },
+        "metrics": {
+            "FP32 top 1": 0.59498
+        }
+    },
+    "densenet121": {
+        "skipped": "temporary excluded due to memory leaks",
+        "model_name": "densenet121",
+        "quantization_params": {
+            "fast_bias_correction": false
+        }
+    },
+    "densenet121_BC": {
+        "skipped": "temporary excluded due to memory leaks",
+        "model_name": "densenet121",
+        "quantization_params": {
+            "fast_bias_correction": false
+        }
+    },
+    "tf_inception_v3": {
+        "model_name": "tf_inception_v3",
+        "quantization_params": {
+            "preset": "MIXED"
+        },
+        "metrics": {
+            "FP32 top 1": 0.75948
+        }
+    },
+    "xception": {
+        "model_name": "xception",
+        "quantization_params": {
+            "preset": "MIXED"
+        },
+        "metrics": {
+            "FP32 top 1": 0.77522
+        }
+    },
+    "efficientnet_b0": {
+        "model_name": "efficientnet_b0",
+        "quantization_params": {
+            "preset": "MIXED"
+        },
+        "metrics": {
+            "FP32 top 1": 0.72912
+        }
+    },
+    "efficientnet_b0_BC": {
+        "model_name": "efficientnet_b0",
+        "quantization_params": {
+            "preset": "MIXED",
+            "fast_bias_correction": false
+        },
+        "metrics": {
+            "FP32 top 1": 0.72912
+        }
+    },
+    "darknet53": {
+        "model_name": "darknet53",
+        "quantization_params": {
+            "preset": "MIXED"
+        },
+        "metrics": {
+            "FP32 top 1": 0.7645
+        }
+    },
+    "resnest14d": {
+        "model_name": "resnest14d",
+        "quantization_params": {
+            "preset": "MIXED"
+        },
+        "metrics": {
+            "FP32 top 1": 0.70102
+        }
+    },
+    "inception_resnet_v2": {
+        "model_name": "inception_resnet_v2",
+        "quantization_params": {},
+        "metrics": {
+            "FP32 top 1": 0.78894
+        }
+    },
+    "wide_resnet50_2": {
+        "model_name": "wide_resnet50_2",
+        "quantization_params": {
+            "preset": "MIXED"
+        },
+        "metrics": {
+            "FP32 top 1": 0.7664
+        }
+    },
+    "regnetx_002": {
+        "model_name": "regnetx_002",
+        "quantization_params": {
+            "preset": "MIXED"
+        },
+        "metrics": {
+            "FP32 top 1": 0.63078
+        }
+    },
+    "mobilenetv3_small_050": {
+        "model_name": "mobilenetv3_small_050",
+        "quantization_params": {
+            "preset": "MIXED"
+        },
+        "metrics": {
+            "FP32 top 1": 0.51764
+        }
+    },
+    "levit_128": {
+        "model_name": "levit_128",
+        "quantization_params": {
+            "preset": "MIXED",
+            "model_type": "TRANSFORMER"
+        },
+        "metrics": {
+            "FP32 top 1": 0.7405
+        }
+    },
+    "deit3_small_patch16_224": {
+        "model_name": "deit3_small_patch16_224",
+        "quantization_params": {
+            "preset": "MIXED",
+            "model_type": "TRANSFORMER"
+        },
+        "metrics": {
+            "FP32 top 1": 0.76974
+        }
+    },
+    "swin_base_patch4_window7_224": {
+        "model_name": "swin_base_patch4_window7_224",
+        "quantization_params": {
+            "preset": "MIXED",
+            "model_type": "TRANSFORMER"
+        },
+        "metrics": {
+            "FP32 top 1": 0.81462
+        }
+    },
+    "convit_tiny": {
+        "skipped" : "Suppressed due to bug - 104173",
+        "model_name": "convit_tiny",
+        "quantization_params": {
+            "preset": "MIXED",
+            "model_type": "TRANSFORMER"
+        }
+    },
+    "visformer_small": {
+        "model_name": "visformer_small",
+        "quantization_params": {
+            "preset": "MIXED",
+            "model_type": "TRANSFORMER"
+        },
+        "metrics": {
+            "FP32 top 1": 0.77902
+        }
+    },
+    "crossvit_9_240": {
+        "model_name": "crossvit_9_240",
+        "quantization_params": {
+            "preset": "MIXED",
+            "model_type": "TRANSFORMER"
+        },
+        "metrics": {
+            "FP32 top 1": 0.69966
+        }
+    },
+    "hrnet_w18": {
+        "model_name": "hrnet_w18",
+        "quantization_params": {
+            "preset": "MIXED"
+        },
+        "metrics": {
+            "FP32 top 1": 0.70656
+        }
+    },
+    "efficientnet_lite0": {
+        "model_name": "efficientnet_lite0",
+        "quantization_params": {
+            "preset": "MIXED"
+        },
+        "metrics": {
+            "FP32 top 1": 0.69878
+        }
+    },
+    "dpn68": {
+        "model_name": "dpn68",
+        "quantization_params": {
+            "preset": "MIXED"
+        },
+        "metrics": {
+            "FP32 top 1": 0.71478
+        }
+    },
+    "dla34": {
+        "model_name": "dla34",
+        "quantization_params": {
+            "preset": "MIXED"
+        },
+        "metrics": {
+            "FP32 top 1": 0.68424
+        }
+    }
+}

--- a/tests/post_training/model_scope.py
+++ b/tests/post_training/model_scope.py
@@ -1,95 +1,53 @@
-"""
- Copyright (c) 2023 Intel Corporation
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-      http://www.apache.org/licenses/LICENSE-2.0
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
-from typing import List
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from nncf import ModelType
-from nncf import QuantizationPreset
+from typing import Any, Dict
+
+from nncf import ModelType, QuantizationPreset
+from tests.post_training.conftest import MODELS_SCOPE_PATH
+from tests.shared.helpers import load_json
 
 
-def get_validation_scope() -> List[dict]:
-    model_scope = []
-    # Basic
-    model_scope.append({"name": "vgg11", "quantization_params": {}})
-    model_scope.append({"name": "resnet18", "quantization_params": {}})
-    model_scope.append({"name": "mobilenetv2_050", "quantization_params": {"preset": QuantizationPreset.MIXED}})
-    model_scope.append(
-        {
-            "name": "mobilenetv2_050",
-            "report_model_name": "mobilenetv2_050_BC",
-            "quantization_params": {"preset": QuantizationPreset.MIXED, "fast_bias_correction": False},
-        }
-    )
-    # Densenet121 temporary excluded due to memory leaks
-    # model_scope.append({"name": "densenet121", "quantization_params": {}})
-    # model_scope.append({"name": "densenet121", "quantization_params": {"fast_bias_correction": False}})
-    model_scope.append({"name": "tf_inception_v3", "quantization_params": {"preset": QuantizationPreset.MIXED}})
-    model_scope.append({"name": "xception", "quantization_params": {"preset": QuantizationPreset.MIXED}})
-    model_scope.append({"name": "efficientnet_b0", "quantization_params": {"preset": QuantizationPreset.MIXED}})
-    model_scope.append(
-        {
-            "name": "efficientnet_b0",
-            "report_model_name": "efficientnet_b0_BC",
-            "quantization_params": {"preset": QuantizationPreset.MIXED, "fast_bias_correction": False},
-        }
-    )
-    model_scope.append({"name": "darknet53", "quantization_params": {"preset": QuantizationPreset.MIXED}})
-    # ResNets
-    model_scope.append({"name": "resnest14d", "quantization_params": {"preset": QuantizationPreset.MIXED}})
-    model_scope.append({"name": "inception_resnet_v2", "quantization_params": {}})
-    model_scope.append({"name": "wide_resnet50_2", "quantization_params": {"preset": QuantizationPreset.MIXED}})
-    model_scope.append({"name": "regnetx_002", "quantization_params": {"preset": QuantizationPreset.MIXED}})
-    # MobileNets
-    model_scope.append({"name": "mobilenetv3_small_050", "quantization_params": {"preset": QuantizationPreset.MIXED}})
-    # Transformers
-    model_scope.append(
-        {
-            "name": "levit_128",
-            "quantization_params": {"preset": QuantizationPreset.MIXED, "model_type": ModelType.TRANSFORMER},
-        }
-    )
-    model_scope.append(
-        {
-            "name": "deit3_small_patch16_224",
-            "quantization_params": {"preset": QuantizationPreset.MIXED, "model_type": ModelType.TRANSFORMER},
-        }
-    )
-    model_scope.append(
-        {
-            "name": "swin_base_patch4_window7_224",
-            "quantization_params": {"preset": QuantizationPreset.MIXED, "model_type": ModelType.TRANSFORMER},
-        }
-    )
-    # convit_tiny supressed due to bug - 104173
-    # model_scope.append({"name": "convit_tiny", "quantization_params": {"preset":QuantizationPreset.MIXED, "model_type": ModelType.TRANSFORMER}})
-    model_scope.append(
-        {
-            "name": "visformer_small",
-            "quantization_params": {"preset": QuantizationPreset.MIXED, "model_type": ModelType.TRANSFORMER},
-        }
-    )
-    model_scope.append(
-        {
-            "name": "crossvit_9_240",
-            "quantization_params": {"preset": QuantizationPreset.MIXED, "model_type": ModelType.TRANSFORMER},
-        }
-    )
-    # Others
-    model_scope.append({"name": "hrnet_w18", "quantization_params": {"preset": QuantizationPreset.MIXED}})
-    model_scope.append({"name": "efficientnet_lite0", "quantization_params": {"preset": QuantizationPreset.MIXED}})
-    model_scope.append({"name": "dpn68", "quantization_params": {"preset": QuantizationPreset.MIXED}})
-    model_scope.append({"name": "dla34", "quantization_params": {"preset": QuantizationPreset.MIXED}})
+def get_validation_scope() -> Dict[str, Any]:
+    """
+    Read json file that collected models to validation from MODELS_SCOPE_PATH.
+    Convert parameters
+
+    :return dict: Dict with model attributes.
+    """
+    model_scope = load_json(MODELS_SCOPE_PATH)
+
+    for model_name in list(model_scope.keys()):
+        model_info = model_scope[model_name]
+        if model_info.get("skipped"):
+            print(f"Skip {model_name} by '{model_info.get('skipped')}'")
+            model_scope.pop(model_name)
+            continue
+
+        qparams = model_info["quantization_params"]
+        if "preset" in qparams.keys():
+            qparams["preset"] = QuantizationPreset[qparams["preset"]]
+        if "model_type" in qparams.keys():
+            qparams["model_type"] = ModelType[qparams["model_type"]]
 
     return model_scope
 
 
 VALIDATION_SCOPE = get_validation_scope()
+
+
+def get_cached_metric(report_model_name, metric_name):
+    cached_metric = None
+    try:
+        cached_metric = VALIDATION_SCOPE[report_model_name]["metrics"][metric_name]
+    except KeyError:
+        pass
+    return cached_metric

--- a/tests/post_training/test_quantize_conformance.py
+++ b/tests/post_training/test_quantize_conformance.py
@@ -17,9 +17,10 @@ import re
 import traceback
 from multiprocessing import Pipe
 from multiprocessing import Process
+from multiprocessing.connection import Connection
 from pathlib import Path
 from pathlib import PosixPath
-from typing import Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import onnx
@@ -28,6 +29,8 @@ import pytest
 import timm
 import torch
 from sklearn.metrics import accuracy_score
+from torch import nn
+from torch.utils.data.dataloader import DataLoader
 from torchvision import datasets
 from torchvision import transforms
 from torchvision.transforms import InterpolationMode
@@ -39,18 +42,32 @@ from nncf.torch.nncf_network import NNCFNetwork
 from tests.post_training.conftest import PipelineType
 from tests.post_training.conftest import RunInfo
 from tests.post_training.model_scope import VALIDATION_SCOPE
+from tests.post_training.model_scope import get_cached_metric
 from tests.shared.command import Command
 
-NOT_AVAILABLE_MESSAGE = "N/A"
 DEFAULT_VAL_THREADS = 4
 
 
-def create_timm_model(name):
+def create_timm_model(name: str) -> nn.Module:
+    """
+    Create timm model by name for ImageNet dataset.
+
+    :param name: Name of model.
+
+    :return: Instance of the timm model.
+    """
     model = timm.create_model(name, num_classes=1000, in_chans=3, pretrained=True, checkpoint_path="")
     return model
 
 
-def get_model_transform(model):
+def get_model_transform(model: nn.Module) -> transforms.Compose:
+    """
+    Generate transformations for model.
+
+    :param model: The model.
+
+    :return: Transformations for the model.
+    """
     config = model.default_cfg
     transformations_list = []
     normalize = transforms.Normalize(mean=config["mean"], std=config["std"])
@@ -73,13 +90,29 @@ def get_model_transform(model):
     return transform
 
 
-def get_torch_dataloader(folder, transform, batch_size=1):
+def get_torch_dataloader(folder: str, transform: transforms.Compose, batch_size: int = 1) -> DataLoader:
+    """
+    Return DataLoader for datasets.
+
+    :param folder: Path to dataset folder.
+    :param transform: Transformations for datasets.
+    :param batch_size: The batch size, defaults to 1.
+
+    :return torch.utils.data.DataLoader: Instance of DataLoader.
+    """
     val_dataset = datasets.ImageFolder(root=folder, transform=transform)
     val_loader = torch.utils.data.DataLoader(val_dataset, batch_size=batch_size, num_workers=2, shuffle=False)
     return val_loader
 
 
-def export_to_onnx(model, save_path, data_sample):
+def export_to_onnx(model: nn.Module, save_path: str, data_sample: torch.Tensor) -> None:
+    """
+    Export Torch model to ONNX format.
+
+    :param model: The target model.
+    :param save_path: Path to save ONNX model.
+    :param data_sample: Data sample for dummy forward.
+    """
     torch.onnx.export(
         model,
         data_sample,
@@ -90,12 +123,28 @@ def export_to_onnx(model, save_path, data_sample):
     )
 
 
-def export_to_ir(model_path, save_path, model_name):
+def export_to_ir(model_path: str, save_path: str, model_name: str) -> None:
+    """
+    Export ONNX model to OpenVINO format.
+
+    :param model_path: Path to ONNX model.
+    :param save_path: Path directory to save OpenVINO IR model.
+    :param model_name: Model name.
+    """
     runner = Command(f"mo -m {model_path} -o {save_path} -n {model_name}")
     runner.run()
 
 
-def run_benchmark(model_path):
+def run_benchmark(model_path: str) -> Tuple[Optional[float], str]:
+    """
+    Run benchmark_app to collect performance statistics.
+
+    :param model_path: Path to the OpenVINO IR model.
+
+    :return:
+        - FPS for successful run, otherwise None.
+        - Output of benchmark_app.
+    """
     runner = Command(f"benchmark_app -m {model_path} -d CPU -niter 300")
     runner.run()
     cmd_output = " ".join(runner.output)
@@ -108,30 +157,50 @@ def run_benchmark(model_path):
     return None, cmd_output
 
 
-def benchmark_performance(model_path, model_name):
+def benchmark_performance(model_path: str, model_name: str, skip_bench: bool) -> Optional[float]:
     """
     Receives the OpenVINO IR model and runs benchmark tool for it
+
+    :param model_path: Path to the OpenVINO IR model.
+    :param model_name: Model name.
+    :param skip_bench: Boolean flag to skip or run benchmark.
+
+    :return: FPS for successful run of benchmark_app, otherwise None.
     """
-    model_perf = NOT_AVAILABLE_MESSAGE
+    if skip_bench:
+        return None
 
     try:
         model_perf, bench_output = run_benchmark(model_path)
 
         if model_perf is None:
             logging.info(f"Cannot measure performance for the model: {model_name}\nDetails: {bench_output}\n")
-            model_perf = NOT_AVAILABLE_MESSAGE
     except BaseException as error:
-        logging.error(f"Error when becnhmarking the model: {model_name} Details: {error}")
+        logging.error(f"Error when benchmarking the model: {model_name}. Details: {error}")
 
     return model_perf
 
 
-def validate_accuracy(model_path, val_loader):
+def validate_accuracy(model_path: str, val_loader: DataLoader) -> float:
+    """
+    VAlidate the OpenVINO IR models on validation dataset.
+
+    :param model_path: Path to the OpenVINO IR models.
+    :param val_loader: Validation dataloader.
+
+    :return float: Accuracy score.
+    """
     dataset_size = len(val_loader)
     predictions = [0] * dataset_size
     references = [-1] * dataset_size
 
     core = ov.Core()
+
+    if os.environ.get("CPU_THREADS_NUM"):
+        # Set CPU_THREADS_NUM for OpenVINO inference
+        cpu_threads_num = os.environ.get("CPU_THREADS_NUM")
+        core.set_property("CPU", properties={"CPU_THREADS_NUM": str(cpu_threads_num)})
+
     ov_model = core.read_model(model_path)
     compiled_model = core.compile_model(ov_model)
 
@@ -157,7 +226,26 @@ def validate_accuracy(model_path, val_loader):
     return accuracy_score(predictions, references)
 
 
-def benchmark_torch_model(model, dataloader, model_name, output_path):
+def benchmark_torch_model(
+    model: nn.Module,
+    dataloader: DataLoader,
+    model_name: str,
+    output_path: str,
+    skip_bench: bool = False,
+    eval: bool = True,
+) -> RunInfo:
+    """
+    Benchmark the torch model.
+
+    :param model: The Torch Model.
+    :param dataloader: Validation dataloader.
+    :param model_name: Model name.
+    :param output_path: Path to save ONNX and OpenVINO IR models.
+    :param eval: Boolean flag to run validation, defaults to True.
+    :param skip_bench: Boolean flag to skip or run benchmark, defaults to False.
+
+    :return RunInfo: Accuracy and performance metrics.
+    """
     data_sample, _ = next(iter(dataloader))
     # Dump model
     onnx_path = Path(output_path) / (model_name + ".onnx")
@@ -166,13 +254,34 @@ def benchmark_torch_model(model, dataloader, model_name, output_path):
     export_to_ir(onnx_path, output_path, model_name)
 
     # Benchmark performance
-    performance = benchmark_performance(ov_path, model_name)
+    performance = benchmark_performance(ov_path, model_name, skip_bench)
+
     # Validate accuracy
-    accuracy = validate_accuracy(ov_path, dataloader)
-    return performance, accuracy
+    accuracy = None
+    if eval:
+        accuracy = validate_accuracy(ov_path, dataloader)
+
+    return RunInfo(top_1=accuracy, fps=performance)
 
 
-def benchmark_onnx_model(model, dataloader, model_name, output_path):
+def benchmark_onnx_model(
+    model: onnx.ModelProto,
+    dataloader: DataLoader,
+    model_name: str,
+    output_path: str,
+    skip_bench: bool,
+) -> RunInfo:
+    """
+    Benchmark the ONNX model.
+
+    :param model: The ONNX model.
+    :param dataloader: Validation dataloader.
+    :param model_name: Model name.
+    :param output_path: Path to save ONNX and OpenVINO IR models.
+    :param skip_bench: Boolean flag to skip or run benchmark.
+
+    :return RunInfo: Accuracy and performance metrics.
+    """
     # Dump model
     onnx_path = Path(output_path) / (model_name + ".onnx")
     onnx.save(model, onnx_path)
@@ -180,22 +289,39 @@ def benchmark_onnx_model(model, dataloader, model_name, output_path):
     export_to_ir(onnx_path, output_path, model_name)
 
     # Benchmark performance
-    performance = benchmark_performance(ov_path, model_name)
+    performance = benchmark_performance(ov_path, model_name, skip_bench)
     # Validate accuracy
     accuracy = validate_accuracy(ov_path, dataloader)
-    return performance, accuracy
+    return RunInfo(top_1=accuracy, fps=performance)
 
 
-def benchmark_ov_model(model, dataloader, model_name, output_path):
+def benchmark_ov_model(
+    model: ov.Model,
+    dataloader: DataLoader,
+    model_name: str,
+    output_path: str,
+    skip_bench: bool,
+) -> RunInfo:
+    """
+    Benchmark the OpenVINO model.
+
+    :param model: The OpenVINO model.
+    :param dataloader: Validation dataloader.
+    :param model_name: Model name.
+    :param output_path: Path to save ONNX and OpenVINO IR models.
+    :param skip_bench: Boolean flag to skip or run benchmark.
+
+    :return RunInfo: Accuracy and performance metrics.
+    """
     # Dump model
     ov_path = Path(output_path) / (model_name + ".xml")
     ov.serialize(model, str(ov_path))
 
     # Benchmark performance
-    performance = benchmark_performance(ov_path, model_name)
+    performance = benchmark_performance(ov_path, model_name, skip_bench)
     # Validate accuracy
     accuracy = validate_accuracy(ov_path, dataloader)
-    return performance, accuracy
+    return RunInfo(top_1=accuracy, fps=performance)
 
 
 @pytest.fixture(scope="session")
@@ -223,6 +349,9 @@ def quantize_ov_native(
     model_type: Optional[nncf.ModelType] = None,
     ignored_scope: Optional[nncf.IgnoredScope] = None,
 ) -> ov.Model:
+    """
+    Quantize the OpenVINO model by OPENVINO_NATIVE backend.
+    """
     quantized_model = ov_quantize_impl(
         model,
         calibration_dataset,
@@ -246,32 +375,62 @@ def quantize_torch_ptq(
     model_type: Optional[nncf.ModelType] = None,
     ignored_scope: Optional[nncf.IgnoredScope] = None,
 ) -> NNCFNetwork:
+    """
+    Quantize the Torch model by TORCH_PTQ backend.
+    """
     quantized_model = pt_impl_experimental(
-        model, calibration_dataset, preset, target_device, subset_size, fast_bias_correction, model_type, ignored_scope
+        model,
+        calibration_dataset,
+        preset,
+        target_device,
+        subset_size,
+        fast_bias_correction,
+        model_type,
+        ignored_scope,
     )
     return quantized_model
 
 
 def torch_runner(
-    model, calibration_dataset, model_quantization_params, output_folder, model_name, batch_one_dataloader
+    model: nn.Module,
+    calibration_dataset: nncf.Dataset,
+    model_quantization_params: Dict[str, Any],
+    output_folder: str,
+    model_name: str,
+    batch_one_dataloader: DataLoader,
+    skip_bench: bool,
 ) -> RunInfo:
+    """
+    Run quantization of the Torch model by TORCH backend.
+    """
     torch_quantized_model = nncf.quantize(model, calibration_dataset, **model_quantization_params)
     # benchmark quantized torch model
     torch_output_path = output_folder / "torch"
     torch_output_path.mkdir(parents=True, exist_ok=True)
     q_torch_model_name = model_name + "_torch_int8"
-    q_torch_perf, q_torch_acc = benchmark_torch_model(
+    run_info = benchmark_torch_model(
         torch_quantized_model,
         batch_one_dataloader,
         q_torch_model_name,
         torch_output_path,
+        skip_bench,
     )
-    return RunInfo(q_torch_acc, q_torch_perf)
+    return run_info
 
 
 def torch_ptq_runner(
-    model, calibration_dataset, model_quantization_params, output_folder, model_name, batch_one_dataloader
+    model: nn.Module,
+    calibration_dataset: nncf.Dataset,
+    model_quantization_params: Dict[str, Any],
+    output_folder: str,
+    model_name: str,
+    batch_one_dataloader: DataLoader,
+    skip_bench: bool,
 ) -> RunInfo:
+    """
+    Run quantization of the Torch model by TORCH_PTQ backend.
+    """
+
     def transform_fn(data_item):
         images, _ = data_item
         return images
@@ -283,17 +442,28 @@ def torch_ptq_runner(
     torch_output_path = output_folder / "torch_ptq"
     torch_output_path.mkdir(parents=True, exist_ok=True)
     q_torch_model_name = model_name + "_torch_ptq_int8"
-    q_torch_ptq_perf, q_torch_ptq_acc = benchmark_torch_model(
+    run_info = benchmark_torch_model(
         torch_quantized_model,
         batch_one_dataloader,
         q_torch_model_name,
         torch_output_path,
+        skip_bench,
     )
+    return run_info
 
-    return RunInfo(q_torch_ptq_acc, q_torch_ptq_perf)
 
-
-def onnx_runner(model, calibration_dataset, model_quantization_params, output_folder, model_name, batch_one_dataloader):
+def onnx_runner(
+    model: nn.Module,
+    calibration_dataset: nncf.Dataset,
+    model_quantization_params: Dict[str, Any],
+    output_folder: str,
+    model_name: str,
+    batch_one_dataloader: DataLoader,
+    skip_bench: bool,
+):
+    """
+    Run quantization of the ONNX model by ONNX backend.
+    """
     onnx_model_path = output_folder / (model_name + ".onnx")
     onnx_model = onnx.load(onnx_model_path)
     onnx_input_name = onnx_model.graph.input[0].name
@@ -309,18 +479,28 @@ def onnx_runner(model, calibration_dataset, model_quantization_params, output_fo
     onnx_output_path = output_folder / "onnx"
     onnx_output_path.mkdir(parents=True, exist_ok=True)
     q_onnx_model_name = model_name + "_onnx_int8"
-    q_onnx_perf, q_onnx_acc = benchmark_onnx_model(
+    run_info = benchmark_onnx_model(
         onnx_quantized_model,
         batch_one_dataloader,
         q_onnx_model_name,
         onnx_output_path,
+        skip_bench,
     )
-    return RunInfo(q_onnx_acc, q_onnx_perf)
+    return run_info
 
 
 def ov_native_runner(
-    model, calibration_dataset, model_quantization_params, output_folder, model_name, batch_one_dataloader
+    model: nn.Module,
+    calibration_dataset: nncf.Dataset,
+    model_quantization_params: Dict[str, Any],
+    output_folder: str,
+    model_name: str,
+    batch_one_dataloader: DataLoader,
+    skip_bench: bool,
 ):
+    """
+    Run quantization of the OpenVINO model by OV_NATIVE backend.
+    """
     ov_native_model_path = output_folder / (model_name + ".xml")
     core = ov.Core()
     ov_native_model = core.read_model(ov_native_model_path)
@@ -342,18 +522,29 @@ def ov_native_runner(
     ov_native_output_path = output_folder / "openvino_native"
     ov_native_output_path.mkdir(parents=True, exist_ok=True)
     q_ov_native_model_name = model_name + "_openvino_native_int8"
-    q_ov_native_perf, q_ov_native_acc = benchmark_ov_model(
+    run_info = benchmark_ov_model(
         ov_native_quantized_model,
         batch_one_dataloader,
         q_ov_native_model_name,
         ov_native_output_path,
+        skip_bench,
     )
-    return RunInfo(q_ov_native_acc, q_ov_native_perf)
+    return run_info
 
 
 def ov_runner(
-    model, calibration_dataset, model_quantization_params, output_folder, model_name, batch_one_dataloader
+    model: nn.Module,
+    calibration_dataset: nncf.Dataset,
+    model_quantization_params: Dict[str, Any],
+    output_folder: str,
+    model_name: str,
+    batch_one_dataloader: DataLoader,
+    skip_bench: bool,
 ) -> RunInfo:
+    """
+    Run quantization of the OpenVINO model by OV backend.
+    """
+
     def ov_transform_fn(data_item):
         images, _ = data_item
         return images.numpy()
@@ -367,13 +558,14 @@ def ov_runner(
     ov_output_path = output_folder / "openvino"
     ov_output_path.mkdir(parents=True, exist_ok=True)
     q_ov_model_name = model_name + "_openvino_int8"
-    q_ov_perf, q_ov_acc = benchmark_ov_model(
+    run_info = benchmark_ov_model(
         ov_quantized_model,
         batch_one_dataloader,
         q_ov_model_name,
         ov_output_path,
+        skip_bench,
     )
-    return RunInfo(q_ov_acc, q_ov_perf)
+    return run_info
 
 
 RUNNERS = {
@@ -386,8 +578,29 @@ RUNNERS = {
 
 
 def run_ptq_timm(
-    data, output, timm_model_name, backends, model_quantization_params, process_connection, report_model_name
-):  # pylint: disable=W0703
+    data: str,
+    output: str,
+    timm_model_name: str,
+    backends: List[PipelineType],
+    model_quantization_params: Dict[str, Any],
+    process_connection: Connection,
+    report_model_name: str,
+    eval_fp32: bool,
+    skip_bench: bool,
+) -> None:  # pylint: disable=W0703
+    """
+    Run test for the target model on selected backends.
+
+    :param data: Path to dataset folder.
+    :param output: Output directory to save tested models.
+    :param timm_model_name: Name of model from timm module.
+    :param backends: List of backends.
+    :param model_quantization_params: Quantization parameters.
+    :param process_connection: Connection to send results to main process.
+    :param report_model_name: Reported name of the model.
+    :param eval_fp32: Boolean flag to validate fp32.
+    :param skip_bench: Boolean flag to skip or run benchmark.
+    """
     torch.multiprocessing.set_sharing_strategy("file_system")  # W/A to avoid RuntimeError
 
     runinfos = {}
@@ -403,8 +616,17 @@ def run_ptq_timm(
 
         batch_one_dataloader = get_torch_dataloader(data, transform, batch_size=1)
         # benchmark original models (once)
-        orig_perf, orig_acc = benchmark_torch_model(model, batch_one_dataloader, model_name, output_folder)
-        runinfos[PipelineType.FP32] = RunInfo(orig_acc, orig_perf)
+        runinfos[PipelineType.FP32] = benchmark_torch_model(
+            model,
+            batch_one_dataloader,
+            model_name,
+            output_folder,
+            skip_bench,
+            eval_fp32,
+        )
+        # Get cached accuracy
+        if not eval_fp32:
+            runinfos[PipelineType.FP32].top_1 = get_cached_metric(report_model_name, "FP32 top 1")
 
         val_dataloader = get_torch_dataloader(data, transform, batch_size=128)
 
@@ -424,13 +646,14 @@ def run_ptq_timm(
                     output_folder,
                     model_name,
                     batch_one_dataloader,
+                    skip_bench,
                 )
             except Exception as error:
                 backend_dir = backend.value.replace(" ", "_")
                 traceback_path = Path.joinpath(output_folder, backend_dir, model_name + "_error_log.txt")
                 create_error_log(traceback_path)
                 status = get_error_msg(traceback_path, backend_dir)
-                runinfo = RunInfo(-1, -1, status)
+                runinfo = RunInfo(None, None, status)
             runinfos[backend] = runinfo
 
         process_connection.send(runinfos)
@@ -438,12 +661,15 @@ def run_ptq_timm(
         traceback_path = Path.joinpath(output_folder, model_name + "_error_log.txt")
         create_error_log(traceback_path)
         status = f"{model_name} traceback: {traceback_path}"
-        runinfos[PipelineType.FP32] = RunInfo(-1, -1, status)
+        runinfos[PipelineType.FP32] = RunInfo(None, None, status)
         process_connection.send(runinfos)
         raise error
 
 
 def create_error_log(traceback_path: PosixPath) -> None:
+    """
+    Create file with error log.
+    """
     traceback_path.parents[0].mkdir(parents=True, exist_ok=True)
     with open(traceback_path, "w") as file:
         traceback.print_exc(file=file)
@@ -452,19 +678,35 @@ def create_error_log(traceback_path: PosixPath) -> None:
 
 
 def get_error_msg(traceback_path: PosixPath, backend_name: str) -> str:
+    """
+    Generate error message.
+    """
     return f"{backend_name} traceback: {traceback_path}"
 
 
-@pytest.mark.parametrize("model_args", VALIDATION_SCOPE, ids=[desk["name"] for desk in VALIDATION_SCOPE])
-def test_ptq_timm(data, output, result, model_args, backends_list):  # pylint: disable=W0703
+@pytest.mark.parametrize("report_model_name,", VALIDATION_SCOPE.keys())
+def test_ptq_timm(data, output, result, report_model_name, backends_list, eval_fp32, skip_bench):
+    """
+    Test quantization of classification models from timm module by different backends.
+    """
+    model_args = VALIDATION_SCOPE[report_model_name]
     backends = [PipelineType[backend] for backend in backends_list.split(",")]
-    model_name = model_args["name"]
-    report_model_name = model_args.get("report_model_name", model_name)
+    model_name = model_args["model_name"]
     quantization_params = model_args["quantization_params"]
     main_connection, process_connection = Pipe()
     process = Process(
         target=run_ptq_timm,
-        args=(data, output, model_name, backends, quantization_params, process_connection, report_model_name),
+        args=(
+            data,
+            output,
+            model_name,
+            backends,
+            quantization_params,
+            process_connection,
+            report_model_name,
+            eval_fp32,
+            skip_bench,
+        ),
     )
     process.start()
     process.join()


### PR DESCRIPTION
### Changes

- Add `model_scope.json` that will be used in CI to parallel jobs by models. 
- Add `--skip_bench` to skip collect performances metrics (for manual use).
- Add `--eval_fp32` arguments. By defaults evaluation of fp32 models will be skipped and get `top 1` metric from  `model_scope.json`. The `top 1` metric of fp32 model is not changed by update quantization algorithms. 
 And it's the slowest model. It' should save 20-30% of time for full tests. And 60% of manual test only 1 backend (example: mobilnetv2: fp32 - 20 mins, torch_ptq - 10min).
- Set `CPU_THREADS_NUM` for OpenVINO inference by env variable. To control number of threads, need to optimize inference in Docker with `cpu_limit`.
- Use `None` instead of `-1` for failed metrics. And replace all `None` to  `N/A` in results.csv.

### Reason for changes

` test_ptq_timm` test is too long.

### Related tickets

109005

