### PR TITLE
Remove convert_to_mixed_preset parameter

### DIFF
--- a/nncf/experimental/openvino/quantization/quantize_model.py
+++ b/nncf/experimental/openvino/quantization/quantize_model.py
@@ -94,12 +94,6 @@ def quantize_with_accuracy_control(
             "Quantization algorithm with accuracy control from the "
             "OpenVINO backend does not support tuning hyperparams yet"
         )
-    if advanced_accuracy_restorer_parameters.convert_to_mixed_preset:
-        raise RuntimeError(
-            "Quantization algorithm with accuracy control from the "
-            "OpenVINO backend does not support the option to convert "
-            "to the mixed preset yet"
-        )
 
     compress_weights = is_weight_compression_needed(advanced_quantization_parameters)
 

--- a/nncf/openvino/pot/quantization/quantize_model.py
+++ b/nncf/openvino/pot/quantization/quantize_model.py
@@ -392,7 +392,6 @@ def _create_accuracy_restorer_config(
 
     config["max_num_iterations"] = advanced_parameters.max_num_iterations
     config["tune_hyperparams"] = advanced_parameters.tune_hyperparams
-    config["convert_to_mixed_preset"] = advanced_parameters.convert_to_mixed_preset
     if advanced_parameters.ranking_subset_size is not None:
         config["ranking_subset_size"] = advanced_parameters.ranking_subset_size
 

--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -163,12 +163,6 @@ def native_quantize_with_accuracy_control_impl(
             "Quantization algorithm with accuracy control from the "
             "OpenVINO backend does not support tuning hyperparams yet"
         )
-    if advanced_accuracy_restorer_parameters.convert_to_mixed_preset:
-        raise RuntimeError(
-            "Quantization algorithm with accuracy control from the "
-            "OpenVINO backend does not support the option to convert "
-            "to the mixed preset yet"
-        )
 
     compress_weights = is_weight_compression_needed(advanced_quantization_parameters)
 

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -179,10 +179,6 @@ class AdvancedAccuracyRestorerParameters:
         It can bring an additional boost in performance and accuracy, at the cost of
         increased overall quantization time. The default value is `False`.
     :type tune_hyperparams: int
-    :param convert_to_mixed_preset: Whether to convert the model to mixed mode if
-        the accuracy criteria of the symmetrically quantized model are not satisfied.
-        The default value is `False`.
-    :type convert_to_mixed_preset: bool
     :param ranking_subset_size: Size of a subset that is used to rank layers by their
         contribution to the accuracy drop.
     :type ranking_subset_size: Optional[int]
@@ -190,7 +186,6 @@ class AdvancedAccuracyRestorerParameters:
 
     max_num_iterations: int = sys.maxsize
     tune_hyperparams: bool = False
-    convert_to_mixed_preset: bool = False
     ranking_subset_size: Optional[int] = None
 
 

--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -443,13 +443,6 @@ def map_tune_hyperparams(tune_hyperparams):
     return {"advanced_accuracy_restorer_parameters": advanced_parameters}
 
 
-def map_convert_to_mixed_preset(convert_to_mixed_preset):
-    ctx = get_algorithm_parameters_context()
-    advanced_parameters = ctx.params.get("advanced_accuracy_restorer_parameters", AdvancedAccuracyRestorerParameters())
-    advanced_parameters.convert_to_mixed_preset = convert_to_mixed_preset
-    return {"advanced_accuracy_restorer_parameters": advanced_parameters}
-
-
 def create_parameters_for_algorithm(
     pot_parameters, supported_parameters, default_parameters, ignored_parameters, param_name_map
 ):
@@ -529,7 +522,6 @@ def map_quantize_with_accuracy_control_parameters(pot_parameters):
             "max_iter_num": map_max_iter_num,
             "ranking_subset_size": map_ranking_subset_size,
             "tune_hyperparams": map_tune_hyperparams,
-            "convert_to_mixed_preset": map_convert_to_mixed_preset,
             "drop_type": map_drop_type,
         }
     )
@@ -546,6 +538,7 @@ def map_quantize_with_accuracy_control_parameters(pot_parameters):
         [
             "annotation_conf_threshold",
             "metric_subset_ratio",
+            "convert_to_mixed_preset",
         ]
     )
 


### PR DESCRIPTION
### Changes

- The `convert_to_mixed_preset`  parameter was removed from the `AdvancedAccuracyRestorerParameters`.

### Reason for changes

- As we decided we will convert a model to a mixed preset as part of the tune hyperparameters algorithm. So we don't need this parameter anymore.

### Related tickets

N/A

### Tests

N/A
