### PR TITLE
[PTQ][OV] Fix inplace statistic reducers names and hashes

### DIFF
--- a/nncf/experimental/common/tensor_statistics/collectors.py
+++ b/nncf/experimental/common/tensor_statistics/collectors.py
@@ -598,5 +598,5 @@ AGGREGATORS_MAP = {
     AggregatorType.MEAN: MeanAggregator,
     AggregatorType.MEAN_NO_OUTLIERS: MeanNoOutliersAggregator,
     AggregatorType.MEDIAN: MedianAggregator,
-    AggregatorType.MEAN_NO_OUTLIERS: MedianNoOutliersAggregator,
+    AggregatorType.MEDIAN_NO_OUTLIERS: MedianNoOutliersAggregator,
 }

--- a/nncf/experimental/common/tensor_statistics/collectors.py
+++ b/nncf/experimental/common/tensor_statistics/collectors.py
@@ -13,7 +13,7 @@ from abc import ABC
 from abc import abstractmethod
 from collections import defaultdict
 from collections import deque
-from typing import Any, Dict, Hashable, List, Optional, Set, Tuple, TypeVar, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, TypeVar, Union
 
 from nncf.common.tensor import TensorType
 from nncf.common.tensor_statistics.collectors import NNCFCollectorTensorProcessor

--- a/nncf/openvino/statistics/collectors.py
+++ b/nncf/openvino/statistics/collectors.py
@@ -148,8 +148,6 @@ class OVNNCFCollectorTensorProcessor(NNCFCollectorTensorProcessor):
 
 
 class OVNoopReducer(NoopReducer):
-    NAME = "noop"
-
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
         return [get_result_node_name(target_node_name, port_id)]
 

--- a/nncf/openvino/statistics/collectors.py
+++ b/nncf/openvino/statistics/collectors.py
@@ -155,107 +155,83 @@ class OVNoopReducer(NoopReducer):
 
 
 class OVMinReducer(MinReducer):
-    NAME = "min"
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        return get_inplace_min_op(self.NAME, self._reduction_shape)
+        return get_inplace_min_op(self.name, self._reduction_shape)
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVMaxReducer(MaxReducer):
-    NAME = "max"
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        return get_inplace_max_op(self.NAME, self._reduction_shape, False)
+        return get_inplace_max_op(self.name, self._reduction_shape, False)
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVAbsMaxReducer(AbsMaxReducer):
-    NAME = "abs_max"
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        return get_inplace_max_op(self.NAME, self._reduction_shape, True)
+        return get_inplace_max_op(self.name, self._reduction_shape, True)
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVMeanReducer(MeanReducer):
-    NAME = "mean"
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        return get_inplace_mean_op(self.NAME, self._reduction_shape)
+        return get_inplace_mean_op(self.name, self._reduction_shape)
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVBatchMeanReducer(BatchMeanReducer):
-    NAME = "batch_mean"
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        return get_inplace_batch_mean_op(self.NAME)
+        return get_inplace_batch_mean_op(self.name)
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVMeanPerChanelReducer(MeanPerChReducer):
-    NAME = "mean_per_ch"
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        return get_inplace_mean_per_ch(self.NAME, self._reduction_shape)
+        return get_inplace_mean_per_ch(self.name, self._reduction_shape)
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVQuantileReducer(QuantileReducer):
-    NAME = "quantile"
-
-    @property
-    def inplace(self):
-        return False
+    def get_inplace_fn(self) -> Optional[InplaceInsertionFNType]:
+        return None
 
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
-    def get_inplace_fn(self) -> Optional[InplaceInsertionFNType]:
-        return None
-
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVAbsQuantileReducer(AbsQuantileReducer):
-    NAME = "abs_quantile"
-
-    @property
-    def inplace(self):
-        return False
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
@@ -263,7 +239,7 @@ class OVAbsQuantileReducer(AbsQuantileReducer):
         return None
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 def get_mean_stat_collector(num_samples, channel_axis, window_size=None, inplace=True):

