### PR TITLE
Add LINEAR_ACTIVATIONS_UNSQUEEZE_BN_SQUEEZE fused pattern

### DIFF
--- a/nncf/common/graph/patterns/patterns.py
+++ b/nncf/common/graph/patterns/patterns.py
@@ -346,6 +346,7 @@ class HWFusedPatternNames(Enum):
     LINEAR_SCALE_SHIFT_ACTIVATIONS = PatternDesc("linear_scale_shift_activations")
     LINEAR_CONST_MULTIPLY = PatternDesc("linear_const_multiply")
     LINEAR_SQUEEZE_ACTIVATIONS = PatternDesc("linear_squeeze_activations")
+    LINEAR_ACTIVATIONS_UNSQUEEZE_BN_SQUEEZE = PatternDesc("linear_activations_unsqueeze_bn_squeeze")
     SCALE_SHIFT_ACTIVATIONS = PatternDesc("scale_shift_activations")
     MVN_SCALE_SHIFT_ACTIVATIONS = PatternDesc("mvn_scale_shift_activations")
 

--- a/nncf/openvino/hardware/fused_patterns.py
+++ b/nncf/openvino/hardware/fused_patterns.py
@@ -768,6 +768,21 @@ def create_mvn_scale_shift_activations() -> GraphPattern:
     return pattern
 
 
+@OPENVINO_HW_FUSED_PATTERNS.register(HWFusedPatternNames.LINEAR_ACTIVATIONS_UNSQUEEZE_BN_SQUEEZE)
+def create_linear_activations_unsqueeze_bn_squeeze():
+    linear_biased = create_biased_op()
+    activations = atomic_activations_operations()
+    unsqueeze_op = unsqueeze_operation()
+    scale_shift = create_scale_shift()
+    squeeze_op = squeeze_operation()
+
+    linear_biased.join_patterns(activations)
+    linear_biased.join_patterns(unsqueeze_op)
+    linear_biased.join_patterns(scale_shift)
+    linear_biased.join_patterns(squeeze_op)
+    return linear_biased
+
+
 # DEVICE PATTERNS
 
 
@@ -896,6 +911,12 @@ def arithmetic_operations() -> GraphPattern:
 def squeeze_operation() -> GraphPattern:
     pattern = GraphPattern()
     pattern.add_node(**{GraphPattern.LABEL_ATTR: "SQUEEZE", GraphPattern.METATYPE_ATTR: om.OVSqueezeMetatype})
+    return pattern
+
+
+def unsqueeze_operation() -> GraphPattern:
+    pattern = GraphPattern()
+    pattern.add_node(**{GraphPattern.LABEL_ATTR: "UNSQUEEZE", GraphPattern.METATYPE_ATTR: om.OVUnsqueezeMetatype})
     return pattern
 
 

--- a/tests/onnx/test_pattern_manager.py
+++ b/tests/onnx/test_pattern_manager.py
@@ -53,6 +53,7 @@ IGNORING_HW_PATTERN_REASONS = {
     HWFusedPatternNames.LINEAR_ACTIVATION_ELEMENTWISE: "Not relevant for ONNX.",
     HWFusedPatternNames.LINEAR_BIASED_ACTIVATION_ELEMENTWISE: "Not relevant for ONNX.",
     HWFusedPatternNames.MVN_SCALE_SHIFT_ACTIVATIONS: "Not relevant for ONNX.",
+    HWFusedPatternNames.LINEAR_ACTIVATIONS_UNSQUEEZE_BN_SQUEEZE: "Not relevant for ONNX.",
 }
 
 IGNORING_IGNORED_PATTERN_REASONS = {}

--- a/tests/torch/test_pattern_manager.py
+++ b/tests/torch/test_pattern_manager.py
@@ -67,6 +67,7 @@ IGNORING_HW_PATTERN_REASONS = {
     HWFusedPatternNames.LINEAR_BIASED_ACTIVATION_ELEMENTWISE: "Not relevant for Torch.",
     HWFusedPatternNames.MVN_SCALE_SHIFT_ACTIVATIONS: "Not relevant for Torch.",
     HWFusedPatternNames.LINEAR_SQUEEZE_ACTIVATIONS: "Not relevant for Torch.",
+    HWFusedPatternNames.LINEAR_ACTIVATIONS_UNSQUEEZE_BN_SQUEEZE: "Not relevant for Torch.",
 }
 
 IGNORING_IGNORED_PATTERN_REASONS = {}


### PR DESCRIPTION
### Changes

Add LINEAR_ACTIVATIONS_UNSQUEEZE_BN_SQUEEZE fused pattern

![pattern](https://github.com/openvinotoolkit/nncf/assets/77268007/85744dda-4f5b-47c6-be93-f523235960d3)


### Reason for changes

- These nodes are fused to Convolution/GroupConvolution in the execution graph.

### Related tickets

Ref: 112991

### Tests

N/A
