### PR TITLE
[Release][PTQ][OV] Inplace statistic reducers names and hashes fix

### DIFF
--- a/nncf/experimental/common/tensor_statistics/collectors.py
+++ b/nncf/experimental/common/tensor_statistics/collectors.py
@@ -50,9 +50,9 @@ class TensorReducerBase(ABC):
     def output_port_id(self) -> int:
         return 0
 
-    @classmethod
-    def name(cls):
-        return cls.__name__
+    @property
+    def name(self):
+        return self.__class__.__name__ + str(self.__hash__())
 
     @staticmethod
     @abstractmethod
@@ -90,8 +90,6 @@ class TensorReducerBase(ABC):
         if self.inplace:
             return x
 
-        if self._reduction_shape is None:
-            self._reduction_shape = tuple(range(len(x[0].shape)))
         return self._reduce_out_of_place(x)
 
     def __eq__(self, __o: object) -> bool:
@@ -102,7 +100,12 @@ class TensorReducerBase(ABC):
         )
 
     def __hash__(self) -> int:
-        return hash((self.name(), self._inplace))
+        return hash((self.__class__.__name__, self.inplace, self._reduction_shape))
+
+    def _get_reduction_shape(self, tensor: NNCFTensor) -> Union[int, Tuple[int, ...]]:
+        if self._reduction_shape is not None:
+            return self._reduction_shape
+        return tuple(range(len(tensor.shape)))
 
 
 class TensorAggregatorBase:
@@ -127,10 +130,6 @@ class TensorAggregatorBase:
     @property
     def num_samples(self) -> int:
         return self._num_samples
-
-    @classmethod
-    def name(cls):
-        return cls.__name__
 
     def register_reduced_input(self, x: TensorType):
         if self._num_samples is not None and self._collected_samples >= self._num_samples:
@@ -162,7 +161,7 @@ class TensorAggregatorBase:
         return isinstance(__o, self.__class__) and self._num_samples == __o.num_samples
 
     def __hash__(self) -> int:
-        return hash((self.name()))
+        return hash(self.__class__.__name__)
 
 
 class TensorCollector:
@@ -407,23 +406,30 @@ class NoopReducer(TensorReducerBase):
 
 class MinReducer(TensorReducerBase):
     def _reduce_out_of_place(self, x: List[NNCFTensor]) -> List[NNCFTensor]:
-        return [self._tensor_processor.reduce_min(x[0], self._reduction_shape, keepdims=True)]
+        x = x[0]
+        reduction_shape = self._get_reduction_shape(x)
+        return [self._tensor_processor.reduce_min(x, reduction_shape, keepdims=True)]
 
 
 class MaxReducer(TensorReducerBase):
     def _reduce_out_of_place(self, x: List[NNCFTensor]) -> List[NNCFTensor]:
-        return [self._tensor_processor.reduce_max(x[0], self._reduction_shape, keepdims=True)]
+        x = x[0]
+        reduction_shape = self._get_reduction_shape(x)
+        return [self._tensor_processor.reduce_max(x, reduction_shape, keepdims=True)]
 
 
 class AbsMaxReducer(TensorReducerBase):
     def _reduce_out_of_place(self, x: List[NNCFTensor]) -> List[NNCFTensor]:
         x = self._tensor_processor.abs(x[0])
-        return [self._tensor_processor.reduce_max(x, self._reduction_shape, keepdims=True)]
+        reduction_shape = self._get_reduction_shape(x)
+        return [self._tensor_processor.reduce_max(x, reduction_shape, keepdims=True)]
 
 
 class MeanReducer(TensorReducerBase):
     def _reduce_out_of_place(self, x: List[NNCFTensor]) -> List[NNCFTensor]:
-        return [self._tensor_processor.mean(x[0], self._reduction_shape, keepdims=True)]
+        x = x[0]
+        reduction_shape = self._get_reduction_shape(x)
+        return [self._tensor_processor.mean(x, reduction_shape, keepdims=True)]
 
 
 class QuantileReducerBase(TensorReducerBase):
@@ -433,19 +439,21 @@ class QuantileReducerBase(TensorReducerBase):
         quantile: Union[float, List[float]] = [0.01, 0.99],
         inplace: bool = False,
     ):