--- a/tests/common/test_statistics_aggregator.py
+++ b/tests/common/test_statistics_aggregator.py
@@ -12,7 +12,8 @@ from abc import abstractmethod
 from collections import Counter
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Type, Union
+from itertools import product
+from typing import Any, List, Type, Union
 
 import numpy as np
 import pytest
@@ -24,6 +25,9 @@ from nncf.common.quantization.structs import QuantizationMode
 from nncf.common.quantization.structs import QuantizerConfig
 from nncf.common.tensor_statistics.statistic_point import StatisticPoint
 from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
+from nncf.experimental.common.tensor_statistics.collectors import NoopAggregator
+from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
+from nncf.experimental.common.tensor_statistics.collectors import TensorReducerBase
 from nncf.quantization.algorithms.bias_correction.backend import BiasCorrectionAlgoBackend
 from nncf.quantization.algorithms.fast_bias_correction.backend import FastBiasCorrectionAlgoBackend
 from nncf.quantization.algorithms.min_max.backend import MinMaxAlgoBackend
@@ -34,7 +38,7 @@ from nncf.quantization.range_estimator import StatisticsCollectorParameters
 from nncf.quantization.range_estimator import StatisticsType
 
 
-# pylint:disable=too-many-public-methods
+# pylint: disable=too-many-public-methods
 class TemplateTestStatisticsAggregator:
     @abstractmethod
     def get_min_max_algo_backend_cls(self) -> Type[MinMaxAlgoBackend]:
@@ -94,6 +98,10 @@ class TemplateTestStatisticsAggregator:
     @abstractmethod
     @pytest.fixture
     def is_backend_support_custom_estimators(self) -> bool:
+        pass
+
+    @abstractmethod
+    def reducers_map(self) -> List[TensorReducerBase]:
         pass
 
     @pytest.fixture
@@ -780,6 +788,58 @@ class TemplateTestStatisticsAggregator:
             if isinstance(ref[0], np.ndarray):
                 assert stat.min_values.shape == ref[0].shape
                 assert stat.max_values.shape == ref[1].shape
