### PR TITLE
Use nncf_graph for FBC

### DIFF
--- a/nncf/common/factory.py
+++ b/nncf/common/factory.py
@@ -40,7 +40,7 @@ class NNCFGraphFactory:
 
             return GraphConverter.create_nncf_graph(model)
         if model_backend == BackendType.TORCH:
-            return model.nncf.get_original_graph()
+            return model.nncf.get_graph()
         raise RuntimeError("Cannot create backend-specific graph because {} is not supported!".format(model_backend))
 
 

--- a/nncf/common/graph/layer_attributes.py
+++ b/nncf/common/graph/layer_attributes.py
@@ -109,7 +109,7 @@ class GenericWeightedLayerAttributes(WeightedLayerAttributes):
 
 
 class LinearLayerAttributes(WeightedLayerAttributes):
-    def __init__(self, weight_requires_grad: bool, in_features: int, out_features: int, with_bias: bool = False):
+    def __init__(self, weight_requires_grad: bool, in_features: int, out_features: int, with_bias: bool = True):
         """
 
         :param weight_requires_grad: Is True if gradients need to be computed for the corresponding Tensor,

--- a/nncf/experimental/torch/sparsity/movement/layers.py
+++ b/nncf/experimental/torch/sparsity/movement/layers.py
@@ -160,7 +160,7 @@ class MovementSparsifier(nn.Module):
         """
         super().__init__()
         self.target_module_node = target_module_node
-        self.prune_bias = bool(target_module_node.layer_attributes.bias)
+        self.prune_bias = bool(target_module_node.layer_attributes.with_bias)
         self.frozen = frozen
         self.layerwise_loss_lambda = layerwise_loss_lambda
         self._importance_threshold = -math.inf

--- a/nncf/quantization/algorithms/fast_bias_correction/backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/backend.py
@@ -145,17 +145,15 @@ class FastBiasCorrectionAlgoBackend(ABC):
 
     @staticmethod
     @abstractmethod
-    def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph, model: TModel) -> bool:
+    def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         """
         Checks whether the node is quantized or not.
 
         :param node: NNCFNode to check.
         :param nncf_graph: NNCFGraph instance.
-        :param model: Backend-specific model.
 
         :return: boolean indicating whether the node has a quantized weights or not
         """
-        # TODO(AlexanderDokuchaev): use only nncf_graph instead of model, after fix 111576
 
     @staticmethod
     @abstractmethod
@@ -170,16 +168,14 @@ class FastBiasCorrectionAlgoBackend(ABC):
 
     @staticmethod
     @abstractmethod
-    def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph, model: TModel) -> bool:
+    def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         """
         Checks whether the node has a bias or not.
 
         :param node: NNCFNode with the attributes.
         :param nncf_graph: NNCFGraph that contains node.
-        :param model: Backend-specific model.
         :return: Boolean indicating whether the node has a bias or not.
         """
-        # TODO(AlexanderDokuchaev): use only nncf_graph instead of model, after fix 111576
 
     @staticmethod
     @abstractmethod
@@ -214,15 +210,14 @@ class FastBiasCorrectionAlgoBackend(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_node_names_for_input_output_statistics(node: NNCFNode, model: TModel) -> Tuple[str, str]:
+    def get_node_names_for_input_output_statistics(node: NNCFNode, nncf_graph: NNCFGraph) -> Tuple[str, str]:
         """
         Return name of nodes to collect statistics.
 
         :param node: NNCFNode to check.
-        :param model: Backend-specific model.
+        :param nncf_graph: NNCFGraph instance.
 
         :return:
             Name of node to collect input statistics
             Name of node to collect output statistics
         """
-        # TODO(AlexanderDokuchaev): use nncf_graph instead of model, after fix 111576

--- a/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
@@ -100,14 +100,14 @@ class ONNXFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         return ONNXNNCFTensor(raw_data[output_name])
 
     @staticmethod
-    def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph, model: onnx.ModelProto) -> bool:
+    def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         input_nodes = [edge.from_node for edge in nncf_graph.get_input_edges(node)]
         weight_port_id = node.metatype.weight_definitions.weight_port_id
         weight_node = input_nodes[weight_port_id]
         return weight_node.metatype == ONNXDequantizeLinearMetatype
 
     @staticmethod
-    def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph, model: onnx.ModelProto) -> bool:
+    def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         return is_node_with_bias(node)
 
     @staticmethod
@@ -126,5 +126,5 @@ class ONNXFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         return data.reshape(new_shape)
 
     @staticmethod
