### PR TITLE
Remove CUDA spec from torch installation in tests

### DIFF
--- a/tests/torch/sparsity/movement/test_training_with_third_party.py
+++ b/tests/torch/sparsity/movement/test_training_with_third_party.py
@@ -37,13 +37,13 @@ class TestMovementWithTransformers:
         self.env = TransformersVirtualEnvInstaller(temp_folder["venv"], temp_folder["repo"])
 
     @pytest.mark.dependency(name="install_transformers")
-    def test_install_transformers_env(self, third_party, pip_cache_dir, torch_with_cuda11):
+    def test_install_transformers_env(self, third_party, pip_cache_dir):
         if not third_party:
             pytest.skip(
                 "Skip tests of movement sparsity with patched transformers package "
                 "since `--third-party-sanity` is False."
             )
-        self.env.install_env(pip_cache_dir, torch_with_cuda11)
+        self.env.install_env(pip_cache_dir)
 
     @pytest.mark.dependency(depends=["install_transformers"], name="glue_movement_train")
     def test_movement_glue_train(self):

--- a/tests/torch/test_sanity_third_party.py
+++ b/tests/torch/test_sanity_third_party.py
@@ -78,7 +78,7 @@ class TransformersVirtualEnvInstaller:
             )
         )
 
-    def install_env(self, pip_cache_dir, torch_with_cuda11):
+    def install_env(self, pip_cache_dir):
         version_string = "{}.{}".format(sys.version_info[0], sys.version_info[1])
         subprocess.call("virtualenv -ppython{} {}".format(version_string, self.VENV_PATH), shell=True)
         pip_runner = CachedPipRunner(self.VENV_ACTIVATE, pip_cache_dir)
@@ -87,8 +87,6 @@ class TransformersVirtualEnvInstaller:
         pip_runner.run_pip("install setuptools")
         pip_runner.run_pip("install onnx")
         torch_install_cmd = "install torch=={}".format(BKC_TORCH_VERSION)
-        if torch_with_cuda11:
-            pip_runner.run_pip(torch_install_cmd + "+cu116 --extra-index-url https://download.pytorch.org/whl/cu116")
         pip_runner.run_pip(torch_install_cmd)
         subprocess.run(
             "git clone https://github.com/huggingface/transformers {}".format(self.TRANSFORMERS_REPO_PATH),
@@ -121,8 +119,8 @@ class TestTransformers:
         self.env = TransformersVirtualEnvInstaller(temp_folder["venv"], temp_folder["repo"])
 
     @pytest.mark.dependency(name="install_trans")
-    def test_install_trans_(self, pip_cache_dir, torch_with_cuda11):
-        self.env.install_env(pip_cache_dir, torch_with_cuda11)
+    def test_install_trans_(self, pip_cache_dir):
+        self.env.install_env(pip_cache_dir)
 
     @pytest.mark.dependency(depends=["install_trans"], name="xnli_train")
     def test_xnli_train(self, temp_folder):


### PR DESCRIPTION
### Changes
As stated in the title

### Reason for changes
TPS installation tests cannot find the torch version with the CUDA-specific index URL. Also removed the associated test parameter since we don't need this kind of disambiguation for supported torch versions anymore.

### Related tickets
N/A

### Tests
third_party_sanity run