+
+    @pytest.mark.parametrize(
+        "statistics_type",
+        [
+            StatisticsType.MIN,
+            StatisticsType.MAX,
+            StatisticsType.ABS_MAX,
+            StatisticsType.MEAN,
+            StatisticsType.QUANTILE,
+            StatisticsType.ABS_QUANTILE,
+            "batch_mean",
+            "mean_per_ch",
+        ],
+    )
+    def test_same_collectors_different_attrs_dont_merge(self, statistics_type, test_params, dataset_samples):
+        params = test_params["test_statistic_merging"]["split_concat"]
+        model = params["model"](dataset_samples)
+        params = {}
+        if statistics_type in [StatisticsType.MIN, StatisticsType.MAX, StatisticsType.ABS_MAX, StatisticsType.MEAN]:
+            params["reduction_shape"] = [None, (0, 1, 3), (1, 2, 3)]
+            params["inplace"] = [False, True]
+        elif statistics_type in [StatisticsType.QUANTILE, StatisticsType.ABS_QUANTILE]:
+            params["reduction_shape"] = [None, (0, 1, 3), (1, 2, 3)]
+            params["quantile"] = [[0.01, 0.99], [0.001, 0.999]]
+        elif statistics_type == "batch_mean":
+            params["inplace"] = [False, True]
+        elif statistics_type == "mean_per_ch":
+            params["inplace"] = [False, True]
+            params["channel_dim"] = [1, 2]
+
+        def product_dict(**kwargs):
+            keys = kwargs.keys()
+            for instance in product(*kwargs.values()):
+                yield dict(zip(keys, instance))
+
+        tensor_collector = TensorCollector()
+        statistics_points = StatisticPointsContainer()
+        target_point_cls = self.get_target_point_cls()
+        target_point_args = (TargetType.POST_LAYER_OPERATION, "split", 0)
+        for params_ in product_dict(**params):
+            reducer = self.reducers_map()[statistics_type](**params_)
+            aggregator = NoopAggregator(1)
+            tensor_collector.register_statistic_branch(str(params_), reducer, aggregator)
+            target_point = target_point_cls(*target_point_args)
+            stat_point = StatisticPoint(target_point, tensor_collector, "TEST")
+            statistics_points.add_statistic_point(stat_point)
+
+        dataset = self.get_dataset(dataset_samples)
+        statistics_aggregator = self.get_statistics_aggregator(dataset)
+        statistics_aggregator.register_statistic_points(statistics_points)
+        # Run statistic collection to check output names matches reduer names
+        statistics_aggregator.collect_statistics(model)
 
     @pytest.mark.parametrize(
         "statistic_point_params",

--- a/tests/common/test_statistics_aggregator.py
+++ b/tests/common/test_statistics_aggregator.py
@@ -813,9 +813,11 @@ class TemplateTestStatisticsAggregator:
             params["reduction_shape"] = [None, (0, 1, 3), (1, 2, 3)]
             params["quantile"] = [[0.01, 0.99], [0.001, 0.999]]
         elif statistics_type == "batch_mean":
+            pytest.skip("Inplace statistic woun't work until openvino==2023.0.0 release")
             params["inplace"] = [False, True]
         elif statistics_type == "mean_per_ch":
-            params["inplace"] = [False, True]
+            # TODO(dlyakhov) uncoment when nncf will switch to openvino==2023.0.0
+            # params["inplace"] = [False, True]
             params["channel_dim"] = [1, 2]
 
         def product_dict(**kwargs):

--- a/tests/experimental/common/test_reducers_and_aggregators.py
+++ b/tests/experimental/common/test_reducers_and_aggregators.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 from abc import abstractmethod
+from itertools import product
 
 import numpy as np
 import pytest
@@ -223,3 +224,52 @@ class TemplateTestReducersAggreagtors:
             aggregator.register_reduced_input(self.get_nncf_tensor(input_with_outliers * mult))
         ret_val = aggregator.aggregate()
         assert self.all_close(ret_val, refs)
+
+    @pytest.mark.parametrize(
+        "reducer_name",
+        ["noop", "min", "max", "abs_max", "mean", "quantile", "abs_quantile", "batch_mean", "mean_per_ch"],
+    )
+    def test_reducers_hash_equal(self, reducer_name, reducers):
+        if reducer_name == "noop":
+            reducers_instances = [reducers[reducer_name]() for _ in range(2)]
+            assert hash(reducers_instances[0]) == hash(reducers_instances[1])
+            assert reducers_instances[0] == reducers_instances[1]
+            assert len(set(reducers_instances)) == 1
+            return
+
+        params = {}
+        if reducer_name in ["min", "max", "abs_max", "mean"]:
+            params["reduction_shape"] = [None, (0, 1, 3), (1, 2, 3)]
+            params["inplace"] = [False, True]
+        elif reducer_name in ["quantile", "abs_quantile"]:
+            params["reduction_shape"] = [None, (0, 1, 3), (1, 2, 3)]
+            params["quantile"] = [[0.01, 0.99], [0.001, 0.999]]
+        elif reducer_name == "batch_mean":
+            params["inplace"] = [False, True]
+        elif reducer_name == "mean_per_ch":
+            params["inplace"] = [False, True]
+            params["channel_dim"] = [1, 2]
+        else:
+            raise RuntimeError(
+                "test_min_max_mean_reducer_hash_equal configurated in a wrong way."
+                f" Wrong reducer_name: {reducer_name}"
+            )
+
+        def product_dict(**kwargs):
+            keys = kwargs.keys()
+            for instance in product(*kwargs.values()):
+                yield dict(zip(keys, instance))
+
+        reducer_cls = reducers[reducer_name]
+        reducers_instances = []
+        for params_ in product_dict(**params):
+            reducers_instances.append(reducer_cls(**params_))
+
+        assert len(set(reducers_instances)) == len(reducers_instances)
+        assert all(hash(reducers_instances[0]) != instns for instns in reducers_instances[1:])
+
+        hashes = [hash(reducer) for reducer in reducers_instances]
+        test_input = [self.get_nncf_tensor(np.empty((1, 3, 4, 4)))]
+        for reducer, init_hash in zip(reducers_instances, hashes):
+            reducer(test_input)
+            assert hash(reducer) == init_hash

--- a/tests/experimental/common/test_reducers_and_aggregators.py
+++ b/tests/experimental/common/test_reducers_and_aggregators.py
@@ -229,11 +229,12 @@ class TemplateTestReducersAggreagtors:
         "reducer_name",
         ["noop", "min", "max", "abs_max", "mean", "quantile", "abs_quantile", "batch_mean", "mean_per_ch"],
     )
