### PR TITLE
Use unique key for statistics points

### DIFF
--- a/nncf/common/tensor_statistics/statistic_point.py
+++ b/nncf/common/tensor_statistics/statistic_point.py
@@ -25,9 +25,7 @@ class StatisticPoint:
     algorithm implies on what algorithm nedeed this statistics.
     """
 
-    def __init__(
-        self, target_point: TargetPoint, tensor_collector: TensorStatisticCollectorBase, algorithm: "Algorithm"
-    ):
+    def __init__(self, target_point: TargetPoint, tensor_collector: TensorStatisticCollectorBase, algorithm: str):
         self.target_point = target_point
         self.algorithm_to_tensor_collectors = {algorithm: [tensor_collector]}
 
@@ -88,7 +86,7 @@ class StatisticPointsContainer(UserDict):
 
     def get_tensor_collectors(
         self, filter_fn: Optional[Callable[[StatisticPoint], bool]] = None
-    ) -> Generator[Tuple["Algorithm", StatisticPoint, TensorStatisticCollectorBase], None, None]:
+    ) -> Generator[Tuple[str, StatisticPoint, TensorStatisticCollectorBase], None, None]:
         """
         Returns iterable through all tensor collectors.
 
@@ -114,7 +112,7 @@ class StatisticPointsContainer(UserDict):
         self,
         target_node_name: str,
         filter_fn: Callable[[StatisticPoint], bool],