-        super().__init__(reduction_shape, inplace)
+        super().__init__(reduction_shape, False)
         self._quantile = quantile
 
     def __eq__(self, __o: object) -> bool:
         return super().__eq__(__o) and self._quantile == __o._quantile
 
     def __hash__(self) -> int:
-        return hash((self.name(), self._inplace, tuple(self._quantile)))
+        return hash((self.__class__.__name__, self.inplace, self._reduction_shape, tuple(self._quantile)))
 
 
 class QuantileReducer(QuantileReducerBase):
     def _reduce_out_of_place(self, x: List[NNCFTensor]) -> List[NNCFTensor]:
-        return self._tensor_processor.quantile(x[0], self._quantile, self._reduction_shape, keepdims=True)
+        x = x[0]
+        reduction_shape = self._get_reduction_shape(x)
+        return self._tensor_processor.quantile(x, self._quantile, reduction_shape, keepdims=True)
 
 
 class AbsQuantileReducer(QuantileReducerBase):
@@ -455,11 +463,12 @@ class AbsQuantileReducer(QuantileReducerBase):
         quantile: Union[float, List[float]] = 0.99,
         inplace: bool = False,
     ):
-        super().__init__(reduction_shape, quantile, inplace)
+        super().__init__(reduction_shape, quantile, False)
 
     def _reduce_out_of_place(self, x: List[NNCFTensor]) -> List[NNCFTensor]:
         x = self._tensor_processor.abs(x[0])
-        return self._tensor_processor.quantile(x, [self._quantile], self._reduction_shape, keepdims=True)
+        reduction_shape = self._get_reduction_shape(x)
+        return self._tensor_processor.quantile(x, [self._quantile], reduction_shape, keepdims=True)
 
 
 class BatchMeanReducer(TensorReducerBase):
@@ -576,7 +585,7 @@ class NoOutliersAggregatorBase(OfflineAggregatorBase):
         return super().__eq__(__o) and self._quantile == __o._quantile
 
     def __hash__(self) -> int:
-        return hash((self.name(), self._quantile))
+        return hash((self.__class__.__name__, self._quantile))
 
 
 class MeanNoOutliersAggregator(NoOutliersAggregatorBase):
@@ -595,5 +604,5 @@ AGGREGATORS_MAP = {
     AggregatorType.MEAN: MeanAggregator,
     AggregatorType.MEAN_NO_OUTLIERS: MeanNoOutliersAggregator,
     AggregatorType.MEDIAN: MedianAggregator,
-    AggregatorType.MEAN_NO_OUTLIERS: MedianNoOutliersAggregator,
+    AggregatorType.MEDIAN_NO_OUTLIERS: MedianNoOutliersAggregator,
 }

--- a/nncf/openvino/statistics/collectors.py
+++ b/nncf/openvino/statistics/collectors.py
@@ -148,114 +148,88 @@ class OVNNCFCollectorTensorProcessor(NNCFCollectorTensorProcessor):
 
 
 class OVNoopReducer(NoopReducer):
-    NAME = "noop"
-
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
         return [get_result_node_name(target_node_name, port_id)]
 
 
 class OVMinReducer(MinReducer):
-    NAME = "min"
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        return get_inplace_min_op(self.NAME, self._reduction_shape)
+        return get_inplace_min_op(self.name, self._reduction_shape)
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVMaxReducer(MaxReducer):
-    NAME = "max"
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        return get_inplace_max_op(self.NAME, self._reduction_shape, False)
+        return get_inplace_max_op(self.name, self._reduction_shape, False)
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVAbsMaxReducer(AbsMaxReducer):
-    NAME = "abs_max"
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        return get_inplace_max_op(self.NAME, self._reduction_shape, True)
+        return get_inplace_max_op(self.name, self._reduction_shape, True)
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVMeanReducer(MeanReducer):
-    NAME = "mean"
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        return get_inplace_mean_op(self.NAME, self._reduction_shape)
+        return get_inplace_mean_op(self.name, self._reduction_shape)
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVBatchMeanReducer(BatchMeanReducer):
-    NAME = "batch_mean"
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        return get_inplace_batch_mean_op(self.NAME)
+        return get_inplace_batch_mean_op(self.name)
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVMeanPerChanelReducer(MeanPerChReducer):
-    NAME = "mean_per_ch"
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        return get_inplace_mean_per_ch(self.NAME, self._reduction_shape)
+        return get_inplace_mean_per_ch(self.name, self._reduction_shape)
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVQuantileReducer(QuantileReducer):
-    NAME = "quantile"
-
-    @property
-    def inplace(self):
-        return False
+    def get_inplace_fn(self) -> Optional[InplaceInsertionFNType]:
+        return None
 
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
-    def get_inplace_fn(self) -> Optional[InplaceInsertionFNType]:
-        return None
-
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 class OVAbsQuantileReducer(AbsQuantileReducer):
-    NAME = "abs_quantile"
-
-    @property
-    def inplace(self):
-        return False
-
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
@@ -263,7 +237,7 @@ class OVAbsQuantileReducer(AbsQuantileReducer):
         return None
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        return get_reducer_output_node_names(self.NAME, target_node_name, port_id, self.output_port_id, self.inplace)
+        return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
 def get_mean_stat_collector(num_samples, channel_axis, window_size=None, inplace=True):

