### PR TITLE
[PTQ][OV] Insert null biases pass for BC

### DIFF
--- a/nncf/onnx/graph/transformations/commands.py
+++ b/nncf/onnx/graph/transformations/commands.py
@@ -133,3 +133,19 @@ class ONNXQDQNodeRemovingCommand(TransformationCommand):
     def union(self, other: "TransformationCommand") -> "TransformationCommand":
         # Have a look at nncf/torch/graph/transformations/commands/PTInsertionCommand
         raise NotImplementedError()
+
+
+class ONNXNullBiasInsertionCommand(TransformationCommand):
+    """
+    Inserts null bias for the corresponding node.
+    """
+
+    def __init__(self, target_point: ONNXTargetPoint):
+        """
+        :param target_point: The TargetPoint instance for the insertion that contains layer's information.
+        """
+        super().__init__(TransformationType.INSERT, target_point)
+
+    def union(self, other: "TransformationCommand") -> "TransformationCommand":
+        # Have a look at nncf/torch/graph/transformations/commands/PTInsertionCommand
+        raise NotImplementedError()

--- a/nncf/openvino/graph/model_transformer.py
+++ b/nncf/openvino/graph/model_transformer.py
@@ -448,7 +448,7 @@ class OVModelTransformer(ModelTransformer):
         for transformation in transformations:
             node_name = transformation.target_point.target_node_name
             node = name_to_node_mapping[node_name]
-            # Since layers that may have biases mostly are Convolution or MatMul variations, 
+            # Since layers that may have biases mostly are Convolution or MatMul variations,
             # we may use only 0 output port.
             node_shape = node.output(0).partial_shape.get_max_shape()
             node_output_port = node.output(transformation.target_point.port_id)

--- a/nncf/openvino/graph/model_transformer.py
+++ b/nncf/openvino/graph/model_transformer.py
@@ -448,7 +448,8 @@ class OVModelTransformer(ModelTransformer):
         for transformation in transformations:
             node_name = transformation.target_point.target_node_name
             node = name_to_node_mapping[node_name]
-            # Since layers that may have biases mostly are Convolution or MatMul variations, we may use only 0 output port.
+            # Since layers that may have biases mostly are Convolution or MatMul variations, 
+            # we may use only 0 output port.
             node_shape = node.output(0).partial_shape.get_max_shape()
             node_output_port = node.output(transformation.target_point.port_id)
             node_output_source_ports = node_output_port.get_target_inputs()

--- a/nncf/openvino/graph/model_transformer.py
+++ b/nncf/openvino/graph/model_transformer.py
@@ -49,7 +49,7 @@ class OVModelTransformer(ModelTransformer):
             (OVModelExtractionCommand, self._apply_model_extraction_transformation),
             (OVInplaceFnInsertionCommand, self._apply_insert_operation),
             (OVOutputInsertionCommand, self._apply_output_insertion_transformations),
-            (OVBiasInsertionCommand, self._apply_bias_insertion_transformations)
+            (OVBiasInsertionCommand, self._apply_bias_insertion_transformations),
         ]
 
     @staticmethod
@@ -435,7 +435,9 @@ class OVModelTransformer(ModelTransformer):
         raise RuntimeError(f"Transform type {transform_type} is not supported")
 
     @staticmethod