-    def get_node_names_for_input_output_statistics(node: NNCFNode, model: onnx.ModelProto) -> Tuple[str, str]:
+    def get_node_names_for_input_output_statistics(node: NNCFNode, nncf_graph: NNCFGraph) -> Tuple[str, str]:
         return node.node_name, node.node_name

--- a/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
@@ -88,7 +88,7 @@ class OVFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         return 0, 0
 
     @staticmethod
-    def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph, model: ov.Model) -> bool:
+    def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         # At first, checks whether the node has weight tensor
         if node.layer_attributes is None:
             return False
@@ -102,7 +102,7 @@ class OVFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         return OVNNCFTensor(raw_data[output_name])
 
     @staticmethod
-    def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph, model: ov.Model) -> bool:
+    def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         return is_node_with_bias(node, nncf_graph)
 
     @staticmethod
@@ -121,5 +121,5 @@ class OVFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         return data.reshape(new_shape)
 
     @staticmethod
-    def get_node_names_for_input_output_statistics(node: NNCFNode, model: ov.Model) -> Tuple[str, str]:
+    def get_node_names_for_input_output_statistics(node: NNCFNode, nncf_graph: NNCFGraph) -> Tuple[str, str]:
         return node.node_name, node.node_name

--- a/nncf/quantization/algorithms/fast_bias_correction/torch_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/torch_backend.py
@@ -102,12 +102,12 @@ class PTFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         return PTNNCFTensor(raw_data)
 
     @staticmethod
-    def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph, model: NNCFNetwork) -> bool:
-        return is_quantized_weights(node, model)
+    def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        return is_quantized_weights(node, nncf_graph)
 
     @staticmethod
-    def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph, model: NNCFNetwork) -> bool:
-        return is_node_with_fused_bias(node, model)
+    def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        return is_node_with_fused_bias(node, nncf_graph)
 
     @staticmethod
     def get_bias_shift_magnitude(current_bias_value: torch.Tensor, updated_bias_value: torch.Tensor) -> float:
@@ -125,8 +125,8 @@ class PTFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         return data.reshape(new_shape)
 
     @staticmethod
-    def get_node_names_for_input_output_statistics(node: NNCFNode, model: NNCFNetwork) -> Tuple[str, str]:
+    def get_node_names_for_input_output_statistics(node: NNCFNode, nncf_graph: NNCFGraph) -> Tuple[str, str]:
         input_node_name = node.node_name
-        next_norm_node = get_potential_fused_node(node.node_name, model)
+        next_norm_node = get_potential_fused_node(input_node_name, nncf_graph)
         output_node_name = next_norm_node.node_name if next_norm_node else input_node_name
         return input_node_name, output_node_name

