### PR TITLE
Support for models with multiple inputs was added

### DIFF
--- a/nncf/openvino/pot/engine.py
+++ b/nncf/openvino/pot/engine.py
@@ -188,4 +188,7 @@ class OVEngine(pot.IEEngine):
     @staticmethod
     def _process_batch(batch):
         index, input_data = batch
-        return [(index, None)], [input_data], None
+        return [(index, None)], input_data, None
+
+    def _fill_input(self, model, image_batch):
+        return image_batch


### PR DESCRIPTION
### Changes

The `_fill_input()` method was overridden. It returns the value that was given from tranform_fn.

### Reason for changes

The following code does not work, but the transformation function is valid

```python
import nncf
from nncf.openvino.quantization.backend_parameters import BackendParameters
from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
import torch
from torch import nn
import numpy as np
from openvino.tools import mo
import openvino.runtime as ov


class ModelWithMultipleInputs(nn.Module):
    def __init__(self):
        super().__init__()
        self._conv2d_0 = nn.Conv2d(3, 64, kernel_size=3, stride=2, padding=1)
        self._conv2d_1 = nn.Conv2d(3, 64, kernel_size=3, stride=2, padding=1)

    def forward(self, input_0, input_1):
        output_0 = self._conv2d_0(input_0)
        output_1 = self._conv2d_1(input_1)
        return output_0 + output_1

dataset = [
    {
        'input_0': np.zeros((2, 3, 32, 32), dtype=np.float32),
        'input_1': np.ones((2, 3, 32, 32), dtype=np.float32),
    }
]

model = ModelWithMultipleInputs()
ov_model = mo.convert_model(model.cpu(), input_shape=[[-1, 3, 32, 32], [-1, 3, 32, 32]])

def transform_fn(data_item):
    return data_item['input_0'], data_item['input_1']

# Check the transformation function
compiled_model = ov.compile_model(ov_model)
for data_item in dataset:
    output = compiled_model(transform_fn(data_item))

calibration_dataset = nncf.Dataset(dataset, transform_fn)
params = AdvancedQuantizationParameters(
    backend_params={
        BackendParameters.USE_POT: True,
    }
)
quantized_model = nncf.quantize(ov_model, calibration_dataset, advanced_parameters=params)
```

### Related tickets

Ref: 96928

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
