### PR TITLE
Fix converting FQ to native torch given  `narrow_range`  (#1797)

### DIFF
--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -743,9 +743,15 @@ class SymmetricQuantizer(BaseQuantizer):
 
             scale, zero_point = get_scale_zp_from_input_low_input_high(level_low, level_high, input_low, input_high)
 
+            if self.narrow_range:
+                if level_low < 0:
+                    level_low -= 1
+                else:
+                    level_high += 1
+
             if self._half_range:
-                level_low = 2 * self.level_low
-                level_high = 2 * self.level_high + 1
+                level_low = 2 * level_low
+                level_high = 2 * level_high + 1
 
             scale = scale.view(-1)
             zero_point = zero_point.view(-1).to(dtype=torch.int32)

--- a/nncf/torch/quantization/strip.py
+++ b/nncf/torch/quantization/strip.py
@@ -42,9 +42,9 @@ def replace_quantizer_to_torch_native_module(model: NNCFNetwork) -> NNCFNetwork:
             for key in list(nncf_module.pre_ops.keys()):
                 op = nncf_module.get_pre_op(key)
                 if isinstance(op.op, BaseQuantizer) and op.op.is_enabled_quantization():
-                    if op.op.is_half_range:
-                        # Half range require to clamp weights of module
-                        # Note: Half range used only for weight.
+                    if op.op.is_half_range or op.op.narrow_range:
+                        # Half range and narrow_range require to clamp weights of module
+                        # Note: Half range and narrow_range used only for weight.
                         input_low, input_high = op.op.get_input_low_input_high()
 
                         data = nncf_module.weight.data


### PR DESCRIPTION
### Changes

- When converting FQ to native torch levels, increase levels if `narrow_range` is `True` for `SymmetricQuantizaer`.
- Clamp weights on strip model, if `narrow_range` is `True`.
- Add tests converting to ONNX for 8bit.

### Reason for changes

Error on export to ONNX
```
SymbolicValueError: For (quant_min, quant_max), ONNX allows only (0, 127), (0, 255) and (-128, 127). Got (-127, 127)
```

### Related tickets

110498
