### PR TITLE
Update torch to 2.0.1 for ptq tests

### DIFF
--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==1.13.1
+torch==2.0.1
 --extra-index-url https://download.pytorch.org/whl/cpu
-torchvision==0.14.1
+torchvision==0.15.2
 onnx==1.13.1
 onnxruntime==1.14.1
 pytest

--- a/tests/post_training/test_quantize_conformance.py
+++ b/tests/post_training/test_quantize_conformance.py
@@ -29,6 +29,7 @@ import timm
 import torch
 import tqdm
 from sklearn.metrics import accuracy_score
+from timm.layers.config import set_fused_attn
 from torch import nn
 from torch.utils.data.dataloader import DataLoader
 from torchvision import datasets
@@ -50,6 +51,9 @@ from tests.post_training.model_scope import get_cached_metric
 from tests.shared.command import Command
 
 DEFAULT_VAL_THREADS = 4
+
+# Disable using aten::scaled_dot_product_attention
+set_fused_attn(False, False)
 
 
 def create_timm_model(name: str) -> nn.Module:


### PR DESCRIPTION
### Changes

- Update torch to 2.0.1 
- Disable used fused attention operation `aten::scaled_dot_product_attention` 

### Related tickets

112589

- [x] build: 62,63