-    def test_reducers_hash_equal(self, reducer_name, reducers):
+    def test_reducers_name_hash_equal(self, reducer_name, reducers):
         if reducer_name == "noop":
             reducers_instances = [reducers[reducer_name]() for _ in range(2)]
             assert hash(reducers_instances[0]) == hash(reducers_instances[1])
             assert reducers_instances[0] == reducers_instances[1]
+            assert reducers_instances[0].name == reducers_instances[1].name
             assert len(set(reducers_instances)) == 1
             return
 
@@ -266,7 +267,8 @@ class TemplateTestReducersAggreagtors:
             reducers_instances.append(reducer_cls(**params_))
 
         assert len(set(reducers_instances)) == len(reducers_instances)
-        assert all(hash(reducers_instances[0]) != instns for instns in reducers_instances[1:])
+        assert len({hash(reducer) for reducer in reducers_instances}) == len(reducers_instances)
+        assert len({reducer.name for reducer in reducers_instances}) == len(reducers_instances)
 
         hashes = [hash(reducer) for reducer in reducers_instances]
         test_input = [self.get_nncf_tensor(np.empty((1, 3, 4, 4)))]

--- a/tests/onnx/test_statistics_aggregator.py
+++ b/tests/onnx/test_statistics_aggregator.py
@@ -9,13 +9,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Type
+from typing import List, Type
 
 import numpy as np
 import pytest
 
 from nncf import Dataset
 from nncf.common.graph.transformations.commands import TargetType
+from nncf.experimental.common.tensor_statistics.collectors import TensorReducerBase
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
 from nncf.onnx.statistics.aggregator import ONNXStatisticsAggregator
 from nncf.quantization.algorithms.bias_correction.onnx_backend import ONNXBiasCorrectionAlgoBackend
@@ -75,6 +76,9 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
     def get_target_point_cls(self):
         return ONNXTargetPoint
 
+    def reducers_map(self) -> List[TensorReducerBase]:
+        return None
+
     @pytest.fixture
     def dataset_samples(self, dataset_values):
         input_shape = INPUT_SHAPE
@@ -96,6 +100,10 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
 
     @pytest.mark.skip("Merging is not implemented yet")
     def test_statistics_merging_simple(self, dataset_samples, inplace_statistics, statistic_point_params):
+        pass
+
+    @pytest.mark.skip("Merging is not implemented yet")
+    def test_same_collectors_different_attrs_dont_merge(self, statistics_type, test_params, dataset_samples):
         pass
 
     @pytest.mark.skip("Merging is not implemented yet")

