### PR TITLE
Added quantization config for ReduceSum operation

### DIFF
--- a/nncf/common/hardware/configs/cpu.json
+++ b/nncf/common/hardware/configs/cpu.json
@@ -252,6 +252,12 @@
                 "weights": "q8_w_sym"
             }
         },
+        {
+            "type": "ReduceSum",
+            "quantization": {
+                "activations": "q8_a"
+            }
+        },
         {"type": "Flatten"},
         {"type": "Squeeze"},
         {"type": "Unsqueeze"},

--- a/nncf/common/hardware/configs/gpu.json
+++ b/nncf/common/hardware/configs/gpu.json
@@ -234,6 +234,12 @@
                 "scales": "unified"
             }
         },
+        {
+            "type": "ReduceSum",
+            "quantization": {
+                "activations": "q8_a"
+            }
+        },
         {"type": "Flatten"},
         {"type": "Squeeze"},
         {"type": "Unsqueeze"},


### PR DESCRIPTION
### Changes

Added quantization config for ReduceSum operation

### Reason for changes

OpenVINO supports int8 precision for ReduceSum operation

### Related tickets

https://github.com/openvinotoolkit/openvino/issues/17389

### Tests

N/A