-    def _apply_bias_insertion_transformations(model: ov.Model, transformations: List[OVBiasInsertionCommand]) -> ov.Model:
+    def _apply_bias_insertion_transformations(
+        model: ov.Model, transformations: List[OVBiasInsertionCommand]
+    ) -> ov.Model:
         """
         Inserts bias operation after corresponding layer.
 

--- a/nncf/openvino/graph/model_transformer.py
+++ b/nncf/openvino/graph/model_transformer.py
@@ -448,11 +448,12 @@ class OVModelTransformer(ModelTransformer):
         for transformation in transformations:
             node_name = transformation.target_point.target_node_name
             node = name_to_node_mapping[node_name]
+            node_shape = node.output(0).partial_shape.get_max_shape()
             node_output_port = node.output(transformation.target_point.port_id)
             node_output_source_ports = node_output_port.get_target_inputs()
 
-            bias_shape = [1] * len(node.shape)
-            bias_shape[1] = node.shape[1]
+            bias_shape = [1] * len(node_shape)
+            bias_shape[1] = node_shape[1]
             const_value = np.zeros(bias_shape, dtype=node.get_element_type().to_dtype())
             bias_const_node = opset.constant(const_value, dtype=node.get_element_type())
             bias_const_output_port = bias_const_node.output(0)

--- a/nncf/openvino/graph/model_transformer.py
+++ b/nncf/openvino/graph/model_transformer.py
@@ -24,6 +24,7 @@ from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.transformations.layout import TransformationLayout
 from nncf.openvino.graph.node_utils import get_result_node_name
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
+from nncf.openvino.graph.transformations.commands import OVBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVFQNodeRemovingCommand
 from nncf.openvino.graph.transformations.commands import OVInplaceFnInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVModelExtractionCommand
@@ -48,6 +49,7 @@ class OVModelTransformer(ModelTransformer):
             (OVModelExtractionCommand, self._apply_model_extraction_transformation),
             (OVInplaceFnInsertionCommand, self._apply_insert_operation),
             (OVOutputInsertionCommand, self._apply_output_insertion_transformations),
+            (OVBiasInsertionCommand, self._apply_bias_insertion_transformations)
         ]
 
     @staticmethod
@@ -431,3 +433,31 @@ class OVModelTransformer(ModelTransformer):
             new_node = transformation.inplace_op_fn(output.get_node(), output.get_index())
             return (new_node.output(fn_output_port_id), fn_output_port_id)
         raise RuntimeError(f"Transform type {transform_type} is not supported")
+
+    @staticmethod
+    def _apply_bias_insertion_transformations(model: ov.Model, transformations: List[OVBiasInsertionCommand]) -> ov.Model:
+        """
+        Inserts bias operation after corresponding layer.
+
+        :param transformations: List of the bias insertion transformations.
+        :returns: Transformed model with null biases.
+        """
+        name_to_node_mapping = OVModelTransformer._get_name_to_node_mapping(model)
+        for transformation in transformations:
+            node_name = transformation.target_point.target_node_name
+            node = name_to_node_mapping[node_name]
+            node_output_port = node.output(transformation.target_point.port_id)
+            node_output_source_ports = node_output_port.get_target_inputs()
+
+            bias_shape = [1] * len(node.shape)
+            bias_shape[1] = node.shape[1]
+            const_value = np.zeros(bias_shape, dtype=node.get_element_type().to_dtype())
+            bias_const_node = opset.constant(const_value, dtype=node.get_element_type())
+            bias_const_output_port = bias_const_node.output(0)
+
+            add_node = opset.add(node_output_port, bias_const_output_port, name=f"{node_name}/add_")
+
+            for node_output_source_port in node_output_source_ports:
+                node_output_source_port.replace_source_output(add_node.output(0))
+
+        return model

--- a/nncf/openvino/graph/model_transformer.py
+++ b/nncf/openvino/graph/model_transformer.py
@@ -24,10 +24,10 @@ from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.transformations.layout import TransformationLayout
 from nncf.openvino.graph.node_utils import get_result_node_name
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
-from nncf.openvino.graph.transformations.commands import OVBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVFQNodeRemovingCommand
 from nncf.openvino.graph.transformations.commands import OVInplaceFnInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVModelExtractionCommand
+from nncf.openvino.graph.transformations.commands import OVNullBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVOutputInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVQuantizerInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVWeightUpdateCommand
@@ -49,7 +49,7 @@ class OVModelTransformer(ModelTransformer):
             (OVModelExtractionCommand, self._apply_model_extraction_transformation),
             (OVInplaceFnInsertionCommand, self._apply_insert_operation),
             (OVOutputInsertionCommand, self._apply_output_insertion_transformations),
-            (OVBiasInsertionCommand, self._apply_bias_insertion_transformations),
+            (OVNullBiasInsertionCommand, self._apply_bias_insertion_transformations),
         ]
 
     @staticmethod
@@ -436,10 +436,10 @@ class OVModelTransformer(ModelTransformer):
 
     @staticmethod
     def _apply_bias_insertion_transformations(
-        model: ov.Model, transformations: List[OVBiasInsertionCommand]
+        model: ov.Model, transformations: List[OVNullBiasInsertionCommand]
     ) -> ov.Model:
         """
-        Inserts bias operation after corresponding layer.
+        Inserts null bias operation after corresponding layer.
 
         :param transformations: List of the bias insertion transformations.
         :returns: Transformed model with null biases.
@@ -448,6 +448,7 @@ class OVModelTransformer(ModelTransformer):
         for transformation in transformations:
             node_name = transformation.target_point.target_node_name
             node = name_to_node_mapping[node_name]
+            # Since layers that may have biases mostly are Convolution or MatMul variations, we may use only 0 output port.
             node_shape = node.output(0).partial_shape.get_max_shape()
             node_output_port = node.output(transformation.target_point.port_id)
             node_output_source_ports = node_output_port.get_target_inputs()
@@ -458,7 +459,7 @@ class OVModelTransformer(ModelTransformer):
             bias_const_node = opset.constant(const_value, dtype=node.get_element_type())
             bias_const_output_port = bias_const_node.output(0)
 
-            add_node = opset.add(node_output_port, bias_const_output_port, name=f"{node_name}/add_")
+            add_node = opset.add(node_output_port, bias_const_output_port, name=f"{node_name}/nncf_null_bias_")
 
             for node_output_source_port in node_output_source_ports:
                 node_output_source_port.replace_source_output(add_node.output(0))

