### PR TITLE
[PTQ] Add check number_samples on None in StatisticsAggregator

### DIFF
--- a/nncf/common/tensor_statistics/aggregator.py
+++ b/nncf/common/tensor_statistics/aggregator.py
@@ -72,7 +72,10 @@ class StatisticsAggregator(ABC):
             for _statistic_point in _statistic_points:
                 for _, tensor_collectors in _statistic_point.algorithm_to_tensor_collectors.items():
                     for tensor_collector in tensor_collectors:
-                        self.stat_subset_size = max(self.stat_subset_size, tensor_collector.num_samples)
+                        if tensor_collector.num_samples:
+                            self.stat_subset_size = max(self.stat_subset_size, tensor_collector.num_samples)
+        if not self.stat_subset_size:
+            self.stat_subset_size = len(self.dataset)
 
     @abstractmethod
     def _register_statistics(self, outputs: Dict[str, NNCFTensor], statistic_points: StatisticPointsContainer) -> None:

--- a/nncf/common/tensor_statistics/aggregator.py
+++ b/nncf/common/tensor_statistics/aggregator.py
@@ -8,18 +8,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from abc import ABC
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from itertools import islice
 from typing import Any, Dict, TypeVar
 
 from tqdm import tqdm
 
-from nncf.common.factory import EngineFactory
-from nncf.common.factory import ModelTransformerFactory
+from nncf.common.factory import EngineFactory, ModelTransformerFactory
 from nncf.common.graph.transformations.layout import TransformationLayout
 from nncf.common.tensor import NNCFTensor
-from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
+from nncf.common.tensor_statistics.statistic_point import \
+    StatisticPointsContainer
 from nncf.data.dataset import Dataset
 
 TensorType = TypeVar("TensorType")
@@ -76,8 +75,6 @@ class StatisticsAggregator(ABC):
                             self.stat_subset_size = tensor_collector.num_samples
                         elif tensor_collector.num_samples is not None:
                             self.stat_subset_size = max(self.stat_subset_size, tensor_collector.num_samples)
-        if self.stat_subset_size is None:
-            self.stat_subset_size = len(self.dataset)
 
     @abstractmethod
     def _register_statistics(self, outputs: Dict[str, NNCFTensor], statistic_points: StatisticPointsContainer) -> None:

--- a/nncf/common/tensor_statistics/aggregator.py
+++ b/nncf/common/tensor_statistics/aggregator.py
@@ -33,7 +33,7 @@ class StatisticsAggregator(ABC):
 
     def __init__(self, dataset: Dataset):
         self.dataset = dataset
-        self.stat_subset_size = 0
+        self.stat_subset_size = None
         self.statistic_points = StatisticPointsContainer()
 
     def collect_statistics(self, model: TModel) -> None:
@@ -72,9 +72,11 @@ class StatisticsAggregator(ABC):
             for _statistic_point in _statistic_points:
                 for _, tensor_collectors in _statistic_point.algorithm_to_tensor_collectors.items():
                     for tensor_collector in tensor_collectors:
-                        if tensor_collector.num_samples:
+                        if self.stat_subset_size is None:
+                            self.stat_subset_size = tensor_collector.num_samples
+                        elif tensor_collector.num_samples is not None:
                             self.stat_subset_size = max(self.stat_subset_size, tensor_collector.num_samples)
-        if not self.stat_subset_size:
+        if self.stat_subset_size is None:
             self.stat_subset_size = len(self.dataset)
 
     @abstractmethod

--- a/nncf/common/tensor_statistics/aggregator.py
+++ b/nncf/common/tensor_statistics/aggregator.py
@@ -8,17 +8,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from abc import ABC, abstractmethod
+from abc import ABC
+from abc import abstractmethod
 from itertools import islice
 from typing import Any, Dict, TypeVar
 
 from tqdm import tqdm
 
-from nncf.common.factory import EngineFactory, ModelTransformerFactory
+from nncf.common.factory import EngineFactory
+from nncf.common.factory import ModelTransformerFactory
 from nncf.common.graph.transformations.layout import TransformationLayout
 from nncf.common.tensor import NNCFTensor
