### PR TITLE
Preserve NNCFNetwork.get_nncf_wrapped_model() and deprecate it

### DIFF
--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -964,6 +964,15 @@ class NNCFNetwork(torch.nn.Module, metaclass=NNCFNetworkMeta):
             )
         super().__setattr__(key, value)
 
+    def get_nncf_wrapped_model(self) -> "NNCFNetwork":
+        warning_deprecated(
+            "Calls to NNCFNetwork.get_nncf_wrapped_model() are deprecated and will be removed "
+            "in NNCF v2.6.0.\n"
+            "Starting from NNCF v2.5.0, the compressed model object already inherits the original "
+            "class of the uncompressed model and the forward signature, so the call to "
+            ".get_nncf_wrapped_model() may be simply omitted."
+        )
+        return self
 
 class NNCFSkippingIter:
     """

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -982,9 +982,11 @@ def test_works_when_wrapped_with_dataparallel(simple_net):
     dp_model(torch.zeros([10, *simple_net.INPUT_SIZE[1:]], device="cuda"))
 
 
-def test_works_with_old_wrapping_and_deprecation_warning(simple_net):
+def test_warns_on_old_style_calls(simple_net):
     with pytest.warns(NNCFDeprecationWarning):
         simple_net.get_graph()
+    with pytest.warns(NNCFDeprecationWarning):
+        simple_net.get_nncf_wrapped_model()
 
 
 def test_class_has_same_name_and_module_as_original(simple_net):


### PR DESCRIPTION
#1819 