--- a/nncf/openvino/graph/model_utils.py
+++ b/nncf/openvino/graph/model_utils.py
@@ -30,17 +30,15 @@ def insert_null_biases(model: ov.Model) -> ov.Model:
     :return: Updated ov.Model instance with zero biases
     """
     types_to_insert_bias = [
-            OVConvolutionMetatype,
-            OVGroupConvolutionMetatype,
-            OVDepthwiseConvolutionMetatype,
-            OVConvolutionBackpropDataMetatype,
-            OVGroupConvolutionBackpropDataMetatype,
-        ]
+        OVConvolutionMetatype,
+        OVGroupConvolutionMetatype,
+        OVDepthwiseConvolutionMetatype,
+        OVConvolutionBackpropDataMetatype,
+        OVGroupConvolutionBackpropDataMetatype,
+    ]
     nncf_graph = NNCFGraphFactory.create(model) if self.nncf_graph is None else self.nncf_graph
     nodes_without_biases = nncf_graph.get_nodes_by_metatypes(types_to_insert_bias)
-    nodes_without_biases = [
-        node for node in nodes_without_biases if not is_node_with_bias(node, nncf_graph)
-    ]
+    nodes_without_biases = [node for node in nodes_without_biases if not is_node_with_bias(node, nncf_graph)]
     transformation_layout = TransformationLayout()
     model_transformer = ModelTransformerFactory.create(model)
     for node_without_bias in nodes_without_biases:

--- a/nncf/openvino/graph/model_utils.py
+++ b/nncf/openvino/graph/model_utils.py
@@ -36,7 +36,7 @@ def insert_null_biases(model: ov.Model) -> ov.Model:
         OVConvolutionBackpropDataMetatype,
         OVGroupConvolutionBackpropDataMetatype,
     ]
-    nncf_graph = NNCFGraphFactory.create(model) if self.nncf_graph is None else self.nncf_graph
+    nncf_graph = NNCFGraphFactory.create(model)
     nodes_without_biases = nncf_graph.get_nodes_by_metatypes(types_to_insert_bias)
     nodes_without_biases = [node for node in nodes_without_biases if not is_node_with_bias(node, nncf_graph)]
     transformation_layout = TransformationLayout()

--- a/nncf/openvino/graph/model_utils.py
+++ b/nncf/openvino/graph/model_utils.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import openvino.runtime as ov
+
+from nncf.common.factory import ModelTransformerFactory
+from nncf.common.factory import NNCFGraphFactory
+from nncf.common.graph.transformations.layout import TransformationLayout
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVConvolutionBackpropDataMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVConvolutionMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVDepthwiseConvolutionMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVGroupConvolutionBackpropDataMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVGroupConvolutionMetatype
+from nncf.openvino.graph.node_utils import is_node_with_bias
+from nncf.openvino.graph.transformations.command_creation import OVCommandCreator
+
+
+def insert_null_biases(model: ov.Model) -> ov.Model:
+    """
+    This method finds and inserts zero biases for the layers that should have it.
+
+    :param model: ov.Model instance.
+    :return: Updated ov.Model instance with zero biases
+    """
+    types_to_insert_bias = [
+            OVConvolutionMetatype,
+            OVGroupConvolutionMetatype,
+            OVDepthwiseConvolutionMetatype,
+            OVConvolutionBackpropDataMetatype,
+            OVGroupConvolutionBackpropDataMetatype,
+        ]
+    nncf_graph = NNCFGraphFactory.create(model) if self.nncf_graph is None else self.nncf_graph
+    nodes_without_biases = nncf_graph.get_nodes_by_metatypes(types_to_insert_bias)
+    nodes_without_biases = [
+        node for node in nodes_without_biases if not is_node_with_bias(node, nncf_graph)
+    ]
+    transformation_layout = TransformationLayout()
+    model_transformer = ModelTransformerFactory.create(model)
+    for node_without_bias in nodes_without_biases:
+        bias_insertion_command = OVCommandCreator.create_command_to_insert_bias(node_without_bias)
+        transformation_layout.register(bias_insertion_command)
+    return model_transformer.transform(transformation_layout)

--- a/nncf/openvino/graph/transformations/command_creation.py
+++ b/nncf/openvino/graph/transformations/command_creation.py
@@ -16,6 +16,7 @@ from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.transformations.command_creation import CommandCreator
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
+from nncf.openvino.graph.transformations.commands import OVBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVFQNodeRemovingCommand
 from nncf.openvino.graph.transformations.commands import OVTargetPoint
 from nncf.openvino.graph.transformations.commands import OVWeightUpdateCommand
@@ -48,3 +49,8 @@ class OVCommandCreator(CommandCreator):
     ) -> OVWeightUpdateCommand:
         target_point = OVTargetPoint(TargetType.LAYER, node_with_weight.node_name, weight_port_id)
         return OVWeightUpdateCommand(target_point, weight_value)
+
+    @staticmethod
+    def create_command_to_insert_bias(node_without_bias: NNCFNode) -> OVBiasInsertionCommand:
+        target_point = OVTargetPoint(TargetType.POST_LAYER_OPERATION, node_without_bias.node_name, 0)
+        return OVBiasInsertionCommand(target_point)

--- a/nncf/openvino/graph/transformations/command_creation.py
+++ b/nncf/openvino/graph/transformations/command_creation.py
@@ -16,8 +16,8 @@ from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.transformations.command_creation import CommandCreator
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
-from nncf.openvino.graph.transformations.commands import OVBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVFQNodeRemovingCommand
+from nncf.openvino.graph.transformations.commands import OVNullBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVTargetPoint
 from nncf.openvino.graph.transformations.commands import OVWeightUpdateCommand
 
@@ -51,6 +51,6 @@ class OVCommandCreator(CommandCreator):
         return OVWeightUpdateCommand(target_point, weight_value)
 
     @staticmethod
-    def create_command_to_insert_bias(node_without_bias: NNCFNode) -> OVBiasInsertionCommand:
+    def create_command_to_insert_bias(node_without_bias: NNCFNode) -> OVNullBiasInsertionCommand:
         target_point = OVTargetPoint(TargetType.POST_LAYER_OPERATION, node_without_bias.node_name, 0)
-        return OVBiasInsertionCommand(target_point)
+        return OVNullBiasInsertionCommand(target_point)

--- a/nncf/openvino/graph/transformations/commands.py
+++ b/nncf/openvino/graph/transformations/commands.py
@@ -158,7 +158,6 @@ class OVBiasInsertionCommand(TransformationCommand):
         """
         super().__init__(TransformationType.INSERT, target_point)
 
-
     def union(self, other: "TransformationCommand") -> "TransformationCommand":
         # Have a look at nncf/torch/graph/transformations/commands/PTInsertionCommand
         raise NotImplementedError()

