### PR TITLE
Use new property for telemetry and fix to actually send events

### DIFF
--- a/nncf/telemetry/wrapper.py
+++ b/nncf/telemetry/wrapper.py
@@ -13,7 +13,7 @@ import os
 import sys
 from abc import ABC
 from abc import abstractmethod
-from typing import Callable
+from typing import Callable, Optional
 from unittest.mock import MagicMock
 
 from nncf import __version__
@@ -40,7 +40,13 @@ class ITelemetry(ABC):
 
     @abstractmethod
     def send_event(
-        self, event_category: str, event_action: str, event_label: str, event_value: int = 1, force_send=False, **kwargs
+        self,
+        event_category: str,
+        event_action: str,
+        event_label: str,
+        event_value: Optional[int] = None,
+        force_send=False,
+        **kwargs,
     ):
         """
         Send single event.
@@ -98,8 +104,16 @@ class NNCFTelemetry(ITelemetry):
 
     @skip_if_raised
     def send_event(
-        self, event_category: str, event_action: str, event_label: str, event_value: int = 1, force_send=False, **kwargs
+        self,
+        event_category: str,
+        event_action: str,
+        event_label: str,
+        event_value: Optional[int] = None,
+        force_send=False,
+        **kwargs,
     ):
+        if event_value is None:
+            event_value = 1
         self._impl.send_event(event_category, event_action, event_label, event_value, force_send, **kwargs)
 
     @skip_if_raised

--- a/nncf/telemetry/wrapper.py
+++ b/nncf/telemetry/wrapper.py
@@ -83,11 +83,11 @@ def skip_if_raised(func: Callable[..., None]) -> Callable[..., None]:
 
 
 class NNCFTelemetry(ITelemetry):
-    MEASUREMENT_ID = "UA-17808594-29"
+    MEASUREMENT_ID = "G-W5E9RNLD4H"
 
     def __init__(self):
         try:
-            self._impl = Telemetry(app_name="nncf", app_version=__version__, tid=self.MEASUREMENT_ID)
+            self._impl = Telemetry(app_name="nncf", app_version=__version__, tid=self.MEASUREMENT_ID, backend='ga4')
         # pylint:disable=broad-except
         except Exception as e:
             nncf_logger.debug(f"Failed to instantiate telemetry object: exception {e}")

--- a/nncf/telemetry/wrapper.py
+++ b/nncf/telemetry/wrapper.py
@@ -74,10 +74,10 @@ def skip_if_raised(func: Callable[..., None]) -> Callable[..., None]:
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
         try:
-            func()
+            func(*args, **kwargs)
         # pylint:disable=broad-except
         except Exception as e:
-            nncf_logger.debug(f"Skipped calling {func.__name__} - internally triggered exception {e}")
+            nncf_logger.debug(f"Skipped calling {func} - internally triggered exception {e}")
 
     return wrapped
 
@@ -87,7 +87,7 @@ class NNCFTelemetry(ITelemetry):
 
     def __init__(self):
         try:
-            self._impl = Telemetry(app_name="nncf", app_version=__version__, tid=self.MEASUREMENT_ID, backend='ga4')
+            self._impl = Telemetry(app_name="nncf", app_version=__version__, tid=self.MEASUREMENT_ID, backend="ga4")
         # pylint:disable=broad-except
         except Exception as e:
             nncf_logger.debug(f"Failed to instantiate telemetry object: exception {e}")

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ INSTALL_REQUIRES = [
     "natsort>=7.1.0",
     "pandas>=1.1.5,<2.1",
     "scikit-learn>=0.24.0",
-    "openvino-telemetry",
+    "openvino-telemetry>=2023.1.0",
     "psutil",
 ]
 

--- a/tests/common/test_telemetry.py
+++ b/tests/common/test_telemetry.py
@@ -24,6 +24,7 @@ from nncf.telemetry import TelemetryExtractor
 from nncf.telemetry import tracked_function
 from nncf.telemetry.extractors import CollectedEvent
 from nncf.telemetry.wrapper import NNCFTelemetryStub
+from nncf.telemetry.wrapper import skip_if_raised
 
 
 @pytest.fixture(name="hide_pytest")
@@ -184,3 +185,23 @@ def test_nested_function_different_categories(mocker, spies):
 
     assert start_session_event_spy.call_args_list == expected_session_call_args_list
     assert end_session_event_spy.call_args_list == list(reversed(expected_session_call_args_list))
+
+
+class Raises:
+    def __init__(self):
+        self.call_count = 0
+
+    def __call__(self, arg1, arg2):
+        self.call_count += 1
+        raise Exception()
+
+
+def test_skip_if_raised():
+    raises = Raises()
+    wrapped = skip_if_raised(raises)
+    wrapped(1, 2)
+    assert raises.call_count == 1
+
+    # Incorrect args
+    wrapped(1, 2, 3)
+    assert raises.call_count == 1


### PR DESCRIPTION
### Changes
Use a new measurement ID for `openvino_telemetry` instead of the old one. Fixed the `skip_if_raises` wrapper which silently broke down the telemetry measurements all this time since #1493.

### Reason for changes
The old property has been deprecated by the provider and will no longer work. 

### Related tickets

N/A

### Tests

test_telemetry, test_skip_if_raises
