### PR TITLE
[PyTorch] Fix lower PR version for strip

### DIFF
--- a/examples/torch/common/export.py
+++ b/examples/torch/common/export.py
@@ -25,7 +25,7 @@ def export_model(ctrl: CompressionAlgorithmController, save_path: str, no_strip_
     """
 
     if parse_version(torch.__version__) < parse_version("1.10"):
-        no_strip_on_export = False
+        no_strip_on_export = True
 
     model = ctrl.model if no_strip_on_export else ctrl.strip()
 

--- a/examples/torch/common/export.py
+++ b/examples/torch/common/export.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import torch
+from pkg_resources import parse_version
 
 from nncf.api.compression import CompressionAlgorithmController
 from nncf.torch.exporter import generate_input_names_list
@@ -22,6 +23,9 @@ def export_model(ctrl: CompressionAlgorithmController, save_path: str, no_strip_
     :param save_path: Path to save onnx file.
     :param no_strip_on_export: Set to skip strip model before export.
     """
+
+    if parse_version(torch.__version__) < parse_version("1.10"):
+        no_strip_on_export = False
 
     model = ctrl.model if no_strip_on_export else ctrl.strip()
 


### PR DESCRIPTION
### Changes

- As in the title

### Reason for changes

- Bug with PyTorch 1.9.9:
`11:51:05  observer = torch.ao.quantization.observer.MinMaxObserver`
`11:51:05  AttributeError: module 'torch' has no attribute 'ao'`
- `torch.ao.quantization.observer.MinMaxObserver` was introduced only in the 1.10 version