--- a/tests/openvino/native/quantization/test_reducers_and_aggregators.py
+++ b/tests/openvino/native/quantization/test_reducers_and_aggregators.py
@@ -37,18 +37,15 @@ class TestReducersAggregators(TemplateTestReducersAggreagtors):
     @pytest.fixture(scope="module")
     def reducers(self):
         return {
-            reducer.NAME: reducer
-            for reducer in [
-                OVNoopReducer,
-                OVMinReducer,
-                OVMaxReducer,
-                OVAbsMaxReducer,
-                OVMeanReducer,
-                OVQuantileReducer,
-                OVAbsQuantileReducer,
-                OVBatchMeanReducer,
-                OVMeanPerChanelReducer,
-            ]
+            "noop": OVNoopReducer,
+            "min": OVMinReducer,
+            "max": OVMaxReducer,
+            "abs_max": OVAbsMaxReducer,
+            "mean": OVMeanReducer,
+            "quantile": OVQuantileReducer,
+            "abs_quantile": OVAbsQuantileReducer,
+            "batch_mean": OVBatchMeanReducer,
+            "mean_per_ch": OVMeanPerChanelReducer,
         }
 
     def all_close(self, val, ref) -> bool:

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -25,7 +25,7 @@ from nncf.openvino.graph.node_utils import get_inplace_max_op
 from nncf.openvino.graph.node_utils import get_inplace_mean_op
 from nncf.openvino.graph.node_utils import get_inplace_mean_per_ch
 from nncf.openvino.graph.node_utils import get_inplace_min_op
-from nncf.openvino.graph.node_utils import get_reduce_node_name
+from nncf.openvino.graph.node_utils import get_ov_model_reduce_node_name
 from nncf.openvino.graph.node_utils import get_result_node_name
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
 from nncf.openvino.graph.transformations.commands import OVFQNodeRemovingCommand
@@ -206,7 +206,8 @@ def test_inplace_fn_insertion(test_params: InplaceOpTestCase, target_type, targe
     extra_outputs = get_extra_outputs(model, transformed_model)
     ref_output_names = [
         get_result_node_name(
-            get_reduce_node_name(target_node.get_friendly_name(), test_params.name, port_id), default_output_fn_port
+            get_ov_model_reduce_node_name(target_node.get_friendly_name(), test_params.name, port_id),
+            default_output_fn_port,
         )
         for target_node, port_id in target_nodes
     ]
@@ -243,7 +244,8 @@ def test_split_inplace_fn_insertion(test_params: InplaceOpTestCase):
     default_output_fn_port = 0
     extra_outputs = get_extra_outputs(model, transformed_model)
     ref_output_name = get_result_node_name(
-        get_reduce_node_name(target_node.get_friendly_name(), test_params.name, port_id), default_output_fn_port
+        get_ov_model_reduce_node_name(target_node.get_friendly_name(), test_params.name, port_id),
+        default_output_fn_port,
     )
     assert len(extra_outputs) == 1
     assert ref_output_name in extra_outputs
@@ -284,7 +286,7 @@ def test_inplace_reduce_fn_zero_rank_output(reduction_shape):
     target_node = get_prev_node(get_node_by_name(transformed_model, target_layer), 1)
     check_inplace_op(target_node, ["ReduceMin"], [[]], 1, 0)
     extra_outputs = get_extra_outputs(model, transformed_model)
-    ref_output_name = get_result_node_name(get_reduce_node_name(target_node.get_friendly_name(), name, 0), 0)
+    ref_output_name = get_result_node_name(get_ov_model_reduce_node_name(target_node.get_friendly_name(), name, 0), 0)
     assert len(extra_outputs) == 1
     assert extra_outputs.pop() == ref_output_name
 

--- a/tests/openvino/native/test_statistics_aggregator.py
+++ b/tests/openvino/native/test_statistics_aggregator.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Type
+from typing import List, Type
 
 import numpy as np
 import openvino.runtime as ov
@@ -19,8 +19,12 @@ from openvino.runtime import opset9 as opset
 from nncf import Dataset
 from nncf.common.graph.transformations.commands import TargetPoint
 from nncf.common.graph.transformations.commands import TargetType
+from nncf.experimental.common.tensor_statistics.collectors import TensorReducerBase
 from nncf.openvino.graph.transformations.commands import OVTargetPoint
 from nncf.openvino.statistics.aggregator import OVStatisticsAggregator
+from nncf.openvino.statistics.collectors import OV_REDUCERS_MAP
+from nncf.openvino.statistics.collectors import OVBatchMeanReducer
+from nncf.openvino.statistics.collectors import OVMeanPerChanelReducer
 from nncf.quantization.algorithms.bias_correction.openvino_backend import OVBiasCorrectionAlgoBackend
 from nncf.quantization.algorithms.fast_bias_correction.openvino_backend import OVFastBiasCorrectionAlgoBackend
 from nncf.quantization.algorithms.min_max.openvino_backend import OVMinMaxAlgoBackend
@@ -117,3 +121,8 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
         sample = dataset_samples[0].reshape(INPUT_SHAPE[1:])
         conv_w = self.dataset_samples_to_conv_w(sample)
         return SharedConvModel(input_name=INPUT_NAME, input_shape=INPUT_SHAPE, kernel=conv_w).ov_model
+
+    def reducers_map(self) -> List[TensorReducerBase]:
+        map_ = OV_REDUCERS_MAP.copy()
+        map_.update({"batch_mean": OVBatchMeanReducer, "mean_per_ch": OVMeanPerChanelReducer})
+        return map_

--- a/tests/post_training/test_ptq_params.py
+++ b/tests/post_training/test_ptq_params.py
@@ -232,7 +232,8 @@ class TemplateTestPTQParams:
         ],
     )
     def test_quantization_points_overflow_fix(self, overflow_fix, affected_target_points, ignored_ops):
