### PR TITLE
Use explicit port IDs for parallel edge case instead of the parallel edge count

### DIFF
--- a/nncf/torch/graph/graph.py
+++ b/nncf/torch/graph/graph.py
@@ -35,8 +35,10 @@ class PTNNCFGraph(NNCFGraph):
             edge_attr_dict = self._nx_graph.edges[in_edge]
             port_id = edge_attr_dict[NNCFGraph.INPUT_PORT_ID_EDGE_ATTR]
             assert port_id not in retval
-            for i in range(edge_attr_dict[NNCFGraph.EDGE_MULTIPLICITY_ATTR]):
-                retval[port_id - i] = edge_attr_dict[NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR]
+            for p in [
+                port_id,
+            ] + edge_attr_dict[NNCFGraph.PARALLEL_INPUT_PORT_IDS_ATTR]:
+                retval[p] = edge_attr_dict[NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR]
         return retval
 
     def get_input_shape_for_insertion_point(self, insertion_point: PTTargetPoint) -> Tuple[int]:

--- a/nncf/torch/graph/graph_builder.py
+++ b/nncf/torch/graph/graph_builder.py
@@ -96,7 +96,7 @@ class GraphConverter:
                 input_port_id=dynamic_graph_edge.input_port_id,
                 output_port_id=dynamic_graph_edge.output_port_id,
                 dtype=dynamic_graph_edge.dtype,
-                edge_multiplicity=dynamic_graph_edge.edge_multiplicity,
+                parallel_input_port_ids=dynamic_graph_edge.parallel_input_port_ids,
             )
 
         set_nodes_attributes_in_nncf_graph(nncf_graph)

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -603,8 +603,9 @@ class NNCFNetworkInterface(torch.nn.Module):
             # a port ID attribute.
             in_edges = nncf_graph.get_input_edges(node)
             for edge in in_edges:
-                for i in range(edge.edge_multiplicity):
-                    port_id = edge.input_port_id - i
+                for port_id in [
+                    edge.input_port_id,
+                ] + edge.parallel_input_port_ids:
                     pre_hook_ip = PreHookInsertionPoint(target_node_name=node.node_name, input_port_id=port_id)
                     pre_hooks.append(pre_hook_ip)
 

--- a/tests/common/pruning/test_pruning_operations.py
+++ b/tests/common/pruning/test_pruning_operations.py
@@ -62,7 +62,6 @@ def test_identity_mask_propogation_prune_ops(dummy_op_class):
             input_port_id=0,
             output_port_id=0,
             dtype=Dtype.FLOAT,
-            edge_multiplicity=1,
         )
         identity_ops.append(identity_op)
     # Check with and without masks
@@ -86,12 +85,7 @@ def test_elementwise_prune_ops(valid_masks):
         "elementwise", dummy_types.DummyElementwiseMetatype.name, dummy_types.DummyElementwiseMetatype
     )
     add_node = partial(
-        graph.add_edge_between_nncf_nodes,
-        tensor_shape=[10] * 4,
-        input_port_id=0,
-        output_port_id=0,
-        dtype=Dtype.FLOAT,
-        edge_multiplicity=1,
+        graph.add_edge_between_nncf_nodes, tensor_shape=[10] * 4, input_port_id=0, output_port_id=0, dtype=Dtype.FLOAT
     )
     # conv_op_0 -> elementwise
     add_node(from_node_id=conv_op_0.node_id, to_node_id=elementwise_op.node_id)
@@ -150,7 +144,6 @@ def test_group_norm_pruning_ops(num_channels, num_groups, accept_pruned_input_re
         input_port_id=0,
         output_port_id=0,
         dtype=Dtype.FLOAT,
-        edge_multiplicity=1,
     )
     # Check with and without masks
     for output_mask in [None, NPNNCFTensor(np.ones((10,)))]:
@@ -217,7 +210,6 @@ def test_conv_pruning_ops(transpose, layer_attributes, ref_accept_pruned_input, 
         input_port_id=0,
         output_port_id=0,
         dtype=Dtype.FLOAT,
-        edge_multiplicity=1,
     )
     pruning_op_class = dummy_types.DummyTransposeConvPruningOp if transpose else dummy_types.DummyConvPruningOp
     assert pruning_op_class.accept_pruned_input(conv_op_target) == ref_accept_pruned_input
