### PR TITLE
Fix variadic macros for Windows

### DIFF
--- a/nncf/torch/binarization/reference.py
+++ b/nncf/torch/binarization/reference.py
@@ -62,7 +62,9 @@ class ReferenceDOREFABinarize(ReferenceBase):
 
 
 class ReferenceActivationBinarize(ReferenceBase):
-    def forward(self, x: GeneralizedTensor, scale: GeneralizedTensor, threshold: GeneralizedTensor) -> GeneralizedTensor:
+    def forward(
+        self, x: GeneralizedTensor, scale: GeneralizedTensor, threshold: GeneralizedTensor
+    ) -> GeneralizedTensor:
         shape = [1 for s in x.shape]
         shape[1] = x.shape[1]
         t = threshold * scale

--- a/nncf/torch/binarization/reference.py
+++ b/nncf/torch/binarization/reference.py
@@ -32,11 +32,16 @@ class ReferenceBase:
         else:
             raise RuntimeError("Unknown backend for ReferenceQuantize")
 
+    def _astype(self, tensor: GeneralizedTensor, dtype) -> GeneralizedTensor:
+        if self.backend is np:
+            return tensor.astype(dtype)
+        return tensor.type(dtype)
+
 
 class ReferenceXNORBinarize(ReferenceBase):
     def forward(self, x: GeneralizedTensor) -> GeneralizedTensor:
         norm = self.backend.abs(x).mean((1, 2, 3), keepdims=True)
-        sign = (x > 0).astype(x.dtype) * 2 - 1
+        sign = self._astype((x > 0), x.dtype) * 2 - 1
         output = sign * norm
         return output
 
@@ -48,7 +53,7 @@ class ReferenceXNORBinarize(ReferenceBase):
 class ReferenceDOREFABinarize(ReferenceBase):
     def forward(self, x: GeneralizedTensor) -> GeneralizedTensor:
         norm = self.backend.abs(x).mean()
-        sign = (x > 0).astype(x.dtype) * 2 - 1
+        sign = self._astype((x > 0), x.dtype) * 2 - 1
         return sign * norm
 
     @staticmethod
@@ -57,19 +62,17 @@ class ReferenceDOREFABinarize(ReferenceBase):
 
 
 class ReferenceActivationBinarize(ReferenceBase):
-    @staticmethod
-    def forward(x: GeneralizedTensor, scale: GeneralizedTensor, threshold: GeneralizedTensor) -> GeneralizedTensor:
+    def forward(self, x: GeneralizedTensor, scale: GeneralizedTensor, threshold: GeneralizedTensor) -> GeneralizedTensor:
         shape = [1 for s in x.shape]
         shape[1] = x.shape[1]
         t = threshold * scale
-        output = (x > t).astype(x.dtype) * scale
+        output = self._astype((x > t), x.dtype) * scale
         return output
 
-    @staticmethod
-    def backward(grad_output, x, scale, output):
+    def backward(self, grad_output, x: GeneralizedTensor, scale: GeneralizedTensor, output: GeneralizedTensor):
         # calc gradient for input
-        mask_lower = (x <= scale).astype(x.dtype)
-        grad_input = grad_output * (x >= 0).astype(x.dtype) * mask_lower
+        mask_lower = self._astype((x <= scale), x.dtype)
+        grad_input = grad_output * self._astype((x >= 0), x.dtype) * mask_lower
 
         # calc gradient for scale
         err = (output - x) / scale
@@ -77,7 +80,7 @@ class ReferenceActivationBinarize(ReferenceBase):
         grad_scale = grad_scale.sum()
 
         # calc gradient for threshold
-        grad_threshold = -grad_output * (x > 0).astype(x.dtype) * (x < scale).astype(x.dtype)
+        grad_threshold = -grad_output * self._astype((x > 0), x.dtype) * self._astype((x < scale), x.dtype)
 
         for idx, _ in enumerate(x.shape):
             if idx != 1:  # activation channel dimension

--- a/nncf/torch/extensions/include/dispatch.h
+++ b/nncf/torch/extensions/include/dispatch.h
@@ -3,6 +3,10 @@
 
 #include <torch/types.h>
 
-#define DISPATCH_TENSOR_DATA_TYPES(...) AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, __VA_ARGS__)
+// MSVC cannot even pass __VA_ARGS__ to another macro properly, in contrast with GCC.
+// For the DISPATCH_TENSOR_DATA_TYPES macro to work on Windows, had to apply a workaround as described in
+// https://renenyffenegger.ch/notes/development/languages/C-C-plus-plus/preprocessor/macros/__VA_ARGS__/index
+#define PASS_ON(...) __VA_ARGS__
+#define DISPATCH_TENSOR_DATA_TYPES(...) PASS_ON(PASS_ON(AT_DISPATCH_FLOATING_TYPES_AND2)(at::kHalf, at::kBFloat16, __VA_ARGS__))
 
 #endif // _DISPATCH_H_

--- a/nncf/torch/quantization/reference.py
+++ b/nncf/torch/quantization/reference.py
@@ -89,7 +89,7 @@ class ReferenceQuantize:
         input_high[input_high < 0] = 0
         n = levels - 1
         scale = levels / (input_high - input_low)
-        scale = scale.astype(dtype=input_high.dtype)
+        scale = self._astype(scale, input_high.dtype)
         zp = self.backend.round(-input_low * scale)
 
         new_input_low = self.backend.where(zp < n, zp / (zp - n) * input_high, input_low)
@@ -98,7 +98,7 @@ class ReferenceQuantize:
         range_1 = input_high - new_input_low
         range_2 = new_input_high - input_low
 
