### PR TITLE
[PTQ] Fix BC subset_size usage & operations with bias list

### DIFF
--- a/nncf/onnx/graph/metatypes/onnx_metatypes.py
+++ b/nncf/onnx/graph/metatypes/onnx_metatypes.py
@@ -506,7 +506,6 @@ WEIGHT_LAYER_METATYPES = [
 OPERATIONS_WITH_BIAS_METATYPES = [
     ONNXConvolutionMetatype,
     ONNXDepthwiseConvolutionMetatype,
-    ONNXConvolutionTransposeMetatype,
 ]
 
 

--- a/nncf/openvino/graph/metatypes/openvino_metatypes.py
+++ b/nncf/openvino/graph/metatypes/openvino_metatypes.py
@@ -619,7 +619,6 @@ METATYPES_WITH_CONST_PORT_ID = GENERAL_WEIGHT_LAYER_METATYPES + [OVAddMetatype]
 # Contains the operation metatypes for which bias can be applied.
 OPERATIONS_WITH_BIAS_METATYPES = [
     OVConvolutionMetatype,
-    OVConvolutionBackpropDataMetatype,
     # TODO: add all metatypes with bias
     OVMatMulMetatype,
 ]

--- a/nncf/quantization/algorithms/bias_correction/algorithm.py
+++ b/nncf/quantization/algorithms/bias_correction/algorithm.py
@@ -300,12 +300,22 @@ class BiasCorrection(Algorithm):
         :return: List of the dictionaries with the input data.
         """
         feed_dicts = []
-        for stat_id in range(self.subset_size):
+        statistics_size = self.subset_size
+        statistics_per_input = {}
+
+        for input_node_name in subgraph_data["input_node_names"]:
+            input_tensor_name = self._backend_entity.get_input_name(model, input_node_name)
+            input_fp = self._get_fp_inputs(statistic_points, input_node_name)
+            statistics_per_input[input_tensor_name] = input_fp
+            statistics_size = min(statistics_size, len(input_fp))
+
+        for stat_id in range(statistics_size):
             feed_dict = {}
             for input_node_name in subgraph_data["input_node_names"]:
                 input_tensor_name = self._backend_entity.get_input_name(model, input_node_name)
-                input_fp = self._get_fp_inputs(statistic_points, input_node_name)
-                feed_dict[input_tensor_name] = np.mean(input_fp[stat_id], axis=0, keepdims=True)
+                feed_dict[input_tensor_name] = np.mean(
+                    statistics_per_input[input_tensor_name][stat_id], axis=0, keepdims=True
+                )
             feed_dicts.append(feed_dict)
         return feed_dicts
 


### PR DESCRIPTION
### Changes

- Fixed BiasCorrection `subset_size` usage.
- Removed BackpropData types from the OPERATIONS_WITH_BIAS_METATYPES

### Reason for changes

- Bug
- Alignment with [POT logic](https://github.com/openvinotoolkit/openvino/blob/master/tools/pot/openvino/tools/pot/graph/special_operations.py#L28)

### Related tickets

- 110908
- 110914

### Tests
