### PR TITLE
Fix convert_advanced_parameters_to_dict

### DIFF
--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -19,7 +19,6 @@ from dataclasses import is_dataclass
 from enum import Enum
 from typing import Any, Dict, Optional
 
-from nncf import NNCFConfig
 from nncf.common.quantization.structs import QuantizationMode
 from nncf.common.utils.api_marker import api
 from nncf.quantization.range_estimator import AggregatorType
@@ -297,7 +296,9 @@ def convert_range_estimator_parameters_to_dict(params: RangeEstimatorParameters)
     return result
 
 
-def apply_advanced_parameters_to_config(config: NNCFConfig, params: AdvancedQuantizationParameters) -> NNCFConfig:
+def apply_advanced_parameters_to_config(
+    config: Dict[str, Any], params: AdvancedQuantizationParameters
+) -> Dict[str, Any]:
     """
     Apply advanced parameters to the config in the legacy format
 

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -324,11 +324,21 @@ def apply_advanced_parameters_to_config(
         params.activations_range_estimator_params
     )
     weights_init_range_config = convert_range_estimator_parameters_to_dict(params.weights_range_estimator_params)
+
     if activations_init_range_config or weights_init_range_config:
+        init_range = config["initializer"]["range"]
+
         activations_init_range_config["target_quantizer_group"] = "activations"
         activations_init_range_config["target_scopes"] = "{re}.*"
+        activations_init_range_config["num_init_samples"] = init_range["num_init_samples"]
+        if type not in activations_init_range_config:
+            activations_init_range_config["type"] = init_range["type"]
+
         weights_init_range_config["target_quantizer_group"] = "weights"
         weights_init_range_config["target_scopes"] = "{re}.*"
+        weights_init_range_config["num_init_samples"] = init_range["num_init_samples"]
+        if type not in weights_init_range_config:
+            weights_init_range_config["type"] = init_range["type"]
 
         config["initializer"]["range"] = [activations_init_range_config, weights_init_range_config]
 

--- a/tests/tensorflow/quantization/test_ptq_params.py
+++ b/tests/tensorflow/quantization/test_ptq_params.py
@@ -28,7 +28,6 @@ from nncf.tensorflow.quantization.quantize_model import _create_nncf_config
             "preset": QuantizationPreset.MIXED,
             "target_device": TargetDevice.ANY,
             "subset_size": 1,
-            "model_type": ModelType.TRANSFORMER,
             "ignored_scope": IgnoredScope(names=["node_1"]),
             "advanced_parameters": AdvancedQuantizationParameters(
                 overflow_fix=OverflowFix.DISABLE, quantize_outputs=True, disable_bias_correction=True
@@ -38,7 +37,6 @@ from nncf.tensorflow.quantization.quantize_model import _create_nncf_config
             "preset": QuantizationPreset.MIXED,
             "target_device": TargetDevice.ANY,
             "subset_size": 2,
-            "model_type": None,
             "ignored_scope": None,
             "advanced_parameters": AdvancedQuantizationParameters(
                 overflow_fix=OverflowFix.ENABLE, quantize_outputs=False, disable_bias_correction=False
@@ -48,7 +46,6 @@ from nncf.tensorflow.quantization.quantize_model import _create_nncf_config
             "preset": QuantizationPreset.MIXED,
             "target_device": TargetDevice.ANY,
             "subset_size": 3,
-            "model_type": None,
             "ignored_scope": IgnoredScope(names=["node_1"]),
             "advanced_parameters": AdvancedQuantizationParameters(
                 overflow_fix=OverflowFix.FIRST_LAYER, quantize_outputs=True, disable_bias_correction=False
@@ -66,18 +63,10 @@ def test_create_nncf_config(params):
     assert config["compression"]["initializer"]["range"]["num_init_samples"] == params["subset_size"]
 
     num_bn_samples = config["compression"]["initializer"]["batchnorm_adaptation"]["num_bn_adaptation_samples"]
-    if params["advanced_parameters"].disable_bias_correction is True or params["model_type"] == ModelType.TRANSFORMER:
+    if params["advanced_parameters"].disable_bias_correction is True:
         assert num_bn_samples == 0
     else:
         assert num_bn_samples == params["subset_size"]
 
     ref_scope = params["ignored_scope"].names if params["ignored_scope"] is not None else []
-    if params["model_type"] == ModelType.TRANSFORMER:
-        ref_scope = [
-            "{re}.*Embeddings.*",
-            "{re}.*__add___[0-1]",
-            "{re}.*layer_norm_0",
-            "{re}.*matmul_1",
-            "{re}.*__truediv__*",
-        ] + ref_scope
     assert config["compression"].get("ignored_scopes", []) == ref_scope

--- a/tests/tensorflow/quantization/test_ptq_params.py
+++ b/tests/tensorflow/quantization/test_ptq_params.py
@@ -13,7 +13,6 @@
 import pytest
 
 from nncf.common.quantization.structs import QuantizationPreset
-from nncf.parameters import ModelType
 from nncf.parameters import TargetDevice
 from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
 from nncf.quantization.advanced_parameters import OverflowFix

--- a/tests/tensorflow/quantization/test_ptq_params.py
+++ b/tests/tensorflow/quantization/test_ptq_params.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+from nncf.common.quantization.structs import QuantizationPreset
+from nncf.parameters import ModelType
+from nncf.parameters import TargetDevice
+from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
+from nncf.quantization.advanced_parameters import OverflowFix
+from nncf.scopes import IgnoredScope
+from nncf.tensorflow.quantization.quantize_model import _create_nncf_config
+
+
+@pytest.mark.parametrize(
+    "params",
+    (
+        {
+            "preset": QuantizationPreset.MIXED,
+            "target_device": TargetDevice.ANY,
+            "subset_size": 1,
+            "model_type": ModelType.TRANSFORMER,
+            "ignored_scope": IgnoredScope(names=["node_1"]),
+            "advanced_parameters": AdvancedQuantizationParameters(
+                overflow_fix=OverflowFix.DISABLE, quantize_outputs=True, disable_bias_correction=True
+            ),
+        },
+        {
+            "preset": QuantizationPreset.MIXED,
+            "target_device": TargetDevice.ANY,
+            "subset_size": 2,
+            "model_type": None,
+            "ignored_scope": None,
+            "advanced_parameters": AdvancedQuantizationParameters(
+                overflow_fix=OverflowFix.ENABLE, quantize_outputs=False, disable_bias_correction=False
+            ),
+        },
+        {
+            "preset": QuantizationPreset.MIXED,
+            "target_device": TargetDevice.ANY,
+            "subset_size": 3,
+            "model_type": None,
+            "ignored_scope": IgnoredScope(names=["node_1"]),
+            "advanced_parameters": AdvancedQuantizationParameters(
+                overflow_fix=OverflowFix.FIRST_LAYER, quantize_outputs=True, disable_bias_correction=False
+            ),
+        },
+    ),
+)
+def test_create_nncf_config(params):
+    config = _create_nncf_config(**params)
+
+    assert config["compression"]["overflow_fix"] == params["advanced_parameters"].overflow_fix.value
+    assert config["compression"]["quantize_outputs"] == params["advanced_parameters"].quantize_outputs
+
+    assert config["compression"]["preset"] == params["preset"].value
+    assert config["compression"]["initializer"]["range"]["num_init_samples"] == params["subset_size"]
+
+    num_bn_samples = config["compression"]["initializer"]["batchnorm_adaptation"]["num_bn_adaptation_samples"]
+    if params["advanced_parameters"].disable_bias_correction is True or params["model_type"] == ModelType.TRANSFORMER:
+        assert num_bn_samples == 0
+    else:
+        assert num_bn_samples == params["subset_size"]
+
+    ref_scope = params["ignored_scope"].names if params["ignored_scope"] is not None else []
+    if params["model_type"] == ModelType.TRANSFORMER:
+        ref_scope = [
+            "{re}.*Embeddings.*",
+            "{re}.*__add___[0-1]",
+            "{re}.*layer_norm_0",
+            "{re}.*matmul_1",
+            "{re}.*__truediv__*",
+        ] + ref_scope
+    assert config["compression"].get("ignored_scopes", []) == ref_scope

--- a/tests/torch/ptq/test_ptq_params.py
+++ b/tests/torch/ptq/test_ptq_params.py
@@ -12,6 +12,7 @@
 import pytest
 from torch import nn
 
+from nncf import NNCFConfig
 from nncf.common.graph.patterns import GraphPattern
 from nncf.common.graph.patterns.manager import PatternsManager
 from nncf.common.graph.transformations.commands import TargetType
@@ -21,8 +22,11 @@ from nncf.parameters import ModelType
 from nncf.parameters import TargetDevice
 from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
 from nncf.quantization.advanced_parameters import OverflowFix
+from nncf.quantization.advanced_parameters import QuantizationMode
+from nncf.quantization.advanced_parameters import QuantizationParameters
 from nncf.quantization.algorithms.min_max.torch_backend import PTMinMaxAlgoBackend
 from nncf.quantization.algorithms.post_training.algorithm import PostTrainingQuantization
+from nncf.quantization.range_estimator import RangeEstimatorParametersSet
 from nncf.scopes import IgnoredScope
 from nncf.torch.graph.graph import PTTargetPoint
 from nncf.torch.graph.operator_metatypes import PTModuleConv2dMetatype
@@ -187,6 +191,22 @@ class TestPTQParams(TemplateTestPTQParams):
                 overflow_fix=OverflowFix.FIRST_LAYER, quantize_outputs=True, disable_bias_correction=False
             ),
         },
+        {
+            "preset": QuantizationPreset.MIXED,
+            "target_device": TargetDevice.ANY,
+            "subset_size": 4,
+            "model_type": None,
+            "ignored_scope": IgnoredScope(names=["node_1"]),
+            "advanced_parameters": AdvancedQuantizationParameters(
+                overflow_fix=OverflowFix.FIRST_LAYER,
+                quantize_outputs=True,
+                disable_bias_correction=False,
+                activations_quantization_params=QuantizationParameters(num_bits=8, mode=QuantizationMode.SYMMETRIC),
+                activations_range_estimator_params=RangeEstimatorParametersSet.MINMAX,
+                weights_quantization_params=QuantizationParameters(num_bits=8, mode=QuantizationMode.SYMMETRIC),
+                weights_range_estimator_params=RangeEstimatorParametersSet.MINMAX,
+            ),
+        },
     ),
 )
 def test_create_nncf_config(params):
@@ -196,7 +216,15 @@ def test_create_nncf_config(params):
     assert config["compression"]["quantize_outputs"] == params["advanced_parameters"].quantize_outputs
 
     assert config["compression"]["preset"] == params["preset"].value
-    assert config["compression"]["initializer"]["range"]["num_init_samples"] == params["subset_size"]
+
+    range_config = config["compression"]["initializer"]["range"]
+    if isinstance(range_config, dict):
+        assert range_config["num_init_samples"] == params["subset_size"]
+        assert range_config["type"] == "mean_min_max"
+    else:
+        for rc in range_config:
+            assert rc["num_init_samples"] == params["subset_size"]
+            assert rc["type"] == "mean_min_max"
 
     num_bn_samples = config["compression"]["initializer"]["batchnorm_adaptation"]["num_bn_adaptation_samples"]
     if params["advanced_parameters"].disable_bias_correction is True or params["model_type"] == ModelType.TRANSFORMER:
@@ -214,3 +242,7 @@ def test_create_nncf_config(params):
             "{re}.*__truediv__*",
         ] + ref_scope
     assert config["compression"].get("ignored_scopes", []) == ref_scope
+
+    # To validate NNCFConfig requared input_info
+    config["input_info"] = {"sample_size": [1, 2, 224, 224]}
+    NNCFConfig.validate(config)

--- a/tests/torch/ptq/test_ptq_params.py
+++ b/tests/torch/ptq/test_ptq_params.py
@@ -15,8 +15,12 @@ from torch import nn
 from nncf.common.graph.patterns import GraphPattern
 from nncf.common.graph.patterns.manager import PatternsManager
 from nncf.common.graph.transformations.commands import TargetType
+from nncf.common.quantization.structs import QuantizationPreset
 from nncf.common.utils.backend import BackendType
+from nncf.parameters import ModelType
 from nncf.parameters import TargetDevice
+from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
+from nncf.quantization.advanced_parameters import OverflowFix
 from nncf.quantization.algorithms.min_max.torch_backend import PTMinMaxAlgoBackend
 from nncf.quantization.algorithms.post_training.algorithm import PostTrainingQuantization
 from nncf.scopes import IgnoredScope
@@ -24,6 +28,7 @@ from nncf.torch.graph.graph import PTTargetPoint
 from nncf.torch.graph.operator_metatypes import PTModuleConv2dMetatype
 from nncf.torch.graph.operator_metatypes import PTModuleLinearMetatype
 from nncf.torch.graph.operator_metatypes import PTSoftmaxMetatype
+from nncf.torch.quantization.quantize_model import _create_nncf_config
 from nncf.torch.tensor_statistics.collectors import PTMeanMinMaxStatisticCollector
 from nncf.torch.tensor_statistics.collectors import PTMinMaxStatisticCollector
 from tests.common.quantization.metatypes import Conv2dTestMetatype
@@ -147,3 +152,65 @@ class TestPTQParams(TemplateTestPTQParams):
     @pytest.fixture(params=[(IgnoredScope([]), 1, 1), (IgnoredScope(["/Conv_1_0"]), 0, 0)])
     def ignored_scopes_data(self, request):
         return request.param
+
+
+@pytest.mark.parametrize(
+    "params",
+    (
+        {
+            "preset": QuantizationPreset.MIXED,
+            "target_device": TargetDevice.ANY,
+            "subset_size": 1,
+            "model_type": ModelType.TRANSFORMER,
+            "ignored_scope": IgnoredScope(names=["node_1"]),
+            "advanced_parameters": AdvancedQuantizationParameters(
+                overflow_fix=OverflowFix.DISABLE, quantize_outputs=True, disable_bias_correction=True
+            ),
+        },
+        {
+            "preset": QuantizationPreset.MIXED,
+            "target_device": TargetDevice.ANY,
+            "subset_size": 2,
+            "model_type": None,
+            "ignored_scope": None,
+            "advanced_parameters": AdvancedQuantizationParameters(
+                overflow_fix=OverflowFix.ENABLE, quantize_outputs=False, disable_bias_correction=False
+            ),
+        },
+        {
+            "preset": QuantizationPreset.MIXED,
+            "target_device": TargetDevice.ANY,
+            "subset_size": 3,
+            "model_type": None,
+            "ignored_scope": IgnoredScope(names=["node_1"]),
+            "advanced_parameters": AdvancedQuantizationParameters(
+                overflow_fix=OverflowFix.FIRST_LAYER, quantize_outputs=True, disable_bias_correction=False
+            ),
+        },
+    ),
+)
+def test_create_nncf_config(params):
+    config = _create_nncf_config(**params)
+
+    assert config["compression"]["overflow_fix"] == params["advanced_parameters"].overflow_fix.value
+    assert config["compression"]["quantize_outputs"] == params["advanced_parameters"].quantize_outputs
+
+    assert config["compression"]["preset"] == params["preset"].value
+    assert config["compression"]["initializer"]["range"]["num_init_samples"] == params["subset_size"]
+
+    num_bn_samples = config["compression"]["initializer"]["batchnorm_adaptation"]["num_bn_adaptation_samples"]
+    if params["advanced_parameters"].disable_bias_correction is True or params["model_type"] == ModelType.TRANSFORMER:
+        assert num_bn_samples == 0
+    else:
+        assert num_bn_samples == params["subset_size"]
+
+    ref_scope = params["ignored_scope"].names if params["ignored_scope"] is not None else []
+    if params["model_type"] == ModelType.TRANSFORMER:
+        ref_scope = [
+            "{re}.*Embeddings.*",
+            "{re}.*__add___[0-1]",
+            "{re}.*layer_norm_0",
+            "{re}.*matmul_1",
+            "{re}.*__truediv__*",
+        ] + ref_scope
+    assert config["compression"].get("ignored_scopes", []) == ref_scope


### PR DESCRIPTION
### Changes

Replaceconvert_advanced_parameters_to_dict to apply_advanced_parameters_to_config to avoid missing parameters on config.update().

```python
a = {"a": 1, "b": {"b1": 1, "b2": 2}} 
b = {"b": {"b1": "b1"}} 
a.update(b)  # {"a": 1, "b": {"b1": "b1"}},  missed "b2": 2
```
As result of dict.update batchnorm_adaptation is missed after update config with result of convert_advanced_parameters_to_dict.


### Reason for changes

Incorrect converting advanced parameters to NNCFConfig.

### Related tickets

<!--- Post the numerical ID of the ticket, if available -->

### Tests

test_create_nncf_config