--- a/tests/common/test_statistics_aggregator.py
+++ b/tests/common/test_statistics_aggregator.py
@@ -12,7 +12,9 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Type, Union
+from itertools import product
+from collections import Counter
+from typing import Any, List, Type, Union
 
 import numpy as np
 import pytest
@@ -24,6 +26,9 @@ from nncf.common.quantization.structs import QuantizationMode
 from nncf.common.quantization.structs import QuantizerConfig
 from nncf.common.tensor_statistics.statistic_point import StatisticPoint
 from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
+from nncf.experimental.common.tensor_statistics.collectors import NoopAggregator
+from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
+from nncf.experimental.common.tensor_statistics.collectors import TensorReducerBase
 from nncf.quantization.algorithms.bias_correction.backend import BiasCorrectionAlgoBackend
 from nncf.quantization.algorithms.fast_bias_correction.backend import FastBiasCorrectionAlgoBackend
 from nncf.quantization.algorithms.min_max.backend import MinMaxAlgoBackend
@@ -34,6 +39,7 @@ from nncf.quantization.range_estimator import StatisticsCollectorParameters
 from nncf.quantization.range_estimator import StatisticsType
 
 
+# pylint: disable=too-many-public-methods
 class TemplateTestStatisticsAggregator:
     @abstractmethod
     def get_min_max_algo_backend_cls(self) -> Type[MinMaxAlgoBackend]:
@@ -93,6 +99,10 @@ class TemplateTestStatisticsAggregator:
     @abstractmethod
     @pytest.fixture
     def is_backend_support_custom_estimators(self) -> bool:
+        pass
+
+    @abstractmethod
+    def reducers_map(self) -> List[TensorReducerBase]:
         pass
 
     @pytest.fixture
@@ -799,3 +809,95 @@ class TemplateTestStatisticsAggregator:
             if isinstance(ref[0], np.ndarray):
                 assert stat.min_values.shape == ref[0].shape
                 assert stat.max_values.shape == ref[1].shape
