### PR TITLE
Update versions of packages in requirements for post_training tests

### DIFF
--- a/nncf/experimental/torch/replace_custom_modules/timm_custom_modules.py
+++ b/nncf/experimental/torch/replace_custom_modules/timm_custom_modules.py
@@ -12,10 +12,10 @@
 from copy import deepcopy
 from typing import Optional
 
-from timm.models.layers import Linear
-from timm.models.layers.norm_act import BatchNormAct2d
-from timm.models.layers.norm_act import GroupNormAct
-from timm.models.layers.norm_act import LayerNormAct
+from timm.layers import Linear
+from timm.layers.norm_act import BatchNormAct2d
+from timm.layers.norm_act import GroupNormAct
+from timm.layers.norm_act import LayerNormAct
 from torch import nn
 
 from nncf.torch.nncf_module_replacement import replace_modules_by_nncf_modules

--- a/tests/post_training/model_scope.json
+++ b/tests/post_training/model_scope.json
@@ -3,14 +3,14 @@
         "model_name": "vgg11",
         "quantization_params": {},
         "metrics": {
-            "FP32 top 1": 0.61246
+            "FP32 top 1": 0.68344
         }
     },
     "resnet18": {
         "model_name": "resnet18",
         "quantization_params": {},
         "metrics": {
-            "FP32 top 1": 0.62734
+            "FP32 top 1": 0.70104
         }
     },
     "mobilenetv2_050": {
@@ -19,7 +19,7 @@
             "preset": "MIXED"
         },
         "metrics": {
-            "FP32 top 1": 0.59498
+            "FP32 top 1": 0.64568
         }
     },
     "mobilenetv2_050_BC": {
@@ -29,7 +29,7 @@
             "fast_bias_correction": false
         },
         "metrics": {
-            "FP32 top 1": 0.59498
+            "FP32 top 1": 0.64568
         }
     },
     "densenet121": {
@@ -52,7 +52,7 @@
             "preset": "MIXED"
         },
         "metrics": {
-            "FP32 top 1": 0.75948
+            "FP32 top 1": 0.77728
         }
     },
     "xception": {
@@ -61,7 +61,7 @@
             "preset": "MIXED"
         },
         "metrics": {
-            "FP32 top 1": 0.77522
+            "FP32 top 1": 0.78506
         }
     },
     "efficientnet_b0": {
@@ -70,7 +70,7 @@
             "preset": "MIXED"
         },
         "metrics": {
-            "FP32 top 1": 0.72912
+            "FP32 top 1": 0.77292
         }
     },
     "efficientnet_b0_BC": {
@@ -80,7 +80,7 @@
             "fast_bias_correction": false
         },
         "metrics": {
-            "FP32 top 1": 0.72912
+            "FP32 top 1": 0.77292
         }
     },
     "darknet53": {
@@ -89,7 +89,7 @@
             "preset": "MIXED"
         },
         "metrics": {
-            "FP32 top 1": 0.7645
+            "FP32 top 1": 0.79858
         }
     },
     "resnest14d": {
@@ -98,14 +98,14 @@
             "preset": "MIXED"
         },
         "metrics": {
-            "FP32 top 1": 0.70102
+            "FP32 top 1": 0.74862
         }
     },
     "inception_resnet_v2": {
         "model_name": "inception_resnet_v2",
         "quantization_params": {},
         "metrics": {
-            "FP32 top 1": 0.78894
+            "FP32 top 1": 0.80102
         }
     },
     "wide_resnet50_2": {
@@ -114,7 +114,7 @@
             "preset": "MIXED"
         },
         "metrics": {
-            "FP32 top 1": 0.7664
+            "FP32 top 1": 0.81414
         }
     },
     "regnetx_002": {
@@ -123,7 +123,7 @@
             "preset": "MIXED"
         },
         "metrics": {
-            "FP32 top 1": 0.63078
+            "FP32 top 1": 0.67826
         }
     },
     "mobilenetv3_small_050": {
@@ -132,7 +132,7 @@
             "preset": "MIXED"
         },
         "metrics": {
-            "FP32 top 1": 0.51764
+            "FP32 top 1": 0.56338
         }
     },
     "levit_128": {
@@ -166,7 +166,7 @@
         }
     },
     "convit_tiny": {
-        "skipped" : "Suppressed due to bug - 104173",
+        "skipped": "Suppressed due to bug - 104173",
         "model_name": "convit_tiny",
         "quantization_params": {
             "preset": "MIXED",
@@ -199,7 +199,7 @@
             "preset": "MIXED"
         },
         "metrics": {
-            "FP32 top 1": 0.70656
+            "FP32 top 1": 0.77504
         }
     },
     "efficientnet_lite0": {
@@ -208,7 +208,7 @@
             "preset": "MIXED"
         },
         "metrics": {
-            "FP32 top 1": 0.69878
+            "FP32 top 1": 0.7496
         }
     },
     "dpn68": {
@@ -217,7 +217,7 @@
             "preset": "MIXED"
         },
         "metrics": {
-            "FP32 top 1": 0.71478
+            "FP32 top 1": 0.75964
         }
     },
     "dla34": {
@@ -226,7 +226,7 @@
             "preset": "MIXED"
         },
         "metrics": {
-            "FP32 top 1": 0.68424
+            "FP32 top 1": 0.74416
         }
     }
 }

--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -1,10 +1,10 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch
+torch==1.13.1
 --extra-index-url https://download.pytorch.org/whl/cpu
-torchvision
-onnx
-onnxruntime
+torchvision==0.14.1
+onnx==1.14.0
+onnxruntime==1.6.0
 pytest
 openvino-dev>=2022.1
