### PR TITLE
Return copy of scope from get_nncf_modules

### DIFF
--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -476,7 +476,7 @@ class NNCFNetworkInterface(torch.nn.Module):
         retval = {}
         for module, scope_set in self._nncf_replaced_modules.items():
             canonical_scope = next(iter(scope_set))
-            retval[module] = canonical_scope
+            retval[module] = canonical_scope.copy()
         return retval
 
     def get_weighted_original_graph_nodes(self, nncf_module_names: List[str] = None) -> List[NNCFNode]:

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -692,3 +692,13 @@ def test_forward_hooks_are_preserved():
     assert next(iter(nncf_net._forward_hooks.values())) is hook
     nncf_net(torch.ones(SimplestModel.INPUT_SIZE))
     assert hook.call_count == 1
+
+
+def test_safety_change_scope_in_get_nncf_modules():
+    model = SimplestModel()
+
+    nncf_net = NNCFNetwork(model, [ModelInputInfo(SimplestModel.INPUT_SIZE)])
+
+    orig_id = id(list(nncf_net.nncf._nncf_replaced_modules.values())[0][0])
+    return_id = id(list(nncf_net.nncf.get_nncf_modules().values())[0])
+    assert orig_id != return_id


### PR DESCRIPTION
# Changes

`get_nncf_modules` return copy of the scopes.

# Reason for changes

`get_modules_in_nncf_modules_by_type` chages original scope of the modules by `nncf_module_scope.pop()`
