### PR TITLE
Ignore 0-th port of baddbmm in quantization

### DIFF
--- a/nncf/common/graph/operator_metatypes.py
+++ b/nncf/common/graph/operator_metatypes.py
@@ -22,11 +22,13 @@ class OperatorMetatype:
     :param name: The name of the operator.
     :param hw_config_names: The names of the hardware configurations.
     :param output_channel_axis: The axis along which the output channels of the operator are arranged.
+    :param ignored_input_ports: Input ports of the operations that should not be considered for purposes of compression.
     """
 
     name: str = ""
     hw_config_names: List[str] = []
     output_channel_axis: Optional[int] = None
+    ignored_input_ports: List[int] = []
 
     @classmethod
     def get_all_aliases(cls) -> List[str]:

--- a/nncf/common/quantization/quantizer_propagation/solver.py
+++ b/nncf/common/quantization/quantizer_propagation/solver.py
@@ -1155,6 +1155,11 @@ class QuantizerPropagationSolver:
                 pred_node_type
             ), "Invalid insertion point graph supplied for quantizer propagation!"
 
+            ip = pred_node[QuantizerPropagationStateGraph.QUANT_INSERTION_POINT_DATA_NODE_ATTR]
+            input_port_id = ip.input_port_id
+            if input_port_id in metatype.ignored_input_ports:
+                continue
+
             edge = quant_prop_graph.edges[pred_ip_key, operator_node_key]
             if not edge[QuantizerPropagationStateGraph.IS_INTEGER_PATH_EDGE_ATTR]:
                 pred_ip_key_vs_qconf_dict[pred_ip_key] = qconf_list

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -498,9 +498,20 @@ class PTMatMulMetatype(PTOperatorMetatype):
     name = "MatMulOp"
     module_to_function_names = {
         NamespaceTarget.TORCH_TENSOR: ["matmul", "__matmul__"],
-        NamespaceTarget.TORCH: ["matmul", "bmm", "mm", "baddbmm"],
+        NamespaceTarget.TORCH: ["matmul", "bmm", "mm"],
     }
     hw_config_names = [HWConfigOpName.MATMUL]
+
+
+@PT_OPERATOR_METATYPES.register()
+class PTBaddBmmMetatype(PTOperatorMetatype):
+    name = "MatMulOp"
+    module_to_function_names = {NamespaceTarget.TORCH: ["baddbmm"]}
+    hw_config_names = [HWConfigOpName.MATMUL]
+    # 0-th arg to the baddbmm is basically a (b)ias to be (add)ed to the (bmm) operation,
+    # presuming that most runtime implementations will fuse the bias addition into the matrix multiplication
+    # and therefore won't quantize the bias input, as this would break the hardware-fused pattern.
+    ignored_input_ports: List[int] = [0]
 
 
 @PT_OPERATOR_METATYPES.register()

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/Baddbmm.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/Baddbmm.dot
@@ -1,17 +1,15 @@
 strict digraph  {
 "0 /nncf_model_input_0" [id=0, type=nncf_model_input];
-"1 SymmetricQuantizer/symmetric_quantize_0" [id=1, type=symmetric_quantize];
-"2 /nncf_model_input_1" [id=2, type=nncf_model_input];
-"3 SymmetricQuantizer/symmetric_quantize_1" [id=3, type=symmetric_quantize];
-"4 /nncf_model_input_2" [id=4, type=nncf_model_input];
-"5 SymmetricQuantizer/symmetric_quantize_2" [id=5, type=symmetric_quantize];
-"6 Baddbmm/baddbmm_0" [id=6, type=baddbmm];
-"7 /nncf_model_output_0" [id=7, type=nncf_model_output];
-"0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
-"1 SymmetricQuantizer/symmetric_quantize_0" -> "6 Baddbmm/baddbmm_0";
-"2 /nncf_model_input_1" -> "3 SymmetricQuantizer/symmetric_quantize_1";
-"3 SymmetricQuantizer/symmetric_quantize_1" -> "6 Baddbmm/baddbmm_0";
-"4 /nncf_model_input_2" -> "5 SymmetricQuantizer/symmetric_quantize_2";
-"5 SymmetricQuantizer/symmetric_quantize_2" -> "6 Baddbmm/baddbmm_0";
-"6 Baddbmm/baddbmm_0" -> "7 /nncf_model_output_0";
+"1 /nncf_model_input_1" [id=1, type=nncf_model_input];
+"2 SymmetricQuantizer/symmetric_quantize_0" [id=2, type=symmetric_quantize];
+"3 /nncf_model_input_2" [id=3, type=nncf_model_input];
+"4 SymmetricQuantizer/symmetric_quantize_1" [id=4, type=symmetric_quantize];
+"5 Baddbmm/baddbmm_0" [id=5, type=baddbmm];
+"6 /nncf_model_output_0" [id=6, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "5 Baddbmm/baddbmm_0";
+"1 /nncf_model_input_1" -> "2 SymmetricQuantizer/symmetric_quantize_0";
+"2 SymmetricQuantizer/symmetric_quantize_0" -> "5 Baddbmm/baddbmm_0";
+"3 /nncf_model_input_2" -> "4 SymmetricQuantizer/symmetric_quantize_1";
+"4 SymmetricQuantizer/symmetric_quantize_1" -> "5 Baddbmm/baddbmm_0";
+"5 Baddbmm/baddbmm_0" -> "6 /nncf_model_output_0";
 }


### PR DESCRIPTION
### Changes
Add a field to `OperatorMetatype` that specifies input ports to be ignored and use it to disable quantization on the 0-th input port of the `torch.baddbmm` operation.

### Reason for changes
The 0-th input for baddbmm is a bias addition in essence, and if the input tensor is a constant, then adding a quantizer there breaks down a hardware-fused pattern and reduces performance. It is still possible that the 0-th input may be a runtime-dynamic activation tensor, in which case the quantization of this input would probably still be relevant, but right now there is no way in NNCF PT to discern activation and constant inputs.

### Related tickets
110848

### Tests
test_synthetic_model_quantization
