### PR TITLE
[PTQ][OV] Remove inplace = False workaround for previous OpenVino release

### DIFF
--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -240,7 +240,7 @@ def get_inplace_mean_per_ch(op_type: str, axis: int) -> InplaceInsertionFnType:
         if len(input_shape) < 3:
             return opset.reduce_mean(
                 node.output(output_port_id),
-                reduction_axes=0,
+                reduction_axes=np.array([0]),
                 keep_dims=False,
                 name=get_ov_model_reduce_node_name(output_name, op_type, name_output_port_id),
             )

--- a/nncf/openvino/statistics/collectors.py
+++ b/nncf/openvino/statistics/collectors.py
@@ -241,9 +241,6 @@ class OVAbsQuantileReducer(AbsQuantileReducer):
 
 
 def get_mean_stat_collector(num_samples, channel_axis, window_size=None, inplace=True):
-    # TODO(dlyakhov): use inplace OVBatchMeanReducer and OVMeanPerChanelReducer
-    # after migration on openvino-dev=2023.0
-    inplace = False
     if channel_axis == 0:
         reducer = OVBatchMeanReducer(inplace)
     else:
@@ -266,9 +263,6 @@ def get_mean_stat_collector(num_samples, channel_axis, window_size=None, inplace
 
 
 def get_mean_batch_stat_collector(num_samples, inplace=True):
-    # TODO(dlyakhov): use inplace OVBatchMeanReducer
-    # after migration on openvino-dev=2023.0
-    inplace = False
     reducer = OVBatchMeanReducer(inplace=inplace)
     aggregator = NoopAggregator(num_samples)
 


### PR DESCRIPTION
### Changes

inplace = False workaround removed from the code

### Reason for changes

To insert all operation possible operation inplase therefore to safe more memory during quantization