-        # Checks the return value of _get_quantization_points_overflow_fix based on the overflow_fix and weight target points.
+        # Checks the return value of _get_quantization_points_overflow_fix
+        # based on the overflow_fix and weight target points.
         model = ModelToTestOverflowFix(self.metatypes_mapping)
         nncf_graph = model.nncf_graph
 

--- a/tests/torch/test_statistics_aggregator.py
+++ b/tests/torch/test_statistics_aggregator.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Type
+from typing import List, Type
 
 import numpy as np
 import pytest
@@ -18,6 +18,7 @@ from torch import nn
 
 from nncf import Dataset
 from nncf.common.graph.transformations.commands import TargetType
+from nncf.experimental.common.tensor_statistics.collectors import TensorReducerBase
 from nncf.quantization.algorithms.min_max.torch_backend import PTMinMaxAlgoBackend
 from nncf.torch.graph.graph import PTTargetPoint
 from nncf.torch.statistics.aggregator import PTStatisticsAggregator
@@ -86,6 +87,9 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
     def get_target_point_cls(self):
         return PTTargetPoint
 
+    def reducers_map(self) -> List[TensorReducerBase]:
+        return None
+
     @pytest.fixture
     def dataset_samples(self, dataset_values):
         input_shape = INPUT_SHAPE
@@ -111,6 +115,10 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
 
     @pytest.mark.skip("Merging is not implemented yet")
     def test_statistic_merging(self, dataset_samples, inplace_statistics):
+        pass
+
+    @pytest.mark.skip("Merging is not implemented yet")
+    def test_same_collectors_different_attrs_dont_merge(self, statistics_type, test_params, dataset_samples):
         pass
 
     @pytest.mark.skip("Bias correction and Fast bias correction is not implemented yet")


### PR DESCRIPTION
### Changes

* Names of reducers is used instead of types of reducers to name statistic subnet operations
* Reducer names now differs one from another if they have different attributes and aren't merged
* Hash of reducer now take into account `reduction_shape`

### Reason for changes

To fix problem when two different statistics that are instances of one class and share target point have equal name

### Related tickets

109989

### Tests

TODO: 

- [x] Add test on reducers merging
- [x] Add test with a model that have target point with two different reducers that are instances of one class
