### PR TITLE
Fix setting forward/backward hooks on NNCFNetwork

### DIFF
--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -257,6 +257,7 @@ class OriginalOpInfo:
 
 
 ORIGINAL_OPERATORS = []  # type: List[OriginalOpInfo]
+ORIGINAL_CALL = torch.nn.Module.__call__
 _JIT_ALREADY_WRAPPED = False
 _OPERATORS_ALREADY_WRAPPED = False
 _ORIG_JIT_SCRIPT = None

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -47,6 +47,7 @@ from nncf.torch.dynamic_graph.io_handling import InputInfoWrapManager
 from nncf.torch.dynamic_graph.io_handling import replicate_same_tensors
 from nncf.torch.dynamic_graph.io_handling import wrap_nncf_model_outputs_with_objwalk
 from nncf.torch.dynamic_graph.operation_address import OperationAddress
+from nncf.torch.dynamic_graph.patch_pytorch import ORIGINAL_CALL
 from nncf.torch.dynamic_graph.scope import Scope
 from nncf.torch.dynamic_graph.scope_access import get_module_by_scope
 from nncf.torch.dynamic_graph.trace_tensor import TracedTensor
@@ -882,7 +883,7 @@ class NNCFNetwork(torch.nn.Module, metaclass=NNCFNetworkMeta):
         Ensures that functor-like calls of the processed model object will directly trigger the NNCF-specific
         forward call.
         """
-        return self.forward(*args, **kwargs)
+        return ORIGINAL_CALL(self, *args, **kwargs)
 
     def forward(self, *args, **kwargs):
         """

--- a/tests/torch/ptq/test_calculation_quantizer_params.py
+++ b/tests/torch/ptq/test_calculation_quantizer_params.py
@@ -291,12 +291,12 @@ def calculate_fq_params(model, input_data):
     conv2_w = model.conv2.weight
     conv2_w_stats = calculate_statistics(conv2_w, QuantizationMode.SYMMETRIC, QuantizerGroup.WEIGHTS)
     return {
-        "FakeQuantize_6": conv1_stats,
-        "relu/FakeQuantize": bn1_stats,
-        "avg_pool/FakeQuantize": avg_pool_stats,
-        "bn1/FakeQuantize": conv2_stats,
-        "conv1/pre_ops.0/op/FakeQuantize": conv1_w_stats,
-        "conv2/pre_ops.0/op/FakeQuantize": conv2_w_stats,
+        "/FakeQuantize": conv1_stats,
+        "/relu/FakeQuantize": bn1_stats,
+        "/avg_pool/FakeQuantize": avg_pool_stats,
+        "/bn1/FakeQuantize": conv2_stats,
+        "/conv1/pre_ops.0/op/FakeQuantize": conv1_w_stats,
+        "/conv2/pre_ops.0/op/FakeQuantize": conv2_w_stats,
     }
 
 

--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -30,12 +30,10 @@ from nncf.common.quantization.structs import QuantizerConfig
 from nncf.common.quantization.structs import WeightQuantizerId
 from nncf.common.utils.debug import nncf_debug
 from nncf.torch import create_compressed_model
-from nncf.torch import patch_torch_operators
 from nncf.torch import register_default_init_args
 from nncf.torch import register_module
 from nncf.torch.checkpoint_loading import load_state
 from nncf.torch.compression_method_api import PTCompressionLoss
-from nncf.torch.dynamic_graph.patch_pytorch import unpatch_torch_operators
 from nncf.torch.dynamic_graph.scope import Scope
 from nncf.torch.dynamic_graph.scope import ScopeElement
 from nncf.torch.layers import NNCFConv2d
@@ -62,7 +60,6 @@ from tests.torch.helpers import get_empty_config
 from tests.torch.helpers import register_bn_adaptation_init_args
 from tests.torch.quantization.quantization_helpers import get_quantization_config_without_range_init
 from tests.torch.quantization.quantization_helpers import get_squeezenet_quantization_config
-from tests.torch.test_onnx_export import LinearTestModel
 
 
 def compare_qspecs(qspec: PTQuantizerSpec, quantizer: BaseQuantizer):
@@ -915,6 +912,3 @@ def test_works_when_wrapped_with_dataparallel():
     model, _ = create_compressed_model_and_algo_for_test(model, config)
     model = torch.nn.DataParallel(model.cuda())
     model(torch.ones([10, 1, 1, 1], device="cuda"))
-
-
-

--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -30,10 +30,12 @@ from nncf.common.quantization.structs import QuantizerConfig
 from nncf.common.quantization.structs import WeightQuantizerId
 from nncf.common.utils.debug import nncf_debug
 from nncf.torch import create_compressed_model