--- a/nncf/tensorflow/graph/converter.py
+++ b/nncf/tensorflow/graph/converter.py
@@ -782,6 +782,7 @@ def _get_conv_layer_attributes(layer: tf.keras.layers.Layer, is_depthwise: bool 
     dilations = layer_.dilation_rate
     in_channels = layer.get_input_shape_at(0)[channel_axis]
     out_channels = layer.get_output_shape_at(0)[channel_axis]
+    with_bias = layer_.use_bias
 
     # TF does not deign to properly set the groups attribute on a depthwise layer, and for compatibility
     # with common code the groups attribute of the returned ConvolutionLayerAttribute must be set equal
@@ -790,7 +791,6 @@ def _get_conv_layer_attributes(layer: tf.keras.layers.Layer, is_depthwise: bool 
     kernel_size = layer_.kernel_size
 
     transpose = layer_metatype in DECONV_LAYER_METATYPES
-    with_bias = layer.use_bias
 
     return ConvolutionLayerAttributes(
         weight_requires_grad=layer.trainable,

--- a/nncf/tensorflow/graph/converter.py
+++ b/nncf/tensorflow/graph/converter.py
@@ -790,6 +790,7 @@ def _get_conv_layer_attributes(layer: tf.keras.layers.Layer, is_depthwise: bool 
     kernel_size = layer_.kernel_size
 
     transpose = layer_metatype in DECONV_LAYER_METATYPES
+    with_bias = layer.use_bias
 
     return ConvolutionLayerAttributes(
         weight_requires_grad=layer.trainable,
@@ -801,6 +802,7 @@ def _get_conv_layer_attributes(layer: tf.keras.layers.Layer, is_depthwise: bool 
         groups=groups,
         transpose=transpose,
         padding_values=([0, 0, 0, 0]),
+        with_bias=with_bias,
     )
 
 
@@ -808,9 +810,9 @@ def _get_linear_layer_attributes(layer: tf.keras.layers.Layer) -> LinearLayerAtt
     channel_axis = get_input_channel_axis(layer)
     in_features = layer.get_input_shape_at(0)[channel_axis]
     out_features = layer.get_output_shape_at(0)[channel_axis]
-    bias = layer.use_bias
+    with_bias = layer.use_bias
     return LinearLayerAttributes(
-        weight_requires_grad=layer.trainable, in_features=in_features, out_features=out_features, bias=bias
+        weight_requires_grad=layer.trainable, in_features=in_features, out_features=out_features, with_bias=with_bias
     )
 
 

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -922,3 +922,5 @@ OPERATORS_WITH_BIAS_METATYPES = [
 OPERATORS_FUSED_METATYPES = [
     PTModuleBatchNormMetatype,
 ]
+
+OP_NAMES_QUANTIZE_NODE = ["symmetric_quantize", "asymmetric_quantize"]

--- a/nncf/torch/model_analyzer.py
+++ b/nncf/torch/model_analyzer.py
@@ -15,10 +15,10 @@ import torch
 
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
+from nncf.torch.graph.operator_metatypes import OP_NAMES_QUANTIZE_NODE
 from nncf.torch.graph.operator_metatypes import OPERATORS_FUSED_METATYPES
 from nncf.torch.graph.operator_metatypes import OPERATORS_WITH_BIAS_METATYPES
 from nncf.torch.nncf_network import NNCFNetwork
-from nncf.torch.quantization.quantize_functions import QUANTIZE_OPERATION_NAMES
 
 
 def get_potential_fused_node(node_name: str, nncf_graph: NNCFGraph) -> Optional[NNCFNode]:
@@ -82,6 +82,6 @@ def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
     :return bool: return `True` if the node is quantized.
     """
     for prev_node in nncf_graph.get_previous_nodes(node):
-        if prev_node.node_type in QUANTIZE_OPERATION_NAMES:
+        if prev_node.node_type in OP_NAMES_QUANTIZE_NODE:
             return True
     return False

--- a/nncf/torch/model_analyzer.py
+++ b/nncf/torch/model_analyzer.py
@@ -12,51 +12,48 @@
 from typing import Optional
 
 import torch
-from torch import nn
-from torch.quantization.fake_quantize import FakeQuantize
 
+from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
 from nncf.torch.graph.operator_metatypes import OPERATORS_FUSED_METATYPES
 from nncf.torch.graph.operator_metatypes import OPERATORS_WITH_BIAS_METATYPES
-from nncf.torch.module_operations import UpdateWeight
 from nncf.torch.nncf_network import NNCFNetwork
-from nncf.torch.quantization.layers import BaseQuantizer
+from nncf.torch.quantization.quantize_functions import QUANTIZE_OPERATION_NAMES
 
 
-def get_potential_fused_node(node_name: str, model: NNCFNetwork) -> Optional[NNCFNode]:
+def get_potential_fused_node(node_name: str, nncf_graph: NNCFGraph) -> Optional[NNCFNode]:
     """
     Get next node that can contain fused bias in runtime.
 
     :param node_name: The node name.
-    :param model: The model that contains this operation.
-
+    :param nncf_graph: The NNCF graph.
     :return: The node that can be fused or None.
     """
-    graph = model.nncf.get_original_graph()
-    target_node = graph.get_node_by_name(node_name)
+    target_node = nncf_graph.get_node_by_name(node_name)
 
     if target_node.metatype in OPERATORS_WITH_BIAS_METATYPES:
-        next_nodes = graph.get_next_nodes(target_node)
+        next_nodes = nncf_graph.get_next_nodes(target_node)
         for node in next_nodes:
             if node.metatype in OPERATORS_FUSED_METATYPES:
                 return node
     return None
 
 
-def is_node_with_fused_bias(node: NNCFNode, model: NNCFNetwork) -> bool:
+def is_node_with_fused_bias(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
     """
     Checks if the node has a fused bias.
 
     :param node: The node to check.
-    :param model: The model that contains this operation.
+    :param nncf_graph: The NNCF graph.
     :return: Return `True` if `node` corresponds to the operation
         with bias (bias is added to the output tensor of that operation),
         `False` otherwise.
     """
-    fused_node = get_potential_fused_node(node.node_name, model)
-    node_module = model.nncf.get_containing_module(node.node_name)
+    fused_node = get_potential_fused_node(node.node_name, nncf_graph)
 
-    return node.metatype in OPERATORS_WITH_BIAS_METATYPES and (node_module.bias is not None or fused_node is not None)
+    return node.metatype in OPERATORS_WITH_BIAS_METATYPES and (
+        node.layer_attributes.with_bias if fused_node is None else fused_node.layer_attributes.with_bias
+    )
 
 
 def get_fused_bias_value(node: NNCFNode, model: NNCFNetwork) -> Optional[torch.Tensor]:
@@ -67,7 +64,8 @@ def get_fused_bias_value(node: NNCFNode, model: NNCFNetwork) -> Optional[torch.T
     :param model: The model that contains this operation.
     :return: The bias value that is applied to the output tensor of the node's operation.
     """
-    fused_node = get_potential_fused_node(node.node_name, model)
+    nncf_graph = model.nncf.get_graph()
+    fused_node = get_potential_fused_node(node.node_name, nncf_graph)
     target_node_name = fused_node.node_name if fused_node else node.node_name
     node_module = model.nncf.get_containing_module(target_node_name)
     if node_module.bias is None:
@@ -75,29 +73,15 @@ def get_fused_bias_value(node: NNCFNode, model: NNCFNetwork) -> Optional[torch.T
     return node_module.bias.data
 
 
-def find_fake_quantizer_for_weight(module: nn.Module) -> Optional[nn.Module]:
-    """
-    Return quantizer operator for weight of module if exists, otherwise return None.
-
-    :param module: The target module.
-
-    :return nn.Module: Quantizer module.
-    """
-    for pre_op in module.pre_ops.values():
-        if isinstance(pre_op, UpdateWeight) and isinstance(pre_op.op, (BaseQuantizer, FakeQuantize)):
-            return pre_op.op
-    return None
-
-
-def is_quantized_weights(node: NNCFNode, model: NNCFNetwork) -> bool:
+def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
     """
     Check that module have fake_quantizer for weight.
 
     :param node: The target node.
-    :param model: The model.
-
-    :return bool: return `True` if module have FQ pre_ops for weight.
+    :param nncf_graph: The NNCF graph.
+    :return bool: return `True` if the node is quantized.
     """
-    node_module = model.nncf.get_containing_module(node.node_name)
-    fq_module = find_fake_quantizer_for_weight(node_module)
-    return fq_module is not None
+    for prev_node in nncf_graph.get_previous_nodes(node):
+        if prev_node.node_type in QUANTIZE_OPERATION_NAMES:
+            return True
+    return False

--- a/nncf/torch/model_transformer.py
+++ b/nncf/torch/model_transformer.py
@@ -139,7 +139,8 @@ def update_fused_bias(target_node_name: str, new_bias: Tensor, model: NNCFNetwor
     :param new_bias: New bias value.
     :param model: The model.
     """
-    fused_node = get_potential_fused_node(target_node_name, model)
+    nncf_graph = model.get_graph()
+    fused_node = get_potential_fused_node(target_node_name, nncf_graph)
     if fused_node:
         target_node_name = fused_node.node_name
 
@@ -157,8 +158,8 @@ def extraction_potential_fused_modules(node_name: str, model: NNCFNetwork) -> nn
     :return nn.Sequential: Copy of the modules.
     """
     extracted_node_names = [node_name]
-
-    fused_node = get_potential_fused_node(node_name, model)
+    nncf_graph = model.get_graph()
+    fused_node = get_potential_fused_node(node_name, nncf_graph)
     if fused_node:
         extracted_node_names.append(fused_node.node_name)
 

--- a/nncf/torch/quantization/quantize_functions.py
+++ b/nncf/torch/quantization/quantize_functions.py
@@ -20,8 +20,6 @@ from nncf.torch.quantization.extensions import QuantizedFunctionsCPU
 from nncf.torch.quantization.extensions import QuantizedFunctionsCUDA
 from nncf.torch.utils import add_domain
 
-QUANTIZE_OPERATION_NAMES = ["symmetric_quantize", "asymmetric_quantize"]
-
 
 # pylint:disable=abstract-method
 class QuantizeSymmetric(torch.autograd.Function):

--- a/nncf/torch/quantization/quantize_functions.py
+++ b/nncf/torch/quantization/quantize_functions.py
@@ -20,6 +20,8 @@ from nncf.torch.quantization.extensions import QuantizedFunctionsCPU
 from nncf.torch.quantization.extensions import QuantizedFunctionsCUDA
 from nncf.torch.utils import add_domain
 
+QUANTIZE_OPERATION_NAMES = ["symmetric_quantize", "asymmetric_quantize"]
+
 
 # pylint:disable=abstract-method
 class QuantizeSymmetric(torch.autograd.Function):

--- a/tests/torch/ptq/test_fast_bias_correction.py
+++ b/tests/torch/ptq/test_fast_bias_correction.py
@@ -52,7 +52,7 @@ class TestTorchFBCAlgorithm(TemplateTestFBCAlgorithm):
         ref_bias = torch.Tensor(ref_bias)
         nncf_graph = NNCFGraphFactory.create(model)
         for node in nncf_graph.get_all_nodes():
-            if not is_node_with_fused_bias(node, model):
+            if not is_node_with_fused_bias(node, nncf_graph):
                 continue
             bias_value = get_fused_bias_value(node, model)
             # TODO(AlexanderDokuchaev): return atol=0.0001 after fix 109189

--- a/tests/torch/sparsity/movement/helpers/utils.py
+++ b/tests/torch/sparsity/movement/helpers/utils.py
@@ -40,7 +40,9 @@ def mock_linear_nncf_node(
         node_name,
         "linear",
         Mock(),
-        LinearLayerAttributes(weight_requires_grad=True, in_features=in_features, out_features=out_features, bias=bias),
+        LinearLayerAttributes(
+            weight_requires_grad=True, in_features=in_features, out_features=out_features, with_bias=bias
+        ),
     )
     return linear
 

--- a/tests/torch/test_layer_attributes.py
+++ b/tests/torch/test_layer_attributes.py
@@ -98,7 +98,7 @@ class LayerAttributesTestDesc:
 
 
 BATCH_NORM_REF_ATTR = GenericWeightedLayerAttributes(
-    weight_requires_grad=True, weight_shape=Size([1]), filter_dimension_idx=0
+    weight_requires_grad=True, weight_shape=Size([1]), filter_dimension_idx=0, with_bias=True
 )
 LIST_TEST_DESCS = [
     LayerAttributesTestDesc(
@@ -138,6 +138,7 @@ LIST_TEST_DESCS = [
             groups=1,
             transpose=False,
             padding_values=(0, 0),
+            with_bias=True,
         ),
         metatype_cls=PTConv2dMetatype,
     ),
@@ -154,6 +155,7 @@ LIST_TEST_DESCS = [
             groups=2,
             transpose=False,
             padding_values=(0, 0),
+            with_bias=True,
         ),
         metatype_cls=PTConv2dMetatype,
     ),
@@ -170,6 +172,7 @@ LIST_TEST_DESCS = [
             groups=1,
             transpose=False,
             padding_values=(0,),
+            with_bias=True,
         ),
         metatype_cls=PTConv1dMetatype,
     ),
@@ -186,6 +189,7 @@ LIST_TEST_DESCS = [
             groups=1,
             transpose=False,
             padding_values=(0, 0, 0),
+            with_bias=True,
         ),
         metatype_cls=PTConv3dMetatype,
     ),
@@ -202,6 +206,7 @@ LIST_TEST_DESCS = [
             groups=1,
             transpose=True,
             padding_values=(0,),
+            with_bias=True,
         ),
         metatype_cls=PTConvTranspose1dMetatype,
     ),
@@ -218,6 +223,7 @@ LIST_TEST_DESCS = [
             groups=1,
             transpose=True,
             padding_values=(0, 0),
+            with_bias=True,
         ),
         metatype_cls=PTConvTranspose2dMetatype,
     ),
@@ -234,6 +240,7 @@ LIST_TEST_DESCS = [
             groups=1,
             transpose=True,
             padding_values=(0, 0, 0),
+            with_bias=True,
         ),
         metatype_cls=PTConvTranspose3dMetatype,
     ),
@@ -246,7 +253,9 @@ LIST_TEST_DESCS = [
     LayerAttributesTestDesc(
         module=nn.Linear(1, 1, bias=False),
         model_input_info_list=[ModelInputInfo([1, 1, 1, 1])],
-        layer_attributes=LinearLayerAttributes(weight_requires_grad=True, in_features=1, out_features=1, bias=False),
+        layer_attributes=LinearLayerAttributes(
+            weight_requires_grad=True, in_features=1, out_features=1, with_bias=False
+        ),
         metatype_cls=PTLinearMetatype,
     ),
     LayerAttributesTestDesc(


### PR DESCRIPTION
### Changes

- Use compressed graph for torch backend
- Add `with_bias` for `WeightedLayerAttributes` what means that layer contain bias inside module (will true only for torch and tf)
- Removed `bias` from `LinearLayerAttributes`, use `with_bias`.
- Remove `model` from functions backend of `fast_bias_correction`
 
### Related tickets
111576