--- a/nncf/openvino/graph/transformations/commands.py
+++ b/nncf/openvino/graph/transformations/commands.py
@@ -145,3 +145,20 @@ class OVModelExtractionCommand(Command):
     def union(self, other: "Command") -> "Command":
         # Have a look at nncf/torch/graph/transformations/commands/PTInsertionCommand
         raise NotImplementedError()
+
+
+class OVBiasInsertionCommand(TransformationCommand):
+    """
+    Inserts null bias for the corresponding node.
+    """
+
+    def __init__(self, target_point: OVTargetPoint):
+        """
+        :param target_point: The TargetPoint instance for the insertion that contains layer's information.
+        """
+        super().__init__(TransformationType.INSERT, target_point)
+
+
+    def union(self, other: "TransformationCommand") -> "TransformationCommand":
+        # Have a look at nncf/torch/graph/transformations/commands/PTInsertionCommand
+        raise NotImplementedError()

--- a/nncf/openvino/graph/transformations/commands.py
+++ b/nncf/openvino/graph/transformations/commands.py
@@ -147,7 +147,7 @@ class OVModelExtractionCommand(Command):
         raise NotImplementedError()
 
 
-class OVBiasInsertionCommand(TransformationCommand):
+class OVNullBiasInsertionCommand(TransformationCommand):
     """
     Inserts null bias for the corresponding node.
     """

--- a/nncf/quantization/algorithms/bias_correction/algorithm.py
+++ b/nncf/quantization/algorithms/bias_correction/algorithm.py
@@ -130,7 +130,7 @@ class BiasCorrection(Algorithm):
         dataset: Optional[Dataset] = None,
     ) -> TModel:
         self._set_backend_entity(model)
-        model = self._insert_null_biases(model)
+        model = self._backend_entity.insert_null_biases(model)
         main_transformations_layout = TransformationLayout()
         main_model_transformer = ModelTransformerFactory.create(model)
 
@@ -447,7 +447,7 @@ class BiasCorrection(Algorithm):
     def get_statistic_points(self, model: TModel) -> StatisticPointsContainer:
         self._set_backend_entity(model)
         model_copy = self._remove_fq_from_inputs(copy_model(model))
-        model_copy = self._insert_null_biases(model_copy)
+        model_copy = self._backend_entity.insert_null_biases(model_copy)
         nncf_graph = NNCFGraphFactory.create(model_copy)
         statistic_container = StatisticPointsContainer()
 
@@ -500,25 +500,6 @@ class BiasCorrection(Algorithm):
                 )
 
         return statistic_container
-
-    def _insert_null_biases(self, model: TModel) -> TModel:
-        """
-        This method finds and inserts zero biases for the layers that should have it.
-
-        :param model: TModel instance.
-        :return: Updated TModel instance with zero biases
-        """
-        nncf_graph = NNCFGraphFactory.create(model) if self.nncf_graph is None else self.nncf_graph
-        nodes_without_biases = nncf_graph.get_nodes_by_metatypes(self._backend_entity.types_to_insert_bias)
-        nodes_without_biases = [
-            node for node in nodes_without_biases if not self._backend_entity.is_node_with_bias(node, nncf_graph)
-        ]
-        transformation_layout = TransformationLayout()
-        model_transformer = ModelTransformerFactory.create(model)
-        for node_without_bias in nodes_without_biases:
-            bias_insertion_command = self._backend_entity.create_bias_insertion_command(node_without_bias)
-            transformation_layout.register(bias_insertion_command)
-        return model_transformer.transform(transformation_layout)
 
     def _get_biased_after_input_nodes(self, nncf_graph: NNCFGraph, model_inputs: List[NNCFNode]) -> Dict[str, str]:
         """

--- a/nncf/quantization/algorithms/bias_correction/algorithm.py
+++ b/nncf/quantization/algorithms/bias_correction/algorithm.py
@@ -520,7 +520,6 @@ class BiasCorrection(Algorithm):
             transformation_layout.register(bias_insertion_command)
         return model_transformer.transform(transformation_layout)
 
-
     def _get_biased_after_input_nodes(self, nncf_graph: NNCFGraph, model_inputs: List[NNCFNode]) -> Dict[str, str]:
         """
         This method finds and returns the first nodes with the bias in the model that follows after the input nodes.

--- a/nncf/quantization/algorithms/bias_correction/algorithm.py
+++ b/nncf/quantization/algorithms/bias_correction/algorithm.py
@@ -130,11 +130,11 @@ class BiasCorrection(Algorithm):
         dataset: Optional[Dataset] = None,
     ) -> TModel:
         self._set_backend_entity(model)
+        model = self._insert_null_biases(model)
         main_transformations_layout = TransformationLayout()
         main_model_transformer = ModelTransformerFactory.create(model)
 
         model_copy = copy_model(model)
-        model_copy = self._insert_null_biases(model_copy)
         model_copy = self._remove_fq_from_inputs(model_copy)
         nncf_graph = NNCFGraphFactory.create(model_copy)
 

--- a/nncf/quantization/algorithms/bias_correction/backend.py
+++ b/nncf/quantization/algorithms/bias_correction/backend.py
@@ -46,6 +46,13 @@ class BiasCorrectionAlgoBackend(ABC):
         Returns backend-specific list of the quantizer metatypes.
         """
 
+    @property
+    @abstractmethod
+    def types_to_insert_bias(self):
+        """
+        Returns backend-specific list of the metatypes that should be with bias.
+        """
+
     @staticmethod
     @abstractmethod
     def target_point(target_type: TargetType, target_node_name: str, port_id: int) -> TargetPoint:

--- a/nncf/quantization/algorithms/bias_correction/backend.py
+++ b/nncf/quantization/algorithms/bias_correction/backend.py
@@ -46,13 +46,6 @@ class BiasCorrectionAlgoBackend(ABC):
         Returns backend-specific list of the quantizer metatypes.
         """
 
