### PR TITLE
Trace for FQ nodes by torch.jit.trace

### DIFF
--- a/examples/post_training_quantization/torch/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/torch/mobilenet_v2/main.py
@@ -33,7 +33,6 @@ CHECKPOINT_URL = "https://huggingface.co/alexsu52/mobilenet_v2_imagenette/resolv
 DATASET_URL = "https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz"
 DATASET_PATH = "~/.cache/nncf/datasets"
 DATASET_CLASSES = 10
-USE_EXPERIMENTAL_MO_CONVERTOR = False
 
 
 def download_dataset() -> Path:
@@ -151,31 +150,27 @@ torch_quantized_model = nncf.quantize(
 
 dummy_input = torch.randn(1, 3, 224, 224)
 
-if USE_EXPERIMENTAL_MO_CONVERTOR:
-    ov_model = mo.convert_model(torch_model, example_input=dummy_input)
-    ov_quantized_model = mo.convert_model(torch_quantized_model, example_input=dummy_input)
-else:
-    fp32_onnx_path = f"{ROOT}/mobilenet_v2_fp32.onnx"
-    torch.onnx.export(
-        torch_model.cpu(),
-        dummy_input,
-        fp32_onnx_path,
-        input_names=["input"],
-        output_names=["output"],
-        dynamic_axes={"input": {0: "-1"}},
-    )
-    ov_model = mo.convert_model(fp32_onnx_path)
+fp32_onnx_path = f"{ROOT}/mobilenet_v2_fp32.onnx"
+torch.onnx.export(
+    torch_model.cpu(),
+    dummy_input,
+    fp32_onnx_path,
+    input_names=["input"],
+    output_names=["output"],
+    dynamic_axes={"input": {0: "-1"}},
+)
+ov_model = mo.convert_model(fp32_onnx_path)
 
-    int8_onnx_path = f"{ROOT}/mobilenet_v2_int8.onnx"
-    torch.onnx.export(
-        torch_quantized_model.cpu(),
-        dummy_input,
-        int8_onnx_path,
-        input_names=["input"],
-        output_names=["output"],
-        dynamic_axes={"input": {0: "-1"}},
-    )
-    ov_quantized_model = mo.convert_model(int8_onnx_path)
+int8_onnx_path = f"{ROOT}/mobilenet_v2_int8.onnx"
+torch.onnx.export(
+    torch_quantized_model.cpu(),
+    dummy_input,
+    int8_onnx_path,
+    input_names=["input"],
+    output_names=["output"],
+    dynamic_axes={"input": {0: "-1"}},
+)
+ov_quantized_model = mo.convert_model(int8_onnx_path)
 
 fp32_ir_path = f"{ROOT}/mobilenet_v2_fp32.xml"
 ov.serialize(ov_model, fp32_ir_path)

--- a/nncf/torch/quantization/quantize_functions.py
+++ b/nncf/torch/quantization/quantize_functions.py
@@ -136,7 +136,9 @@ def _quantize_autograd_to_range(input_, input_low, input_high, levels):
 # pylint:disable=abstract-method
 class ExportQuantizeToFakeQuantize(torch.autograd.Function):
     @staticmethod
-    def symbolic(g, input_, levels, input_low, input_high, output_low, output_high):
+    def symbolic(
+        g, input_, levels, input_low, input_high, output_low, output_high, scale, zero_point, q_min, q_max, ch_axis
+    ):
         output = g.op(
             add_domain("FakeQuantize"), input_, input_low, input_high, output_low, output_high, levels_i=levels
         )
@@ -145,8 +147,12 @@ class ExportQuantizeToFakeQuantize(torch.autograd.Function):
         return output
 
     @staticmethod
-    def forward(ctx, input_, levels, input_low, input_high, output_low, output_high):
-        return torch.clone(input_)
+    def forward(
+        ctx, input_, levels, input_low, input_high, output_low, output_high, scale, zero_point, q_min, q_max, ch_axis
+    ):
+        if ch_axis is not None:
+            return torch.fake_quantize_per_channel_affine(input_, scale, zero_point, ch_axis, q_min, q_max)
+        return torch.fake_quantize_per_tensor_affine(input_, scale, zero_point, q_min, q_max)
 
     @staticmethod
     def backward(ctx: Any, *grad_outputs: Any) -> Any:

--- a/nncf/torch/quantization/quantize_functions.py
+++ b/nncf/torch/quantization/quantize_functions.py
@@ -228,7 +228,7 @@ class TuneRange(torch.autograd.Function):
         input_low_copy[input_low_copy > 0] = 0
         input_high[input_high < 0] = 0
         n = levels - 1
-        # Need a cast here because fp16 division yileds fp32 results sometimes
+        # Need a cast here because fp16 division yields fp32 results sometimes
         scale = (levels / (input_high - input_low_copy)).to(dtype=input_high.dtype)
         zp = torch.round(-input_low_copy * scale)
 

--- a/tests/torch/quantization/test_tracing.py
+++ b/tests/torch/quantization/test_tracing.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import torch
+from torch import nn
+
+from nncf.common.quantization.structs import QuantizationMode
+from nncf.torch.quantization.layers import AsymmetricQuantizer
+from nncf.torch.quantization.layers import PTQuantizerSpec
+from nncf.torch.quantization.layers import SymmetricQuantizer
+
+
+class TestModel(nn.Module):
+    def __init__(self, fq) -> None:
+        super().__init__()
+        self.fq = fq
+
+    def forward(self, x):
+        return self.fq(x)
+
+
+def test_trace_asymmetric_quantizer(is_per_channel):
+    if is_per_channel:
+        input_low = torch.tensor([-0.1, 0.1]).reshape(1, 2, 1, 1)
+        input_range = torch.tensor([0.3, 0.4]).reshape(1, 2, 1, 1)
+    else:
+        input_low = torch.tensor([-0.1])
+        input_range = torch.tensor([1.1])
+
+    qspec = PTQuantizerSpec(
+        num_bits=8,
+        mode=QuantizationMode.ASYMMETRIC,
+        signedness_to_force=False,
+        narrow_range=False,
+        scale_shape=tuple(input_low.shape),
+        logarithm_scale=False,
+        half_range=False,
+        is_quantized_on_export=True,
+    )
+    quantizer = AsymmetricQuantizer(qspec)
+    quantizer.input_low.data = input_low
+    quantizer.input_range.data = input_range
+
+    model = TestModel(quantizer)
+    torch.jit.trace(model, torch.ones(1, 2, 1, 1))
+
+
+def test_trace_symmetric_quantizer(is_per_channel, is_signed):
+    if is_per_channel:
+        scale = torch.tensor([0.3, 0.4]).reshape(1, 2, 1, 1)
+    else:
+        scale = torch.tensor([1.1])
+
+    qspec = PTQuantizerSpec(
+        num_bits=8,
+        mode=QuantizationMode.SYMMETRIC,
+        signedness_to_force=False,
+        narrow_range=False,
+        scale_shape=tuple(scale.shape),
+        logarithm_scale=False,
+        half_range=False,
+        is_quantized_on_export=True,
+    )
+    quantizer = SymmetricQuantizer(qspec)
+    quantizer.scale.data = scale
+    quantizer.signed = is_signed
+
+    model = TestModel(quantizer)
+    torch.jit.trace(model, torch.ones(1, 2, 1, 1))

--- a/tests/torch/quantization/test_tracing.py
+++ b/tests/torch/quantization/test_tracing.py
@@ -29,14 +29,12 @@ class TestModel(nn.Module):
 def check_fq_op(traced_graph: nn.Module, is_per_channel: bool):
     aten_op = "aten::fake_quantize_per_channel_affine" if is_per_channel else "aten::fake_quantize_per_tensor_affine"
     is_fq_node = False
-    for node in traced_graph.inlined_graph.nodes():
-        print(node.kind())
-        if node.kind() == "prim::PythonOp":
-            if "Subgraph" in node.attributeNames():
-                subgraph = getattr(node, node.kindOf("Subgraph"))("Subgraph")
-                for node in subgraph.nodes():
-                    print(node.kind())
-                    if node.kind() == aten_op:
+    for graph_node in traced_graph.inlined_graph.nodes():
+        if graph_node.kind() == "prim::PythonOp":
+            if "Subgraph" in graph_node.attributeNames():
+                subgraph = getattr(graph_node, graph_node.kindOf("Subgraph"))("Subgraph")
+                for subgraph_node in subgraph.nodes():
+                    if subgraph_node.kind() == aten_op:
                         is_fq_node = True
                         break
         if is_fq_node:


### PR DESCRIPTION
### Changes

Trace FQ nodes by torch.jit.trace to convert model by model_optimizer, without calling `strip` function.

### Reason for changes

Add experimental convertor of model_optimizer for torch model without export to onnx.

```python
mo.convert_model(torch_quantized_model, example_input=dummy_input)
```

### Related tickets

115483

### Tests

- test_trace_symmetric_quantizer
- test_trace_asymmetric_quantizer