### PR TITLE
 [PTQ] Extend num_samples=1 for weights statistics collection for all backends

### DIFF
--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -270,7 +270,8 @@ class MinMaxQuantization(Algorithm):
 
         :param nncf_graph: NNCFGraph instance.
         :param target_point: Target point indicates where statistics should be collected.
-        :param quantizer_config: Configuration of a quantizer layer defines the configuration of created statistic collector.
+        :param quantizer_config: Configuration of a quantizer layer,
+        defining the configuration of created statistic collector.
         :param num_samples: Number of samples to collect from the 'target_point'.
         :return: Statistic Collector.
         """

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -259,13 +259,20 @@ class MinMaxQuantization(Algorithm):
         return RangeEstimatorParameters(min_statistic_collector, max_statistic_collector)
 
     def _get_stat_collector(
-        self, nncf_graph: NNCFGraph, target_point: TargetPoint, quantizer_config: QuantizerConfig
+        self,
+        nncf_graph: NNCFGraph,
+        target_point: TargetPoint,
+        quantizer_config: QuantizerConfig,
+        num_samples: int,
     ) -> TensorStatisticCollectorBase:
         """
-        Creates and returns statistic collector instance based on the quantizer's configuration.
+        Creates and returns a statistic collector based on the quantizer's configuration.
 
-        :param quantizer_config: QuantizerConfig instance for the current layer.
-        :return: One of the TensorStatisticCollectorBase instances
+        :param nncf_graph: NNCFGraph instance.
+        :param target_point: Target point indicates where statistics should be collected.
+        :param quantizer_config: Configuration of a quantizer layer defines the configuration of created statistic collector.
+        :param num_samples: Number of samples to collect from the 'target_point'.
+        :return: Statistic Collector.
         """
         range_estimator_params = self._get_range_estimator_parameters(target_point, quantizer_config)
 
@@ -275,7 +282,7 @@ class MinMaxQuantization(Algorithm):
             target_point,
             quantizer_config,
             inplace=self._inplace_statistics,
-            num_samples=self._subset_size,
+            num_samples=num_samples,
         )
 
     def _get_default_qconfig(self, constraints: QuantizationConstraints = None) -> QuantizerConfig:
@@ -678,7 +685,11 @@ class MinMaxQuantization(Algorithm):
                 f"Adding target point {quantization_target_point.target_node_name}"
                 f" with type {quantization_target_point.type} for statistics collection"
             )
-            stat_collector = self._get_stat_collector(nncf_graph, quantization_target_point, qconfig)
+            num_samples = self._subset_size
+            if quantization_target_point.is_weight_target_point():
+                # Weight statistics is constant, so only one collection is enough.
+                num_samples = 1
+            stat_collector = self._get_stat_collector(nncf_graph, quantization_target_point, qconfig, num_samples)
             output.add_statistic_point(
                 StatisticPoint(
                     target_point=quantization_target_point,

--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -20,6 +20,7 @@ from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.hardware.config import HWConfig
 from nncf.common.quantization.structs import QuantizationMode
 from nncf.common.quantization.structs import QuantizerConfig
+from nncf.common.tensor_statistics.collectors import ReductionShape
 from nncf.common.utils.backend import BackendType
 from nncf.onnx.graph.metatypes import onnx_metatypes as om
 from nncf.onnx.graph.node_utils import get_input_edges_mapping
@@ -157,7 +158,7 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
     @staticmethod
     def _get_reduction_shape_and_use_abs_max(
         nncf_graph: NNCFGraph, target_point: ONNXTargetPoint, quantizer_config: QuantizerConfig
-    ) -> Tuple[Optional[Tuple[int, ...]], bool]:
+    ) -> Tuple[ReductionShape, bool]:
         use_abs_max = quantizer_config.mode == QuantizationMode.SYMMETRIC
         if not quantizer_config.per_channel:
             return None, use_abs_max

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -151,14 +151,7 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
             axes = tuple(i for i in range(len(const_shape)) if i not in channel_axes)
         else:
             axes = tuple(range(len(const_shape)))
-
         return axes, use_abs_max
-
-    @staticmethod
-    def _get_num_samples(num_samples, target_point: OVTargetPoint):
-        if target_point.is_weight_target_point():
-            return 1
-        return num_samples
 
     @staticmethod
     def get_statistic_collector(
@@ -172,7 +165,6 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
         reduction_shape, use_abs_max = OVMinMaxAlgoBackend._get_reduction_shape_and_use_abs_max(
             nncf_graph, target_point, quantizer_config
         )
-        _num_samples = OVMinMaxAlgoBackend._get_num_samples(num_samples, target_point)
 
         collector = TensorCollector(OVMinMaxTensorStatistic)
         for params, container_key in zip(
@@ -202,7 +194,7 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
                 statistic_type = StatisticsType.ABS_MAX
             reducer = OV_REDUCERS_MAP[statistic_type](**kwargs)
 
-            kwargs = {"num_samples": _num_samples, "tensor_processor": OVNNCFCollectorTensorProcessor}
+            kwargs = {"num_samples": num_samples, "tensor_processor": OVNNCFCollectorTensorProcessor}
             aggregator = AGGREGATORS_MAP[params.aggregator_type](**kwargs)
 
             collector.register_statistic_branch(container_key, reducer, aggregator)

--- a/tests/post_training/test_templates/test_quantizer_config.py
+++ b/tests/post_training/test_templates/test_quantizer_config.py
@@ -184,11 +184,13 @@ class TemplateTestQuantizerConfig:
     )
     @pytest.mark.parametrize("q_config_mode", [QuantizationMode.SYMMETRIC, QuantizationMode.ASYMMETRIC])
     @pytest.mark.parametrize("q_config_per_channel", [True, False])
+    @pytest.mark.parametrize("num_samples", [5, 12])
     def test_get_stat_collector(
         self,
         range_estimator_params,
         q_config_mode,
         q_config_per_channel,
+        num_samples,
         conv_sum_aggregation_nncf_graph,
         statistic_collector_parameters: TestGetStatisticsCollectorParameters,
     ):
@@ -214,7 +216,7 @@ class TemplateTestQuantizerConfig:
 
         target_point = list(min_max_algo._quantization_target_points_to_qconfig.keys())[0]
         tensor_collector = min_max_algo._get_stat_collector(
-            conv_sum_aggregation_nncf_graph.nncf_graph, target_point, q_config
+            conv_sum_aggregation_nncf_graph.nncf_graph, target_point, q_config, num_samples
         )
 
         is_weight_tp = target_point.is_weight_target_point()
@@ -251,3 +253,5 @@ class TemplateTestQuantizerConfig:
                 assert reducer._reduction_shape == params.ref_per_ch_reduction_shape
             else:
                 assert reducer._reduction_shape == params.ref_per_tensor_reduction_shape
+
+        assert tensor_collector.num_samples == num_samples


### PR DESCRIPTION
### Changes

Make num_samples=1 for weights statistics collection for all backends

### Reason for changes

Speed up statistics collection for ONNX, Torch.
Generalize logic.

### Related tickets

N/A

### Tests

Update `test_get_stat_collector`