-    @property
-    @abstractmethod
-    def types_to_insert_bias(self):
-        """
-        Returns backend-specific list of the metatypes that should be with bias.
-        """
-
     @staticmethod
     @abstractmethod
     def target_point(target_type: TargetType, target_node_name: str, port_id: int) -> TargetPoint:
@@ -85,16 +78,6 @@ class BiasCorrectionAlgoBackend(ABC):
         :param inputs: List of the input names for sub-model beggining.
         :param outputs: List of the output names for sub-model end.
         :return: Backend-specific TransformationCommand for the model extraction.
-        """
-
-    @staticmethod
-    @abstractmethod
-    def create_bias_insertion_command(node: NNCFNode) -> TransformationCommand:
-        """
-        Returns backend-specific command that inserts null bias.
-
-        :param node: The node for which bias should be inserted.
-        :return: Backend-specific command that inserts output.
         """
 
     @staticmethod
@@ -223,4 +206,14 @@ class BiasCorrectionAlgoBackend(ABC):
         :param node: NNCFNode with the attributes.
         :param nncf_graph: NNCFGraph instance with the node.
         :return: Boolean indicating whether the node has a bias or not.
+        """
+
+    @staticmethod
+    @abstractmethod
+    def insert_null_biases(model: TModel) -> TModel:
+        """
+        This method finds and inserts zero biases for the layers that should have it.
+
+        :param model: TModel instance.
+        :return: TModel instance with zero biases
         """

--- a/nncf/quantization/algorithms/bias_correction/backend.py
+++ b/nncf/quantization/algorithms/bias_correction/backend.py
@@ -89,6 +89,16 @@ class BiasCorrectionAlgoBackend(ABC):
 
     @staticmethod
     @abstractmethod
+    def create_bias_insertion_command(node: NNCFNode) -> TransformationCommand:
+        """
+        Returns backend-specific command that inserts null bias.
+
+        :param node: The node for which bias should be inserted.
+        :return: Backend-specific command that inserts output.
+        """
+
+    @staticmethod
+    @abstractmethod
     def output_insertion_command(nncf_graph: NNCFGraph, target_point: TargetPoint) -> TransformationCommand:
         """
         Returns backend-specific command that inserts output.

--- a/nncf/quantization/algorithms/bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/onnx_backend.py
@@ -135,4 +135,4 @@ class ONNXBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
 
     @staticmethod
     def insert_null_biases(model: onnx.ModelProto) -> onnx.ModelProto:
-        pass
+        return model

--- a/nncf/quantization/algorithms/bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/onnx_backend.py
@@ -50,6 +50,10 @@ class ONNXBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
     def quantizer_types(self) -> List[OperatorMetatype]:
         return [ONNXQuantizeLinearMetatype, ONNXDequantizeLinearMetatype]
 
+    @property
+    def types_to_insert_bias(self):
+        return []
+
     @staticmethod
     def target_point(target_type: TargetType, target_node_name: str, port_id: int) -> ONNXTargetPoint:
         return ONNXTargetPoint(target_type, target_node_name, port_id)

--- a/nncf/quantization/algorithms/bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/onnx_backend.py
@@ -28,6 +28,7 @@ from nncf.onnx.graph.onnx_graph import ONNXGraph
 from nncf.onnx.graph.transformations.command_creation import create_bias_correction_command
 from nncf.onnx.graph.transformations.commands import ONNXBiasCorrectionCommand
 from nncf.onnx.graph.transformations.commands import ONNXModelExtractionCommand
+from nncf.onnx.graph.transformations.commands import ONNXNullBiasInsertionCommand
 from nncf.onnx.graph.transformations.commands import ONNXOutputInsertionCommand
 from nncf.onnx.graph.transformations.commands import ONNXQDQNodeRemovingCommand
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
@@ -67,6 +68,10 @@ class ONNXBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
     @staticmethod
     def model_extraction_command(inputs: List[str], outputs: List[str]) -> ONNXModelExtractionCommand:
         return ONNXModelExtractionCommand(inputs, outputs)
+
+    @staticmethod
+    def create_bias_insertion_command(node: NNCFNode) -> ONNXNullBiasInsertionCommand:
+        return ONNXNullBiasInsertionCommand(node)
 
     @staticmethod
     def output_insertion_command(nncf_graph: NNCFGraph, target_point: ONNXTargetPoint) -> ONNXOutputInsertionCommand:

--- a/nncf/quantization/algorithms/bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/onnx_backend.py
@@ -132,3 +132,7 @@ class ONNXBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
     @staticmethod
     def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         return is_node_with_bias(node)
+
+    @staticmethod
+    def insert_null_biases(model: onnx.ModelProto) -> onnx.ModelProto:
+        pass

--- a/nncf/quantization/algorithms/bias_correction/openvino_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/openvino_backend.py
@@ -31,9 +31,9 @@ from nncf.openvino.graph.node_utils import get_bias_value
 from nncf.openvino.graph.node_utils import is_node_with_bias
 from nncf.openvino.graph.transformations.command_creation import OVCommandCreator
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
-from nncf.openvino.graph.transformations.commands import OVBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVFQNodeRemovingCommand
 from nncf.openvino.graph.transformations.commands import OVModelExtractionCommand
+from nncf.openvino.graph.transformations.commands import OVNullBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVOutputInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVTargetPoint
 from nncf.openvino.statistics.collectors import OVNNCFCollectorTensorProcessor
@@ -80,7 +80,7 @@ class OVBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
         return OVModelExtractionCommand(inputs, outputs)
 
     @staticmethod
-    def create_bias_insertion_command(node: NNCFNode) -> OVBiasInsertionCommand:
+    def create_bias_insertion_command(node: NNCFNode) -> OVNullBiasInsertionCommand:
         return OVCommandCreator.create_command_to_insert_bias(node)
 
     @staticmethod

--- a/nncf/quantization/algorithms/bias_correction/openvino_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/openvino_backend.py
@@ -57,7 +57,13 @@ class OVBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
 
     @property
     def types_to_insert_bias(self):
-        return [OVConvolutionMetatype, OVGroupConvolutionMetatype, OVDepthwiseConvolutionMetatype, OVConvolutionBackpropDataMetatype, OVGroupConvolutionBackpropDataMetatype]
+        return [
+            OVConvolutionMetatype,
+            OVGroupConvolutionMetatype,
+            OVDepthwiseConvolutionMetatype,
+            OVConvolutionBackpropDataMetatype,
+            OVGroupConvolutionBackpropDataMetatype,
+        ]
 
     @staticmethod
     def target_point(target_type: TargetType, target_node_name: str, port_id: int) -> OVTargetPoint:

--- a/nncf/quantization/algorithms/fast_bias_correction/algorithm.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/algorithm.py
@@ -122,16 +122,15 @@ class FastBiasCorrection(Algorithm):
         dataset: Optional[Dataset] = None,
     ) -> TModel:
         self._set_backend_entity(model)
-        model_copy = copy_model(model)
-        model_copy = self._insert_null_biases(model_copy)
+        model = self._insert_null_biases(model)
 
-        nncf_graph = NNCFGraphFactory.create(model_copy)
+        nncf_graph = NNCFGraphFactory.create(model)
         node_and_bias_value = (
-            (node, self._backend_entity.get_bias_value(node, nncf_graph, model_copy))
+            (node, self._backend_entity.get_bias_value(node, nncf_graph, model))
             for node in nncf_graph.get_all_nodes()
             if self._backend_entity.is_node_with_bias(node, nncf_graph)
         )
-        model_transformer = ModelTransformerFactory.create(model_copy)
+        model_transformer = ModelTransformerFactory.create(model)
         # Fill `node_and_new_bias_value` list. It is a correspondence between nodes
         # for which we should update bias and new bias values.
         node_and_new_bias_value = []

--- a/nncf/quantization/algorithms/fast_bias_correction/backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/backend.py
@@ -40,13 +40,6 @@ class FastBiasCorrectionAlgoBackend(ABC):
 
     @property
     @abstractmethod
-    def types_to_insert_bias(self):
-        """
-        Returns backend-specific list of the metatypes that should be with bias.
-        """
-
-    @property
-    @abstractmethod
     def tensor_processor(self):
         """
         Returns backend-specific instance of the NNCFCollectorTensorProcessor.
