### PR TITLE
Fix onnx-1.13.1 onnxruntime-1.14.1 for torch and ptq tests

### DIFF
--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -2,8 +2,8 @@
 torch==1.13.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torchvision==0.14.1
-onnx==1.14.0
-onnxruntime==1.6.0
+onnx==1.13.1
+onnxruntime==1.14.1
 pytest
 openvino-dev>=2022.1
 timm==0.9.2

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -1,7 +1,7 @@
 yattag>=1.14.0
 prettytable>=2.0.0
-onnx>=1.8.0
-onnxruntime==1.6.0
+onnx==1.13.1
+onnxruntime==1.14.1
 pytest-mock>=3.3.1
 pytest-dependency>=0.5.1
 virtualenv


### PR DESCRIPTION
### Changes

Fix version of `onnx==1.13.1` and `onnxruntime==1.14.1` for torch and post_training tests.

### Related tickets
112492

TODO: 
- [x]  PTQ tests (build - 57)
- [x] e2e PT (build 355)
