### PR TITLE
Add label `NNCF PTQ`

### DIFF
--- a/.github/action_configs/labeler.yml
+++ b/.github/action_configs/labeler.yml
@@ -28,6 +28,10 @@ NNCF OpenVINO:
   - 'nncf/openvino/**/*'
   - 'tests/openvino/**/*'
 
+NNCF PTQ:
+  - 'nncf/quantization/**/*'
+  - 'tests/post_training/**/*'
+
 documentation:
   - '**/README.md'
   - 'docs/**/*'


### PR DESCRIPTION
### Changes

Add label `NNCF PTQ`

### Reason for changes

If changes files for post training quantization it's not set label, as result CI can be skipped (in case when set only `documentation` label)

