### PR TITLE
Fix compression training tests

### DIFF
--- a/examples/torch/classification/main.py
+++ b/examples/torch/classification/main.py
@@ -345,6 +345,7 @@ def train(
     best_acc1=0,
 ):
     best_compression_stage = CompressionStage.UNCOMPRESSED
+
     for epoch in range(config.start_epoch, config.epochs):
         # update compression scheduler state at the begin of the epoch
         compression_ctrl.scheduler.epoch_step()

--- a/examples/torch/common/example_logger.py
+++ b/examples/torch/common/example_logger.py
@@ -2,6 +2,7 @@ import logging
 import sys
 
 logger = logging.getLogger("example")
+logger.propagate = False
 
 if not logger.hasHandlers():
     logger.setLevel(logging.INFO)

--- a/nncf/common/hardware/config.py
+++ b/nncf/common/hardware/config.py
@@ -163,10 +163,10 @@ class HWConfig(list, ABC):
             if mode == QuantizationMode.SYMMETRIC:
                 if quantization_subdict["level_low"] < 0 < quantization_subdict["level_high"]:
                     signedness_to_force = True
-                true_level_low, true_level_high, _ = quant.calculate_symmetric_level_ranges(bits, signed=True)
+                true_level_low, true_level_high = quant.calculate_symmetric_level_ranges(bits, signed=True)
             else:
                 signedness_to_force = True
