### PR TITLE
Use packaging instead pkg_resources

### DIFF
--- a/examples/torch/common/models/segmentation/icnet.py
+++ b/examples/torch/common/models/segmentation/icnet.py
@@ -21,7 +21,7 @@ from collections import OrderedDict
 import torch
 import torch.nn.functional as F
 from numpy import lcm
-from pkg_resources import parse_version
+from packaging import version
 from torch import nn
 
 from examples.torch.common.example_logger import logger
@@ -393,7 +393,7 @@ class ICNet(nn.Module):
         fused_features_ds4 = F.interpolate(fused_features_sub421, self._input_size_hw_ds4, **self.sampling_params)
         label_scores_ds4 = self.conv6_cls(fused_features_ds4)
         label_scores = F.interpolate(label_scores_ds4, self._input_size_hw, **self.sampling_params)
-        if is_tracing_state() and parse_version(torch.__version__) >= parse_version("1.1.0"):
+        if is_tracing_state() and version.parse(torch.__version__) >= version.parse("1.1.0"):
             # While exporting, add extra post-processing layers into the graph
             # so that the model outputs class probabilities instead of class scores
             softmaxed = F.softmax(label_scores, dim=1)

--- a/examples/torch/common/models/segmentation/unet.py
+++ b/examples/torch/common/models/segmentation/unet.py
@@ -14,7 +14,7 @@
 
 import torch
 import torch.nn.functional as F
-from pkg_resources import parse_version
+from packaging import version
 from torch import nn
 
 from examples.torch.common.example_logger import logger
@@ -85,7 +85,7 @@ class UNet(nn.Module):
             x = up(x, blocks[-i - 1])
 
         x = self.last(x)
-        if is_tracing_state() and parse_version(torch.__version__) >= parse_version("1.1.0"):
+        if is_tracing_state() and version.parse(torch.__version__) >= version.parse("1.1.0"):
             # While exporting, add extra post-processing layers into the graph
             # so that the model outputs class probabilities instead of class scores
             softmaxed = F.softmax(x, dim=1)

--- a/nncf/common/deprecation.py
+++ b/nncf/common/deprecation.py
@@ -14,7 +14,7 @@ import inspect
 import warnings
 from typing import Callable, Type, TypeVar
 
-from pkg_resources import parse_version
+from packaging import version
 
 
 def warning_deprecated(msg):
@@ -37,8 +37,8 @@ class deprecated:
         :param msg: Custom message to be added after the boilerplate deprecation text.
         """
         self.msg = msg
-        self.start_version = parse_version(start_version) if start_version is not None else None
-        self.end_version = parse_version(end_version) if end_version is not None else None
+        self.start_version = version.parse(start_version) if start_version is not None else None
+        self.end_version = version.parse(end_version) if end_version is not None else None
 
     def __call__(self, fn_or_class: ClassOrFn) -> ClassOrFn:
         name = fn_or_class.__module__ + "." + fn_or_class.__name__

--- a/nncf/tensorflow/__init__.py
+++ b/nncf/tensorflow/__init__.py
@@ -12,7 +12,7 @@
 Base subpackage for NNCF TensorFlow functionality.
 """
 import tensorflow
-from pkg_resources import parse_version
+from packaging import version
 
 from nncf import nncf_logger
 from nncf.common.logging.logger import warn_bkc_version_mismatch
@@ -22,11 +22,11 @@ from nncf.version import BKC_TF_VERSION
 
 try:
     _tf_version = tensorflow.__version__
-    tensorflow_version = parse_version(_tf_version).base_version
+    tensorflow_version = version.parse(_tf_version).base_version
 except:
     nncf_logger.debug("Could not parse tensorflow version")
     _tf_version = "0.0.0"
-    tensorflow_version = parse_version(_tf_version).base_version
+    tensorflow_version = version.parse(_tf_version).base_version
 tensorflow_version_major, tensorflow_version_minor = tuple(map(int, tensorflow_version.split(".")))[:2]
 if not tensorflow_version.startswith(BKC_TF_VERSION[:-2]):
     warn_bkc_version_mismatch("tensorflow", BKC_TF_VERSION, _tf_version)