+
+    @pytest.mark.parametrize(
+        "statistics_type",
+        [
+            StatisticsType.MIN,
+            StatisticsType.MAX,
+            StatisticsType.ABS_MAX,
+            StatisticsType.MEAN,
+            StatisticsType.QUANTILE,
+            StatisticsType.ABS_QUANTILE,
+            "batch_mean",
+            "mean_per_ch",
+        ],
+    )
+    def test_same_collectors_different_attrs_dont_merge(self, statistics_type, test_params, dataset_samples):
+        params = test_params["test_statistic_merging"]["split_concat"]
+        model = params["model"](dataset_samples)
+        params = {}
+        if statistics_type in [StatisticsType.MIN, StatisticsType.MAX, StatisticsType.ABS_MAX, StatisticsType.MEAN]:
+            params["reduction_shape"] = [None, (0, 1, 3), (1, 2, 3)]
+            params["inplace"] = [False, True]
+        elif statistics_type in [StatisticsType.QUANTILE, StatisticsType.ABS_QUANTILE]:
+            params["reduction_shape"] = [None, (0, 1, 3), (1, 2, 3)]
+            params["quantile"] = [[0.01, 0.99], [0.001, 0.999]]
+        elif statistics_type == "batch_mean":
+            pytest.skip("Inplace statistic woun't work until openvino==2023.0.0 release")
+            params["inplace"] = [False, True]
+        elif statistics_type == "mean_per_ch":
+            # TODO(dlyakhov) uncoment when nncf will switch to openvino==2023.0.0
+            # params["inplace"] = [False, True]
+            params["channel_dim"] = [1, 2]
+
+        def product_dict(**kwargs):
+            keys = kwargs.keys()
+            for instance in product(*kwargs.values()):
+                yield dict(zip(keys, instance))
+
+        tensor_collector = TensorCollector()
+        statistics_points = StatisticPointsContainer()
+        target_point_cls = self.get_target_point_cls()
+        target_point_args = (TargetType.POST_LAYER_OPERATION, "split", 0)
+        for params_ in product_dict(**params):
+            reducer = self.reducers_map()[statistics_type](**params_)
+            aggregator = NoopAggregator(1)
+            tensor_collector.register_statistic_branch(str(params_), reducer, aggregator)
+            target_point = target_point_cls(*target_point_args)
+            stat_point = StatisticPoint(target_point, tensor_collector, "TEST")
+            statistics_points.add_statistic_point(stat_point)
+
+        dataset = self.get_dataset(dataset_samples)
+        statistics_aggregator = self.get_statistics_aggregator(dataset)
+        statistics_aggregator.register_statistic_points(statistics_points)
+        # Run statistic collection to check output names matches reduer names
+        statistics_aggregator.collect_statistics(model)
+
+    @pytest.mark.parametrize(
+        "statistic_point_params",
+        (
+            (
+                ("AAA", RangeEstimatorParametersSet.MINMAX, TargetType.PRE_LAYER_OPERATION, 100),
+                ("BBB", RangeEstimatorParametersSet.MINMAX, TargetType.POST_LAYER_OPERATION, 10),
+                ("CCC", RangeEstimatorParametersSet.MEAN_MINMAX, TargetType.PRE_LAYER_OPERATION, None),
+                ("CCC", RangeEstimatorParametersSet.MEAN_MINMAX, TargetType.PRE_LAYER_OPERATION, -1),
+            ),
+        ),
+    )
+    def test_register_statistics(self, dataset_samples, statistic_point_params):
+        model = self.get_backend_model(dataset_samples)
+        quantizer_config = QuantizerConfig(mode=QuantizationMode.SYMMETRIC, per_channel=False)
+        statistics_points = StatisticPointsContainer()
+        ref_val = {}
+
+        for statistic_point_param in statistic_point_params:
+            algorithm_name, range_estimator, target_point_type, subset_size = statistic_point_param
+            ref_val[algorithm_name] = subset_size
+            target_point = self.get_target_point(target_point_type)
+            statistics_point = self.create_statistics_point(
+                model, quantizer_config, target_point, subset_size, algorithm_name, True, range_estimator
+            )
+            statistics_points.add_statistic_point(statistics_point)
+
+        dataset = self.get_dataset(dataset_samples)
+        statistics_aggregator = self.get_statistics_aggregator(dataset)
+        statistics_aggregator.register_statistic_points(statistics_points)
+        assert Counter(statistics_points) == Counter(statistics_aggregator.statistic_points)
+        ref_subset_size = None
+        for subset_size in ref_val.values():
+            if subset_size and ref_subset_size:
+                ref_subset_size = max(ref_subset_size, subset_size)
+            else:
+                ref_subset_size = subset_size
+        assert statistics_aggregator.stat_subset_size == ref_subset_size

--- a/tests/onnx/test_statistics_aggregator.py
+++ b/tests/onnx/test_statistics_aggregator.py
@@ -9,13 +9,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Type
+from typing import List, Type
 
 import numpy as np
 import pytest
 
 from nncf import Dataset
 from nncf.common.graph.transformations.commands import TargetType
+from nncf.experimental.common.tensor_statistics.collectors import TensorReducerBase
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
 from nncf.onnx.statistics.aggregator import ONNXStatisticsAggregator
 from nncf.quantization.algorithms.bias_correction.onnx_backend import ONNXBiasCorrectionAlgoBackend
@@ -75,6 +76,9 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
     def get_target_point_cls(self):
         return ONNXTargetPoint
 
+    def reducers_map(self) -> List[TensorReducerBase]:
+        return None
+
     @pytest.fixture
     def dataset_samples(self, dataset_values):
         input_shape = INPUT_SHAPE
