### PR TITLE
Add Divide and Sqrt to ignored scope for ModelType.TRANSFORMER

### DIFF
--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -24,6 +24,7 @@ from nncf.common.utils.backend import BackendType
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXAddLayerMetatype
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXConvolutionMetatype
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXConvolutionTransposeMetatype
+from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXDivLayerMetatype
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXLinearMetatype
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXMulLayerMetatype
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXNonMaxSuppressionMetatype
@@ -224,6 +225,7 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
                 ONNXSqueezeMetatype,
                 ONNXSubMetatype,
                 ONNXReduceMeanMetatype,
+                ONNXDivLayerMetatype,
             ]
             if device != TargetDevice.CPU_SPR:
                 metatypes_to_add.append(ONNXMulLayerMetatype)

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -28,6 +28,7 @@ from nncf.openvino.graph.metatypes.openvino_metatypes import GENERAL_WEIGHT_LAYE
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVAddMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVConvolutionBackpropDataMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVConvolutionMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVDivideMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVGroupConvolutionBackpropDataMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVGroupConvolutionMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVMatMulMetatype
@@ -38,6 +39,7 @@ from nncf.openvino.graph.metatypes.openvino_metatypes import OVPowerMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVReadValueMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVReduceMeanMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVShapeOfMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVSqrtMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVSquaredDifferenceMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVSqueezeMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVSubtractMetatype
@@ -236,6 +238,8 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
                 OVReduceMeanMetatype,
                 OVSquaredDifferenceMetatype,
                 OVMVNMetatype,
+                OVDivideMetatype,
+                OVSqrtMetatype,
             ]
             if device != TargetDevice.CPU_SPR:
                 metatypes_to_add.append(OVMultiplyMetatype)

--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -312,7 +312,13 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
     def get_model_type_ignore_scope(model_type: ModelType, device: TargetDevice) -> IgnoredScope:
         if model_type == ModelType.TRANSFORMER:
             types = []
-            metatypes_to_add = [om.PTAddMetatype, om.PTPowerMetatype, om.PTSubMetatype, om.PTMeanMetatype]
+            metatypes_to_add = [
+                om.PTAddMetatype,
+                om.PTPowerMetatype,
+                om.PTSubMetatype,
+                om.PTMeanMetatype,
+                om.PTDivMetatype,
+            ]
             if device != TargetDevice.CPU_SPR:
                 metatypes_to_add.append(om.PTMulMetatype)
             type_name_to_add = ["squeeze"]


### PR DESCRIPTION
### Changes

`Divide`, `Sqrt` operations are part of LayerNorm. We shouldn't insert FQs inside LayerNorm pattern, because it is fused at runtime.

### Reason for changes

* To improve accuracy and performance of transformers

### Related tickets

* 111764

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
