### PR TITLE
Fix OV sanity test - make dataset processing in separate directory

### DIFF
--- a/tests/openvino/data/ov_dataset_definitions.yml
+++ b/tests/openvino/data/ov_dataset_definitions.yml
@@ -19,9 +19,9 @@ datasets:
   - name: imagenette2-320
     annotation_conversion:
       converter: imagenet
-      annotation_file: imagenette2-320/imagenette2-320_val.txt
+      annotation_file: ac_imagenette2-320/imagenette2-320_val.txt
     annotation: imagenette2-320.pickle
-    data_source: imagenette2-320/val/
+    data_source: ac_imagenette2-320/
     metrics:
       - name: accuracy@top1
         type: accuracy

--- a/tests/openvino/datasets_helpers.py
+++ b/tests/openvino/datasets_helpers.py
@@ -18,9 +18,9 @@ from fastdownload import FastDownload
 from openvino.tools.accuracy_checker.argparser import build_arguments_parser
 from openvino.tools.accuracy_checker.config import ConfigReader
 from openvino.tools.accuracy_checker.evaluators import ModelEvaluator
+from tests.openvino.omz_helpers import OPENVINO_DATASET_DEFINITIONS_PATH
 
 from nncf import Dataset
-from tests.openvino.omz_helpers import OPENVINO_DATASET_DEFINITIONS_PATH
 
 IMAGENETTE_URL = "https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz"
 IMAGENETTE_ANNOTATION_URL = (
@@ -35,18 +35,17 @@ def download(url: str, path: str) -> Path:
     return downloader.get(url)
 
 
-def preprocess_imagenette_data(dataset_path: str) -> None:
-    destination = os.path.join(dataset_path, "val")
-    for filename in os.listdir(destination):
-        path = os.path.join(destination, filename)
-        if os.path.isdir(path):
-            for img_name in os.listdir(path):
-                img_path = os.path.join(path, img_name)
-                shutil.move(img_path, destination)
-            os.rmdir(path)
+def preprocess_imagenette_data(dataset_path: Path, destination_path: Path) -> None:
+    val_dataset_path = dataset_path / 'val'
+    for filename in os.listdir(val_dataset_path):
+        path = val_dataset_path / filename
+        if path.is_dir():
+            for img_name in path.iterdir():
+                img_path = path / img_name
+                shutil.copy(img_path, destination_path)
 
 
-def preprocess_imagenette_labels(dataset_path: str) -> None:
+def preprocess_imagenette_labels(destination_path: Path) -> None:
     labels_map = {
         "n01440764": 0,  # tench
         "n02102040": 217,  # English springer
@@ -59,23 +58,30 @@ def preprocess_imagenette_labels(dataset_path: str) -> None:
         "n03445777": 574,  # golf ball
         "n03888257": 701,  # parachute
     }
-
     response = requests.get(IMAGENETTE_ANNOTATION_URL, timeout=10)
-    annotation_path = dataset_path / "imagenette2-320_val.txt"
-    with open(annotation_path, "w", encoding="utf-8") as output_file:
+    annotation_path = destination_path / "imagenette2-320_val.txt"
+
+    with open(annotation_path, "w+", encoding="utf-8") as output_file:
         for line in response.iter_lines():
             image_path = line.decode("utf-8").split("/")
             class_name = image_path[2]
-            new_path = os.path.join(image_path[0], image_path[1], image_path[3])
+            new_path = os.path.join(image_path[0], image_path[1], image_path[2], image_path[3])
             label = labels_map[class_name]
             img_path_with_labels = f"{new_path} {label}\n"
             output_file.write(img_path_with_labels)
 
 
+def convert_dataset_to_ac_format(dataset_path: Path, destination_path: Path) -> None:
+    preprocess_imagenette_labels(destination_path)
+    preprocess_imagenette_data(dataset_path, destination_path)
+
+
 def prepare_imagenette_for_test(data_dir: Path) -> Path:
     dataset_path = download(IMAGENETTE_URL, data_dir)
-    preprocess_imagenette_labels(dataset_path)
-    preprocess_imagenette_data(dataset_path)
+    destination_path = dataset_path.parent / 'ac_imagenette2-320/'
+    if not destination_path.exists():
+        destination_path.mkdir()
+    convert_dataset_to_ac_format(dataset_path, destination_path)
     return dataset_path
 
 

--- a/tests/openvino/datasets_helpers.py
+++ b/tests/openvino/datasets_helpers.py
@@ -18,9 +18,9 @@ from fastdownload import FastDownload
 from openvino.tools.accuracy_checker.argparser import build_arguments_parser
 from openvino.tools.accuracy_checker.config import ConfigReader
 from openvino.tools.accuracy_checker.evaluators import ModelEvaluator
-from tests.openvino.omz_helpers import OPENVINO_DATASET_DEFINITIONS_PATH
 
 from nncf import Dataset
+from tests.openvino.omz_helpers import OPENVINO_DATASET_DEFINITIONS_PATH
 
 IMAGENETTE_URL = "https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz"
 IMAGENETTE_ANNOTATION_URL = (
@@ -36,7 +36,7 @@ def download(url: str, path: str) -> Path:
 
 
 def preprocess_imagenette_data(dataset_path: Path, destination_path: Path) -> None:
-    val_dataset_path = dataset_path / 'val'
+    val_dataset_path = dataset_path / "val"
     for filename in os.listdir(val_dataset_path):
         path = val_dataset_path / filename
         if path.is_dir():
@@ -78,7 +78,7 @@ def convert_dataset_to_ac_format(dataset_path: Path, destination_path: Path) -> 
 
 def prepare_imagenette_for_test(data_dir: Path) -> Path:
     dataset_path = download(IMAGENETTE_URL, data_dir)
-    destination_path = dataset_path.parent / 'ac_imagenette2-320/'
+    destination_path = dataset_path.parent / "ac_imagenette2-320/"
     if not destination_path.exists():
         destination_path.mkdir()
     convert_dataset_to_ac_format(dataset_path, destination_path)

--- a/tests/openvino/native/quantization/test_sanity.py
+++ b/tests/openvino/native/quantization/test_sanity.py
@@ -13,17 +13,17 @@ import os
 
 import openvino.runtime as ov
 import pytest
-
-import nncf
-from nncf.common.quantization.structs import QuantizationPreset
-from nncf.common.utils.os import is_windows
-from nncf.parameters import TargetDevice
 from tests.openvino.conftest import AC_CONFIGS_DIR
 from tests.openvino.datasets_helpers import get_dataset_for_test
 from tests.openvino.datasets_helpers import get_nncf_dataset_from_ac_config
 from tests.openvino.omz_helpers import calculate_metrics
 from tests.openvino.omz_helpers import convert_model
 from tests.openvino.omz_helpers import download_model
+
+import nncf
+from nncf.common.quantization.structs import QuantizationPreset
+from nncf.common.utils.os import is_windows
+from nncf.parameters import TargetDevice
 
 OMZ_MODELS = [
     ("resnet-18-pytorch", "imagenette2-320", {"accuracy@top1": 0.777, "accuracy@top5": 0.948}),

--- a/tests/openvino/native/quantization/test_sanity.py
+++ b/tests/openvino/native/quantization/test_sanity.py
@@ -13,17 +13,17 @@ import os
 
 import openvino.runtime as ov
 import pytest
+
+import nncf
+from nncf.common.quantization.structs import QuantizationPreset
+from nncf.common.utils.os import is_windows
+from nncf.parameters import TargetDevice
 from tests.openvino.conftest import AC_CONFIGS_DIR
 from tests.openvino.datasets_helpers import get_dataset_for_test
 from tests.openvino.datasets_helpers import get_nncf_dataset_from_ac_config
 from tests.openvino.omz_helpers import calculate_metrics
 from tests.openvino.omz_helpers import convert_model
 from tests.openvino.omz_helpers import download_model
-
-import nncf
-from nncf.common.quantization.structs import QuantizationPreset
-from nncf.common.utils.os import is_windows
-from nncf.parameters import TargetDevice
 
 OMZ_MODELS = [
     ("resnet-18-pytorch", "imagenette2-320", {"accuracy@top1": 0.777, "accuracy@top5": 0.948}),


### PR DESCRIPTION
### Changes

Place AC dataset format of imagenette in a separate directory, not removing the original format.

### Reason for changes

Dataset processing prepares the dataset for test_sanity rewriting the original format. This adds conflicts in running ONNX and OV tests on one machine.

### Related tickets

No

### Tests

Tested locally.