+from nncf.torch import patch_torch_operators
 from nncf.torch import register_default_init_args
 from nncf.torch import register_module
 from nncf.torch.checkpoint_loading import load_state
 from nncf.torch.compression_method_api import PTCompressionLoss
+from nncf.torch.dynamic_graph.patch_pytorch import unpatch_torch_operators
 from nncf.torch.dynamic_graph.scope import Scope
 from nncf.torch.dynamic_graph.scope import ScopeElement
 from nncf.torch.layers import NNCFConv2d
@@ -60,6 +62,7 @@ from tests.torch.helpers import get_empty_config
 from tests.torch.helpers import register_bn_adaptation_init_args
 from tests.torch.quantization.quantization_helpers import get_quantization_config_without_range_init
 from tests.torch.quantization.quantization_helpers import get_squeezenet_quantization_config
+from tests.torch.test_onnx_export import LinearTestModel
 
 
 def compare_qspecs(qspec: PTQuantizerSpec, quantizer: BaseQuantizer):
@@ -912,3 +915,6 @@ def test_works_when_wrapped_with_dataparallel():
     model, _ = create_compressed_model_and_algo_for_test(model, config)
     model = torch.nn.DataParallel(model.cuda())
     model(torch.ones([10, 1, 1, 1], device="cuda"))
+
+
+

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -1090,3 +1090,30 @@ def test_wrap_original_forward():
 
     # Ideally, the condition below should fail but currently there is no means to implement it
     assert inspect.signature(original_model.forward) != inspect.signature(nncf_model.forward)
+
+
+def test_forward_hooks_are_preserved():
+    original_obj = SimplestModel()
+
+    class CallCounter:
+        def __init__(self):
+            self.enabled = True
+            self.call_count = 0
+
+        def __call__(self, *args, **kwargs):
+            if self.enabled:
+                self.call_count += 1
+
+    hook = CallCounter()
+    original_obj.register_forward_hook(hook)
+    assert len(original_obj._forward_hooks) == 1
+    assert next(iter(original_obj._forward_hooks.values())) is hook
+
+    hook.enabled = False
+    nncf_net = NNCFNetwork(original_obj, [ModelInputInfo(SimplestModel.INPUT_SIZE)])
+    hook.enabled = True
+
+    assert len(nncf_net._forward_hooks) == 1
+    assert next(iter(nncf_net._forward_hooks.values())) is hook
+    nncf_net(torch.ones(SimplestModel.INPUT_SIZE))
+    assert hook.call_count == 1

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -1093,6 +1093,7 @@ def test_wrap_original_forward():
 
 
 def test_forward_hooks_are_preserved():
+    # Testing only for the forward hook - other hooks use the same mechanism.
     original_obj = SimplestModel()
 
     class CallCounter:
@@ -1106,8 +1107,6 @@ def test_forward_hooks_are_preserved():
 
     hook = CallCounter()
     original_obj.register_forward_hook(hook)
-    assert len(original_obj._forward_hooks) == 1
-    assert next(iter(original_obj._forward_hooks.values())) is hook
 
     hook.enabled = False
     nncf_net = NNCFNetwork(original_obj, [ModelInputInfo(SimplestModel.INPUT_SIZE)])

--- a/tests/torch/test_onnx_export.py
+++ b/tests/torch/test_onnx_export.py
@@ -17,9 +17,15 @@ import torch
 from torch import nn
 
 from nncf import NNCFConfig
+from nncf.torch import patch_torch_operators
+from nncf.torch.dynamic_graph.graph_tracer import ModelInputInfo
+from nncf.torch.dynamic_graph.patch_pytorch import unpatch_torch_operators
 from nncf.torch.exporter import PTExporter
+from nncf.torch.nncf_network import NNCFNetwork
 from tests.torch.helpers import MockModel
+from tests.torch.helpers import create_bn
 from tests.torch.helpers import create_compressed_model_and_algo_for_test
+from tests.torch.helpers import create_conv
 from tests.torch.helpers import get_nodes_by_type
 from tests.torch.helpers import load_exported_onnx_version
 from tests.torch.helpers import register_bn_adaptation_init_args
@@ -139,3 +145,52 @@ def test_can_export_with_model_args(tmp_path):
     _, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
     compression_ctrl.export_model(str(test_path), model_args=({"param3": 42},))
     assert test_path.exists()