-from nncf.common.tensor_statistics.statistic_point import \
-    StatisticPointsContainer
+from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
 from nncf.data.dataset import Dataset
 
 TensorType = TypeVar("TensorType")

--- a/nncf/experimental/common/tensor_statistics/collectors.py
+++ b/nncf/experimental/common/tensor_statistics/collectors.py
@@ -183,8 +183,14 @@ class TensorCollector:
         self._enabled = True
 
     @property
-    def num_samples(self) -> int:
-        return max(aggregator.num_samples for aggregator in self._aggregators.values())
+    def num_samples(self) -> Optional[int]:
+        output = None
+        for aggregator in self._aggregators.values():
+            if aggregator.num_samples and output:
+                output = max(output, aggregator.num_samples)
+            else:
+                output = aggregator.num_samples
+        return output
 
     @property
     def enabled(self) -> bool:

--- a/tests/common/test_statistics_aggregator.py
+++ b/tests/common/test_statistics_aggregator.py
@@ -11,6 +11,7 @@
 
 from abc import abstractmethod
 from dataclasses import dataclass
+from collections import Counter
 from enum import Enum
 from typing import Any, Type, Union
 
@@ -366,15 +367,10 @@ class TemplateTestStatisticsAggregator:
         inplace_statistics,
         is_backend_support_custom_estimators,
     ):
-        algo_backend = self.get_min_max_algo_backend_cls()
         model = self.get_backend_model(dataset_samples)
-        nncf_graph = NNCFGraphFactory.create(model)
-
         quantizer_config = QuantizerConfig(
             mode=test_parameters.quantization_mode, per_channel=test_parameters.per_channel
         )
