### PR TITLE
Changed NNCFEmbedding target dim for compression.

### DIFF
--- a/nncf/torch/layers.py
+++ b/nncf/torch/layers.py
@@ -349,7 +349,7 @@ class NNCFConvTranspose3d(_NNCFModuleMixin, nn.ConvTranspose3d):
 
 class NNCFEmbedding(_NNCFModuleMixin, nn.Embedding):
     op_func_name = "embedding"
-    target_weight_dim_for_compression = 1
+    target_weight_dim_for_compression = 0
 
     # Note that this does not require activation quantization because it's basically a lookup.
     @staticmethod


### PR DESCRIPTION
### Changes

Changed default NNCFEmbedding target dim for compression.

### Reason for changes

Keep better accuracy for compressed LLMs.

