### PR TITLE
Fix torch E2E

### DIFF
--- a/tests/torch/test_sota_checkpoints.py
+++ b/tests/torch/test_sota_checkpoints.py
@@ -552,8 +552,7 @@ class TestSotaCheckpoints:
         mean_val = eval_test_struct.mean_val_
         scale_val = eval_test_struct.scale_val_
         mo_cmd_tail_template = (
-            "--framework=onnx --compress_to_fp16 --reverse_input_channels"
-            " --mean_values={} --scale_values={} --output_dir {}"
+            "--framework=onnx --reverse_input_channels  --mean_values={} --scale_values={} --output_dir {}"
         )
         if onnx_type == "q_dq":
             model_folder = q_dq_ir_model_folder

--- a/tests/torch/test_sota_checkpoints.py
+++ b/tests/torch/test_sota_checkpoints.py
@@ -552,7 +552,7 @@ class TestSotaCheckpoints:
         mean_val = eval_test_struct.mean_val_
         scale_val = eval_test_struct.scale_val_
         mo_cmd_tail_template = (
-            "--framework=onnx --data_type=FP16 --reverse_input_channels"
+            "--framework=onnx --compress_to_fp16 --reverse_input_channels"
             " --mean_values={} --scale_values={} --output_dir {}"
         )
         if onnx_type == "q_dq":


### PR DESCRIPTION
### Changes
Replace an outdated MO parameter with a new version.

### Reason for changes
Tests on newer OV package versions fail otherwise.

### Related tickets
N/A

### Tests
PT E2E run TBA