--- a/nncf/torch/__init__.py
+++ b/nncf/torch/__init__.py
@@ -19,17 +19,17 @@ from nncf.common.logging.logger import warn_bkc_version_mismatch
 from nncf.version import BKC_TORCH_VERSION
 
 import torch
-from pkg_resources import parse_version
+from packaging import version
 
 try:
     _torch_version = torch.__version__
-    torch_version = parse_version(_torch_version).base_version
+    torch_version = version.parse(_torch_version).base_version
 except:
     nncf_logger.debug("Could not parse torch version")
     _torch_version = "0.0.0"
-    torch_version = parse_version(_torch_version).base_version
+    torch_version = version.parse(_torch_version).base_version
 
-if parse_version(BKC_TORCH_VERSION).base_version != torch_version:
+if version.parse(BKC_TORCH_VERSION).base_version != torch_version:
     warn_bkc_version_mismatch("torch", BKC_TORCH_VERSION, torch.__version__)
 
 

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
-from pkg_resources import parse_version
+from packaging import version
 from torch import distributed
 from torch import nn
 
@@ -618,7 +618,7 @@ class SymmetricQuantizer(BaseQuantizer):
             )
         )
 
-        if parse_version(torch.__version__) >= parse_version("1.12"):
+        if version.parse(torch.__version__) >= version.parse("1.12"):
             # Values of level_low, level_high must be recalculated for load new signed parameter.
             self.register_load_state_dict_post_hook(lambda module, _: module.set_level_ranges())
         else:

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ INSTALL_REQUIRES = [
     # reference files no longer match against the graphs produced in tests.
     # Using 2.x versions of pyparsing seems to fix the issue.
     # Ticket: 69520
+    "packaging>=20.0",
     "pyparsing<3.0",
     "pymoo==0.5.0",
     "jsonschema>=3.2.0",

--- a/setup.py
+++ b/setup.py
@@ -41,14 +41,14 @@ import sys
 import sysconfig
 
 import setuptools
-from packaging import version
+from pkg_resources import parse_version
 from setuptools import find_packages
 from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 BKC_SETUPTOOLS_VERSION = "59.5.0"
 
-setuptools_version = version.parse(setuptools.__version__).base_version
+setuptools_version = parse_version(setuptools.__version__).base_version
 if setuptools_version < "43.0.0":
     raise RuntimeError(
         "To properly install NNCF, please install setuptools>=43.0.0, "

--- a/setup.py
+++ b/setup.py
@@ -41,14 +41,14 @@ import sys
 import sysconfig
 
 import setuptools
-from pkg_resources import parse_version
+from packaging import version
 from setuptools import find_packages
 from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 BKC_SETUPTOOLS_VERSION = "59.5.0"
 
-setuptools_version = parse_version(setuptools.__version__).base_version
+setuptools_version = version.parse(setuptools.__version__).base_version
 if setuptools_version < "43.0.0":
     raise RuntimeError(
         "To properly install NNCF, please install setuptools>=43.0.0, "

--- a/tests/tensorflow/test_compressed_graph.py
+++ b/tests/tensorflow/test_compressed_graph.py
@@ -15,7 +15,7 @@ from typing import List
 import networkx as nx
 import pytest
 import tensorflow as tf
-from pkg_resources import parse_version
+from packaging import version
 
 from nncf import NNCFConfig
 from nncf.common.hardware.config import HWConfigType
@@ -356,7 +356,7 @@ def prepare_and_check_nx_graph(
 
 
 def check_model_graph(compressed_model, ref_graph_filename, ref_graph_dir, rename_resource_nodes):
-    tf_version = parse_version(tf.__version__).base_version
+    tf_version = version.parse(tf.__version__).base_version
     tf_version_major, tf_version_minor = tuple(map(int, tf_version.split(".")))[:2]
     data_dir = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "data", "reference_graphs", f"{tf_version_major}.{tf_version_minor}"

--- a/tests/tensorflow/test_transformations.py
+++ b/tests/tensorflow/test_transformations.py
@@ -13,7 +13,7 @@ import os
 
 import pytest
 import tensorflow as tf
-from pkg_resources import parse_version
+from packaging import version
 from tensorflow.keras import layers
 from tensorflow.keras import models
 
@@ -523,7 +523,7 @@ def apply_insert_before(model):
 
 
 def check_graphs(model, ref_graph_filename):
-    tf_version = parse_version(tf.__version__).base_version
+    tf_version = version.parse(tf.__version__).base_version
     tf_version_major, tf_version_minor = tuple(map(int, tf_version.split(".")))[:2]
     data_dir = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "data", "model_transormer", f"{tf_version_major}.{tf_version_minor}"

--- a/tests/torch/nas/test_elastic_depth.py
+++ b/tests/torch/nas/test_elastic_depth.py
@@ -15,7 +15,7 @@ import onnx
 import onnxruntime as rt
 import pytest
 import torch
-from pkg_resources import parse_version
+from packaging import version
 from torch import nn
 
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.elasticity_dim import ElasticityDim
@@ -238,7 +238,7 @@ def test_can_export_model_with_one_skipped_block_resnet18(tmp_path):
     num_not_skipped_nodes = len(onnx_resnet18_without_one_block.graph.node)
     ref_num_nodes = 65
     ref_not_skipped_nodes = 63
-    if parse_version(torch.__version__) < parse_version("1.12"):
+    if version.parse(torch.__version__) < version.parse("1.12"):
         # different ONNX format for older pytorch version - no Identity nodes
         ref_num_nodes = 49
         ref_not_skipped_nodes = 48

--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -16,7 +16,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 import torch.utils.data
-from pkg_resources import parse_version
+from packaging import version
 from torch import nn
 from torchvision.models import resnet50
 from torchvision.models import squeezenet1_1
@@ -694,7 +694,7 @@ def test_quantization_can_be_run_with_no_data_loaders_if_zero_init_samples():
     )
 
 
-if parse_version(torch.__version__).base_version <= parse_version("1.9.1").base_version:
+if version.parse(torch.__version__).base_version <= version.parse("1.9.1").base_version:
     from torch.cuda.amp import autocast
 else:
     from torch import autocast

--- a/tests/torch/sparsity/movement/test_model_saving.py
+++ b/tests/torch/sparsity/movement/test_model_saving.py
@@ -25,7 +25,7 @@ from openvino.runtime import serialize
 from openvino.tools.mo.back.offline_transformations import apply_fused_names_cleanup
 from openvino.tools.mo.back.offline_transformations import apply_moc_transformations
 from openvino.tools.mo.back.offline_transformations import apply_user_transformations
-from pkg_resources import parse_version
+from packaging import version
 from scipy.special import softmax
 from transformers.trainer_utils import PREFIX_CHECKPOINT_DIR
 
@@ -78,7 +78,7 @@ class TestONNXExport:
         PTTensorListComparator.check_equal(list(state_before.values()), list(state_after.values()))
 
     @pytest.mark.skipif(
-        parse_version(torch.__version__) < parse_version("1.12"),
+        version.parse(torch.__version__) < version.parse("1.12"),
         reason=f"torch {torch.__version__} is not compatible with installed transformers package. "
         f"Some tests may fail with segmentation fault",
     )
@@ -126,7 +126,7 @@ class TestONNXExport:
         assert np.allclose(softmax(onnx_outputs, axis=-1), softmax(torch_outputs, axis=-1), atol=1e-6)
 
     @pytest.mark.skipif(
-        parse_version(torch.__version__) < parse_version("1.12"),
+        version.parse(torch.__version__) < version.parse("1.12"),
         reason=f"torch {torch.__version__} is not compatible with installed transformers package. "
         f"Some tests may fail with segmentation fault",
     )

--- a/tests/torch/sparsity/movement/test_structured_mask.py
+++ b/tests/torch/sparsity/movement/test_structured_mask.py
@@ -17,7 +17,7 @@ from unittest.mock import Mock
 import pandas as pd
 import pytest
 import torch
-from pkg_resources import parse_version
+from packaging import version
 
 from nncf.common.logging import nncf_logger
 from nncf.config import NNCFConfig
@@ -169,7 +169,7 @@ class TestStructuredMaskContext:
             setattr(ctx, mask_name, torch.ones(2))
 
     @pytest.mark.skipif(
-        parse_version(torch.__version__) < parse_version("1.12"),
+        version.parse(torch.__version__) < version.parse("1.12"),
         reason=f"torch {torch.__version__} may not compatible with installed transformers package. "
         f"Some tests may fail with error",
     )

--- a/tests/torch/sparsity/movement/test_training.py
+++ b/tests/torch/sparsity/movement/test_training.py
@@ -17,7 +17,7 @@ from typing import Dict, Union
 import jstyleson as json
 import pytest
 import torch.cuda
-from pkg_resources import parse_version
+from packaging import version
 from pytest import approx
 
 from tests.shared.paths import PROJECT_ROOT
@@ -317,7 +317,7 @@ class TestMovementTraining:
         self._validate_train_metric(movement_desc_long)
 
     @pytest.mark.skipif(
-        parse_version(torch.__version__) < parse_version("1.12"),
+        version.parse(torch.__version__) < version.parse("1.12"),
         reason=f"torch {torch.__version__} may not compatible with installed transformers package. "
         f"Some tests may fail with error",
     )

--- a/tests/torch/test_sanity_sample.py
+++ b/tests/torch/test_sanity_sample.py
@@ -18,7 +18,7 @@ from contextlib import nullcontext
 import pytest
 import torch
 import torchvision
-from pkg_resources import parse_version
+from packaging import version
 from pytest_dependency import depends
 
 from examples.common.sample_config import EVAL_ONLY_ERROR_TEXT
@@ -185,7 +185,7 @@ def fixture_case_common_dirs(tmp_path_factory):
 
 @pytest.mark.parametrize(" multiprocessing_distributed", (True, False), ids=["distributed", "dataparallel"])
 def test_pretrained_model_eval(config, tmp_path, multiprocessing_distributed, case_common_dirs):
-    if parse_version(torchvision.__version__) < parse_version("0.13") and "voc" in str(config["dataset_path"]):
+    if version.parse(torchvision.__version__) < version.parse("0.13") and "voc" in str(config["dataset_path"]):
         pytest.skip(
             f"Test calls sample that uses `datasets.VOCDetection.parse_voc_xml` function from latest "
             f"torchvision.\nThe signature of the function is not compatible with the corresponding signature "
@@ -269,7 +269,7 @@ def depends_on_pretrained_train(request, test_case_id: str, current_multiprocess
 @pytest.mark.dependency()
 @pytest.mark.parametrize("multiprocessing_distributed", [True, False], ids=["distributed", "dataparallel"])
 def test_trained_model_eval(request, config, tmp_path, multiprocessing_distributed, case_common_dirs):
-    if parse_version(torchvision.__version__) < parse_version("0.13") and "voc" in str(config["dataset_path"]):
+    if version.parse(torchvision.__version__) < version.parse("0.13") and "voc" in str(config["dataset_path"]):
         pytest.skip(
             f"Test calls sample that uses `datasets.VOCDetection.parse_voc_xml` function from latest "
             f"torchvision.\nThe signature of the function is not compatible with the corresponding signature "

--- a/tests/torch/test_tracing_context.py
+++ b/tests/torch/test_tracing_context.py
@@ -10,14 +10,14 @@
 # limitations under the License.
 import pytest
 import torch
-from pkg_resources import parse_version
+from packaging import version
 
 from nncf.torch.dynamic_graph.context import TracingContext
 from nncf.torch.dynamic_graph.trace_tensor import TracedTensor
 
 
 @pytest.mark.skipif(
-    parse_version(torch.__version__) < parse_version("1.11"),
+    version.parse(torch.__version__) < version.parse("1.11"),
     reason="__getitem__ works unexpectedly for TracedTensor until fix in torch 1.11.\n"
     "Fix in pytorch: https://github.com/pytorch/pytorch/pull/67202\n"
     "Related ticket: 82065",


### PR DESCRIPTION
### Changes

- Use `packaging` instead pkg_resources to parse package version
- Add `packaging` to INSTALL_REQUIRES, because it installs as dependency of `pymoo`
- Setup.py still uses pkg_resources, because `packaging` is not installed on initialization of virtualenv

### Reason for changes

```
DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('sphinxcontrib')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```