@@ -96,6 +100,10 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
 
     @pytest.mark.skip("Merging is not implemented yet")
     def test_statistics_merging_simple(self, dataset_samples, inplace_statistics):
+        pass
+
+    @pytest.mark.skip("Merging is not implemented yet")
+    def test_same_collectors_different_attrs_dont_merge(self, statistics_type, test_params, dataset_samples):
         pass
 
     @pytest.mark.skip("Merging is not implemented yet")

--- a/tests/openvino/native/quantization/test_reducers_and_aggregators.py
+++ b/tests/openvino/native/quantization/test_reducers_and_aggregators.py
@@ -37,18 +37,15 @@ class TestReducersAggregators(TemplateTestReducersAggreagtors):
     @pytest.fixture(scope="module")
     def reducers(self):
         return {
-            reducer.NAME: reducer
-            for reducer in [
-                OVNoopReducer,
-                OVMinReducer,
-                OVMaxReducer,
-                OVAbsMaxReducer,
-                OVMeanReducer,
-                OVQuantileReducer,
-                OVAbsQuantileReducer,
-                OVBatchMeanReducer,
-                OVMeanPerChanelReducer,
-            ]
+            "noop": OVNoopReducer,
+            "min": OVMinReducer,
+            "max": OVMaxReducer,
+            "abs_max": OVAbsMaxReducer,
+            "mean": OVMeanReducer,
+            "quantile": OVQuantileReducer,
+            "abs_quantile": OVAbsQuantileReducer,
+            "batch_mean": OVBatchMeanReducer,
+            "mean_per_ch": OVMeanPerChanelReducer,
         }
 
     def all_close(self, val, ref) -> bool:

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -25,7 +25,7 @@ from nncf.openvino.graph.node_utils import get_inplace_max_op
 from nncf.openvino.graph.node_utils import get_inplace_mean_op
 from nncf.openvino.graph.node_utils import get_inplace_mean_per_ch
 from nncf.openvino.graph.node_utils import get_inplace_min_op
-from nncf.openvino.graph.node_utils import get_reduce_node_name
+from nncf.openvino.graph.node_utils import get_ov_model_reduce_node_name
 from nncf.openvino.graph.node_utils import get_result_node_name
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
 from nncf.openvino.graph.transformations.commands import OVFQNodeRemovingCommand
