### PR TITLE
Batched wave2vec fix

### DIFF
--- a/nncf/experimental/common/pruning/propagation_data.py
+++ b/nncf/experimental/common/pruning/propagation_data.py
@@ -147,12 +147,14 @@ class PropagationGroup:
         block: PruningBlock,
         producers: Optional[Set[ProducerInfo]] = None,
         consumers: Optional[Set[ConsumerInfo]] = None,
+        is_mixed: bool = False,
     ) -> None:
         self.block = block
         self._children: List["PropagationGroup"] = []
         self._is_invalid = False
         self._producers = set() if producers is None else producers
         self._consumers = set() if consumers is None else consumers
+        self.is_mixed = is_mixed
 
     @property
     def is_invalid(self):
@@ -190,10 +192,12 @@ class PropagationGroup:
         )
 
         new_group = PropagationGroup(block=first_block)
+        is_mixed = any(group.is_mixed for group in args)
         for group in args:
             group.add_child(new_group)
             new_group.add_producers(group.get_producers())
             new_group.add_consumers(group.get_consumers())
+        new_group.is_mixed = is_mixed
         return new_group
 
     def add_consumers(self, consumers: Set[ConsumerInfo]):

--- a/tests/torch/pruning/experimental/test_nodes_grouping.py
+++ b/tests/torch/pruning/experimental/test_nodes_grouping.py
@@ -426,7 +426,7 @@ AUDIO_DESCS = [
     GroupTestDesc(
         model_desc=GeneralModelDesc(
             model_name="Wave2Vec 2.0",
-            input_info=dict(sample_size=[1, 400]),
+            input_info=dict(sample_size=[3, 400]),
             model_builder=partial(
                 AutoModelForAudioClassification.from_config,
                 Wav2Vec2Config(

--- a/tests/torch/sparsity/movement/helpers/run_recipe.py
+++ b/tests/torch/sparsity/movement/helpers/run_recipe.py
@@ -280,6 +280,27 @@ class Wav2Vec2RunRecipe(BaseMockRunRecipe):
         return AutoModelForAudioClassification.from_config(self.model_config)
 
 
+class Wav2Vec2RunRecipeBatched(Wav2Vec2RunRecipe):
+    default_model_config = Wav2Vec2Config(
+        vocab_size=2,
+        hidden_size=4,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        conv_dim=(4, 4),
+        conv_stride=(1, 1),
+        conv_kernel=(3, 3),
+        num_conv_pos_embeddings=3,
+        num_conv_pos_embedding_groups=1,
+        proj_codevector_dim=4,
+        classifier_proj_size=3,
+        num_labels=2,
+    )
+
+    @property
+    def model_input_info(self) -> List[ModelInputInfo]:
+        return [ModelInputInfo(shape=[3, 32], keyword="input_values")]
+
+
 class BertRunRecipe(BaseMockRunRecipe):
     model_family = "huggingface_bert"
     supports_structured_masking = True

--- a/tests/torch/sparsity/movement/test_model_saving.py
+++ b/tests/torch/sparsity/movement/test_model_saving.py
@@ -44,6 +44,7 @@ from tests.torch.sparsity.movement.helpers import Wav2Vec2RunRecipe
 from tests.torch.sparsity.movement.helpers import build_compression_trainer
 from tests.torch.sparsity.movement.helpers import force_update_sparsifier_binary_masks_by_threshold
 from tests.torch.sparsity.movement.helpers import initialize_sparsifier_parameters_by_linspace
+from tests.torch.sparsity.movement.helpers.run_recipe import Wav2Vec2RunRecipeBatched
 
 
 class TestONNXExport:
@@ -177,6 +178,11 @@ class TestONNXExport:
                 ),
             ),
             Dict(
+                nncf_weight_ratio=0.74,
+                ov_weight_ratio=0.74,
+                recipe=Wav2Vec2RunRecipeBatched().model_config_(),
+            ),
+            Dict(
                 nncf_weight_ratio=0.43,
                 ov_weight_ratio=0.29,
                 recipe=SwinRunRecipe().model_config_(
@@ -239,7 +245,7 @@ class TestONNXExport:
         ctrl.resolve_structured_mask()
         ctrl.populate_structured_mask()
         compression_rate = ctrl.statistics().movement_sparsity.model_statistics.sparsity_level
-
+        print(ctrl.statistics().to_str())
         onnx_model_path = str(tmp_path / "structured.onnx")
         ctrl.export_model(onnx_model_path)
         core = Core()


### PR DESCRIPTION
### Changes

Allow to mix pruning and non-pruning dimensions if they are unmixed further in the graph. 

### Reason for changes

Wave2Vec 2.0 had a degradation in the automatic structured algorithm with batch != 1

### Related tickets

110126

### Tests
test_groups
test_ngraph_pruning