-                true_level_low, true_level_high, _ = quant.calculate_asymmetric_level_ranges(bits)
+                true_level_low, true_level_high = quant.calculate_asymmetric_level_ranges(bits)
 
             assert (
                 quantization_subdict["level_low"] == true_level_low

--- a/nncf/common/quantization/quantizers.py
+++ b/nncf/common/quantization/quantizers.py
@@ -11,7 +11,7 @@
 from typing import Tuple
 
 
-def calculate_symmetric_level_ranges(num_bits: int, signed: bool, narrow_range: bool = False) -> Tuple[int, int, int]:
+def calculate_symmetric_level_ranges(num_bits: int, signed: bool, narrow_range: bool = False) -> Tuple[int, int]:
     """
     Calculates the numbers of the low and high quant and the number of
     quantization levels for the symmetric quantization scheme.
@@ -25,7 +25,6 @@ def calculate_symmetric_level_ranges(num_bits: int, signed: bool, narrow_range: 
     :return: A Tuple
         level_low - the low quant number
         level_high - the high quant number
-        levels - the number of quantization levels
     """
     levels = 2**num_bits
 
@@ -41,12 +40,11 @@ def calculate_symmetric_level_ranges(num_bits: int, signed: bool, narrow_range: 
             level_low += 1
         else:
             level_high -= 1
-        levels = levels - 1
 
-    return level_low, level_high, levels
+    return level_low, level_high
 
 
-def calculate_asymmetric_level_ranges(num_bits: int, narrow_range: bool = False) -> Tuple[int, int, int]:
+def calculate_asymmetric_level_ranges(num_bits: int, narrow_range: bool = False) -> Tuple[int, int]:
     """
     Calculates the numbers of the low and high quant and the number of
     quantization levels for the asymmetric quantization scheme.
@@ -57,7 +55,6 @@ def calculate_asymmetric_level_ranges(num_bits: int, narrow_range: bool = False)
     :return: A Tuple
         level_low - the low quant number
         level_high - the high quant number
-        levels - the number of quantization levels
     """
     levels = 2**num_bits
     level_high = levels - 1
@@ -65,6 +62,9 @@ def calculate_asymmetric_level_ranges(num_bits: int, narrow_range: bool = False)
 
     if narrow_range:
         level_low = level_low + 1
-        levels = levels - 1
 
-    return level_low, level_high, levels
+    return level_low, level_high
+
+
+def get_num_levels(level_low: int, level_high: int):
+    return level_high - level_low + 1

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -8,6 +8,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# pylint:disable=too-many-lines
+
+from abc import ABC
+from abc import abstractmethod
 from enum import Enum
 from functools import partial
 from typing import Any, Dict, List, Optional, Tuple
@@ -24,6 +29,7 @@ from nncf.common.quantization.quantizer_setup import QuantizationPointId
 from nncf.common.quantization.quantizer_setup import QuantizerSetupBase
 from nncf.common.quantization.quantizers import calculate_asymmetric_level_ranges
 from nncf.common.quantization.quantizers import calculate_symmetric_level_ranges
+from nncf.common.quantization.quantizers import get_num_levels
 from nncf.common.quantization.structs import QuantizationMode
 from nncf.common.quantization.structs import QuantizerConfig
 from nncf.common.quantization.structs import QuantizerSpec
@@ -275,7 +281,7 @@ class PTQuantizerSetup(QuantizerSetupBase):
         self.quantization_points[qp_id] = qp
 
 
-class BaseQuantizer(nn.Module):
+class BaseQuantizer(nn.Module, ABC):
     # pylint:disable=too-many-public-methods
     def __init__(self, qspec: PTQuantizerSpec):
         super().__init__()
@@ -290,10 +296,12 @@ class BaseQuantizer(nn.Module):
             compression_lr_multiplier=qspec.compression_lr_multiplier,
         )
         OPTIONAL_PARAMETERS_REGISTRY.register("_num_bits")
-        self.level_high = None
-        self.level_low = None
 
-        self.levels = 0
+        # These must be made buffers, since they impact the "forward" behaviour and the model can be used
+        # in DDP scenarios, so these must be properly synchronized across processes.
+        self.register_buffer("_level_low", torch.IntTensor([0]), persistent=False)
+        self.register_buffer("_level_high", torch.IntTensor([0]), persistent=False)
+
         ENABLED_VAR_NAME = "enabled"
         self.register_buffer(ENABLED_VAR_NAME, torch.IntTensor([1]))
         OPTIONAL_PARAMETERS_REGISTRY.register(ENABLED_VAR_NAME)
@@ -325,11 +333,33 @@ class BaseQuantizer(nn.Module):
         self.load_listener = LoadStateListener(self)
         self._old_level_range_setting = False
 
-    def enable_gradients(self):
-        raise NotImplementedError
+    @property
+    def level_low(self) -> int:
+        return self._level_low.item()
 
+    @level_low.setter
+    def level_low(self, val: int):
+        self._level_low.fill_(val)
+
+    @property
+    def level_high(self) -> int:
+        return self._level_high.item()
+
+    @level_high.setter
+    def level_high(self, val: int):
+        self._level_high.fill_(val)
+
+    @property
+    def levels(self):
+        return get_num_levels(self.level_low, self.level_high)
+
+    @abstractmethod
+    def enable_gradients(self):
+        pass
+
+    @abstractmethod
     def disable_gradients(self):
-        raise NotImplementedError
+        pass
 
     def is_enabled_quantization(self):
         with no_jit_trace():
@@ -367,14 +397,16 @@ class BaseQuantizer(nn.Module):
 
         return self.quantize(x, execute_traced_op_as_identity=False)
 
+    @abstractmethod
     def quantize(self, x, execute_traced_op_as_identity: bool = False):
-        raise NotImplementedError
+        pass
 
     def reset_call_counter(self):
         self.call_count = 0
 
+    @abstractmethod
     def get_trainable_params(self) -> Dict[str, torch.Tensor]:
-        raise NotImplementedError
+        pass
 
     def apply_minmax_init(self, min_values: torch.Tensor, max_values: torch.Tensor, log_module_name: str = None):
         """min_values and max_values must have the same shape as specified in self.scale_shape"""
@@ -393,11 +425,15 @@ class BaseQuantizer(nn.Module):
         max_values = max_values.to(own_device)
         self._apply_minmax_init(min_values, max_values, log_module_name)
 
+    @abstractmethod
     def _apply_minmax_init(self, min_values: torch.Tensor, max_values: torch.Tensor, log_module_name: str = None):
-        raise NotImplementedError
+        pass
 
-    def set_level_ranges(self):
-        raise NotImplementedError
+    @abstractmethod
+    def set_levels(self):
+        """Must set the self._level_low and self._level_high buffers according to the current quantizer state
+        and type, and called whenever the state of the quantizer is updated in a way that affects the effective level
+        ranges."""
 
     @property
     def is_half_range(self):
@@ -408,8 +444,9 @@ class BaseQuantizer(nn.Module):
         return self._is_using_log_scale_storage
 
     @property
+    @abstractmethod
     def signed(self):
-        raise NotImplementedError
+        pass
 
     @property
     def num_bits(self):
@@ -419,7 +456,7 @@ class BaseQuantizer(nn.Module):
     @num_bits.setter
     def num_bits(self, num_bits: int):
         self._num_bits.fill_(num_bits)
-        self.set_level_ranges()
+        self.set_levels()
 
     @property
     def narrow_range(self) -> bool:
@@ -436,11 +473,13 @@ class BaseQuantizer(nn.Module):
     def set_export_mode(self, mode: QuantizerExportMode):
         self._export_mode = mode
 
+    @abstractmethod
     def _get_input_low_input_high(self):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def _prepare_export_quantization(self, x: torch.Tensor):
-        raise NotImplementedError
+        pass
 
     def _prepare_fq_export_quantization(self, x: torch.Tensor):
         x, level_high, level_low, input_low, input_high = self._prepare_export_quantization(x)
@@ -488,8 +527,9 @@ class BaseQuantizer(nn.Module):
     def extra_repr(self):
         return "bit={}, ch={}".format(self.num_bits, self.per_channel)
 
+    @abstractmethod
     def get_quantizer_config(self) -> QuantizerConfig:
-        raise NotImplementedError
+        pass
 
     @property
     def per_channel(self) -> bool:
@@ -499,6 +539,7 @@ class BaseQuantizer(nn.Module):
         is_per_tensor = (numel == 1) and (len(self.scale_shape) == 1)
         return not is_per_tensor
 
+    @abstractmethod
     def get_parameters_for_torch_fq(self) -> Tuple[int, int, torch.Tensor, torch.Tensor]:
         """
         Get parameters for conversion to native FakeQuantize.
@@ -509,7 +550,6 @@ class BaseQuantizer(nn.Module):
             scale - Quantizer scale.
             zero_point - Quantizer zero point.
         """
-        raise NotImplementedError
 
 
 class QuantizersSwitcher:
@@ -600,7 +640,7 @@ class SymmetricQuantizer(BaseQuantizer):
             self.eps = 1e-16
         if qspec.signedness_to_force is not None:
             self.signed = bool(qspec.signedness_to_force)
-        self.set_level_ranges()
+        self.set_levels()
 
         self._register_load_state_dict_pre_hook(
             StorageRedirectingLoadStateDictHook(
@@ -620,7 +660,7 @@ class SymmetricQuantizer(BaseQuantizer):
 
         if parse_version(torch.__version__) >= parse_version("1.12"):
             # Values of level_low, level_high must be recalculated for load new signed parameter.
-            self.register_load_state_dict_post_hook(lambda module, _: module.set_level_ranges())
+            self.register_load_state_dict_post_hook(lambda module, _: module.set_levels())
         else:
             self._old_level_range_setting = True
 
@@ -651,15 +691,11 @@ class SymmetricQuantizer(BaseQuantizer):
     def disable_gradients(self):
         self._scale_param_storage.requires_grad = False
 
-    def set_level_ranges(self):
+    def set_levels(self):
         scaled_num_bits = 1 if self._half_range else 0
-        self.level_low, self.level_high, self.levels = self.calculate_level_ranges(
+        self.level_low, self.level_high = calculate_symmetric_level_ranges(
             self.num_bits - scaled_num_bits, self.signed, self._narrow_range
         )
-
-    @staticmethod
-    def calculate_level_ranges(num_bits, signed, narrow_range):
-        return calculate_symmetric_level_ranges(num_bits, signed, narrow_range)
 
     @property
     def signed(self):
@@ -669,7 +705,7 @@ class SymmetricQuantizer(BaseQuantizer):
     @signed.setter
     def signed(self, signed: bool):
         self.signed_tensor.fill_(int(signed))
-        self.set_level_ranges()
+        self.set_levels()
 
     def quantize(self, x, execute_traced_op_as_identity: bool = False):
         return symmetric_quantize(
@@ -801,7 +837,7 @@ class AsymmetricQuantizer(BaseQuantizer):
             self.eps = 0
         else:
             self.eps = 1e-16
-        self.set_level_ranges()
+        self.set_levels()
 
         self._register_load_state_dict_pre_hook(
             StorageRedirectingLoadStateDictHook(
@@ -854,13 +890,9 @@ class AsymmetricQuantizer(BaseQuantizer):
     def signed(self):
         return True
 
-    def set_level_ranges(self):
+    def set_levels(self):
         scaled_num_bits = 1 if self._half_range else 0
-        self.level_low, self.level_high, self.levels = self.calculate_level_ranges(self.num_bits - scaled_num_bits)
-
-    @staticmethod
-    def calculate_level_ranges(num_bits):
-        return calculate_asymmetric_level_ranges(num_bits)
+        self.level_low, self.level_high = calculate_asymmetric_level_ranges(self.num_bits - scaled_num_bits)
 
     def quantize(self, x, execute_traced_op_as_identity: bool = False):
         return asymmetric_quantize(

--- a/nncf/torch/quantization/strip.py
+++ b/nncf/torch/quantization/strip.py
@@ -71,8 +71,8 @@ def convert_to_torch_fakequantizer(nncf_quantizer: BaseQuantizer) -> FakeQuantiz
     :return: Instance of FakeQuantize similar to the input quantizer.
     """
 
-    # Call set_level_ranges to set actual values
-    nncf_quantizer.set_level_ranges()
+    # Call set_ranges in case the basic parameters impacting levels had changed
+    nncf_quantizer.set_levels()
 
     per_channel = nncf_quantizer.per_channel
     scale_shape = nncf_quantizer.scale_shape

--- a/tests/torch/quantization/test_strip.py
+++ b/tests/torch/quantization/test_strip.py
@@ -18,6 +18,7 @@ from torch.quantization.fake_quantize import FakeQuantize
 
 from nncf.common.quantization.quantizers import calculate_asymmetric_level_ranges
 from nncf.common.quantization.quantizers import calculate_symmetric_level_ranges
+from nncf.common.quantization.quantizers import get_num_levels
 from nncf.common.quantization.structs import QuantizationMode
 from nncf.config import NNCFConfig
 from nncf.torch.quantization.layers import AsymmetricQuantizer
@@ -127,9 +128,11 @@ def test_converting_symmetric_quantizer(
     np_scale = generate_random_scale_by_input_size(input_size, is_per_channel, is_weights)
     tensor_scale = get_test_data([np_scale], use_cuda)
 
-    level_low, level_high, levels = calculate_symmetric_level_ranges(
+    level_low, level_high = calculate_symmetric_level_ranges(
         num_bits=real_num_bits, signed=is_signed, narrow_range=narrow_range
     )
+
+    levels = get_num_levels(level_low, level_high)
 
     input_low = np_scale * (level_low / level_high)
     input_range = np_scale - input_low
@@ -203,7 +206,8 @@ def test_converting_asymmetric_quantizer(input_size, num_bits, is_per_channel, i
     real_num_bits = num_bits - 1 if is_half_range else num_bits
 
     input_low, input_range = generate_random_low_and_range_by_input_size(input_size, is_per_channel, is_weights)
-    _, _, levels = calculate_asymmetric_level_ranges(real_num_bits)
+    level_low, level_high = calculate_asymmetric_level_ranges(real_num_bits)
+    levels = get_num_levels(level_low, level_high)
 
     ######################################################################
     # TODO: Workaround for issue 105241 (remove after fix)

--- a/tests/torch/test_compression_training.py
+++ b/tests/torch/test_compression_training.py
@@ -391,7 +391,7 @@ LEGR_TEST_CASE_DESCRIPTORS = [
     .expected_accuracy(68.11)
     .weights_filename("mobilenet_v2_32x32_cifar100_68.11.pth")
     .absolute_tolerance_train(1.5)
-    .absolute_tolerance_eval(2e-2),
+    .absolute_tolerance_eval(3e-2),
 ]
 
 


### PR DESCRIPTION
### Changes
LeGR compression training threshold for comparing checkpoint's saved eval metric value with the currently measured one was increased. Levels in `BaseQuantizer`s have been made into torch buffers.

### Reason for changes
#1578 removed the level updating code on forward and sadly this broke down the DDP training because the levels, which were not torch buffers but instead simple Python attributes, were not synchronized across DDP processes and no calls to level-updating property setters (`num_bits` or `signed`) have been made, so while the model in the 0-th (main) DDP process started out the training OK, the other DDP replicas started from pretty much 0 accuracy.

### Related tickets
N/A

### Tests
PT compression training weekly tests