-        target_point = self.get_target_point(test_parameters.target_type)
-
         is_standart_estimator = test_parameters.range_estimator_params in [
             RangeEstimatorParametersSet.MINMAX,
             RangeEstimatorParametersSet.MEAN_MINMAX,
@@ -382,20 +378,20 @@ class TemplateTestStatisticsAggregator:
         if not is_standart_estimator and not is_backend_support_custom_estimators:
             pytest.skip("Custom estimators are not supported for this backend yet")
 
-        tensor_collector = algo_backend.get_statistic_collector(
-            test_parameters.range_estimator_params,
-            nncf_graph=nncf_graph,
-            target_point=target_point,
-            quantizer_config=quantizer_config,
-            num_samples=len(dataset_samples),
-            inplace=inplace_statistics,
-        )
-
-        statistics_points = StatisticPointsContainer()
+        target_point = self.get_target_point(test_parameters.target_type)
         algorithm_name = "TestAlgo"
-        statistics_points.add_statistic_point(
-            StatisticPoint(target_point=target_point, tensor_collector=tensor_collector, algorithm=algorithm_name)
+        statistic_point = self.create_statistics_point(
+            model,
+            quantizer_config,
+            target_point,
+            len(dataset_samples),
+            algorithm_name,
+            inplace_statistics,
+            test_parameters.range_estimator_params,
         )
+        statistics_points = StatisticPointsContainer()
+        statistics_points.add_statistic_point(statistic_point)
+        
         dataset = self.get_dataset(dataset_samples)
         statistics_aggregator = self.get_statistics_aggregator(dataset)
         statistics_aggregator.register_statistic_points(statistics_points)
@@ -615,61 +611,48 @@ class TemplateTestStatisticsAggregator:
                     assert ref.shape == val.shape
                 assert np.allclose(val, ref)
 
-    def test_statistics_merging_simple(self, dataset_samples, inplace_statistics):
+    def create_statistics_point(
+        self, model, q_config, target_point, subset_size, algorithm_name, inplace_statistics, range_estimator
+    ):
         algo_backend = self.get_min_max_algo_backend_cls()
-        model = self.get_backend_model(dataset_samples)
         nncf_graph = NNCFGraphFactory.create(model)
+        tensor_collector = algo_backend.get_statistic_collector(
+            range_estimator,
+            nncf_graph=nncf_graph,
+            target_point=target_point,
+            quantizer_config=q_config,
+            num_samples=subset_size,
+            inplace=inplace_statistics,
+        )
+        return StatisticPoint(target_point=target_point, tensor_collector=tensor_collector, algorithm=algorithm_name)
 
+    @pytest.mark.parametrize(
+        'statistic_point_params',
+        (
+            (
+                ('AAA', RangeEstimatorParametersSet.MINMAX, TargetType.PRE_LAYER_OPERATION, -128.0, 128),
+                ('BBB', RangeEstimatorParametersSet.MINMAX, TargetType.POST_LAYER_OPERATION, -128.0, 128),
+                ('CCC', RangeEstimatorParametersSet.MEAN_MINMAX, TargetType.POST_LAYER_OPERATION, -63.5, 64.5),
+            ),
+        ),
+    )
+    def test_statistics_merging_simple(self, dataset_samples, inplace_statistics, statistic_point_params):
+        model = self.get_backend_model(dataset_samples)
         quantizer_config = QuantizerConfig(mode=QuantizationMode.SYMMETRIC, per_channel=False)
-        pre_layer_target_point = self.get_target_point(TargetType.PRE_LAYER_OPERATION)
-        pre_tensor_collector = algo_backend.get_statistic_collector(
-            RangeEstimatorParametersSet.MINMAX,
-            nncf_graph=nncf_graph,
-            target_point=pre_layer_target_point,
-            quantizer_config=quantizer_config,
-            num_samples=len(dataset_samples),
-            inplace=inplace_statistics,
-        )
-
-        post_layer_target_point = self.get_target_point(TargetType.POST_LAYER_OPERATION)
-        post_tensor_collector = algo_backend.get_statistic_collector(
-            RangeEstimatorParametersSet.MINMAX,
-            nncf_graph=nncf_graph,
-            target_point=post_layer_target_point,
-            quantizer_config=quantizer_config,
-            num_samples=len(dataset_samples),
-            inplace=inplace_statistics,
-        )
-        unique_post_tensor_collector = algo_backend.get_statistic_collector(
-            RangeEstimatorParametersSet.MEAN_MINMAX,
-            nncf_graph=nncf_graph,
-            target_point=post_layer_target_point,
-            quantizer_config=quantizer_config,
-            num_samples=len(dataset_samples),
-            inplace=inplace_statistics,
-        )
+        subset_size = len(dataset_samples)
 
         statistics_points = StatisticPointsContainer()
-        algorithm_names = ["AAA", "BBB", "CCC"]
-        statistics_points.add_statistic_point(
-            StatisticPoint(
-                target_point=pre_layer_target_point, tensor_collector=pre_tensor_collector, algorithm=algorithm_names[0]
+        ref_val = {}
+
+        for statistic_point_param in statistic_point_params:
+            algorithm_name, range_estimator, target_point_type, ref_min_val, ref_max_val = statistic_point_param
+            ref_val[algorithm_name] = (ref_min_val, ref_max_val)
+            target_point = self.get_target_point(target_point_type)
+            statistics_point = self.create_statistics_point(
+                model, quantizer_config, target_point, subset_size, algorithm_name, inplace_statistics, range_estimator
             )
-        )
-        statistics_points.add_statistic_point(
-            StatisticPoint(
-                target_point=post_layer_target_point,
-                tensor_collector=post_tensor_collector,
-                algorithm=algorithm_names[1],
-            )
-        )
-        statistics_points.add_statistic_point(
-            StatisticPoint(
-                target_point=post_layer_target_point,
-                tensor_collector=unique_post_tensor_collector,
-                algorithm=algorithm_names[2],
-            )
-        )
+            statistics_points.add_statistic_point(statistics_point)
+
         dataset = self.get_dataset(dataset_samples)
         statistics_aggregator = self.get_statistics_aggregator(dataset)
         statistics_aggregator.register_statistic_points(statistics_points)
@@ -677,11 +660,9 @@ class TemplateTestStatisticsAggregator:
 
         tensor_collectors = list(statistics_points.get_tensor_collectors())
         assert len(tensor_collectors) == 3
-        for _, _, tensor_collector in tensor_collectors:
+        for algorithm, _, tensor_collector in tensor_collectors:
             stat = tensor_collector.get_statistics()
-            ref_min_val, ref_max_val = -128.0, 128
-            if tensor_collector is unique_post_tensor_collector:
-                ref_min_val, ref_max_val = -63.5, 64.5
+            ref_min_val, ref_max_val = ref_val[algorithm]
             assert np.allclose(stat.min_values, ref_min_val)
             assert np.allclose(stat.max_values, ref_max_val)
 
@@ -799,3 +780,41 @@ class TemplateTestStatisticsAggregator:
             if isinstance(ref[0], np.ndarray):
                 assert stat.min_values.shape == ref[0].shape
                 assert stat.max_values.shape == ref[1].shape
+
+    @pytest.mark.parametrize(
+        'statistic_point_params',
+        (
+            (
+                ('AAA', RangeEstimatorParametersSet.MINMAX, TargetType.PRE_LAYER_OPERATION, 100),
+                ('BBB', RangeEstimatorParametersSet.MINMAX, TargetType.POST_LAYER_OPERATION, 10),
+                ('CCC', RangeEstimatorParametersSet.MEAN_MINMAX, TargetType.PRE_LAYER_OPERATION, None),
+                ('CCC', RangeEstimatorParametersSet.MEAN_MINMAX, TargetType.PRE_LAYER_OPERATION, -1),
+            ),
+        ),
+    )
+    def test_register_statistics(self, dataset_samples, statistic_point_params):
+        model = self.get_backend_model(dataset_samples)
+        quantizer_config = QuantizerConfig(mode=QuantizationMode.SYMMETRIC, per_channel=False)
+        statistics_points = StatisticPointsContainer()
+        ref_val = {}
+
+        for statistic_point_param in statistic_point_params:
+            algorithm_name, range_estimator, target_point_type, subset_size = statistic_point_param
+            ref_val[algorithm_name] = subset_size
+            target_point = self.get_target_point(target_point_type)
+            statistics_point = self.create_statistics_point(
+                model, quantizer_config, target_point, subset_size, algorithm_name, True, range_estimator
+            )
+            statistics_points.add_statistic_point(statistics_point)
+
+        dataset = self.get_dataset(dataset_samples)
+        statistics_aggregator = self.get_statistics_aggregator(dataset)
+        statistics_aggregator.register_statistic_points(statistics_points)
+        assert Counter(statistics_points) == Counter(statistics_aggregator.statistic_points)
+        ref_subset_size = None
+        for subset_size in ref_val.values():
+            if subset_size and ref_subset_size:
+                ref_subset_size = max(ref_subset_size, subset_size)
+            else:
+                ref_subset_size = subset_size
+        assert statistics_aggregator.stat_subset_size == ref_subset_size

--- a/tests/common/test_statistics_aggregator.py
+++ b/tests/common/test_statistics_aggregator.py
@@ -34,6 +34,7 @@ from nncf.quantization.range_estimator import StatisticsCollectorParameters
 from nncf.quantization.range_estimator import StatisticsType
 
 
+# pylint:disable=too-many-public-methods
 class TemplateTestStatisticsAggregator:
     @abstractmethod
     def get_min_max_algo_backend_cls(self) -> Type[MinMaxAlgoBackend]:

--- a/tests/common/test_statistics_aggregator.py
+++ b/tests/common/test_statistics_aggregator.py
@@ -8,10 +8,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from abc import abstractmethod
-from dataclasses import dataclass
 from collections import Counter
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Type, Union
 
@@ -19,20 +18,20 @@ import numpy as np
 import pytest
 
 from nncf.common.factory import NNCFGraphFactory
-from nncf.common.graph.transformations.commands import TargetPoint
-from nncf.common.graph.transformations.commands import TargetType
-from nncf.common.quantization.structs import QuantizationMode
-from nncf.common.quantization.structs import QuantizerConfig
-from nncf.common.tensor_statistics.statistic_point import StatisticPoint
-from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
-from nncf.quantization.algorithms.bias_correction.backend import BiasCorrectionAlgoBackend
-from nncf.quantization.algorithms.fast_bias_correction.backend import FastBiasCorrectionAlgoBackend
+from nncf.common.graph.transformations.commands import TargetPoint, TargetType
+from nncf.common.quantization.structs import QuantizationMode, QuantizerConfig
+from nncf.common.tensor_statistics.statistic_point import (
+    StatisticPoint, StatisticPointsContainer)
+from nncf.quantization.algorithms.bias_correction.backend import \
+    BiasCorrectionAlgoBackend
+from nncf.quantization.algorithms.fast_bias_correction.backend import \
+    FastBiasCorrectionAlgoBackend
 from nncf.quantization.algorithms.min_max.backend import MinMaxAlgoBackend
-from nncf.quantization.range_estimator import AggregatorType
-from nncf.quantization.range_estimator import RangeEstimatorParameters
-from nncf.quantization.range_estimator import RangeEstimatorParametersSet
-from nncf.quantization.range_estimator import StatisticsCollectorParameters
-from nncf.quantization.range_estimator import StatisticsType
+from nncf.quantization.range_estimator import (AggregatorType,
+                                               RangeEstimatorParameters,
+                                               RangeEstimatorParametersSet,
+                                               StatisticsCollectorParameters,
+                                               StatisticsType)
 
 
 class TemplateTestStatisticsAggregator:
@@ -391,7 +390,7 @@ class TemplateTestStatisticsAggregator:
         )
         statistics_points = StatisticPointsContainer()
         statistics_points.add_statistic_point(statistic_point)
-        
+
         dataset = self.get_dataset(dataset_samples)
         statistics_aggregator = self.get_statistics_aggregator(dataset)
         statistics_aggregator.register_statistic_points(statistics_points)

--- a/tests/common/test_statistics_aggregator.py
+++ b/tests/common/test_statistics_aggregator.py
@@ -18,20 +18,20 @@ import numpy as np
 import pytest
 
 from nncf.common.factory import NNCFGraphFactory
-from nncf.common.graph.transformations.commands import TargetPoint, TargetType
-from nncf.common.quantization.structs import QuantizationMode, QuantizerConfig
-from nncf.common.tensor_statistics.statistic_point import (
-    StatisticPoint, StatisticPointsContainer)
-from nncf.quantization.algorithms.bias_correction.backend import \
-    BiasCorrectionAlgoBackend
-from nncf.quantization.algorithms.fast_bias_correction.backend import \
-    FastBiasCorrectionAlgoBackend
+from nncf.common.graph.transformations.commands import TargetPoint
+from nncf.common.graph.transformations.commands import TargetType
+from nncf.common.quantization.structs import QuantizationMode
+from nncf.common.quantization.structs import QuantizerConfig
+from nncf.common.tensor_statistics.statistic_point import StatisticPoint
+from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
+from nncf.quantization.algorithms.bias_correction.backend import BiasCorrectionAlgoBackend
+from nncf.quantization.algorithms.fast_bias_correction.backend import FastBiasCorrectionAlgoBackend
 from nncf.quantization.algorithms.min_max.backend import MinMaxAlgoBackend
-from nncf.quantization.range_estimator import (AggregatorType,
-                                               RangeEstimatorParameters,
-                                               RangeEstimatorParametersSet,
-                                               StatisticsCollectorParameters,
-                                               StatisticsType)
+from nncf.quantization.range_estimator import AggregatorType
+from nncf.quantization.range_estimator import RangeEstimatorParameters
+from nncf.quantization.range_estimator import RangeEstimatorParametersSet
+from nncf.quantization.range_estimator import StatisticsCollectorParameters
+from nncf.quantization.range_estimator import StatisticsType
 
 
 class TemplateTestStatisticsAggregator:
@@ -626,12 +626,12 @@ class TemplateTestStatisticsAggregator:
         return StatisticPoint(target_point=target_point, tensor_collector=tensor_collector, algorithm=algorithm_name)
 
     @pytest.mark.parametrize(
-        'statistic_point_params',
+        "statistic_point_params",
         (
             (
-                ('AAA', RangeEstimatorParametersSet.MINMAX, TargetType.PRE_LAYER_OPERATION, -128.0, 128),
-                ('BBB', RangeEstimatorParametersSet.MINMAX, TargetType.POST_LAYER_OPERATION, -128.0, 128),
-                ('CCC', RangeEstimatorParametersSet.MEAN_MINMAX, TargetType.POST_LAYER_OPERATION, -63.5, 64.5),
+                ("AAA", RangeEstimatorParametersSet.MINMAX, TargetType.PRE_LAYER_OPERATION, -128.0, 128),
+                ("BBB", RangeEstimatorParametersSet.MINMAX, TargetType.POST_LAYER_OPERATION, -128.0, 128),
+                ("CCC", RangeEstimatorParametersSet.MEAN_MINMAX, TargetType.POST_LAYER_OPERATION, -63.5, 64.5),
             ),
         ),
     )
@@ -781,13 +781,13 @@ class TemplateTestStatisticsAggregator:
                 assert stat.max_values.shape == ref[1].shape
 
     @pytest.mark.parametrize(
-        'statistic_point_params',
+        "statistic_point_params",
         (
             (
-                ('AAA', RangeEstimatorParametersSet.MINMAX, TargetType.PRE_LAYER_OPERATION, 100),
-                ('BBB', RangeEstimatorParametersSet.MINMAX, TargetType.POST_LAYER_OPERATION, 10),
-                ('CCC', RangeEstimatorParametersSet.MEAN_MINMAX, TargetType.PRE_LAYER_OPERATION, None),
-                ('CCC', RangeEstimatorParametersSet.MEAN_MINMAX, TargetType.PRE_LAYER_OPERATION, -1),
+                ("AAA", RangeEstimatorParametersSet.MINMAX, TargetType.PRE_LAYER_OPERATION, 100),
+                ("BBB", RangeEstimatorParametersSet.MINMAX, TargetType.POST_LAYER_OPERATION, 10),
+                ("CCC", RangeEstimatorParametersSet.MEAN_MINMAX, TargetType.PRE_LAYER_OPERATION, None),
+                ("CCC", RangeEstimatorParametersSet.MEAN_MINMAX, TargetType.PRE_LAYER_OPERATION, -1),
             ),
         ),
     )

--- a/tests/onnx/test_statistics_aggregator.py
+++ b/tests/onnx/test_statistics_aggregator.py
@@ -95,7 +95,7 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
         return request.param
 
     @pytest.mark.skip("Merging is not implemented yet")
-    def test_statistics_merging_simple(self, dataset_samples, inplace_statistics):
+    def test_statistics_merging_simple(self, dataset_samples, inplace_statistics, statistic_point_params):
         pass
 
     @pytest.mark.skip("Merging is not implemented yet")

--- a/tests/torch/test_statistics_aggregator.py
+++ b/tests/torch/test_statistics_aggregator.py
@@ -106,7 +106,7 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
         return request.param
 
     @pytest.mark.skip("Merging is not implemented yet")
-    def test_statistics_merging_simple(self, dataset_samples, inplace_statistics):
+    def test_statistics_merging_simple(self, dataset_samples, inplace_statistics, statistic_point_params):
         pass
 
     @pytest.mark.skip("Merging is not implemented yet")


### PR DESCRIPTION
### Changes

If `tensor_collector.num_samples is None` skip it. None in tensor_collector.num_samples means that there is no limitation for registering numbers of tensors.

### Reason for changes

Fix Failure when `tensor_collector.num_samples is None`

### Related tickets

109341

### Tests

Add test on `register_statistic_points()`