@@ -62,16 +55,6 @@ class FastBiasCorrectionAlgoBackend(ABC):
         :param target_node_name: Name of the located node.
         :param port_id: Port ID of the tensor for the statistics distribution.
         :return: Backend-specific TargetPoint.
-        """
-
-    @staticmethod
-    @abstractmethod
-    def create_bias_insertion_command(node: NNCFNode) -> TransformationCommand:
-        """
-        Returns backend-specific command that inserts null bias.
-
-        :param node: The node for which bias should be inserted.
-        :return: Backend-specific command that inserts output.
         """
 
     @staticmethod
@@ -194,4 +177,14 @@ class FastBiasCorrectionAlgoBackend(ABC):
         :param node: NNCFNode with the attributes.
         :param nncf_graph: NNCFGraph that contains node.
         :return: Boolean indicating whether the node has a bias or not.
+        """
+
+    @staticmethod
+    @abstractmethod
+    def insert_null_biases(model: TModel) -> TModel:
+        """
+        This method finds and inserts zero biases for the layers that should have it.
+
+        :param model: TModel instance.
+        :return: TModel instance with zero biases
         """

--- a/nncf/quantization/algorithms/fast_bias_correction/backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/backend.py
@@ -40,6 +40,13 @@ class FastBiasCorrectionAlgoBackend(ABC):
 
     @property
     @abstractmethod
+    def types_to_insert_bias(self):
+        """
+        Returns backend-specific list of the metatypes that should be with bias.
+        """
+
+    @property
+    @abstractmethod
     def tensor_processor(self):
         """
         Returns backend-specific instance of the NNCFCollectorTensorProcessor.
@@ -59,7 +66,19 @@ class FastBiasCorrectionAlgoBackend(ABC):
 
     @staticmethod
     @abstractmethod
-    def create_bias_correction_command(node: NNCFNode, bias_value: np.ndarray, nncf_graph: NNCFGraph):
+    def create_bias_insertion_command(node: NNCFNode) -> TransformationCommand:
+        """
+        Returns backend-specific command that inserts null bias.
+
+        :param node: The node for which bias should be inserted.
+        :return: Backend-specific command that inserts output.
+        """
+
+    @staticmethod
+    @abstractmethod
+    def create_bias_correction_command(
+        node: NNCFNode, bias_value: np.ndarray, nncf_graph: NNCFGraph
+    ) -> TransformationCommand:
         """
         Creates backend-specific command to update bias value.
 

