### PR TITLE
Fix pylint

### DIFF
--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -706,7 +706,7 @@ def test_safety_change_scope_in_get_nncf_modules():
 
 
 class EmbeddingWithSharedWeights(torch.nn.Embedding):
-    def forward(self, x, run_as_matmul=False):
+    def forward(self, x, run_as_matmul=False):  # pylint: disable=arguments-renamed
         if run_as_matmul:
             return F.linear(x, self.weight)
         return super().forward(x)


### PR DESCRIPTION
### Changes

Fix warning:
```
W0237: Parameter 'input' has been renamed to 'x' in overridden 'EmbeddingWithSharedWeights.forward' method (arguments-renamed)
```

### Reason for changes

Pylint is red

### Related tickets

N/A

### Tests

N/A
