### PR TITLE
[TF] Updated configs for MobileNets

### DIFF
--- a/examples/tensorflow/classification/configs/quantization/mobilenet_v2_imagenet_int8.json
+++ b/examples/tensorflow/classification/configs/quantization/mobilenet_v2_imagenet_int8.json
@@ -26,12 +26,6 @@
             "batchnorm_adaptation": {
                 "num_bn_adaptation_samples": 2048
             }
-        },
-        "weights": {
-            "per_channel": false
-        },
-        "activations": {
-            "per_channel": false
         }
     }
 }

--- a/examples/tensorflow/classification/configs/quantization/mobilenet_v3_large_imagenet_int8.json
+++ b/examples/tensorflow/classification/configs/quantization/mobilenet_v3_large_imagenet_int8.json
@@ -20,8 +20,6 @@
     "dataset": "imagenet2012",
     "dataset_type": "tfds",
 
-    "disable_tensor_float_32_execution": true,
-
     "compression": {
         "algorithm": "quantization",
         "preset": "mixed",
@@ -29,14 +27,6 @@
             "batchnorm_adaptation": {
                 "num_bn_adaptation_samples": 2048
             }
-        },
-        "weights": {
-           "bits": 8,
-           "per_channel": true
-       },
-        "activations": {
-            "bits": 8,
-            "per_channel": false
         }
    }
 }

--- a/examples/tensorflow/classification/configs/quantization/mobilenet_v3_small_imagenet_int8.json
+++ b/examples/tensorflow/classification/configs/quantization/mobilenet_v3_small_imagenet_int8.json
@@ -17,8 +17,6 @@
         }
     },
 
-    "disable_tensor_float_32_execution": true,
-
     "dataset": "imagenet2012",
     "dataset_type": "tfds",
 
@@ -29,14 +27,6 @@
             "batchnorm_adaptation": {
                 "num_bn_adaptation_samples": 2048
             }
-        },
-        "weights": {
-           "bits": 8,
-           "per_channel": true
-       },
-        "activations": {
-            "bits": 8,
-            "per_channel": false
         }
    }
 }

--- a/examples/tensorflow/classification/configs/sparsity_quantization/mobilenet_v2_imagenet_rb_sparsity_int8.json
+++ b/examples/tensorflow/classification/configs/sparsity_quantization/mobilenet_v2_imagenet_rb_sparsity_int8.json
@@ -31,13 +31,7 @@
             }
         },
         {
-            "algorithm": "quantization",
-            "weights": {
-                "per_channel": false
-            },
-            "activations": {
-                "per_channel": false
-            }
+            "algorithm": "quantization"
         }
     ]
 }

--- a/examples/tensorflow/classification/configs/sparsity_quantization/mobilenet_v3_large_imagenet_rb_sparsity_int8.json
+++ b/examples/tensorflow/classification/configs/sparsity_quantization/mobilenet_v3_large_imagenet_rb_sparsity_int8.json
@@ -20,8 +20,6 @@
     "dataset": "imagenet2012",
     "dataset_type": "tfds",
 
-    "disable_tensor_float_32_execution": true,
-
     "compression":[
         {
             "algorithm": "rb_sparsity",
@@ -34,14 +32,6 @@
         },
         {
             "algorithm": "quantization",
-            "preset": "mixed",
-            "weights": {
-                "bits": 8,
-                "per_channel": true
-            },
-            "activations": {
-                "bits": 8,
-                "per_channel": false
-            }
+            "preset": "mixed"
         }]
 }


### PR DESCRIPTION
## Work in progress

### Changes

- Removed `"disable_tensor_float_32_execution": true` since it's no longer needed
- Made activations quantization per-channel
- Retrained all affected models

| Config| Old Accuracy | New Accuracy|
| ----------- | ----------- | - |
| mobilenet_v2_imagenet_int8 | 71.63%       | 72.11%|
| mobilenet_v3_large_imagenet_int8| 74.91% | 75.08% |
| mobilenet_v2_imagenet_rb_sparsity_int8| 70.94% | |
|mobilenet_v3_large_imagenet_rb_sparsity_int8 | 75.23% | |
| mobilenet_v3_small_imagenet_rb_sparsity_int8| 67.41%| 67.63%|
