### PR TITLE
Fix calculation of the accuracy drop when the drop_type is DropType.RELATIVE

### DIFF
--- a/tests/common/accuracy_control/test_calculate_drop.py
+++ b/tests/common/accuracy_control/test_calculate_drop.py
@@ -87,7 +87,7 @@ class TestCase:
             drop_type=DropType.RELATIVE,
             expected_should_terminate=True,
             expected_accuracy_drop=None,
-        )
+        ),
     ],
 )
 def test_calculate_accuracy_drop(ts: TestCase):

--- a/tests/common/accuracy_control/test_calculate_drop.py
+++ b/tests/common/accuracy_control/test_calculate_drop.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+import pytest
+
+from nncf.parameters import DropType
+from nncf.quantization.algorithms.accuracy_control.algorithm import calculate_accuracy_drop
+
+
+@dataclass
+class TestCase:
+    initial_metric: float
+    quantized_metric: float
+    drop_type: DropType
+    expected_should_terminate: bool
+    expected_accuracy_drop: float
+    max_drop: float = 0.01
+
+
+@pytest.mark.parametrize(
+    "ts",
+    [
+        # ABSOLUTE
+        TestCase(
+            initial_metric=0.2923,
+            quantized_metric=0.3185,
+            drop_type=DropType.ABSOLUTE,
+            expected_should_terminate=True,
+            expected_accuracy_drop=-0.0262,
+        ),
+        TestCase(
+            initial_metric=0.3185,
+            quantized_metric=0.2923,
+            drop_type=DropType.ABSOLUTE,
+            expected_should_terminate=False,
+            expected_accuracy_drop=0.0262,
+        ),
+        TestCase(
+            initial_metric=-0.2923,
+            quantized_metric=-0.3185,
+            drop_type=DropType.ABSOLUTE,
+            expected_should_terminate=False,
+            expected_accuracy_drop=0.0262,
+        ),
+        TestCase(
+            initial_metric=-0.3185,
+            quantized_metric=-0.2923,
+            drop_type=DropType.ABSOLUTE,
+            expected_should_terminate=True,
+            expected_accuracy_drop=-0.0262,
+        ),
+        # RELATIVE
+        TestCase(
+            initial_metric=0.2923,
+            quantized_metric=0.3185,
+            drop_type=DropType.RELATIVE,
+            expected_should_terminate=True,
+            expected_accuracy_drop=None,
+        ),
+        TestCase(
+            initial_metric=0.3185,
+            quantized_metric=0.2923,
+            drop_type=DropType.RELATIVE,
+            expected_should_terminate=False,
+            expected_accuracy_drop=0.08226059,
+        ),
+        TestCase(
+            initial_metric=-0.2923,
+            quantized_metric=-0.3185,
+            drop_type=DropType.RELATIVE,
+            expected_should_terminate=False,
+            expected_accuracy_drop=0.0896339,
+        ),
+        TestCase(
+            initial_metric=-0.3185,
+            quantized_metric=-0.2923,
+            drop_type=DropType.RELATIVE,
+            expected_should_terminate=True,
+            expected_accuracy_drop=None,
+        )
+    ],
+)
+def test_calculate_accuracy_drop(ts: TestCase):
+    should_terminate, accuracy_drop = calculate_accuracy_drop(
+        ts.initial_metric, ts.quantized_metric, ts.max_drop, ts.drop_type
+    )
+    assert should_terminate == ts.expected_should_terminate
+    assert pytest.approx(accuracy_drop) == ts.expected_accuracy_drop


### PR DESCRIPTION
### Changes

Incorrect calculation of the drop when the `drop_type` is `DropType.RELATIVE`.

### Reason for changes
Reproducer:
```python
initial_metric = -0.2923
quantized_metric = -0.3185
# (accuracy_drop =-0.0896 <= max_drop=0.01) but quantized_metric < initial_metric
accuracy_drop = 1 - quantized_metric / initial_metric <= max_drop 
```

### Related tickets

Ref: 110824

### Tests

- tests/common/accuracy_control/test_calculate_drop.py