--- a/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
@@ -27,6 +27,7 @@ from nncf.onnx.graph.node_utils import is_node_with_bias
 from nncf.onnx.graph.transformations.command_creation import create_bias_correction_command
 from nncf.onnx.graph.transformations.commands import ONNXBiasCorrectionCommand
 from nncf.onnx.graph.transformations.commands import ONNXModelExtractionCommand
+from nncf.onnx.graph.transformations.commands import ONNXNullBiasInsertionCommand
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
 from nncf.onnx.statistics.collectors import ONNXMeanStatisticCollector
 from nncf.onnx.statistics.collectors import ONNXNNCFCollectorTensorProcessor
@@ -42,12 +43,20 @@ class ONNXFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         return ONNX_OPERATION_METATYPES
 
     @property
+    def types_to_insert_bias(self):
+        return []
+
+    @property
     def tensor_processor(self) -> ONNXNNCFCollectorTensorProcessor:
         return ONNXNNCFCollectorTensorProcessor()
 
     @staticmethod
     def target_point(target_type: TargetType, target_node_name: str, port_id: int) -> ONNXTargetPoint:
         return ONNXTargetPoint(target_type, target_node_name, port_id)
+
+    @staticmethod
+    def create_bias_insertion_command(node: NNCFNode) -> ONNXNullBiasInsertionCommand:
+        return ONNXNullBiasInsertionCommand(node)
 
     @staticmethod
     def create_bias_correction_command(

--- a/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
@@ -115,4 +115,4 @@ class ONNXFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
 
     @staticmethod
     def insert_null_biases(model: onnx.ModelProto) -> onnx.ModelProto:
-        pass
+        return model

--- a/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
@@ -112,3 +112,7 @@ class ONNXFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
     @staticmethod
     def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         return is_node_with_bias(node)
+
+    @staticmethod
+    def insert_null_biases(model: onnx.ModelProto) -> onnx.ModelProto:
+        pass

--- a/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
@@ -23,17 +23,12 @@ from nncf.common.utils.registry import Registry
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
 from nncf.openvino.graph.metatypes.common import FAKE_QUANTIZE_OPERATIONS
 from nncf.openvino.graph.metatypes.openvino_metatypes import OV_OPERATOR_METATYPES
-from nncf.openvino.graph.metatypes.openvino_metatypes import OVConvolutionBackpropDataMetatype
-from nncf.openvino.graph.metatypes.openvino_metatypes import OVConvolutionMetatype
-from nncf.openvino.graph.metatypes.openvino_metatypes import OVDepthwiseConvolutionMetatype
-from nncf.openvino.graph.metatypes.openvino_metatypes import OVGroupConvolutionBackpropDataMetatype
-from nncf.openvino.graph.metatypes.openvino_metatypes import OVGroupConvolutionMetatype
+from nncf.openvino.graph.model_utils import insert_null_biases
 from nncf.openvino.graph.node_utils import get_bias_value
 from nncf.openvino.graph.node_utils import is_node_with_bias
 from nncf.openvino.graph.transformations.command_creation import OVCommandCreator
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
 from nncf.openvino.graph.transformations.commands import OVModelExtractionCommand
-from nncf.openvino.graph.transformations.commands import OVNullBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVTargetPoint
 from nncf.openvino.statistics.collectors import OVNNCFCollectorTensorProcessor
 from nncf.openvino.statistics.collectors import get_mean_stat_collector
@@ -49,26 +44,12 @@ class OVFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         return OV_OPERATOR_METATYPES
 
     @property
-    def types_to_insert_bias(self):
-        return [
-            OVConvolutionMetatype,
-            OVGroupConvolutionMetatype,
-            OVDepthwiseConvolutionMetatype,
-            OVConvolutionBackpropDataMetatype,
-            OVGroupConvolutionBackpropDataMetatype,
-        ]
-
-    @property
     def tensor_processor(self) -> OVNNCFCollectorTensorProcessor:
         return OVNNCFCollectorTensorProcessor
 
     @staticmethod
     def target_point(target_type: TargetType, target_node_name: str, port_id: int) -> OVTargetPoint:
         return OVTargetPoint(target_type, target_node_name, port_id)
-
-    @staticmethod
-    def create_bias_insertion_command(node: NNCFNode) -> OVNullBiasInsertionCommand:
-        return OVCommandCreator.create_command_to_insert_bias(node)
 
     @staticmethod
     def create_bias_correction_command(
@@ -127,3 +108,7 @@ class OVFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
     @staticmethod
     def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         return is_node_with_bias(node, nncf_graph)
+
+    @staticmethod
+    def insert_null_biases(model: ov.Model) -> ov.Model:
+        return insert_null_biases(model)

--- a/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
@@ -23,11 +23,17 @@ from nncf.common.utils.registry import Registry
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
 from nncf.openvino.graph.metatypes.common import FAKE_QUANTIZE_OPERATIONS
 from nncf.openvino.graph.metatypes.openvino_metatypes import OV_OPERATOR_METATYPES
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVConvolutionBackpropDataMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVConvolutionMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVDepthwiseConvolutionMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVGroupConvolutionBackpropDataMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVGroupConvolutionMetatype
 from nncf.openvino.graph.node_utils import get_bias_value
 from nncf.openvino.graph.node_utils import is_node_with_bias
 from nncf.openvino.graph.transformations.command_creation import OVCommandCreator
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
 from nncf.openvino.graph.transformations.commands import OVModelExtractionCommand
+from nncf.openvino.graph.transformations.commands import OVNullBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVTargetPoint
 from nncf.openvino.statistics.collectors import OVNNCFCollectorTensorProcessor
 from nncf.openvino.statistics.collectors import get_mean_stat_collector
@@ -43,12 +49,26 @@ class OVFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         return OV_OPERATOR_METATYPES
 
     @property
+    def types_to_insert_bias(self):
+        return [
+            OVConvolutionMetatype,
+            OVGroupConvolutionMetatype,
+            OVDepthwiseConvolutionMetatype,
+            OVConvolutionBackpropDataMetatype,
+            OVGroupConvolutionBackpropDataMetatype,
+        ]
+
+    @property
     def tensor_processor(self) -> OVNNCFCollectorTensorProcessor:
         return OVNNCFCollectorTensorProcessor
 
     @staticmethod
     def target_point(target_type: TargetType, target_node_name: str, port_id: int) -> OVTargetPoint:
         return OVTargetPoint(target_type, target_node_name, port_id)
+
+    @staticmethod
+    def create_bias_insertion_command(node: NNCFNode) -> OVNullBiasInsertionCommand:
+        return OVCommandCreator.create_command_to_insert_bias(node)
 
     @staticmethod
     def create_bias_correction_command(

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -28,9 +28,9 @@ from nncf.openvino.graph.node_utils import get_inplace_min_op
 from nncf.openvino.graph.node_utils import get_reduce_node_name
 from nncf.openvino.graph.node_utils import get_result_node_name
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
-from nncf.openvino.graph.transformations.commands import OVBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVFQNodeRemovingCommand
 from nncf.openvino.graph.transformations.commands import OVInplaceFnInsertionCommand
+from nncf.openvino.graph.transformations.commands import OVNullBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVOutputInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVQuantizerInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVTargetPoint
@@ -534,7 +534,7 @@ def test_null_biases_insertion(model_with_parameters):
     model = model_with_parameters["model"]
     layers = model_with_parameters["layers"]
 
-    transformed_model = create_transformed_model(model, layers, TargetType.LAYER, OVBiasInsertionCommand, port_id=0)
+    transformed_model = create_transformed_model(model, layers, TargetType.LAYER, OVNullBiasInsertionCommand, port_id=0)
     ops_dict = {op.get_friendly_name(): op for op in transformed_model.get_ops()}
 
     for layer_name in layers:

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -28,6 +28,7 @@ from nncf.openvino.graph.node_utils import get_inplace_min_op
 from nncf.openvino.graph.node_utils import get_reduce_node_name
 from nncf.openvino.graph.node_utils import get_result_node_name
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
+from nncf.openvino.graph.transformations.commands import OVBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVFQNodeRemovingCommand
 from nncf.openvino.graph.transformations.commands import OVInplaceFnInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVOutputInsertionCommand
@@ -37,10 +38,12 @@ from nncf.quantization.fake_quantize import FakeQuantizeParameters
 from tests.openvino.conftest import OPENVINO_NATIVE_TEST_ROOT
 from tests.openvino.native.common import compare_nncf_graphs
 from tests.openvino.native.models import ConvModel
+from tests.openvino.native.models import ConvNotBiasModel
 from tests.openvino.native.models import FPModel
 from tests.openvino.native.models import LinearModel
 from tests.openvino.native.models import QuantizedModel
 from tests.openvino.native.models import SimpleSplitModel
+from tests.openvino.native.models import WeightsModel
 from tests.openvino.native.models import ZeroRankEltwiseModel
 
 REFERENCE_GRAPHS_DIR = OPENVINO_NATIVE_TEST_ROOT / "data" / "reference_graphs" / "original_nncf_graph"
@@ -518,3 +521,34 @@ def test_no_transformations():
     for output in ret_val_1.keys():
         assert np.allclose(ret_val_1[output], ret_val_2[output])
     assert id(transformed_model) != id(model)
+
+
+MODELS_WITH_PARAMETERS = [
+    {"model": ConvNotBiasModel().ov_model, "layers": ["Conv"]},
+    {"model": WeightsModel().ov_model, "layers": ["Conv", "Conv_backprop"]},
+]
+
+
+@pytest.mark.parametrize("model_with_parameters", MODELS_WITH_PARAMETERS)
+def test_null_biases_insertion(model_with_parameters):
+    model = model_with_parameters["model"]
+    layers = model_with_parameters["layers"]
+
+    transformed_model = create_transformed_model(model, layers, TargetType.LAYER, OVBiasInsertionCommand, port_id=0)
+    ops_dict = {op.get_friendly_name(): op for op in transformed_model.get_ops()}
+
+    for layer_name in layers:
+        node = ops_dict[layer_name]
+        layer_shape = ops_dict[layer_name].shape
+        bias_dtype = node.get_element_type().to_dtype()
+
+        # We assume that there is only ONE bias after convolution
+        output_port = node.output(0)
+        add_with_bias = list(output_port.get_target_inputs())[0].get_node()
+        assert add_with_bias.get_type_name() == "Add"
+
+        # We assume that the bias inserts only on 1st position for Add layer
+        bias_node = add_with_bias.input(1).get_source_output().get_node()
+        assert bias_node.get_type_name() == "Constant"
+
+        assert all(bias_node.get_vector() == np.zeros(layer_shape[1], dtype=bias_dtype))


### PR DESCRIPTION
### Changes

- Added `insert_null_biases` pass into the BiasCorrection algorithm.

### Reason for changes

- This pass allows us to correct the bias in the layers that could have it.
### Related tickets

104117

### Tests

conformance run - 123

ONNX ticket - 110696
PT ticket - 110697