### PR TITLE
Move the FC_BN_HSWISH_ACTIVATION pattern from fused to ignored

### DIFF
--- a/nncf/common/graph/patterns/patterns.py
+++ b/nncf/common/graph/patterns/patterns.py
@@ -292,7 +292,6 @@ class HWFusedPatternNames(Enum):
     ADD_SCALE_SHIFT_OUTPUT = PatternDesc("add_scale_shift_output")
     BATCH_INDEX = PatternDesc("batch_index")
     EQUAL_LOGICALNOT = PatternDesc("equal_logicalnot")
-    FC_BN_HSWISH_ACTIVATION = PatternDesc("fc_bn_hswish_activation")
     LINEAR_WITH_BIAS = PatternDesc("linear_with_bias")
     MVN_SCALE_SHIFT = PatternDesc("mvn_scale_shift")
     NORMALIZE_L2_MULTIPLY = PatternDesc("normalize_l2_multiply")
@@ -387,3 +386,4 @@ class IgnoredPatternNames(Enum):
     """
 
     MULTIHEAD_ATTENTION_OUTPUT = PatternDesc("multihead_attention_output", model_types=[ModelType.TRANSFORMER])
+    FC_BN_HSWISH_ACTIVATION = PatternDesc("fc_bn_hswish_activation")

--- a/nncf/openvino/hardware/fused_patterns.py
+++ b/nncf/openvino/hardware/fused_patterns.py
@@ -193,26 +193,6 @@ def create_equal_logicalnot() -> GraphPattern:
     return pattern
 
 
-@OPENVINO_HW_FUSED_PATTERNS.register(HWFusedPatternNames.FC_BN_HSWISH_ACTIVATION)
-def create_fc_bn_hswish() -> GraphPattern:
-    pattern = GraphPattern()
-    unsqueeze_node = pattern.add_node(
-        **{GraphPattern.LABEL_ATTR: "UNSQUEEZE", GraphPattern.METATYPE_ATTR: om.OVUnsqueezeMetatype}
-    )
-    multiply_node = pattern.add_node(
-        **{GraphPattern.LABEL_ATTR: "MULTIPLY", GraphPattern.METATYPE_ATTR: om.OVMultiplyMetatype}
-    )
-    add_node = pattern.add_node(**{GraphPattern.LABEL_ATTR: "ADD", GraphPattern.METATYPE_ATTR: om.OVAddMetatype})
-    squeeze_node = pattern.add_node(
-        **{GraphPattern.LABEL_ATTR: "SQUEEZE", GraphPattern.METATYPE_ATTR: om.OVSqueezeMetatype}
-    )
-
-    pattern.add_edge(unsqueeze_node, multiply_node)
-    pattern.add_edge(multiply_node, add_node)
-    pattern.add_edge(add_node, squeeze_node)
-    return pattern
-
-
 # ACTIVATIONS
 
 

--- a/nncf/openvino/quantization/ignored_patterns.py
+++ b/nncf/openvino/quantization/ignored_patterns.py
@@ -76,3 +76,23 @@ def create_multihead_attention_output() -> GraphPattern:
     _add_softmax_matmul(pattern)
     _add_softmax_reshape_matmul(pattern)
     return pattern
+
+
+@OPENVINO_IGNORED_PATTERNS.register(IgnoredPatternNames.FC_BN_HSWISH_ACTIVATION)
+def create_fc_bn_hswish() -> GraphPattern:
+    pattern = GraphPattern()
+    unsqueeze_node = pattern.add_node(
+        **{GraphPattern.LABEL_ATTR: "UNSQUEEZE", GraphPattern.METATYPE_ATTR: om.OVUnsqueezeMetatype}
+    )
+    multiply_node = pattern.add_node(
+        **{GraphPattern.LABEL_ATTR: "MULTIPLY", GraphPattern.METATYPE_ATTR: om.OVMultiplyMetatype}
+    )
+    add_node = pattern.add_node(**{GraphPattern.LABEL_ATTR: "ADD", GraphPattern.METATYPE_ATTR: om.OVAddMetatype})
+    squeeze_node = pattern.add_node(
+        **{GraphPattern.LABEL_ATTR: "SQUEEZE", GraphPattern.METATYPE_ATTR: om.OVSqueezeMetatype}
+    )
+
+    pattern.add_edge(unsqueeze_node, multiply_node)
+    pattern.add_edge(multiply_node, add_node)
+    pattern.add_edge(add_node, squeeze_node)
+    return pattern

--- a/tests/onnx/test_pattern_manager.py
+++ b/tests/onnx/test_pattern_manager.py
@@ -8,7 +8,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from nncf.common.graph.patterns import HWFusedPatternNames
+from nncf.common.graph.patterns import IgnoredPatternNames
 from nncf.common.utils.backend import BackendType
 from tests.shared.patterns import check_hw_patterns
 from tests.shared.patterns import check_ignored_patterns
@@ -51,7 +53,9 @@ IGNORING_HW_PATTERN_REASONS = {
     HWFusedPatternNames.LINEAR_ACTIVATIONS_UNSQUEEZE_BN_SQUEEZE: "Not relevant for ONNX.",
 }
 
-IGNORING_IGNORED_PATTERN_REASONS = {}
+IGNORING_IGNORED_PATTERN_REASONS = {
+    IgnoredPatternNames.FC_BN_HSWISH_ACTIVATION: "Not relevant for ONNX.",
+}
 
 
 def test_pattern_manager():

--- a/tests/onnx/test_pattern_manager.py
+++ b/tests/onnx/test_pattern_manager.py
@@ -25,7 +25,6 @@ IGNORING_HW_PATTERN_REASONS = {
     HWFusedPatternNames.SE_BLOCK: "Not relevant for ONNX.",
     HWFusedPatternNames.SOFTMAX_DIV: "Not relevant for ONNX.",
     HWFusedPatternNames.EQUAL_LOGICALNOT: "Not relevant for ONNX.",
-    HWFusedPatternNames.FC_BN_HSWISH_ACTIVATION: "Not relevant for ONNX.",
     HWFusedPatternNames.HSWISH_ACTIVATION: "Not relevant for ONNX.",
     HWFusedPatternNames.HSWISH_ACTIVATION_V2: "Not relevant for ONNX.",
     HWFusedPatternNames.HSWISH_ACTIVATION_WITHOUT_DENOMINATOR: "Not relevant for ONNX.",

--- a/tests/torch/test_pattern_manager.py
+++ b/tests/torch/test_pattern_manager.py
@@ -17,7 +17,6 @@ IGNORING_HW_PATTERN_REASONS = {
     HWFusedPatternNames.ADD_SCALE_SHIFT_OUTPUT: "Not relevant for Torch.",
     HWFusedPatternNames.BATCH_INDEX: "Not relevant for Torch.",
     HWFusedPatternNames.EQUAL_LOGICALNOT: "Not relevant for Torch.",
-    HWFusedPatternNames.FC_BN_HSWISH_ACTIVATION: "Not relevant for Torch.",
     HWFusedPatternNames.LINEAR_WITH_BIAS: "Not relevant for Torch.",
     HWFusedPatternNames.MVN_SCALE_SHIFT: "Not relevant for Torch.",
     HWFusedPatternNames.NORMALIZE_L2_MULTIPLY: "Not relevant for Torch.",

--- a/tests/torch/test_pattern_manager.py
+++ b/tests/torch/test_pattern_manager.py
@@ -8,7 +8,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from nncf.common.graph.patterns import HWFusedPatternNames
+from nncf.common.graph.patterns import IgnoredPatternNames
 from nncf.common.utils.backend import BackendType
 from tests.shared.patterns import check_hw_patterns
 from tests.shared.patterns import check_ignored_patterns
@@ -65,7 +67,9 @@ IGNORING_HW_PATTERN_REASONS = {
     HWFusedPatternNames.LINEAR_ACTIVATIONS_UNSQUEEZE_BN_SQUEEZE: "Not relevant for Torch.",
 }
 
-IGNORING_IGNORED_PATTERN_REASONS = {}
+IGNORING_IGNORED_PATTERN_REASONS = {
+    IgnoredPatternNames.FC_BN_HSWISH_ACTIVATION: "Not relevant for Torch.",
+}
 
 
 def test_pattern_manager():


### PR DESCRIPTION
### Changes

Move the `FC_BN_HSWISH_ACTIVATION` pattern from fused patterns to ignored patterns.

### Reason for changes

This is an incorrect fused pattern because we cannot fuse batch normalization in `Unsqueeze` operation. The correct fused pattern is

Convolution + Bias + Activation + Unsqueeze + BatchNormalization + Squeeze

### Related tickets

Ref: 112991

### Tests

N/A
