### PR TITLE
Force range initialization to be applied in eval mode

### DIFF
--- a/nncf/torch/initialization.py
+++ b/nncf/torch/initialization.py
@@ -23,7 +23,6 @@ from nncf.torch.utils import default_distributed_unwrapper
 from nncf.torch.utils import default_distributed_wrapper
 from nncf.torch.utils import get_model_device
 from nncf.torch.utils import is_tensor
-from nncf.torch.utils import training_mode_switcher
 
 
 class PTInitializingDataLoader(NNCFDataLoader):
@@ -147,9 +146,8 @@ class DataLoaderBaseRunner:
         data_loader = wrap_dataloader_for_init(data_loader)
 
         with torch.no_grad():
-            with training_mode_switcher(self.model, is_training=False):
-                self._run_model_inference(data_loader, num_init_steps, device)
-                self._apply_initializers()
+            self._run_model_inference(data_loader, num_init_steps, device)
+            self._apply_initializers()
 
         if self.init_device is not None:
             self.model.to(original_device)

--- a/nncf/torch/initialization.py
+++ b/nncf/torch/initialization.py
@@ -23,6 +23,7 @@ from nncf.torch.utils import default_distributed_unwrapper
 from nncf.torch.utils import default_distributed_wrapper
 from nncf.torch.utils import get_model_device
 from nncf.torch.utils import is_tensor
+from nncf.torch.utils import training_mode_switcher
 
 
 class PTInitializingDataLoader(NNCFDataLoader):
@@ -146,8 +147,9 @@ class DataLoaderBaseRunner:
         data_loader = wrap_dataloader_for_init(data_loader)
 
         with torch.no_grad():
-            self._run_model_inference(data_loader, num_init_steps, device)
-            self._apply_initializers()
+            with training_mode_switcher(self.model, is_training=False):
+                self._run_model_inference(data_loader, num_init_steps, device)
+                self._apply_initializers()
 
         if self.init_device is not None:
             self.model.to(original_device)

--- a/tests/torch/quantization/test_range_init.py
+++ b/tests/torch/quantization/test_range_init.py
@@ -810,9 +810,18 @@ def test_quantize_range_init_sets_correct_scale_shapes(quantizer_range_init_test
 
 
 def test_range_initialization_in_train_mode():
-    # Check that if a model in train mode is being compressed, range initialization still runs in eval mode
+    """
+    Check that if a model in train mode is being compressed,
+    the range initialization statistic collection still runs in eval mode
+    """
+
     class Model(nn.Module):
         def forward(self, x):
+            # This forward produces different number of operations depending on
+            # the self.training state. If statistics collection was run in
+            # training mode it would fail with StatisticsNotCollectedError,
+            # because it wouldn't find some nodes discovered during model graph
+            # building, which runs in eval mode.
             if self.training:
                 return x
             return x * x * x

--- a/tests/torch/quantization/test_range_init.py
+++ b/tests/torch/quantization/test_range_init.py
@@ -815,8 +815,7 @@ def test_range_initialization_in_train_mode():
         def forward(self, x):
             if self.training:
                 return x
-            else:
-                return x * x * x
+            return x * x * x
 
     config = get_empty_config()
     config["compression"] = {"algorithm": "quantization", "initializer": {"range": {"num_init_samples": 1}}}


### PR DESCRIPTION
### Changes

Force range initialization to be applied in eval mode.

### Reason for changes

If model in train mode is given to `create_compressed_model()`, the graph is built for the model in eval mode, but range initialization statistics are collected in train mode. This may result in wrong statistics collection if model behaves differently in train and eval modes.

### Tests

Added a test failing before the fix.
