### PR TITLE
Fix convert_to_dict_recursively function

### DIFF
--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -224,9 +224,10 @@ def convert_to_dict_recursively(params: Any) -> Dict[str, Any]:
         value = getattr(params, f.name)
         if is_dataclass(value):
             result[f.name] = convert_to_dict_recursively(value)
-        if isinstance(value, Enum):
+        elif isinstance(value, Enum):
             result[f.name] = value.value
-        result[f.name] = value
+        else:
+            result[f.name] = value
 
     return result
 


### PR DESCRIPTION
### Changes

- Fix implementation of the `convert_to_dict_recursively function()` function

### Reason for changes

Incorrect implementation

```python
from dataclasses import dataclass

@dataclass
class A:
    param_a: int

@dataclass
class B:
    param_b: int

@dataclass
class C:
    a: A
    b: B

# Test case
obj = C(A(0), B(1))

# Expected result for `convert_to_dict_recursively(obj)`
{'a': {'param_a': 0}, 'b': {'param_b': 1}}

# Actual result for `convert_to_dict_recursively(obj)`
{'a': A(param_a=0), 'b': B(param_b=1)}
```

### Related tickets

N/A

### Tests

N/A