+
+class LinearTestModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = create_conv(3, 3, 1)
+        self.bn1 = create_bn(3)
+        self.relu = nn.ReLU()
+        self.avg_pool = nn.AdaptiveAvgPool2d(1)
+        self.conv2 = create_conv(3, 1, 1)
+        self.bn2 = create_bn(1)
+
+    def forward(self, x):
+        # input_shape = [1, 3, 32, 32]
+        x = self.relu(self.conv1(x))
+        x = self.bn1(x)
+        x = self.avg_pool(x)
+        x = self.relu(self.conv2(x))
+        x = self.bn2(x)
+        return x
+
+
+@pytest.mark.parametrize('compression_section', [
+    {},
+    {"compression": {"algorithm": "quantization"}},
+    {"compression": {"algorithm": "filter_pruning"}}], ids=['none', 'quantization', 'filter_pruning'])
+def test_preserves_onnx_node_name_format(tmp_path, compression_section):
+    model = LinearTestModel()
+    model.eval().cpu()
+    try:
+        unpatch_torch_operators()
+        without_nncf_path = tmp_path / 'without_nncf.onnx'
+        torch.onnx.export(model,
+                          torch.ones([1, 3, 32, 32]),
+                          without_nncf_path,
+                          export_params=True,
+                          opset_version=13,
+                          do_constant_folding=False)
+        original_model_proto = onnx.load_model(str(without_nncf_path))
+        patch_torch_operators()
+
+        config = NNCFConfig.from_dict({"input_info": {"sample_size": [1, 3, 32, 32]},
+                                       **compression_section})
+        compressed_model_proto = load_exported_onnx_version(config, model, tmp_path)
+
+        compressed_model_onnx_node_names = {node.name for node in compressed_model_proto.graph.node}
+        for node in original_model_proto.graph.node:
+            assert node.name in compressed_model_onnx_node_names
+    finally:
+        patch_torch_operators()

--- a/tests/torch/test_onnx_export.py
+++ b/tests/torch/test_onnx_export.py
@@ -18,10 +18,8 @@ from torch import nn
 
 from nncf import NNCFConfig
 from nncf.torch import patch_torch_operators
-from nncf.torch.dynamic_graph.graph_tracer import ModelInputInfo
 from nncf.torch.dynamic_graph.patch_pytorch import unpatch_torch_operators
 from nncf.torch.exporter import PTExporter
-from nncf.torch.nncf_network import NNCFNetwork
 from tests.torch.helpers import MockModel
 from tests.torch.helpers import create_bn
 from tests.torch.helpers import create_compressed_model_and_algo_for_test
@@ -146,6 +144,7 @@ def test_can_export_with_model_args(tmp_path):
     compression_ctrl.export_model(str(test_path), model_args=({"param3": 42},))
     assert test_path.exists()
 
+
 class LinearTestModel(nn.Module):
     def __init__(self):
         super().__init__()
@@ -166,27 +165,29 @@ class LinearTestModel(nn.Module):
         return x
 
 
-@pytest.mark.parametrize('compression_section', [
-    {},
-    {"compression": {"algorithm": "quantization"}},
-    {"compression": {"algorithm": "filter_pruning"}}], ids=['none', 'quantization', 'filter_pruning'])
+@pytest.mark.parametrize(
+    "compression_section",
+    [{}, {"compression": {"algorithm": "quantization"}}, {"compression": {"algorithm": "filter_pruning"}}],
+    ids=["none", "quantization", "filter_pruning"],
+)
 def test_preserves_onnx_node_name_format(tmp_path, compression_section):
     model = LinearTestModel()
     model.eval().cpu()
     try:
         unpatch_torch_operators()
-        without_nncf_path = tmp_path / 'without_nncf.onnx'
-        torch.onnx.export(model,
-                          torch.ones([1, 3, 32, 32]),
-                          without_nncf_path,
-                          export_params=True,
-                          opset_version=13,
-                          do_constant_folding=False)
+        without_nncf_path = tmp_path / "without_nncf.onnx"
+        torch.onnx.export(
+            model,
+            torch.ones([1, 3, 32, 32]),
+            without_nncf_path,
+            export_params=True,
+            opset_version=13,
+            do_constant_folding=False,
+        )
         original_model_proto = onnx.load_model(str(without_nncf_path))
         patch_torch_operators()
 
-        config = NNCFConfig.from_dict({"input_info": {"sample_size": [1, 3, 32, 32]},
-                                       **compression_section})
+        config = NNCFConfig.from_dict({"input_info": {"sample_size": [1, 3, 32, 32]}, **compression_section})
         compressed_model_proto = load_exported_onnx_version(config, model, tmp_path)
 
         compressed_model_onnx_node_names = {node.name for node in compressed_model_proto.graph.node}


### PR DESCRIPTION
### Changes

#1584 seems to have broken down the use case where the original model object has forward or backward hooks set up via `torch.nn.Module.register_forward_hook` etc. This PR restores the corresponding functionality.

### Reason for changes

Although the use case is not common, leaving things as-is means that a limitation is introduced by NNCF in regards to the fundamental torch behaviour, which is not something we want.

### Related tickets

N/A

### Tests

tests.torch.test_nncf_network.test_forward_hooks_are_preserved