@@ -206,7 +206,8 @@ def test_inplace_fn_insertion(test_params: InplaceOpTestCase, target_type, targe
     extra_outputs = get_extra_outputs(model, transformed_model)
     ref_output_names = [
         get_result_node_name(
-            get_reduce_node_name(target_node.get_friendly_name(), test_params.name, port_id), default_output_fn_port
+            get_ov_model_reduce_node_name(target_node.get_friendly_name(), test_params.name, port_id),
+            default_output_fn_port,
         )
         for target_node, port_id in target_nodes
     ]
@@ -243,7 +244,8 @@ def test_split_inplace_fn_insertion(test_params: InplaceOpTestCase):
     default_output_fn_port = 0
     extra_outputs = get_extra_outputs(model, transformed_model)
     ref_output_name = get_result_node_name(
-        get_reduce_node_name(target_node.get_friendly_name(), test_params.name, port_id), default_output_fn_port
+        get_ov_model_reduce_node_name(target_node.get_friendly_name(), test_params.name, port_id),
+        default_output_fn_port,
     )
     assert len(extra_outputs) == 1
     assert ref_output_name in extra_outputs
@@ -284,7 +286,7 @@ def test_inplace_reduce_fn_zero_rank_output(reduction_shape):
     target_node = get_prev_node(get_node_by_name(transformed_model, target_layer), 1)
     check_inplace_op(target_node, ["ReduceMin"], [[]], 1, 0)
     extra_outputs = get_extra_outputs(model, transformed_model)
-    ref_output_name = get_result_node_name(get_reduce_node_name(target_node.get_friendly_name(), name, 0), 0)
+    ref_output_name = get_result_node_name(get_ov_model_reduce_node_name(target_node.get_friendly_name(), name, 0), 0)
     assert len(extra_outputs) == 1
     assert extra_outputs.pop() == ref_output_name
 

--- a/tests/openvino/native/test_statistics_aggregator.py
+++ b/tests/openvino/native/test_statistics_aggregator.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Type
+from typing import List, Type
 
 import numpy as np
 import openvino.runtime as ov
@@ -19,8 +19,12 @@ from openvino.runtime import opset9 as opset
 from nncf import Dataset
 from nncf.common.graph.transformations.commands import TargetPoint
 from nncf.common.graph.transformations.commands import TargetType
+from nncf.experimental.common.tensor_statistics.collectors import TensorReducerBase
 from nncf.openvino.graph.transformations.commands import OVTargetPoint
 from nncf.openvino.statistics.aggregator import OVStatisticsAggregator
+from nncf.openvino.statistics.collectors import OV_REDUCERS_MAP
+from nncf.openvino.statistics.collectors import OVBatchMeanReducer
+from nncf.openvino.statistics.collectors import OVMeanPerChanelReducer
 from nncf.quantization.algorithms.bias_correction.openvino_backend import OVBiasCorrectionAlgoBackend
 from nncf.quantization.algorithms.fast_bias_correction.openvino_backend import OVFastBiasCorrectionAlgoBackend
 from nncf.quantization.algorithms.min_max.openvino_backend import OVMinMaxAlgoBackend
@@ -117,3 +121,8 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
         sample = dataset_samples[0].reshape(INPUT_SHAPE[1:])
         conv_w = self.dataset_samples_to_conv_w(sample)
         return SharedConvModel(input_name=INPUT_NAME, input_shape=INPUT_SHAPE, kernel=conv_w).ov_model
+
+    def reducers_map(self) -> List[TensorReducerBase]:
+        map_ = OV_REDUCERS_MAP.copy()
+        map_.update({"batch_mean": OVBatchMeanReducer, "mean_per_ch": OVMeanPerChanelReducer})
+        return map_

--- a/tests/post_training/test_ptq_params.py
+++ b/tests/post_training/test_ptq_params.py
@@ -232,7 +232,8 @@ class TemplateTestPTQParams:
         ],
     )
     def test_quantization_points_overflow_fix(self, overflow_fix, affected_target_points, ignored_ops):
-        # Checks the return value of _get_quantization_points_overflow_fix based on the overflow_fix and weight target points.
+        # Checks the return value of _get_quantization_points_overflow_fix
+        # based on the overflow_fix and weight target points.
         model = ModelToTestOverflowFix(self.metatypes_mapping)
         nncf_graph = model.nncf_graph
 

--- a/tests/torch/test_statistics_aggregator.py
+++ b/tests/torch/test_statistics_aggregator.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Type
+from typing import List, Type
 
 import numpy as np
 import pytest
@@ -18,6 +18,7 @@ from torch import nn
 
 from nncf import Dataset
 from nncf.common.graph.transformations.commands import TargetType
+from nncf.experimental.common.tensor_statistics.collectors import TensorReducerBase
 from nncf.quantization.algorithms.min_max.torch_backend import PTMinMaxAlgoBackend
 from nncf.torch.graph.graph import PTTargetPoint
 from nncf.torch.statistics.aggregator import PTStatisticsAggregator
@@ -86,6 +87,9 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
     def get_target_point_cls(self):
         return PTTargetPoint
 
+    def reducers_map(self) -> List[TensorReducerBase]:
+        return None
+
     @pytest.fixture
     def dataset_samples(self, dataset_values):
         input_shape = INPUT_SHAPE
@@ -111,6 +115,10 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
 
     @pytest.mark.skip("Merging is not implemented yet")
     def test_statistic_merging(self, dataset_samples, inplace_statistics):
+        pass
+
+    @pytest.mark.skip("Merging is not implemented yet")
+    def test_same_collectors_different_attrs_dont_merge(self, statistics_type, test_params, dataset_samples):
         pass
 
     @pytest.mark.skip("Bias correction and Fast bias correction is not implemented yet")


### PR DESCRIPTION
Copy of #1796 

### Changes
Names of reducers is used instead of types of reducers to name statistic subnet operations
Reducer names now differs one from another if they have different attributes and aren't merged
Hash of reducer now take into account reduction_shape

### Reason for changes
To fix problem when two different statistics that are instances of one class and share target point have equal name

### Related tickets
109989

### Tests

Test on reducers merging
Test with a model that have target point with two different reducers that are instances of one class