-        algorithm: "Algorithm",
+        algorithm: str,
     ) -> Generator[TensorStatisticCollectorBase, None, None]:
         """
         Returns iterable through all statistic collectors in node with target_node_name.

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -169,6 +169,7 @@ class MinMaxQuantization(Algorithm):
             collections.OrderedDict()
         )  # type: OrderedDict[TargetPoint, QuantizerConfig]
         self._unified_scale_groups = []
+        self._algorithm_key = f"MMQ_{hash(self)}"
 
     @property
     def available_backends(self) -> Dict[str, BackendType]:
@@ -606,7 +607,7 @@ class MinMaxQuantization(Algorithm):
 
         def filter_func(point: StatisticPoint) -> bool:
             return (
-                MinMaxQuantization in point.algorithm_to_tensor_collectors
+                self._algorithm_key in point.algorithm_to_tensor_collectors
                 and point.target_point == quantization_target_point
             )
 
@@ -616,7 +617,7 @@ class MinMaxQuantization(Algorithm):
             for quantization_target_point in unified_scale_group:
                 target_node_name = quantization_target_point.target_node_name
                 for tensor_collector in statistic_points.get_algo_statistics_for_node(
-                    target_node_name, filter_func, MinMaxQuantization
+                    target_node_name, filter_func, self._algorithm_key
                 ):
                     group_statistics.append(tensor_collector.get_statistics())
 
@@ -637,7 +638,7 @@ class MinMaxQuantization(Algorithm):
                 continue
             target_node_name = quantization_target_point.target_node_name
             for tensor_collector in statistic_points.get_algo_statistics_for_node(
-                target_node_name, filter_func, MinMaxQuantization
+                target_node_name, filter_func, self._algorithm_key
             ):
                 if quantization_target_point.is_weight_target_point():
                     weights_name = self._backend_entity.get_weight_name(nncf_graph, quantization_target_point)
@@ -682,7 +683,7 @@ class MinMaxQuantization(Algorithm):
                 StatisticPoint(
                     target_point=quantization_target_point,
                     tensor_collector=stat_collector,
-                    algorithm=MinMaxQuantization,
+                    algorithm=self._algorithm_key,
                 )
             )
         return output

--- a/nncf/quantization/algorithms/smooth_quant/algorithm.py
+++ b/nncf/quantization/algorithms/smooth_quant/algorithm.py
@@ -65,6 +65,7 @@ class SmoothQuant(Algorithm):
         self._inplace_statistics = inplace_statistics
         self._backend_entity = None
         self._alpha = alpha
+        self._algorithm_key = f"SQ_{hash(self)}"
 
     @property
     def available_backends(self) -> Dict[str, BackendType]:
@@ -176,13 +177,15 @@ class SmoothQuant(Algorithm):
 
         def filter_func(point: StatisticPoint) -> bool:
             return (
-                SmoothQuant in point.algorithm_to_tensor_collectors
+                self._algorithm_key in point.algorithm_to_tensor_collectors
                 and point.target_point.type == TargetType.PRE_LAYER_OPERATION
                 and point.target_point.port_id == act_port
             )
 
         statistics_for_node = []
-        for tensor_collector in statistic_points.get_algo_statistics_for_node(node_name, filter_func, SmoothQuant):
+        for tensor_collector in statistic_points.get_algo_statistics_for_node(
+            node_name, filter_func, self._algorithm_key
+        ):
             statistics_for_node.append(tensor_collector.get_statistics()[STATISTIC_BRANCH_KEY])
         return statistics_for_node
 
@@ -217,7 +220,7 @@ class SmoothQuant(Algorithm):
                 StatisticPoint(
                     target_point=target_point,
                     tensor_collector=stat_collector,
-                    algorithm=SmoothQuant,
+                    algorithm=self._algorithm_key,
                 )
             )
         return statistic_container

--- a/tests/post_training/test_templates/test_channel_alignment.py
+++ b/tests/post_training/test_templates/test_channel_alignment.py
@@ -323,11 +323,12 @@ class TemplateTestChannelAlignment:
 
             return f
 
+        algorithm = ChannelAlignment()
         tensor_collector = TensorCollector()
         tensor_collector.get_statistics = get_constant_lambda(
             TestTensorStats(np.array([-1], dtype=np.int32), np.array([2], dtype=np.int32))
         )
-        statistic_points.add_statistic_point(StatisticPoint(target_point, tensor_collector, ChannelAlignment))
+        statistic_points.add_statistic_point(StatisticPoint(target_point, tensor_collector, algorithm._algorithm_key))
 
         class MockBackend(backend_cls):
             pass
@@ -339,7 +340,6 @@ class TemplateTestChannelAlignment:
         ref_dims_descr = "ref_dims_descr"
         MockBackend.get_dims_descriptor = get_constant_lambda(ref_dims_descr, True)
 
-        algorithm = ChannelAlignment()
         algorithm._backend_entity = MockBackend
         algorithm._set_backend_entity = mocker.MagicMock()
         ref_bias_in_after_align = "ref_bias_in_after_align"
@@ -456,8 +456,8 @@ class TemplateTestChannelAlignment:
         assert len(stat_points) == 1
 
         assert len(stat_points[0].algorithm_to_tensor_collectors.keys()) == 1
-        assert ChannelAlignment in stat_points[0].algorithm_to_tensor_collectors
-        tensor_collectors = stat_points[0].algorithm_to_tensor_collectors[ChannelAlignment]
+        assert algorithm._algorithm_key in stat_points[0].algorithm_to_tensor_collectors
+        tensor_collectors = stat_points[0].algorithm_to_tensor_collectors[algorithm._algorithm_key]
         assert len(tensor_collectors) == 1
         assert tensor_collectors[0] == ref_stat_collector
         MockBackend.get_statistic_collector.assert_called_once_with((0, 2, 3), 1e-4, ref_subset_size, ref_inplace)

--- a/tests/post_training/test_templates/test_ptq_params.py
+++ b/tests/post_training/test_templates/test_ptq_params.py
@@ -143,7 +143,7 @@ class TemplateTestPTQParams:
 
         for _, stat_point in stat_points.items():
             for stat_point_ in stat_point:
-                for tensor_collector in stat_point_.algorithm_to_tensor_collectors[MinMaxQuantization]:
+                for tensor_collector in stat_point_.algorithm_to_tensor_collectors[min_max_algo._algorithm_key]:
                     if stat_point_.target_point.is_weight_target_point():
                         # default tensor_collector for weights
                         self.check_is_min_max_statistic_collector(tensor_collector)


### PR DESCRIPTION
### Changes

Use the unique key for statistic points per algorithm's instance.

### Reason for changes
The following code does not work with current approach
```python
quant_algo_performance = PostTrainingQuantization(preset=QuantizationPreset.PERFORMANCE)
quant_algo_mixed = PostTrainingQuantization(preset=QuantizationPreset.MIXED)

stats_aggregator = OVStatisticsAggregator(calibration_dataset)
stats_aggregator.register_statistic_points(quant_algo_performance.get_statistic_points(ov_model))
stats_aggregator.register_statistic_points(quant_algo_mixed.get_statistic_points(ov_model))
stats_aggregator.collect_statistics(ov_model)

quantized_model_performance = quant_algo_performance.apply(ov_model, stats_aggregator.statistic_points)
quantized_model_mixed = quant_algo_mixed.apply(ov_model, stats_aggregator.statistic_points)
```

### Related tickets

N/A

### Tests

N/A
