### PR TITLE
Remove xception from ptq tests

### DIFF
--- a/tests/post_training/model_scope.json
+++ b/tests/post_training/model_scope.json
@@ -55,15 +55,6 @@
             "FP32 top 1": 0.77728
         }
     },
-    "xception": {
-        "model_name": "xception",
-        "quantization_params": {
-            "preset": "MIXED"
-        },
-        "metrics": {
-            "FP32 top 1": 0.78506
-        }
-    },
     "efficientnet_b0": {
         "model_name": "efficientnet_b0",
         "quantization_params": {


### PR DESCRIPTION
### Changes

Remove `xception` model from ptq test scope - zero accuracy for OV backend, so can not be used to compare results.


Model | FP32 top 1 | Torch INT8 top 1 | Torch PTQ INT8 top 1 | ONNX INT8 top 1 | OV Native INT8 top 1 | Openvino INT8 top
-- | -- | -- | -- | -- | -- | --
xception | 0.7851 | 0.75048 | 0.7824 | 0.7832 | 0.7826 | 0.0107