@@ -263,7 +255,6 @@ def test_linear_pruning_ops():
         input_port_id=0,
         output_port_id=0,
         dtype=Dtype.FLOAT,
-        edge_multiplicity=1,
     )
     # Check linear layer always accept pruned input
     assert dummy_types.LinearPruningOp.accept_pruned_input(linear_op_target)
@@ -299,9 +290,7 @@ def test_convs_elementwise_source_before_concat(
     concat_node = graph.add_nncf_node(
         "concat_node", "concat", dummy_types.DummyConcatMetatype, layer_attributes=concat_layer_attributes
     )
-    add_node = partial(
-        graph.add_edge_between_nncf_nodes, input_port_id=0, output_port_id=0, dtype=Dtype.FLOAT, edge_multiplicity=1
-    )
+    add_node = partial(graph.add_edge_between_nncf_nodes, input_port_id=0, output_port_id=0, dtype=Dtype.FLOAT)
 
     # conv_op_0 -> elementwise_node
     add_node(from_node_id=conv_op_0.node_id, to_node_id=elementwise_node.node_id, tensor_shape=[10] * 4)
@@ -360,7 +349,6 @@ def test_concat_output_tensor_device():
             input_port_id=0,
             output_port_id=0,
             dtype=Dtype.FLOAT,
-            edge_multiplicity=1,
         )
 
     # Set mask to last dummy node
@@ -448,7 +436,6 @@ def test_reshape_metatype_mask_prop(node_type, input_shape, output_shape, output
         input_port_id=0,
         output_port_id=0,
         dtype=Dtype.FLOAT,
-        edge_multiplicity=1,
     )
     # Check both None mask and not None mask
     for output_mask_cur, output_mask_ref_cur in [(None, None), (output_mask, output_mask_ref)]:
@@ -487,7 +474,6 @@ def test_reshape_is_last_op(node_type):
         input_port_id=0,
         output_port_id=0,
         dtype=Dtype.FLOAT,
-        edge_multiplicity=1,
     )
 
     for output_mask in (None, NPNNCFTensor(np.ones((10,)))):

--- a/tests/cross_fw/examples/test_examples.py
+++ b/tests/cross_fw/examples/test_examples.py
@@ -15,6 +15,7 @@ import subprocess
 import pytest
 
 from tests.shared.case_collection import skip_if_backend_not_selected
+from tests.shared.command import Command
 from tests.shared.helpers import create_venv_with_nncf
 from tests.shared.helpers import get_pip_executable_with_venv
 from tests.shared.helpers import get_python_executable_with_venv
@@ -58,7 +59,8 @@ def test_examples(tmp_path, example_name, example_params, backends_list, is_chec
     python_executable_with_venv = get_python_executable_with_venv(venv_path)
     run_example_py = EXAMPLE_TEST_ROOT / "run_example.py"
     run_cmd_line = f"{python_executable_with_venv} {run_example_py} --name {example_name} --output {metrics_file_path}"
-    subprocess.run(run_cmd_line, check=True, shell=True, env=env, cwd=PROJECT_ROOT)
+    cmd = Command(run_cmd_line, cwd=PROJECT_ROOT, env=env)
+    cmd.run()
 
     measured_metrics = load_json(metrics_file_path)
 

--- a/tests/torch/test_graph_analysis.py
+++ b/tests/torch/test_graph_analysis.py
@@ -57,7 +57,7 @@ def test_graph_pattern_io_building():
             output_port_id=output_port_id,
             tensor_shape=[1, 1, 1, 1],
             dtype=Dtype.FLOAT,
-            edge_multiplicity=1,
+            parallel_input_port_ids=[],
         )
 
     def get_node(name: NNCFNodeName):


### PR DESCRIPTION
### Changes
Fixes the torch graph tracing to correctly handle parallel edge scenario in case when the tensors belonging to parallel edges do are interleaved in the order of the tensor arguments to a given traced torch op.

### Reason for changes
Bugfix

### Related tickets
113539

### Tests
precommit, E2E TBR
