### PR TITLE
Skip crossvit_9_240 TORCH backend in conformance test

### DIFF
--- a/tests/post_training/model_scope.json
+++ b/tests/post_training/model_scope.json
@@ -136,6 +136,9 @@
         }
     },
     "levit_128": {
+        "skipped_by_backends": {
+            "TORCH": "Wrong quantization config, skipped as the model could be quantized by TORCH PTQ and TORCH backend will be deprecated eventially"
+        },
         "model_name": "levit_128",
         "quantization_params": {
             "preset": "MIXED",
@@ -174,6 +177,9 @@
         }
     },
     "visformer_small": {
+        "skipped_by_backends": {
+            "TORCH": "Wrong quantization config, skipped as the model could be quantized by TORCH PTQ and TORCH backend will be deprecated eventially"
+        },
         "model_name": "visformer_small",
         "quantization_params": {
             "preset": "MIXED",
@@ -185,7 +191,7 @@
     },
     "crossvit_9_240": {
         "skipped_by_backends": {
-            "TORCH": "Wrong quantization config, model is validated by TORCH_PTQ backend"
+            "TORCH": "Wrong quantization config, skipped as the model could be quantized by TORCH PTQ and TORCH backend will be deprecated eventially"
         },
         "model_name": "crossvit_9_240",
         "quantization_params": {

--- a/tests/post_training/model_scope.json
+++ b/tests/post_training/model_scope.json
@@ -184,6 +184,9 @@
         }
     },
     "crossvit_9_240": {
+        "skipped_by_backends": {
+            "TORCH": "Wrong quantization config, model is validated by TORCH_PTQ backend"
+        },
         "model_name": "crossvit_9_240",
         "quantization_params": {
             "preset": "MIXED",

--- a/tests/post_training/test_quantize_conformance.py
+++ b/tests/post_training/test_quantize_conformance.py
@@ -717,6 +717,17 @@ def test_ptq_timm(data, output, result, report_model_name, backends_list, eval_f
     """
     model_args = VALIDATION_SCOPE[report_model_name]
     backends = [PipelineType[backend] for backend in backends_list.split(",")]
+    if model_args.get("skipped_by_backends"):
+        for backend_name, skip_message in model_args["skipped_by_backends"].items():
+            skipped_backend = PipelineType[backend_name]
+            if skipped_backend in backends:
+                print(
+                    f"Model {report_model_name} is skipped by {backend_name} backend due to the reason: {skip_message}"
+                )
+                backends.remove(skipped_backend)
+    if not backends:
+        return
+
     model_name = model_args["model_name"]
     quantization_params = model_args["quantization_params"]
     main_connection, process_connection = Pipe()


### PR DESCRIPTION
### Changes

1) Skip by backend approach is implemented in test conformance
2) crossvit_9_240 is skipped for TORCH backend

### Reason for changes

To make conformance test results consistent

### Related tickets

109655

### Tests

- [ ] Conformance test