-        mask = (range_1 > range_2).astype(input_high.dtype)
+        mask = self._astype((range_1 > range_2), input_high.dtype)
         inv_mask = abs(1 - mask)
 
         new_input_low = mask * new_input_low + inv_mask * input_low

--- a/tests/cross_fw/install/install_checks_torch.py
+++ b/tests/cross_fw/install/install_checks_torch.py
@@ -13,15 +13,15 @@ import sys
 
 import torch
 
-# Do not remove - these imports are for testing purposes.
-# pylint:disable=unused-import
-import nncf
-
 if len(sys.argv) != 3:
     raise RuntimeError("Must be run with an execution type as argument (either 'cpu' or 'gpu') and package type")
 execution_type = sys.argv[1]
 package_type = sys.argv[2]
 
+# Do not remove - these imports are for testing purposes.
+# pylint:disable=unused-import
+# pylint:disable=wrong-import-position
+import nncf
 from nncf.torch import create_compressed_model
 
 input_low_tensor = torch.zeros([1])
@@ -34,6 +34,7 @@ levels = 256
 if execution_type == "cpu":
     from nncf.torch.binarization.extensions import BinarizedFunctionsCPU
     from nncf.torch.quantization.extensions import QuantizedFunctionsCPU
+
     output_tensor = QuantizedFunctionsCPU.get("Quantize_forward")(
         input_tensor, input_low_tensor, input_high_tensor, levels
     )
@@ -49,6 +50,7 @@ elif execution_type == "gpu":
     threshold_tensor = threshold_tensor.cuda()
     from nncf.torch.binarization.extensions import BinarizedFunctionsCUDA
     from nncf.torch.quantization.extensions import QuantizedFunctionsCUDA
+
     output_tensor = QuantizedFunctionsCUDA.get("Quantize_forward")(
         input_tensor, input_low_tensor, input_high_tensor, levels
     )

--- a/tests/cross_fw/install/install_checks_torch.py
+++ b/tests/cross_fw/install/install_checks_torch.py
@@ -79,4 +79,4 @@ elif execution_type == "gpu":
     )
     output_tensor = BinarizedFunctionsCUDA.get("WeightBinarize_forward")(output_tensor, True)
 else:
-    raise RuntimeError("Invalid execution type!")
+    raise RuntimeError(f"Invalid execution type {execution_type} (expected 'cpu' or 'gpu')!")

--- a/tests/cross_fw/install/install_checks_torch.py
+++ b/tests/cross_fw/install/install_checks_torch.py
@@ -22,13 +22,7 @@ if len(sys.argv) != 3:
 execution_type = sys.argv[1]
 package_type = sys.argv[2]
 
-if package_type == "pip_pypi":
-    try:
-        from nncf.torch import create_compressed_model
-    except ImportError:
-        from nncf import create_compressed_model
-else:
-    from nncf.torch import create_compressed_model
+from nncf.torch import create_compressed_model
 
 input_low_tensor = torch.zeros([1])
 input_tensor = torch.ones([1, 1, 1, 1])
@@ -38,16 +32,8 @@ threshold_tensor = torch.zeros([1, 1, 1, 1])
 levels = 256
 
 if execution_type == "cpu":
-    if package_type == "pip_pypi":
-        try:
-            from nncf.torch.binarization.extensions import BinarizedFunctionsCPU
-            from nncf.torch.quantization.extensions import QuantizedFunctionsCPU
-        except ImportError:
-            from nncf.binarization.extensions import BinarizedFunctionsCPU
-            from nncf.quantization.extensions import QuantizedFunctionsCPU
-    else:
-        from nncf.torch.binarization.extensions import BinarizedFunctionsCPU
-        from nncf.torch.quantization.extensions import QuantizedFunctionsCPU
+    from nncf.torch.binarization.extensions import BinarizedFunctionsCPU
+    from nncf.torch.quantization.extensions import QuantizedFunctionsCPU
     output_tensor = QuantizedFunctionsCPU.get("Quantize_forward")(
         input_tensor, input_low_tensor, input_high_tensor, levels
     )
@@ -61,16 +47,8 @@ elif execution_type == "gpu":
     input_high_tensor = input_high_tensor.cuda()
     scale_tensor = scale_tensor.cuda()
     threshold_tensor = threshold_tensor.cuda()
-    if package_type == "pip_pypi":
-        try:
-            from nncf.torch.binarization.extensions import BinarizedFunctionsCUDA
-            from nncf.torch.quantization.extensions import QuantizedFunctionsCUDA
-        except ImportError:
-            from nncf.binarization.extensions import BinarizedFunctionsCUDA
-            from nncf.quantization.extensions import QuantizedFunctionsCUDA
-    else:
-        from nncf.torch.binarization.extensions import BinarizedFunctionsCUDA
-        from nncf.torch.quantization.extensions import QuantizedFunctionsCUDA
+    from nncf.torch.binarization.extensions import BinarizedFunctionsCUDA
+    from nncf.torch.quantization.extensions import QuantizedFunctionsCUDA
     output_tensor = QuantizedFunctionsCUDA.get("Quantize_forward")(
         input_tensor, input_low_tensor, input_high_tensor, levels
     )


### PR DESCRIPTION
### Changes
Apply a workaround for __VA_ARGS__ expansion on Windows for the DISPATCH_TENSOR_DATA_TYPES macro and apply some minor fixes to the reference quantization functions.

### Reason for changes
MSVC expands variadic args in macros incorrectly. This may have been fixed in the MSVC, but only very recently.

### Related tickets
N/A

### Tests
windows/install_torch_cpu, windows/precommit_torch_cpu