-timm==0.6.13
-scikit-learn
+timm==0.9.2
+scikit-learn==1.2.2

--- a/tests/torch/experimental/replace_custom_modules/test_replace_timm_custom_modules.py
+++ b/tests/torch/experimental/replace_custom_modules/test_replace_timm_custom_modules.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import timm
+import torch
+from timm.layers import Linear
+from timm.layers.norm_act import BatchNormAct2d
+from timm.layers.norm_act import GroupNormAct
+from timm.layers.norm_act import LayerNormAct
+from torch import nn
+
+from nncf.experimental.torch.replace_custom_modules.timm_custom_modules import convert_timm_custom_modules
+from nncf.experimental.torch.replace_custom_modules.timm_custom_modules import (
+    replace_timm_custom_modules_with_torch_native,
+)
+
+
+def _count_custom_modules(model) -> int:
+    """
+    Get number of custom modules in the model.
+    :param model: The target model.
+    :return int: Number of custom modules.
+    """
+    custom_types = [
+        Linear,
+        BatchNormAct2d,
+        GroupNormAct,
+        LayerNormAct,
+    ]
+    return len([m for _, m in model.named_modules() if type(m) in custom_types])
+
+
+TEST_CUSTOM_MODULES = [
+    Linear(
+        in_features=2,
+        out_features=2,
+    ),
+    BatchNormAct2d(
+        num_features=2,
+        act_layer=nn.ReLU,
+    ),
+    GroupNormAct(
+        num_channels=2,
+        num_groups=2,
+        act_layer=nn.ReLU,
+    ),
+    LayerNormAct(
+        normalization_shape=(2, 2),
+        act_layer=nn.ReLU,
+    ),
+]
+
+
+@pytest.mark.parametrize("custom_module", TEST_CUSTOM_MODULES, ids=[m.__class__.__name__ for m in TEST_CUSTOM_MODULES])
+@pytest.mark.skipif(timm is None, reason="Not install timm package")
+def test_replace_custom_timm_module(custom_module):
+    """
+    Test output of replaced module with custom module
+    """
+    native_module = convert_timm_custom_modules(custom_module)
+    input_data = torch.rand(1, 2, 2, 2)
+    out_custom = custom_module(input_data)
+    out_native = native_module(input_data)
+
+    assert type(custom_module) != type(native_module)
+    assert torch.equal(out_custom, out_native)
+
+
+def test_replace_custom_modules_in_timm_model():
+    """
+    Test that all modules from timm model replaced by replace_custom_modules_with_torch_native
+    """
+    timm_model = timm.create_model(
+        "mobilenetv3_small_050", num_classes=1000, in_chans=3, pretrained=True, checkpoint_path=""
+    )
+    input_data = torch.rand(1, 3, 224, 224)
+    out_timm = timm_model(input_data)
+
+    native_model = replace_timm_custom_modules_with_torch_native(timm_model)
+    out_native = native_model(input_data)
+    assert torch.equal(out_timm, out_native)
+
+    num_custom_modules_in_timm = _count_custom_modules(timm_model)
+    num_custom_modules_in_native = _count_custom_modules(native_model)
+
+    assert num_custom_modules_in_native == 0
+    assert num_custom_modules_in_timm > 0

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -14,5 +14,5 @@ transformers==4.23.1
 # Required for movement_sparsity tests
 datasets==2.6.2
 evaluate==0.3.0
-timm==0.6.13
+timm==0.9.2
 openvino-dev~=2023.0.0.dev

--- a/tests/torch/test_models/swin.py
+++ b/tests/torch/test_models/swin.py
@@ -13,9 +13,9 @@
 # and https://github.com/rwightman/pytorch-image-models
 
 import torch
-from timm.models.layers import DropPath
-from timm.models.layers import to_2tuple
-from timm.models.layers import trunc_normal_
+from timm.layers import DropPath
+from timm.layers import to_2tuple
+from timm.layers import trunc_normal_
 from torch import nn
 
 WindowProcess = None
@@ -177,7 +177,7 @@ class SwinTransformerBlock(nn.Module):
 
     Args:
         dim (int): Number of input channels.
-        input_resolution (tuple[int]): Input resulotion.
+        input_resolution (tuple[int]): Input resolution.
         num_heads (int): Number of attention heads.
         window_size (int): Window size.
         shift_size (int): Shift size for SW-MSA.


### PR DESCRIPTION
### Changes

- Update `timm` to 0.9.2
- Set `torch` to `1.13.1`
- Add tests for `replace_timm_custom_modules_with_torch_native`


### Related tickets

111127

TODO: 
- [x] Update metrics (build 50)

| model_name | new 'FP32 top 1' | old  'FP32 top 1' |
|---|---|---|
| darknet53 | 0.79858 | 0.7645 |
| dla34 | 0.74416 | 0.68424 |
| dpn68 | 0.75964 | 0.71478 |
| efficientnet_b0 | 0.77292 | 0.72912 |
| efficientnet_lite0 | 0.7496 | 0.69878 |
| hrnet_w18 | 0.77504 | 0.70656 |
| inception_resnet_v2 | 0.80102 | 0.78894 |
| mobilenetv2_050 | 0.64568 | 0.59498 |
| mobilenetv3_small_050 | 0.56338 | 0.51764 |
| regnetx_002 | 0.67826 | 0.63078 |
| resnest14d | 0.74862 | 0.70102 |
| resnet18 | 0.70104 | 0.62734 |
| tf_inception_v3 | 0.77728 | 0.75948 |
| vgg11 | 0.68344 | 0.61246 |
| wide_resnet50_2 | 0.81414 | 0.7664 |
| xception | 0.78506 | 0.77522 |
