### PR TITLE
Corrected condition for matching recurrent nodes

### DIFF
--- a/nncf/torch/dynamic_graph/graph.py
+++ b/nncf/torch/dynamic_graph/graph.py
@@ -523,11 +523,10 @@ class NodeManager:
     # TODO: optimize by matching exact module type
     @staticmethod
     def _within_iteration(scope: Scope):
-        scope_name = str(scope)
         from nncf.torch.layers import ITERATION_MODULES  # pylint: disable=cyclic-import
 
-        for iter_scope in ITERATION_MODULES.registry_dict:
-            if iter_scope in scope_name:
+        for scope_element in scope.scope_elements:
+            if scope_element.calling_module_class_name in ITERATION_MODULES.registry_dict:
                 return True
         return False
 

--- a/nncf/torch/dynamic_graph/scope.py
+++ b/nncf/torch/dynamic_graph/scope.py
@@ -97,10 +97,9 @@ class Scope:
 
     def get_iteration_scopes(self) -> List[str]:
         results = []
-        scope_name = str(self)
         from nncf.torch.layers import ITERATION_MODULES  # pylint: disable=cyclic-import
 
-        for iter_scope in ITERATION_MODULES.registry_dict:
-            if iter_scope in scope_name:
-                results.append(iter_scope)
+        for scope_element in self.scope_elements:
+            if scope_element.calling_module_class_name in ITERATION_MODULES.registry_dict:
+                results.append(scope_element.calling_module_class_name)
         return results

--- a/tests/torch/data/reference_graphs/quantized/synthetic_model/OrdinaryModelWithRecurrentInName.dot
+++ b/tests/torch/data/reference_graphs/quantized/synthetic_model/OrdinaryModelWithRecurrentInName.dot
@@ -1,0 +1,13 @@
+strict digraph  {
+"0 /nncf_model_input_0" [id=0, type=nncf_model_input];
+"1 SymmetricQuantizer/symmetric_quantize_0" [id=1, type=symmetric_quantize];
+"2 OrdinaryModelWithRecurrentInName/__getitem___0" [id=2, type=__getitem__];
+"3 OrdinaryModelWithRecurrentInName/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" [id=3, type=symmetric_quantize];
+"4 OrdinaryModelWithRecurrentInName/NNCFConv2d[conv]/conv2d_0" [id=4, type=conv2d];
+"5 /nncf_model_output_0" [id=5, type=nncf_model_output];
+"0 /nncf_model_input_0" -> "1 SymmetricQuantizer/symmetric_quantize_0";
+"1 SymmetricQuantizer/symmetric_quantize_0" -> "2 OrdinaryModelWithRecurrentInName/__getitem___0";
+"2 OrdinaryModelWithRecurrentInName/__getitem___0" -> "4 OrdinaryModelWithRecurrentInName/NNCFConv2d[conv]/conv2d_0";
+"3 OrdinaryModelWithRecurrentInName/NNCFConv2d[conv]/ModuleDict[pre_ops]/UpdateWeight[0]/SymmetricQuantizer[op]/symmetric_quantize_0" -> "4 OrdinaryModelWithRecurrentInName/NNCFConv2d[conv]/conv2d_0";
+"4 OrdinaryModelWithRecurrentInName/NNCFConv2d[conv]/conv2d_0" -> "5 /nncf_model_output_0";
+}

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -67,6 +67,7 @@ from tests.torch.test_models.synthetic import MHA_single_input
 from tests.torch.test_models.synthetic import MMDivConv
 from tests.torch.test_models.synthetic import ModelWithDummyParameter
 from tests.torch.test_models.synthetic import MultiOutputSameTensorModel
+from tests.torch.test_models.synthetic import OrdinaryModelWithRecurrentInName
 from tests.torch.test_models.synthetic import PoolUnPool
 from tests.torch.test_models.synthetic import ReshapeModel
 from tests.torch.test_models.synthetic import ShiftScaleParametrized
@@ -749,6 +750,11 @@ SYNTHETIC_MODEL_DESC_LIST = [
         wrap_inputs_fn=partial(n_inputs_fn, nargs=3),
     ),
     GeneralModelDesc(model_builder=MHA_single_input, input_sample_sizes=(MHA_single_input.INPUT_SIZES,)),
+    GeneralModelDesc(
+        model_name="OrdinaryModelWithRecurrentInName",
+        model_builder=OrdinaryModelWithRecurrentInName,
+        input_sample_sizes=([1, 1, 2, 2]),
+    ),
     *shift_scale_models,
 ]
 

--- a/tests/torch/test_models/synthetic.py
+++ b/tests/torch/test_models/synthetic.py
@@ -335,6 +335,16 @@ class MHA_single_input(torch.nn.Module):
         return self.mha(x, x, x)
 
 
+class OrdinaryModelWithRecurrentInName(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = create_conv(1, 1, 1)
+
+    def forward(self, x):
+        quantize_agnostic = x[:2]
+        return self.conv(quantize_agnostic)
+
+
 class ShiftScaleParametrized(torch.nn.Module):
     NUM_CHANNELS = 3
     INPUT_SIZES = [1, NUM_CHANNELS, 2, 2]


### PR DESCRIPTION
### Changes

The node is considered within iteration scope if the correspondent module name fully matches the registered names of registered recurrent modules (LSTM, GRU cells). 
Previously, there was a less strict rule: the name of the iteration module should include the name of the considered module.

### Reason for changes

The problem appeared with `RecurrentDecoder` with a customer model: 
https://github.com/PeterL1n/RobustVideoMatting/blob/master/model/model.py#L26C28-L26C44
FQ should be propagated up through `concat` and `strided slice`, but it was mistakenly considered within iteration scope and added to ignored scope for quantization.
The concat's scope is `205 MattingNetwork/RecurrentDecoder[decoder2]/OutputBlock[decode0]/cat_0`
It matched with one of the registered iteration scopes – `Recurrent`. With a corrected condition, it's not matched.
![image](https://github.com/openvinotoolkit/nncf/assets/4014476/84d1a79a-45ad-4713-8064-20fa9f0fa9fa)
![image](https://github.com/openvinotoolkit/nncf/assets/4014476/b0108a68-ed3f-4554-b55a-eed8a4a95259)


### Related tickets

112934

### Tests

synthetic tests for model with Recurrent in the name
