### PR TITLE
Fixed typo

### DIFF
--- a/tests/openvino/native/quantization/test_fq_params_calculation.py
+++ b/tests/openvino/native/quantization/test_fq_params_calculation.py
@@ -141,9 +141,8 @@ def test_omz_models_fq_scales(model_name, preset, inplace_statistics, tmp_path):
     ref_stats_path = REFERENCE_SCALES_DIR / ref_stats_name
 
     # Uncomment lines below to generate reference for new models.
-    from tests.shared.helpers import dump_to_json
-
-    dump_to_json(ref_stats_path, nodes)
+    # from tests.shared.helpers import dump_to_json
+    # dump_to_json(ref_stats_path, nodes)
 
     ref_nodes = load_json(ref_stats_path)
     params = ["input_low", "input_high", "output_low", "output_high"]


### PR DESCRIPTION
### Changes

Fixed typo in the test_omz_models_fq_scales test

### Reason for changes

Avoid saving gold values on every test.

### Related tickets

N/A

### Tests

N/A
