### PR TITLE
Fix "use_pot" option in calibrate.py

### DIFF
--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -735,8 +735,12 @@ def quantize_model_with_accuracy_control(
     advanced_parameters = quantization_parameters.get(
         "advanced_quantization_parameters", AdvancedQuantizationParameters()
     )
-    if quantization_impl == "native":
+    if quantization_impl == "pot":
+        advanced_parameters.backend_params["use_pot"] = True
+    elif quantization_impl == "native":
         advanced_parameters.backend_params["use_pot"] = False
+    else:
+        raise NotImplementedError()
     quantization_parameters["advanced_quantization_parameters"] = advanced_parameters
 
     quantization_impl_fn = name_to_quantization_impl_map.get(quantization_impl)


### PR DESCRIPTION
### Changes

* Fixed `quantize_with_accuracy_control` in calibrate.py test for OV (POT) backend

### Reason for changes

<!--- Why should the change be applied -->

### Related tickets

<!--- Post the numerical ID of the ticket, if available -->

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
