### PR TITLE
Add strict parameter for find_matching_subgraphs

### DIFF
--- a/nncf/common/graph/graph.py
+++ b/nncf/common/graph/graph.py
@@ -711,7 +711,7 @@ class NNCFGraph:
         for node_key, node in self._nx_graph.nodes.items():
             self._node_id_to_key_dict[node["id"]] = node_key
 
-    def find_matching_subgraphs(self, patterns: GraphPattern) -> List[List[NNCFNode]]:
+    def find_matching_subgraphs(self, patterns: GraphPattern, strict: bool = True) -> List[List[NNCFNode]]:
         """
         Returns subgraphs of matched pattern in patterns.
 
@@ -722,7 +722,7 @@ class NNCFGraph:
         DiGraphMatcher does not guarantee a specific order for returning isomorphic subgraphs.
         """
         output = []
-        for matched_subgraph in find_subgraphs_matching_pattern(self._nx_graph, patterns):
+        for matched_subgraph in find_subgraphs_matching_pattern(self._nx_graph, patterns, strict):
             subgraph_list = []
             for node_key in matched_subgraph:
                 subgraph_list.append(self.get_node_by_key(node_key))

--- a/nncf/common/graph/graph.py
+++ b/nncf/common/graph/graph.py
@@ -716,7 +716,7 @@ class NNCFGraph:
         Returns subgraphs of matched pattern in patterns.
 
         :param patterns: Instance of GraphPattern containing all patterns.
-        :param strict: If True returns only strict matched subgraphs, otherwise - False.
+        :param strict: If True returns only strict matched subgraphs, if False- all matched subgraphs.
         :return: List of subgraphs that are matching by pattern matching.
             Subgraph is a ordered list of nodes of matched subgraph
         The returned nodes order relies on DiGraphMatcher isomorphic subgraphs matching logic from networkX package.

--- a/nncf/common/graph/graph.py
+++ b/nncf/common/graph/graph.py
@@ -716,6 +716,7 @@ class NNCFGraph:
         Returns subgraphs of matched pattern in patterns.
 
         :param patterns: Instance of GraphPattern containing all patterns.
+        :param strict: If True returns only strict matched subgraphs, otherwise - False.
         :return: List of subgraphs that are matching by pattern matching.
             Subgraph is a ordered list of nodes of matched subgraph
         The returned nodes order relies on DiGraphMatcher isomorphic subgraphs matching logic from networkX package.

--- a/nncf/common/graph/graph.py
+++ b/nncf/common/graph/graph.py
@@ -716,7 +716,7 @@ class NNCFGraph:
         Returns subgraphs of matched pattern in patterns.
 
         :param patterns: Instance of GraphPattern containing all patterns.
-        :param strict: If True returns only strict matched subgraphs, if False- all matched subgraphs.
+        :param strict: If True returns only strict matched subgraphs, if False - all matched subgraphs.
         :return: List of subgraphs that are matching by pattern matching.
             Subgraph is a ordered list of nodes of matched subgraph
         The returned nodes order relies on DiGraphMatcher isomorphic subgraphs matching logic from networkX package.

--- a/nncf/common/graph/graph_matching.py
+++ b/nncf/common/graph/graph_matching.py
@@ -118,7 +118,9 @@ def _copy_subgraph_excluding_non_pattern_node(subgraph: Dict[str, str], pattern_
     return output
 
 
-def find_subgraphs_matching_pattern(graph: nx.DiGraph, pattern_graph: GraphPattern) -> List[List[str]]:
+def find_subgraphs_matching_pattern(
+    graph: nx.DiGraph, pattern_graph: GraphPattern, strict: bool = True
+) -> List[List[str]]:
     """
     Finds a list of nodes which define a subgraph matched a pattern in pattern_graph.
     Nodes in each subgraph is stored in lexicographical_topological_sort.
@@ -134,8 +136,7 @@ def find_subgraphs_matching_pattern(graph: nx.DiGraph, pattern_graph: GraphPatte
     for pattern in patterns:
         matcher = ism.DiGraphMatcher(graph, pattern, node_match=_are_nodes_matched)
         for subgraph in matcher.subgraph_isomorphisms_iter():
-            is_matching_strict = _is_subgraph_matching_strict(graph, pattern, subgraph)
-            if not is_matching_strict:
+            if strict and not _is_subgraph_matching_strict(graph, pattern, subgraph):
                 continue
 
             subgraph = _copy_subgraph_excluding_non_pattern_node(subgraph, pattern_graph)

--- a/nncf/common/graph/graph_matching.py
+++ b/nncf/common/graph/graph_matching.py
@@ -127,6 +127,7 @@ def find_subgraphs_matching_pattern(
 
     :param graph: The model graph.
     :param pattern_graph: A graph consists of patterns to match.
+    :param strict: If True returns only strict matched subgraphs, otherwise - False.
     :return: A list of subgraphs are mathced to the patterns. Each subgraph is defined as a list of node keys.
     """
     subgraphs = []

--- a/nncf/common/graph/graph_matching.py
+++ b/nncf/common/graph/graph_matching.py
@@ -127,8 +127,8 @@ def find_subgraphs_matching_pattern(
 
     :param graph: The model graph.
     :param pattern_graph: A graph consists of patterns to match.
-    :param strict: If True returns only strict matched subgraphs, if False- all matched subgraphs.
-    :return: A list of subgraphs are mathced to the patterns. Each subgraph is defined as a list of node keys.
+    :param strict: If True returns only strict matched subgraphs, if False - all matched subgraphs.
+    :return: A list of subgraphs are matched to the patterns. Each subgraph is defined as a list of node keys.
     """
     subgraphs = []
     matched_nodes = set()

--- a/nncf/common/graph/graph_matching.py
+++ b/nncf/common/graph/graph_matching.py
@@ -127,7 +127,7 @@ def find_subgraphs_matching_pattern(
 
     :param graph: The model graph.
     :param pattern_graph: A graph consists of patterns to match.
-    :param strict: If True returns only strict matched subgraphs, otherwise - False.
+    :param strict: If True returns only strict matched subgraphs, if False- all matched subgraphs.
     :return: A list of subgraphs are mathced to the patterns. Each subgraph is defined as a list of node keys.
     """
     subgraphs = []

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -336,7 +336,7 @@ class MinMaxQuantization(Algorithm):
         :return: IgnoredScope with all node names matched ignored_patterns.
         """
         nncf_node_names = []
-        for subgraph in inference_nncf_graph.find_matching_subgraphs(ignored_patterns):
+        for subgraph in inference_nncf_graph.find_matching_subgraphs(ignored_patterns, strict=False):
             for nncf_node in subgraph:
                 nncf_node_names.append(nncf_node.node_name)
 


### PR DESCRIPTION
### Changes

Add strict with default value True parameter to find_matching_subgraphs.

### Reason for changes

IgnoredPatterns shouldn't be checked on strict matches. This is specific only for HWFusedPatterns.

### Related tickets

N/A

### Tests

N/A
