### PR TITLE
[ReleaseV250] Range initialization fix (#1774)

### DIFF
--- a/nncf/tensorflow/quantization/quantizers.py
+++ b/nncf/tensorflow/quantization/quantizers.py
@@ -494,6 +494,8 @@ class AsymmetricQuantizer(Quantizer):
         return _default_quantize()
 
     def apply_range_initialization(self, weights, min_values, max_values, min_range=0.1, eps=0.01):
+        min_values = tf.minimum(min_values, 0)
+        max_values = tf.maximum(max_values, 0)
         ranges = max_values - min_values
         max_range = tf.reduce_max(ranges)
         lower_threshold = tf.maximum(eps * max_range, min_range)

--- a/tests/tensorflow/quantization/test_range_init.py
+++ b/tests/tensorflow/quantization/test_range_init.py
@@ -24,6 +24,7 @@ from nncf.tensorflow.layers.operation import InputType
 from nncf.tensorflow.layers.wrapper import NNCFWrapper
 from nncf.tensorflow.quantization import FakeQuantize
 from nncf.tensorflow.quantization.init_range import TFRangeInitParams
+from nncf.tensorflow.quantization.quantizers import AsymmetricQuantizer
 from nncf.tensorflow.quantization.quantizers import TFQuantizerSpec
 
 
@@ -151,3 +152,37 @@ class TestPerLayerRangeInitTest:
             input_type,
         ), ref_range_init_config in per_layer_range_init_test_struct.layer_vs_expected_init_config:
             assert params.get_init_config_for_quantization_point(layer, input_type) == ref_range_init_config
+
+
+@pytest.mark.parametrize(
+    ("min_values", "max_values", "input_low", "input_range"),
+    [
+        ([0], [1], [0], [1]),
+        ([1], [2], [0], [2]),
+        ([-1], [0], [-1], [1]),
+        ([-2], [-1], [-2], [2]),
+        ([0], [0.1], [0], [0.1]),
+        ([0], [0.05], [-0.025], [0.1]),
+        ([0], [0.04], [-0.03], [0.1]),
+        ([100], [101], [0], [101]),
+        ([100], [200], [0], [200]),
+        ([0, 1, -1, -2], [1, 2, 0, -1], [0, 0, -1, -2], [1, 2, 1, 2]),
+        ([100, 100], [101, 200], [0, 0], [101, 200]),
+        ([0, 0], [0.04, 100], [-0.48, 0], [1, 100]),
+    ],
+)
+def test_asymmetric_apply_range_initialization(min_values, max_values, input_low, input_range):
+    min_values_tf = tf.constant(min_values, dtype=tf.float32)
+    max_values_tf = tf.constant(max_values, dtype=tf.float32)
+    input_low_tf = tf.constant(input_low, dtype=tf.float32)
+    input_range_tf = tf.constant(input_range, dtype=tf.float32)
+    weights = dict(
+        input_low_var=tf.Variable(tf.zeros_like(min_values_tf)),
+        input_range_var=tf.Variable(tf.zeros_like(min_values_tf)),
+    )
+
+    asymmetric_quantizer = AsymmetricQuantizer("test_quantizer", TFQuantizerSpec(*((None,) * 6)))
+    asymmetric_quantizer.apply_range_initialization(weights, min_values_tf, max_values_tf)
+
+    assert tf.reduce_max(tf.abs(input_low_tf - weights["input_low_var"])).numpy() < 1e-5
+    assert tf.reduce_max(tf.abs(input_range_tf - weights["input_range_var"])).numpy() < 1e-5


### PR DESCRIPTION
This is a copy of #1774 to release branch. This PR fixes TensorFlow MobileNets quantization initialization.

### Changes

Included 0 in quantization ranges computation for TF.

### Reason for changes

MobileNets had accuracy degradation to 0 after quantization initialization. The issue was with the range initialization for outputs of HardSigmoid function which always returned 1 for samples from initializing dataset. This resulted in `input_low=0.95` and `input_range=0.1`, and then TF quantization turns these into `input_low=0`, `input_range=0.1` which doesn't include 1.

The fix forces initializer to include 0 in the range, as it should've done. This in the end results in `input_low=0` and `input_range=1` which allows for proper quantization of HardSigmoid outputs and resolves the accuracy issue.

### Related tickets

56945

### Tests

Added a test for `apply_range_initialization` method.
