### PR TITLE
BootstrapNAS - Add super-network abstraction to simplify third-party search

### DIFF
--- a/examples/experimental/torch/classification/bootstrap_nas.py
+++ b/examples/experimental/torch/classification/bootstrap_nas.py
@@ -213,8 +213,8 @@ def main_worker(current_gpu, config: SampleConfig):
 
         # Maximal subnet
         elasticity_ctrl.multi_elasticity_handler.activate_maximum_subnet()
-        search_algo.bn_adaptation.run(model)
-        top1_acc = validate_model_fn_top1(model, val_loader)
+        search_algo.bn_adaptation.run(nncf_network)
+        top1_acc = validate_model_fn_top1(nncf_network, val_loader)
         logger.info(
             "Maximal subnet Top1 acc: {top1_acc}, Macs: {macs}".format(
                 top1_acc=top1_acc,
@@ -224,8 +224,8 @@ def main_worker(current_gpu, config: SampleConfig):
 
         # Best found subnet
         elasticity_ctrl.multi_elasticity_handler.activate_subnet_for_config(best_config)
-        search_algo.bn_adaptation.run(model)
-        top1_acc = validate_model_fn_top1(model, val_loader)
+        search_algo.bn_adaptation.run(nncf_network)
+        top1_acc = validate_model_fn_top1(nncf_network, val_loader)
         logger.info(
             "Best found subnet Top1 acc: {top1_acc}, Macs: {macs}".format(
                 top1_acc=top1_acc,
@@ -235,7 +235,7 @@ def main_worker(current_gpu, config: SampleConfig):
         elasticity_ctrl.export_model(osp.join(config.log_dir, "best_subnet.onnx"))
 
     if "test" in config.mode:
-        validate(val_loader, model, criterion, config)
+        validate(val_loader, nncf_network, criterion, config)
 
 
 if __name__ == "__main__":

--- a/examples/experimental/torch/classification/bootstrap_nas_search.py
+++ b/examples/experimental/torch/classification/bootstrap_nas_search.py
@@ -164,8 +164,8 @@ def main_worker(current_gpu, config: SampleConfig):
 
         # Maximal subnet
         elasticity_ctrl.multi_elasticity_handler.activate_maximum_subnet()
-        search_algo.bn_adaptation.run(model)
-        top1_acc = validate_model_fn_top1(model, val_loader)
+        search_algo.bn_adaptation.run(nncf_network)
+        top1_acc = validate_model_fn_top1(nncf_network, val_loader)
         logger.info(
             "Maximal subnet Top1 acc: {top1_acc}, Macs: {macs}".format(
                 top1_acc=top1_acc,
@@ -175,8 +175,8 @@ def main_worker(current_gpu, config: SampleConfig):
 
         # Best found subnet
         elasticity_ctrl.multi_elasticity_handler.activate_subnet_for_config(best_config)
-        search_algo.bn_adaptation.run(model)
-        top1_acc = validate_model_fn_top1(model, val_loader)
+        search_algo.bn_adaptation.run(nncf_network)
+        top1_acc = validate_model_fn_top1(nncf_network, val_loader)
         logger.info(
             "Best found subnet Top1 acc: {top1_acc}, Macs: {macs}".format(
                 top1_acc=top1_acc,
@@ -191,7 +191,7 @@ def main_worker(current_gpu, config: SampleConfig):
         assert best_config == elasticity_ctrl.multi_elasticity_handler.get_active_config()
 
     if "test" in config.mode:
-        validate(val_loader, model, criterion, config)
+        validate(val_loader, nncf_network, criterion, config)
 
 
 if __name__ == "__main__":

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/multi_elasticity_handler.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/multi_elasticity_handler.py
@@ -205,9 +205,7 @@ class MultiElasticityHandler(ElasticityHandler):
 
         :return: search space
         """
-        active_handlers = {
-            dim: self._handlers[dim] for dim in self._handlers if self._is_handler_enabled_map[dim]
-        }
+        active_handlers = {dim: self._handlers[dim] for dim in self._handlers if self._is_handler_enabled_map[dim]}
         space = {}
         for handler_id, handler in active_handlers.items():
             space[handler_id.value] = handler.get_search_space()

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/multi_elasticity_handler.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/multi_elasticity_handler.py
@@ -198,6 +198,21 @@ class MultiElasticityHandler(ElasticityHandler):
             self._state_names.IS_HANDLER_ENABLED_MAP: is_handler_enabled_map,
         }
 
+    def get_search_space(self) -> Dict[str, Any]:
+        """
+        Returns a dictionary with Python data structures (dict, list, tuple, str, int, float, True, False, None) that
+        represents the search space of the super-network.
+
+        :return: search space
+        """
+        active_handlers = {
+            dim: self._handlers[dim] for dim in self._handlers if self._is_handler_enabled_map[dim]
+        }
+        space = {}
+        for handler_id, handler in active_handlers.items():
+            space[handler_id.value] = handler.get_search_space()
+        return space
+
     def enable_all(self) -> None:
         """
         Enables all elasticities for being selected on sampling subnets.

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
@@ -14,15 +14,9 @@ from typing import Any, Callable, Dict, List, Tuple, TypeVar
 import torch
 
 from nncf import NNCFConfig
-from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_controller import (
-    ElasticityController,
-)
-from nncf.experimental.torch.nas.bootstrapNAS.elasticity.multi_elasticity_handler import (
-    SubnetConfig,
-)
-from nncf.experimental.torch.nas.bootstrapNAS.training.model_creator_helpers import (
-    resume_compression_from_state,
-)
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_controller import ElasticityController
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.multi_elasticity_handler import SubnetConfig
+from nncf.experimental.torch.nas.bootstrapNAS.training.model_creator_helpers import resume_compression_from_state
 from nncf.torch.checkpoint_loading import load_state
 from nncf.torch.model_creation import create_nncf_network
 from nncf.torch.nncf_network import NNCFNetwork

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
@@ -10,16 +10,18 @@
 # limitations under the License.
 
 import torch
+
 from nncf.experimental.torch.nas.bootstrapNAS.training.model_creator_helpers import resume_compression_from_state
-from nncf.torch.model_creation import create_nncf_network
 from nncf.torch.checkpoint_loading import load_state
+from nncf.torch.model_creation import create_nncf_network
 
 
 class SuperNetwork:
     """
-        An interface for handling pre-trained super-networks. This class can be used to quickly implement
-        third party solutions for subnetwork search on existing super-netwroks. 
+    An interface for handling pre-trained super-networks. This class can be used to quickly implement
+    third party solutions for subnetwork search on existing super-netwroks.
     """
+
     def __init__(self, elastic_ctrl, nncf_network):
         """
         Initializes the super-network interface.
@@ -83,7 +85,7 @@ class SuperNetwork:
     def get_macs_for_active_config(self):
         return self._m_handler.count_flops_and_weights_for_active_subnet()[0] / 2000000
 
-    def export_active_to_onnx(self, filename='subnet'):
+    def export_active_to_onnx(self, filename="subnet"):
         self._elasticity_ctrl.export_model(f"{filename}.onnx")
 
     def get_config_from_pymoo(self, pymoo_config):

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
@@ -60,15 +60,9 @@ class SuperNetwork:
         :return: SuperNetwork with wrapped functionality.
         """
         nncf_network = create_nncf_network(model, nncf_config)
-        compression_state = torch.load(
-            supernet_elasticity_path, map_location=torch.device(nncf_config.device)
-        )
-        model, elasticity_ctrl = resume_compression_from_state(
-            nncf_network, compression_state
-        )
-        model_weights = torch.load(
-            supernet_weights_path, map_location=torch.device(nncf_config.device)
-        )
+        compression_state = torch.load(supernet_elasticity_path, map_location=torch.device(nncf_config.device))
+        model, elasticity_ctrl = resume_compression_from_state(nncf_network, compression_state)
+        model_weights = torch.load(supernet_weights_path, map_location=torch.device(nncf_config.device))
         load_state(model, model_weights, is_resume=True)
         elasticity_ctrl.multi_elasticity_handler.activate_maximum_subnet()
         return SuperNetwork(elasticity_ctrl, model)
@@ -86,16 +80,12 @@ class SuperNetwork:
         """
         self._m_handler.get_design_vars_info()
 
-    def eval_subnet_with_design_vars(
-        self, design_config: List, eval_fn: ValFnType, **kwargs
-    ) -> Any:
+    def eval_subnet_with_design_vars(self, design_config: List, eval_fn: ValFnType, **kwargs) -> Any:
         """
 
         :returns the value produced by the user's function to evaluate the subnetwork.
         """
-        self._m_handler.activate_subnet_for_config(
-            self._m_handler.get_config_from_pymoo(design_config)
-        )
+        self._m_handler.activate_subnet_for_config(self._m_handler.get_config_from_pymoo(design_config))
         return eval_fn(self._model, **kwargs)
 
     def eval_active_subnet(self, eval_fn: ValFnType, **kwargs) -> Any:

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
@@ -49,7 +49,7 @@ class TrainedSuperNet:
         nncf_config: NNCFConfig,
         supernet_elasticity_path: str,
         supernet_weights_path: str,
-    ) -> "SuperNetwork":
+    ) -> "TrainedSuperNet":
         """
         Loads existing super-network weights and elasticity information, and creates the SuperNetwork interface.
 
@@ -65,7 +65,7 @@ class TrainedSuperNet:
         model_weights = torch.load(supernet_weights_path, map_location=torch.device(nncf_config.device))
         load_state(model, model_weights, is_resume=True)
         elasticity_ctrl.multi_elasticity_handler.activate_maximum_subnet()
-        return SuperNetwork(elasticity_ctrl, model)
+        return TrainedSuperNet(elasticity_ctrl, model)
 
     def get_search_space(self) -> Dict:
         """

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
@@ -25,7 +25,7 @@ TModel = TypeVar("TModel")
 ValFnType = Callable[[NNCFNetwork, Any], Any]
 
 
-class SuperNetwork:
+class TrainedSuperNet:
     """
     An interface for handling pre-trained super-networks. This class can be used to quickly implement
     third party solutions for subnetwork search on existing super-networks.
@@ -83,14 +83,13 @@ class SuperNetwork:
     def eval_subnet_with_design_vars(self, design_config: List, eval_fn: ValFnType, **kwargs) -> Any:
         """
 
-        :returns the value produced by the user's function to evaluate the subnetwork.
+        :return: the value produced by the user's function to evaluate the subnetwork.
         """
         self._m_handler.activate_subnet_for_config(self._m_handler.get_config_from_pymoo(design_config))
         return eval_fn(self._model, **kwargs)
 
     def eval_active_subnet(self, eval_fn: ValFnType, **kwargs) -> Any:
         """
-
         :param eval_fn: user's function to evaluate the active subnetwork.
         :return: value of the user's function used to evaluate the subnetwork.
         """
@@ -98,7 +97,6 @@ class SuperNetwork:
 
     def eval_subnet(self, config: SubnetConfig, eval_fn: ValFnType, **kwargs) -> Any:
         """
-
         :param config: subnetwork configuration.
         :param eval_fn: user's function to evaluate the active subnetwork.
         :return: value of the user's function used to evaluate the subnetwork.
@@ -108,7 +106,6 @@ class SuperNetwork:
 
     def activate_config(self, config: SubnetConfig) -> None:
         """
-
         :param config: subnetwork configuration to activate.
         """
         self._m_handler.activate_subnet_for_config(config)
@@ -116,27 +113,23 @@ class SuperNetwork:
     def activate_maximal_subnet(self) -> None:
         """
         Activates the maximal subnetwork in the super-network.
-
         """
         self._m_handler.activate_maximum_subnet()
 
     def activate_minimal_subnet(self) -> None:
         """
         Activates the minimal subnetwork in the super-network.
-
         """
         self._m_handler.activate_minimum_subnet()
 
     def get_active_config(self) -> SubnetConfig:
         """
-
         :return: the active configuration.
         """
         return self._m_handler.get_active_config()
 
     def get_macs_for_active_config(self) -> float:
         """
-
         :return: MACs of active subnet.
         """
         return self._m_handler.count_flops_and_weights_for_active_subnet()[0] / 2e6
@@ -160,7 +153,6 @@ class SuperNetwork:
 
     def get_active_subnet(self) -> NNCFNetwork:
         """
-
         :return: the nncf network with the current active configuration.
         """
         return self._model

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
@@ -9,11 +9,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Callable, Dict, List, Tuple, TypeVar
+
 import torch
 
-from nncf.experimental.torch.nas.bootstrapNAS.training.model_creator_helpers import resume_compression_from_state
+from nncf import NNCFConfig
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_controller import (
+    ElasticityController,
+)
+from nncf.experimental.torch.nas.bootstrapNAS.elasticity.multi_elasticity_handler import (
+    SubnetConfig,
+)
+from nncf.experimental.torch.nas.bootstrapNAS.training.model_creator_helpers import (
+    resume_compression_from_state,
+)
 from nncf.torch.checkpoint_loading import load_state
 from nncf.torch.model_creation import create_nncf_network
+from nncf.torch.nncf_network import NNCFNetwork
+
+TModel = TypeVar("TModel")
+ValFnType = Callable[[NNCFNetwork, Any], Any]
 
 
 class SuperNetwork:
@@ -22,7 +37,7 @@ class SuperNetwork:
     third party solutions for subnetwork search on existing super-networks.
     """
 
-    def __init__(self, elastic_ctrl, nncf_network):
+    def __init__(self, elastic_ctrl: ElasticityController, nncf_network: NNCFNetwork):
         """
         Initializes the super-network interface.
 
@@ -34,61 +49,134 @@ class SuperNetwork:
         self._model = nncf_network
 
     @classmethod
-    def from_checkpoint(cls, model, nncf_config, supernet_path, supernet_weights):
+    def from_checkpoint(
+        cls,
+        model: TModel,
+        nncf_config: NNCFConfig,
+        supernet_elasticity_path: str,
+        supernet_weights_path: str,
+    ) -> "SuperNetwork":
         """
         Loads existing super-network weights and elasticity information, and creates the SuperNetwork interface.
 
         :param model: base model that was used to create the super-network.
         :param nncf_config: configuration used to create the super-network.
-        :param supernet_path: path to file containing state information about the super-network.
-        :param supernet_weights: trained weights to resume the super-network.
+        :param supernet_elasticity_path: path to file containing state information about the super-network.
+        :param supernet_weights_path: trained weights to resume the super-network.
         :return: SuperNetwork with wrapped functionality.
         """
         nncf_network = create_nncf_network(model, nncf_config)
-        compression_state = torch.load(supernet_path, map_location=torch.device(nncf_config.device))
-        model, elasticity_ctrl = resume_compression_from_state(nncf_network, compression_state)
-        model_weights = torch.load(supernet_weights, map_location=torch.device(nncf_config.device))
+        compression_state = torch.load(
+            supernet_elasticity_path, map_location=torch.device(nncf_config.device)
+        )
+        model, elasticity_ctrl = resume_compression_from_state(
+            nncf_network, compression_state
+        )
+        model_weights = torch.load(
+            supernet_weights_path, map_location=torch.device(nncf_config.device)
+        )
         load_state(model, model_weights, is_resume=True)
         elasticity_ctrl.multi_elasticity_handler.activate_maximum_subnet()
         return SuperNetwork(elasticity_ctrl, model)
 
-    def get_search_space(self):
+    def get_search_space(self) -> Dict:
+        """
+        :return: dictionary with possible values for elastic configurations.
+        """
         return self._m_handler.get_search_space()
 
-    def get_design_vars_info(self):
+    def get_design_vars_info(self) -> Tuple[int, List[int]]:
+        """
+        :return: number of possible values in subnet configurations and
+        the number of possible values for each elastic property.
+        """
         self._m_handler.get_design_vars_info()
 
-    def eval_subnet_with_design_vars(self, design_config, eval_fn, **kwargs):
-        self._m_handler.activate_subnet_for_config(self._m_handler.get_config_from_pymoo(design_config))
+    def eval_subnet_with_design_vars(
+        self, design_config: List, eval_fn: ValFnType, **kwargs
+    ) -> Any:
+        """
+
+        :returns the value produced by the user's function to evaluate the subnetwork.
+        """
+        self._m_handler.activate_subnet_for_config(
+            self._m_handler.get_config_from_pymoo(design_config)
+        )
         return eval_fn(self._model, **kwargs)
 
-    def eval_active_subnet(self, eval_fn, **kwargs):
+    def eval_active_subnet(self, eval_fn: ValFnType, **kwargs) -> Any:
+        """
+
+        :param eval_fn: user's function to evaluate the active subnetwork.
+        :return: value of the user's function used to evaluate the subnetwork.
+        """
         return eval_fn(self._model, **kwargs)
 
-    def eval_subnet(self, config, eval_fn, **kwargs):
-        self._m_handler.activate_subnet_for_config(config)
+    def eval_subnet(self, config: SubnetConfig, eval_fn: ValFnType, **kwargs) -> Any:
+        """
+
+        :param config: subnetwork configuration.
+        :param eval_fn: user's function to evaluate the active subnetwork.
+        :return: value of the user's function used to evaluate the subnetwork.
+        """
+        self.activate_config(config)
         return self.eval_active_subnet(eval_fn, **kwargs)
 
-    def activate_config(self, config):
+    def activate_config(self, config: SubnetConfig) -> None:
+        """
+
+        :param config: subnetwork configuration to activate.
+        """
         self._m_handler.activate_subnet_for_config(config)
 
-    def activate_maximal_subnet(self):
+    def activate_maximal_subnet(self) -> None:
+        """
+        Activates the maximal subnetwork in the super-network.
+
+        """
         self._m_handler.activate_maximum_subnet()
 
-    def activate_minimal_subnet(self):
+    def activate_minimal_subnet(self) -> None:
+        """
+        Activates the minimal subnetwork in the super-network.
+
+        """
         self._m_handler.activate_minimum_subnet()
 
-    def get_active_config(self):
+    def get_active_config(self) -> SubnetConfig:
+        """
+
+        :return: the active configuration.
+        """
         return self._m_handler.get_active_config()
 
-    def get_macs_for_active_config(self):
+    def get_macs_for_active_config(self) -> float:
+        """
+
+        :return: MACs of active subnet.
+        """
         return self._m_handler.count_flops_and_weights_for_active_subnet()[0] / 2e6
 
-    def export_active_to_onnx(self, filename="subnet"):
+    def export_active_subnet_to_onnx(self, filename: str = "subnet") -> None:
+        """
+        Exports the active subnetwork to ONNX format.
+
+        :param filename: name of the output file.
+        """
         self._elasticity_ctrl.export_model(f"{filename}.onnx")
 
-    def get_config_from_pymoo(self, pymoo_config):
+    def get_config_from_pymoo(self, pymoo_config: List) -> SubnetConfig:
+        """
+        Converts a Pymoo subnetwork configuration into a SubnetConfig.
+
+        :param pymoo_config: subnetwork configuration in Pymoo format.
+        :return: subnetwork configuration in SubnetConfig format.
+        """
         return self._m_handler.get_config_from_pymoo(pymoo_config)
 
-    def get_active_subnet(self):
+    def get_active_subnet(self) -> NNCFNetwork:
+        """
+
+        :return: the nncf network with the current active configuration.
+        """
         return self._model

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from nncf.experimental.torch.nas.bootstrapNAS.training.model_creator_helpers import resume_compression_from_state
+from nncf.torch.model_creation import create_nncf_network
+from nncf.torch.checkpoint_loading import load_state
+
+
+class SuperNetwork:
+    """
+        An interface for handling pre-trained super-networks. This class can be used to quickly implement
+        third party solutions for subnetwork search on existing super-netwroks. 
+    """
+    def __init__(self, elastic_ctrl, nncf_network):
+        """
+        Initializes the super-network interface.
+
+        :param elastic_ctrl: Elasticity controller to activate subnetworks
+        :param nncf_network: NNCFNetwork that wraps the original PyTorch model.
+        """
+        self._m_handler = elastic_ctrl.multi_elasticity_handler
+        self._elasticity_ctrl = elastic_ctrl
+        self._model = nncf_network
+
+    @classmethod
+    def from_checkpoint(cls, model, nncf_config, supernet_path, supernet_weights):
+        """
+        Loads existing super-network weights and elasticity information, and creates the SuperNetwork interface.
+
+        :param model: base model that was used to create the super-network.
+        :param nncf_config: configuration used to create the super-network.
+        :param supernet_path: path to file containing state information about the super-network.
+        :param supernet_weights: trained weights to resume the super-network.
+        :return: SuperNetwork with wrapped functionality.
+        """
+        nncf_network = create_nncf_network(model, nncf_config)
+        compression_state = torch.load(supernet_path, map_location=torch.device(nncf_config.device))
+        model, elasticity_ctrl = resume_compression_from_state(nncf_network, compression_state)
+        model_weights = torch.load(supernet_weights, map_location=torch.device(nncf_config.device))
+        load_state(model, model_weights, is_resume=True)
+        elasticity_ctrl.multi_elasticity_handler.activate_maximum_subnet()
+        elasticity_ctrl.multi_elasticity_handler.count_flops_and_weights_for_active_subnet()[0] / 2e6
+        return SuperNetwork(elasticity_ctrl, model)
+
+    def get_search_space(self):
+        return self._m_handler.get_search_space()
+
+    def get_design_vars_info(self):
+        self._m_handler.get_design_vars_info()
+
+    def eval_subnet_with_design_vars(self, design_config, eval_fn, **kwargs):
+        self._m_handler.activate_subnet_for_config(self._m_handler.get_config_from_pymoo(design_config))
+        return eval_fn(self._model, **kwargs)
+
+    def eval_active_subnet(self, eval_fn, **kwargs):
+        return eval_fn(self._model, **kwargs)
+
+    def eval_subnet(self, config, eval_fn, **kwargs):
+        self._m_handler.activate_subnet_for_config(config)
+        return self.eval_active_subnet(eval_fn, **kwargs)
+
+    def activate_config(self, config):
+        self._m_handler.activate_subnet_for_config(config)
+
+    def activate_maximal_subnet(self):
+        self._m_handler.activate_maximum_subnet()
+
+    def activate_minimal_subnet(self):
+        self._m_handler.activate_minimum_subnet()
+
+    def get_active_config(self):
+        return self._m_handler.get_active_config()
+
+    def get_macs_for_active_config(self):
+        return self._m_handler.count_flops_and_weights_for_active_subnet()[0] / 2000000
+
+    def export_active_to_onnx(self, filename='subnet'):
+        self._elasticity_ctrl.export_model(f"{filename}.onnx")
+
+    def get_config_from_pymoo(self, pymoo_config):
+        return self._m_handler.get_config_from_pymoo(pymoo_config)
+
+    def get_active_subnet(self):
+        return self._model

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/supernet.py
@@ -19,7 +19,7 @@ from nncf.torch.model_creation import create_nncf_network
 class SuperNetwork:
     """
     An interface for handling pre-trained super-networks. This class can be used to quickly implement
-    third party solutions for subnetwork search on existing super-netwroks.
+    third party solutions for subnetwork search on existing super-networks.
     """
 
     def __init__(self, elastic_ctrl, nncf_network):
@@ -50,7 +50,6 @@ class SuperNetwork:
         model_weights = torch.load(supernet_weights, map_location=torch.device(nncf_config.device))
         load_state(model, model_weights, is_resume=True)
         elasticity_ctrl.multi_elasticity_handler.activate_maximum_subnet()
-        elasticity_ctrl.multi_elasticity_handler.count_flops_and_weights_for_active_subnet()[0] / 2e6
         return SuperNetwork(elasticity_ctrl, model)
 
     def get_search_space(self):
@@ -83,7 +82,7 @@ class SuperNetwork:
         return self._m_handler.get_active_config()
 
     def get_macs_for_active_config(self):
-        return self._m_handler.count_flops_and_weights_for_active_subnet()[0] / 2000000
+        return self._m_handler.count_flops_and_weights_for_active_subnet()[0] / 2e6
 
     def export_active_to_onnx(self, filename="subnet"):
         self._elasticity_ctrl.export_model(f"{filename}.onnx")


### PR DESCRIPTION
### Changes

Adds super-network abstraction to simplify third-party search. 

### Reason for changes

Simple interface for users that are implementing their own search algorithms 

### Example

[Example of how this wrapper is used by third-party search solutions](https://github.com/IntelLabs/Hardware-Aware-Automated-Machine-Learning/blob/main/examples/bootstrapNAS/external_search_resnet50_supernet.ipynb)

### Tests

N/A - Class wraps multi elasticity handler. 
