### PR TITLE
Optimize NNCFGraph

### DIFF
--- a/nncf/common/graph/graph.py
+++ b/nncf/common/graph/graph.py
@@ -187,7 +187,7 @@ class NNCFGraph:
     def __init__(self):
         self._nx_graph = nx.DiGraph()
         self._node_id_to_key_dict = {}
-        self._nodes = {}  # type: Dict[str, NNCFNode]
+        self._nodes: Dict[str, NNCFNode] = {} 
         self._input_nncf_nodes = {}  # type: Dict[int, NNCFNode]
         self._output_nncf_nodes = {}  # type: Dict[int, NNCFNode]
 

--- a/nncf/common/graph/graph.py
+++ b/nncf/common/graph/graph.py
@@ -33,51 +33,73 @@ class NNCFNode:
     Class describing nodes used in NNCFGraph.
     """
 
-    def __init__(self, node_id: int, node_name: NNCFNodeName, data: dict = None):
-        self.node_id = node_id
-        self.data = data if data else {}
-        self.data[NNCFGraph.NODE_NAME_ATTR] = node_name
+    ID_NODE_ATTR = "id"
+    NODE_NAME_ATTR = "node_name"
+    KEY_NODE_ATTR = "key"
+    NODE_TYPE_ATTR = "type"
+    METATYPE_ATTR = "metatype"
+    LAYER_NAME_ATTR = "layer_name"
+    LAYER_ATTRIBUTES = "layer_attributes"
+    IGNORED_ALGOS_ATTR = "ignored_algos"
+    IS_IN_ITERATION_SCOPE_NODE_ATTR = "is_in_iteration_scope"
+    IS_INTEGER_INPUT_NODE_ATTR = "is_integer_input"
+    IS_SHARED_ATTR = "is_shared"
+
+    def __init__(self, attributes: Dict[str, Any]):
+        self._attributes = attributes
+
+    @property
+    def attributes(self) -> Dict[str, Any]:
+        return self._attributes
+
+    @property
+    def node_id(self) -> int:
+        return self._attributes[NNCFNode.ID_NODE_ATTR]
+
+    @property
+    def node_key(self) -> str:
+        return self._attributes[NNCFNode.KEY_NODE_ATTR]
 
     @property
     def node_name(self) -> NNCFNodeName:
-        return self.data.get(NNCFGraph.NODE_NAME_ATTR)
+        return self._attributes[NNCFNode.NODE_NAME_ATTR]
 
     @property
     def metatype(self) -> Type[OperatorMetatype]:
-        return self.data.get(NNCFGraph.METATYPE_ATTR)
+        return self._attributes[NNCFNode.METATYPE_ATTR]
 
     @property
     def node_type(self) -> str:
-        return self.data.get(NNCFGraph.NODE_TYPE_ATTR)
+        return self._attributes[NNCFNode.NODE_TYPE_ATTR]
 
     @property
-    def layer_name(self) -> LayerName:
-        return self.data.get(NNCFGraph.LAYER_NAME_ATTR)
+    def layer_name(self) -> Optional[LayerName]:
+        return self._attributes.get(NNCFNode.LAYER_NAME_ATTR)
 
     @layer_name.setter
-    def layer_name(self, data: Any) -> None:
-        self.data[NNCFGraph.LAYER_NAME_ATTR] = data
+    def layer_name(self, value: str) -> None:
+        self._attributes[NNCFNode.LAYER_NAME_ATTR] = value
 
     @property
-    def layer_attributes(self) -> BaseLayerAttributes:
-        return self.data.get(NNCFGraph.LAYER_ATTRIBUTES)
+    def layer_attributes(self) -> Optional[BaseLayerAttributes]:
+        return self._attributes.get(NNCFNode.LAYER_ATTRIBUTES)
 
     @layer_attributes.setter
-    def layer_attributes(self, data: Any) -> None:
-        self.data[NNCFGraph.LAYER_ATTRIBUTES] = data
+    def layer_attributes(self, value: BaseLayerAttributes) -> None:
+        self._attributes[NNCFNode.LAYER_ATTRIBUTES] = value
 
     @property
     def ignored_algorithms(self) -> List[str]:
-        return self.data.get(NNCFGraph.IGNORED_ALGOS_ATTR, [])
+        return self._attributes[NNCFNode.IGNORED_ALGOS_ATTR]
 
     def is_in_iteration_scope(self) -> bool:
-        return self.data.get(NNCFGraph.IS_IN_ITERATION_SCOPE_NODE_ATTR, False)
+        return self._attributes[NNCFNode.IS_IN_ITERATION_SCOPE_NODE_ATTR]
 
     def is_integer_input(self) -> bool:
-        return self.data.get(NNCFGraph.IS_INTEGER_INPUT_NODE_ATTR, False)
+        return self._attributes[NNCFNode.IS_INTEGER_INPUT_NODE_ATTR]
 
     def is_shared(self) -> bool:
-        return self.data.get(NNCFGraph.IS_SHARED_ATTR, False)
+        return self._attributes[NNCFNode.IS_SHARED_ATTR]
 
     def __repr__(self):
         return str(self)
@@ -89,13 +111,7 @@ class NNCFNode:
         return hash(str(self))
 
     def __eq__(self, other):
-        return (
-            isinstance(other, NNCFNode)
-            and self.node_id == other.node_id
-            and self.data == other.data
-            and self.node_type == other.node_type
-            and self.layer_attributes == other.layer_attributes
-        )
+        return isinstance(other, NNCFNode) and self.attributes == other.attributes
 
 
 class NNCFGraphEdge:
@@ -162,31 +178,25 @@ class NNCFGraph:
     providing some useful methods for graph traversal.
     """
 
-    ID_NODE_ATTR = "id"
-    KEY_NODE_ATTR = "key"
-    NODE_NAME_ATTR = "node_name"
-    NODE_TYPE_ATTR = "type"
-    METATYPE_ATTR = "metatype"
-    LAYER_NAME_ATTR = "layer_name"
-    LAYER_ATTRIBUTES = "layer_attributes"
     ACTIVATION_SHAPE_EDGE_ATTR = "activation_shape"
     INPUT_PORT_ID_EDGE_ATTR = "input_port_id"
     OUTPUT_PORT_ID_EDGE_ATTR = "output_port_id"
-    IGNORED_ALGOS_ATTR = "ignored_algos"
-    IS_IN_ITERATION_SCOPE_NODE_ATTR = "is_in_iteration_scope"
-    IS_INTEGER_INPUT_NODE_ATTR = "is_integer_input"
     DTYPE_EDGE_ATTR = "dtype"
-    IS_SHARED_ATTR = "is_shared"
     PARALLEL_INPUT_PORT_IDS_ATTR = "parallel_input_ports"
 
     def __init__(self):
         self._nx_graph = nx.DiGraph()
         self._node_id_to_key_dict = {}
+        self._nodes = {}  # type: Dict[str, NNCFNode]
         self._input_nncf_nodes = {}  # type: Dict[int, NNCFNode]
         self._output_nncf_nodes = {}  # type: Dict[int, NNCFNode]
 
         self._node_ids_vs_layer_names = {}  # type: Dict[int, LayerName]
         self._layer_name_vs_shared_nodes = defaultdict(list)  # type: Dict[LayerName, List[NNCFNode]]
+
+    @property
+    def nodes(self) -> Dict[str, NNCFNode]:
+        return self._nodes
 
     def get_node_by_id(self, node_id: int) -> NNCFNode:
         """
@@ -200,7 +210,7 @@ class NNCFGraph:
         :param key: key (node_name) of the node.
         :return: NNCFNode in a graph with such key.
         """
-        return self._nx_node_to_nncf_node(self._nx_graph.nodes[key])
+        return self._nodes[key]
 
     def get_input_nodes(self) -> List[NNCFNode]:
         """
@@ -254,12 +264,7 @@ class NNCFGraph:
         """
         Returns list of all graph nodes.
         """
-        all_nodes = []
-        for node_key in self.get_all_node_keys():
-            nx_node = self._nx_graph.nodes[node_key]
-            nncf_node = self._nx_node_to_nncf_node(nx_node)
-            all_nodes.append(nncf_node)
-        return all_nodes
+        return list(self._nodes.values())
 
     def get_all_simple_paths(
         self, start_node_name: NNCFNodeName, end_node_name: NNCFNodeName
@@ -278,12 +283,6 @@ class NNCFGraph:
         start_node_key = self.get_node_key_by_id(start_node.node_id)
         end_node_key = self.get_node_key_by_id(end_node.node_id)
         return nx.all_simple_paths(self._nx_graph, start_node_key, end_node_key)
-
-    @staticmethod
-    def _nx_node_to_nncf_node(nx_node: dict) -> NNCFNode:
-        return NNCFNode(
-            node_id=nx_node[NNCFGraph.ID_NODE_ATTR], node_name=nx_node[NNCFGraph.NODE_NAME_ATTR], data=nx_node
-        )
 
     @staticmethod
     def _get_edge_boundaries(
@@ -311,7 +310,7 @@ class NNCFGraph:
         :return: List of consumer nodes of provided node.
         """
         nx_node_keys = self._nx_graph.succ[self._node_id_to_key_dict[node.node_id]]
-        return [self._nx_node_to_nncf_node(self._nx_graph.nodes[key]) for key in nx_node_keys]
+        return [self._nodes[key] for key in nx_node_keys]
 
     def get_previous_nodes(self, node: NNCFNode) -> List[NNCFNode]:
         """
@@ -322,7 +321,7 @@ class NNCFGraph:
         """
 
         nx_node_keys = self._nx_graph.pred[self._node_id_to_key_dict[node.node_id]]
-        return [self._nx_node_to_nncf_node(self._nx_graph.nodes[key]) for key in nx_node_keys]
+        return [self._nodes[key] for key in nx_node_keys]
 
     def get_input_edges(self, node: NNCFNode) -> List[NNCFGraphEdge]:
         """
@@ -383,10 +382,10 @@ class NNCFGraph:
         node_name: str,
         node_type: str,
         node_metatype: Type[OperatorMetatype],
-        layer_attributes: BaseLayerAttributes = None,
-        node_id_override: int = None,
-        layer_name: LayerName = None,
-        ignored_algorithms: List[str] = None,
+        layer_attributes: Optional[BaseLayerAttributes] = None,
+        node_id_override: Optional[int] = None,
+        layer_name: Optional[LayerName] = None,
+        ignored_algorithms: Optional[List[str]] = None,
         is_in_iteration_scope: bool = False,
         is_integer_input: bool = False,
         is_shared: bool = False,
@@ -433,25 +432,26 @@ class NNCFGraph:
 
         self._node_id_to_key_dict[node_id] = node_key
         attrs = {
-            NNCFGraph.ID_NODE_ATTR: node_id,
-            NNCFGraph.NODE_NAME_ATTR: node_name,
-            NNCFGraph.KEY_NODE_ATTR: node_key,
-            NNCFGraph.NODE_TYPE_ATTR: node_type,
-            NNCFGraph.LAYER_NAME_ATTR: layer_name,
-            NNCFGraph.METATYPE_ATTR: node_metatype,
-            NNCFGraph.IS_SHARED_ATTR: is_shared,
-            NNCFGraph.IS_IN_ITERATION_SCOPE_NODE_ATTR: is_in_iteration_scope,
-            NNCFGraph.IS_INTEGER_INPUT_NODE_ATTR: is_integer_input,
+            NNCFNode.ID_NODE_ATTR: node_id,
+            NNCFNode.NODE_NAME_ATTR: node_name,
+            NNCFNode.KEY_NODE_ATTR: node_key,
+            NNCFNode.NODE_TYPE_ATTR: node_type,
+            NNCFNode.LAYER_NAME_ATTR: layer_name,
+            NNCFNode.METATYPE_ATTR: node_metatype,
+            NNCFNode.IS_SHARED_ATTR: is_shared,
+            NNCFNode.IS_IN_ITERATION_SCOPE_NODE_ATTR: is_in_iteration_scope,
+            NNCFNode.IS_INTEGER_INPUT_NODE_ATTR: is_integer_input,
         }
         if layer_attributes is not None:
-            attrs[NNCFGraph.LAYER_ATTRIBUTES] = layer_attributes
+            attrs[NNCFNode.LAYER_ATTRIBUTES] = layer_attributes
 
         if ignored_algorithms is None:
             ignored_algorithms = []
-        attrs[NNCFGraph.IGNORED_ALGOS_ATTR] = ignored_algorithms
+        attrs[NNCFNode.IGNORED_ALGOS_ATTR] = ignored_algorithms
         self._nx_graph.add_node(node_key, **attrs)
 
-        node = NNCFNode(node_id, node_name, data=self._nx_graph.nodes[node_key])
+        node = NNCFNode(self._nx_graph.nodes[node_key])
+        self._nodes[node_key] = node
 
         if node.metatype in INPUT_NOOP_METATYPES:
             self._input_nncf_nodes[node_id] = node
@@ -519,9 +519,9 @@ class NNCFGraph:
         Returns nodes in topologically sorted order, additionally sorted in ascending node ID order.
         """
         return [
-            self._nx_node_to_nncf_node(self._nx_graph.nodes[node_name])
+            self._nodes[node_name]
             for node_name in nx.lexicographical_topological_sort(
-                self._nx_graph, key=lambda x: self._nx_graph.nodes[x][NNCFGraph.ID_NODE_ATTR]
+                self._nx_graph, key=lambda x: self._nx_graph.nodes[x][NNCFNode.ID_NODE_ATTR]
             )
         ]
 
@@ -548,7 +548,7 @@ class NNCFGraph:
         out_graph = nx.DiGraph()
         for node_name, node in self._nx_graph.nodes.items():
             visualization_node_name = node_name.replace(__RESERVED_DOT_CHARACTER, __CHARACTER_REPLACE_TO)
-            attrs_node = {"id": node[NNCFGraph.ID_NODE_ATTR], "type": node[NNCFGraph.NODE_TYPE_ATTR]}
+            attrs_node = {"id": node[NNCFNode.ID_NODE_ATTR], "type": node[NNCFNode.NODE_TYPE_ATTR]}
             for attr in ["color", "label", "style"]:
                 if attr in node:
                     attrs_node[attr] = node[attr]
@@ -618,7 +618,7 @@ class NNCFGraph:
 
     def __eq__(self, other: "NNCFGraph"):
         nm = iso.categorical_node_match(
-            [NNCFGraph.ID_NODE_ATTR, NNCFGraph.KEY_NODE_ATTR, NNCFGraph.LAYER_ATTRIBUTES], [None, None, None]
+            [NNCFNode.ID_NODE_ATTR, NNCFNode.KEY_NODE_ATTR, NNCFNode.LAYER_ATTRIBUTES], [None, None, None]
         )
         em = iso.categorical_edge_match(
             [NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR, NNCFGraph.INPUT_PORT_ID_EDGE_ATTR], [None, None]
@@ -649,8 +649,8 @@ class NNCFGraph:
             to_node_key = nx_edge[1]
             data = nx_edge[2]
             nncf_edge = NNCFGraphEdge(
-                self._nx_node_to_nncf_node(self._nx_graph.nodes[from_node_key]),
-                self._nx_node_to_nncf_node(self._nx_graph.nodes[to_node_key]),
+                self._nodes[from_node_key],
+                self._nodes[to_node_key],
                 input_port_id=data[NNCFGraph.INPUT_PORT_ID_EDGE_ATTR],
                 output_port_id=data[NNCFGraph.OUTPUT_PORT_ID_EDGE_ATTR],
                 tensor_shape=data[NNCFGraph.ACTIVATION_SHAPE_EDGE_ATTR],
@@ -705,7 +705,8 @@ class NNCFGraph:
         :param nodes: List of NNCFNodes to remove.
         """
         for node in nodes:
-            self._nx_graph.remove_node(node.data["key"])
+            self._nx_graph.remove_node(node.node_key)
+            del self._nodes[node.node_key]
 
         self._node_id_to_key_dict = {}
         for node_key, node in self._nx_graph.nodes.items():

--- a/nncf/common/graph/graph.py
+++ b/nncf/common/graph/graph.py
@@ -187,7 +187,7 @@ class NNCFGraph:
     def __init__(self):
         self._nx_graph = nx.DiGraph()
         self._node_id_to_key_dict = {}
-        self._nodes: Dict[str, NNCFNode] = {} 
+        self._nodes: Dict[str, NNCFNode] = {}
         self._input_nncf_nodes = {}  # type: Dict[int, NNCFNode]
         self._output_nncf_nodes = {}  # type: Dict[int, NNCFNode]
 

--- a/nncf/common/insertion_point_graph.py
+++ b/nncf/common/insertion_point_graph.py
@@ -19,6 +19,7 @@ import networkx as nx
 from nncf.common.graph import Dtype
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNodeName
+from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.graph_matching import find_subgraphs_matching_pattern
 from nncf.common.graph.operator_metatypes import INPUT_NOOP_METATYPES
 from nncf.common.graph.patterns import GraphPattern
@@ -294,8 +295,7 @@ class InsertionPointGraph(nx.DiGraph):
                 continue
             if data[InsertionPointGraph.IS_MERGED_NODE_ATTR]:
                 for nncf_node in data[InsertionPointGraph.MERGED_NNCF_NODE_LIST_NODE_ATTR]:
-                    node_k = nncf_node.data[NNCFGraph.KEY_NODE_ATTR]
-                    if self._base_nx_graph.nodes[node_k][NNCFGraph.METATYPE_ATTR] in INPUT_NOOP_METATYPES:
+                    if self._base_nx_graph.nodes[nncf_node.node_key][NNCFNode.METATYPE_ATTR] in INPUT_NOOP_METATYPES:
                         output.append(node)
                         break
             elif data[InsertionPointGraph.REGULAR_NODE_REF_NODE_ATTR].metatype in INPUT_NOOP_METATYPES:
@@ -316,8 +316,7 @@ class InsertionPointGraph(nx.DiGraph):
                 continue
             if data[InsertionPointGraph.IS_MERGED_NODE_ATTR]:
                 for nncf_node in data[InsertionPointGraph.MERGED_NNCF_NODE_LIST_NODE_ATTR]:
-                    node_k = nncf_node.data[NNCFGraph.KEY_NODE_ATTR]
-                    if node_key == node_k:
+                    if node_key == nncf_node.node_key:
                         return node
         return node_key
 

--- a/nncf/common/pruning/mask_propagation.py
+++ b/nncf/common/pruning/mask_propagation.py
@@ -29,7 +29,7 @@ from nncf.common.pruning.utils import is_grouped_conv
 class MaskPropagationAlgorithm:
     """
     Algorithm responsible for propagation masks across all nodes in the graph.
-    Before call mask_propagation() you need set node.data['output_masks']
+    Before call mask_propagation() you need set node.attributes['output_masks']
     for nodes that have masks already defined.
     """
 
@@ -100,7 +100,7 @@ class MaskPropagationAlgorithm:
         for node in self._graph.topological_sort():
             if node.node_id in can_be_closing_convs and can_prune_after_analysis[node.node_id]:
                 # Set output mask
-                node.data["output_mask"] = SymbolicMask(get_output_channels(node), node.node_id)
+                node.attributes["output_mask"] = SymbolicMask(get_output_channels(node), node.node_id)
             # Propagate masks
             cls = self.get_meta_operation_by_type_name(node.node_type)
             cls.mask_propagation(node, self._graph, SymbolicMaskProcessor)
@@ -140,7 +140,7 @@ class MaskPropagationAlgorithm:
 
         # Clean nodes masks
         for node in self._graph.get_all_nodes():
-            node.data["output_mask"] = None
+            node.attributes["output_mask"] = None
 
         return can_prune_by_dim
 

--- a/nncf/common/pruning/operations.py
+++ b/nncf/common/pruning/operations.py
@@ -74,7 +74,7 @@ class InputPruningOp(BasePruningOp):
     def mask_propagation(
         cls, node: NNCFNode, graph: NNCFGraph, tensor_processor: Type[NNCFPruningBaseTensorProcessor]
     ) -> None:
-        node.data["output_mask"] = None
+        node.attributes["output_mask"] = None
 
 
 class OutputPruningOp(BasePruningOp):
@@ -86,7 +86,7 @@ class OutputPruningOp(BasePruningOp):
     def mask_propagation(
         cls, node: NNCFNode, graph: NNCFGraph, tensor_processor: Type[NNCFPruningBaseTensorProcessor]
     ) -> None:
-        node.data["output_mask"] = None
+        node.attributes["output_mask"] = None
 
 
 class IdentityMaskForwardPruningOp(BasePruningOp):
@@ -113,14 +113,14 @@ class ConvolutionPruningOp(BasePruningOp):
         cls, node: NNCFNode, graph: NNCFGraph, tensor_processor: Type[NNCFPruningBaseTensorProcessor]
     ) -> None:
         input_masks = get_input_masks(node, graph)
-        output_mask = node.data.get("output_mask", None)
+        output_mask = node.attributes.get("output_mask", None)
 
         if is_grouped_conv(node):
             output_mask = None
             if is_prunable_depthwise_conv(node):
                 output_mask = input_masks[0]
 
-        node.data["output_mask"] = output_mask
+        node.attributes["output_mask"] = output_mask
 
 
 class TransposeConvolutionPruningOp(BasePruningOp):
@@ -135,7 +135,7 @@ class TransposeConvolutionPruningOp(BasePruningOp):
         cls, node: NNCFNode, graph: NNCFGraph, tensor_processor: Type[NNCFPruningBaseTensorProcessor]
     ) -> None:
         input_masks = get_input_masks(node, graph)
-        output_mask = node.data.get("output_mask", None)
+        output_mask = node.attributes.get("output_mask", None)
 
         # In case of group convs we can't prune by output filters
         if is_grouped_conv(node):
@@ -143,7 +143,7 @@ class TransposeConvolutionPruningOp(BasePruningOp):
             if is_prunable_depthwise_conv(node):
                 output_mask = input_masks[0]
 
-        node.data["output_mask"] = output_mask
+        node.attributes["output_mask"] = output_mask
 
 
 class LinearPruningOp(BasePruningOp):
@@ -155,8 +155,8 @@ class LinearPruningOp(BasePruningOp):
     def mask_propagation(
         cls, node: NNCFNode, graph: NNCFGraph, tensor_processor: Type[NNCFPruningBaseTensorProcessor]
     ) -> None:
-        output_mask = node.data.get("output_mask", None)
-        node.data["output_mask"] = output_mask
+        output_mask = node.attributes.get("output_mask", None)
+        node.attributes["output_mask"] = output_mask
 
 
 class BatchNormPruningOp(BasePruningOp):
@@ -187,7 +187,7 @@ class GroupNormPruningOp(BasePruningOp):
         if cls.accept_pruned_input(node):
             identity_mask_propagation(node, graph)
         else:
-            node.data["output_mask"] = None
+            node.attributes["output_mask"] = None
 
 
 class LayerNormPruningOp(BasePruningOp):
@@ -222,7 +222,7 @@ class ConcatPruningOp(BasePruningOp):
         """
         input_edges = graph.get_input_edges(node)
         previous_nodes = [edge.from_node for edge in input_edges]
-        input_masks = [input_node.data["output_mask"] for input_node in previous_nodes]
+        input_masks = [input_node.attributes["output_mask"] for input_node in previous_nodes]
         input_masks = [
             input_mask[node.node_name] if isinstance(input_mask, dict) else input_mask for input_mask in input_masks
         ]
@@ -249,7 +249,7 @@ class ConcatPruningOp(BasePruningOp):
         cls, node: NNCFNode, graph: NNCFGraph, tensor_processor: Type[NNCFPruningBaseTensorProcessor]
     ) -> None:
         result_mask = cls.generate_output_mask(node, graph, tensor_processor)
-        node.data["output_mask"] = result_mask
+        node.attributes["output_mask"] = result_mask
 
 
 class SplitPruningOp(BasePruningOp):
@@ -328,7 +328,7 @@ class SplitPruningOp(BasePruningOp):
         cls, node: NNCFNode, graph: NNCFGraph, tensor_processor: Type[NNCFPruningBaseTensorProcessor]
     ) -> None:
         result_masks = cls.generate_output_masks(node, graph, tensor_processor)
-        node.data["output_mask"] = result_masks
+        node.attributes["output_mask"] = result_masks
 
 
 class PadPruningOp(IdentityMaskForwardPruningOp):
@@ -354,7 +354,7 @@ class ElementwisePruningOp(BasePruningOp):
         if output_mask is not None:
             output_mask = tensor_processor.elementwise_mask_propagation(input_masks)
 
-        node.data["output_mask"] = output_mask
+        node.attributes["output_mask"] = output_mask
 
 
 class ReshapePruningOp(BasePruningOp):
@@ -386,9 +386,9 @@ class ReshapePruningOp(BasePruningOp):
             elif cls._is_not_mixing_dim(node):
                 identity_mask_propagation(node, graph)
             else:
-                node.data["output_mask"] = None
+                node.attributes["output_mask"] = None
         else:
-            node.data["output_mask"] = None
+            node.attributes["output_mask"] = None
 
 
 class FlattenPruningOp(BasePruningOp):
@@ -415,7 +415,7 @@ class FlattenPruningOp(BasePruningOp):
             assert flatten_channels % mask_len == 0
             output_mask = tensor_processor.repeat(input_mask, repeats=flatten_channels // mask_len)
 
-        node.data["output_mask"] = output_mask
+        node.attributes["output_mask"] = output_mask
 
 
 class StopMaskForwardPruningOp(BasePruningOp):
@@ -427,4 +427,4 @@ class StopMaskForwardPruningOp(BasePruningOp):
     def mask_propagation(
         cls, node: NNCFNode, graph: NNCFGraph, tensor_processor: Type[NNCFPruningBaseTensorProcessor]
     ) -> None:
-        node.data["output_mask"] = None
+        node.attributes["output_mask"] = None

--- a/nncf/common/pruning/shape_pruning_processor.py
+++ b/nncf/common/pruning/shape_pruning_processor.py
@@ -184,7 +184,7 @@ class ShapePruningProcessor:
         # 1. Propagate symbolic masks throught the net
         for pruned_layer_info in pruning_groups.get_all_nodes():
             node = graph.get_node_by_id(pruned_layer_info.nncf_node_id)
-            node.data["output_mask"] = SymbolicMask(get_output_channels(node), node.node_id)
+            node.attributes["output_mask"] = SymbolicMask(get_output_channels(node), node.node_id)
 
         MaskPropagationAlgorithm(graph, self._pruning_operations_metatype, SymbolicMaskProcessor).mask_propagation()
 
@@ -209,6 +209,6 @@ class ShapePruningProcessor:
 
         # 3. Clean graph output shapes
         for node in graph.get_all_nodes():
-            node.data["output_shape"] = None
+            node.attributes["output_shape"] = None
 
         return next_nodes

--- a/nncf/common/pruning/utils.py
+++ b/nncf/common/pruning/utils.py
@@ -367,7 +367,7 @@ def get_input_masks(node: NNCFNode, graph: NNCFGraph) -> List[Optional[NNCFTenso
     :return: Input masks.
     """
     retval = []
-    input_masks = [input_edge.from_node.data["output_mask"] for input_edge in graph.get_input_edges(node)]
+    input_masks = [input_edge.from_node.attributes["output_mask"] for input_edge in graph.get_input_edges(node)]
     for input_mask in input_masks:
         retval.append(input_mask[node.node_name] if isinstance(input_mask, dict) else input_mask)
     return retval
@@ -416,4 +416,4 @@ def identity_mask_propagation(node: NNCFNode, graph: NNCFGraph) -> None:
         input_masks = [None]
     assert len(input_masks) == 1
 
-    node.data["output_mask"] = input_masks[0]
+    node.attributes["output_mask"] = input_masks[0]

--- a/nncf/common/quantization/quantizer_propagation/solver.py
+++ b/nncf/common/quantization/quantizer_propagation/solver.py
@@ -23,7 +23,7 @@ from nncf.common.graph import INPUT_NOOP_METATYPES
 from nncf.common.graph import OUTPUT_NOOP_METATYPES
 from nncf.common.graph import NNCFNodeName
 from nncf.common.graph import OperatorMetatype
-from nncf.common.graph.graph import NNCFGraph
+from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.transformations.commands import TargetPoint
 from nncf.common.hardware.config import HWConfig
 from nncf.common.insertion_point_graph import InsertionPointGraph
@@ -218,9 +218,7 @@ class PostprocessingNodeLocator:
     ):
         self._quant_prop_graph = quant_prop_graph
         self._post_processing_marker_metatypes = post_processing_marker_metatypes
-        self._quantizable_layer_node_keys = [
-            q_nodes.node.data[NNCFGraph.KEY_NODE_ATTR] for q_nodes in quantizable_layer_nodes
-        ]
+        self._quantizable_layer_node_keys = [q_nodes.node.node_key for q_nodes in quantizable_layer_nodes]
         self._post_processing_marker_encountered = False
 
     def _is_node_has_underlying_weights(self, node_key: str) -> bool:
@@ -228,7 +226,7 @@ class PostprocessingNodeLocator:
             return False
         underlying_nncf_nodes = self._quant_prop_graph.op_node_keys_to_underlying_nodes_mapping[node_key]
         for node in underlying_nncf_nodes:
-            if node.data[NNCFGraph.KEY_NODE_ATTR] in self._quantizable_layer_node_keys:
+            if node.node_key in self._quantizable_layer_node_keys:
                 return True
         return False
 

--- a/nncf/common/quantization/quantizer_removal.py
+++ b/nncf/common/quantization/quantizer_removal.py
@@ -110,7 +110,7 @@ def revert_operations_to_floating_point_precision(
         transformation_layout.register(command_creator.create_command_to_remove_quantizer(node))
 
     for node in operations:
-        original_bias = node.data.get("original_bias", None)
+        original_bias = node.attributes.get("original_bias", None)
         if original_bias is not None:
             transformation_layout.register(
                 command_creator.create_command_to_update_bias(node, original_bias, quantized_model_graph)
@@ -119,7 +119,7 @@ def revert_operations_to_floating_point_precision(
         if node.layer_attributes and node.layer_attributes.constant_attributes is not None:
             weight_port_ids = node.layer_attributes.get_const_port_ids()
             for port_id in weight_port_ids:
-                original_weight = node.data.get(f"original_weight.{port_id}", None)
+                original_weight = node.attributes.get(f"original_weight.{port_id}", None)
                 if original_weight is not None:
                     transformation_layout.register(
                         command_creator.create_command_to_update_weight(node, original_weight, port_id)

--- a/nncf/experimental/common/pruning/nodes_grouping.py
+++ b/nncf/experimental/common/pruning/nodes_grouping.py
@@ -85,14 +85,14 @@ def get_pruning_groups(
         root_group = PropagationGroup(block=PruningBlock(), producers={ProducerInfo(node.node_id, pruning_dim)})
         mask = PropagationMask(dim_groups_map={target_output_dim_for_compression: [root_group]})
         roots[node.node_id] = root_group
-        node.data["output_mask"] = mask
+        node.attributes["output_mask"] = mask
 
     def get_attributes_fn(node: NNCFNode) -> Dict[str, Any]:
         result = {"metatype": str(node.metatype.name), "node_id": str(node.node_id)}
         if node.layer_attributes:
             result.update(map(lambda pair: (pair[0], str(pair[1])), node.layer_attributes.__dict__.items()))
-        if "output_mask" in node.data:
-            output_mask = node.data["output_mask"]
+        if "output_mask" in node.attributes:
+            output_mask = node.attributes["output_mask"]
             if output_mask:
                 result["output_mask"] = str(output_mask)
         return result

--- a/nncf/experimental/common/pruning/operations.py
+++ b/nncf/experimental/common/pruning/operations.py
@@ -86,7 +86,7 @@ class InputPruningOp(BasePruningOp):
     def mask_propagation(
         cls, node: NNCFNode, graph: NNCFGraph, tensor_processor: Type[NNCFPruningBaseTensorProcessor]
     ) -> None:
-        node.data["output_mask"] = None
+        node.attributes["output_mask"] = None
 
 
 class OutputPruningOp(BasePruningOp):
@@ -94,7 +94,7 @@ class OutputPruningOp(BasePruningOp):
     def mask_propagation(
         cls, node: NNCFNode, graph: NNCFGraph, tensor_processor: Type[NNCFPruningBaseTensorProcessor]
     ) -> None:
-        node.data["output_mask"] = None
+        node.attributes["output_mask"] = None
         input_masks = get_input_masks(node, graph)
         cls.invalidate_masks(input_masks)
 
@@ -115,7 +115,7 @@ class LinearPruningOp(BasePruningOp):
         input_masks = get_input_masks(node, graph)
         assert len(input_masks) in [1, 2]
         is_input_mask_empty_map = map(not_, input_masks)
-        output_mask = node.data.get("output_mask", None)
+        output_mask = node.attributes.get("output_mask", None)
         input_tensors_shapes = [x.tensor_shape for x in graph.get_input_edges(node)]
         node_id = node.node_id
         if all(is_input_mask_empty_map):
@@ -133,7 +133,7 @@ class LinearPruningOp(BasePruningOp):
         elif len(input_masks) == 2:
             output_mask = cls._handle_two_inputs(input_masks, input_tensors_shapes, node_id)
 
-        node.data["output_mask"] = output_mask
+        node.attributes["output_mask"] = output_mask
 
     @staticmethod
     def _handle_single_input(
@@ -221,7 +221,7 @@ class GroupNormPruningOp(BasePruningOp):
         if cls.accept_pruned_input(node):
             identity_mask_propagation(node, graph)
         else:
-            node.data["output_mask"] = None
+            node.attributes["output_mask"] = None
 
 
 class ElementwisePruningOp(BasePruningOp):
@@ -230,7 +230,7 @@ class ElementwisePruningOp(BasePruningOp):
         cls, node: NNCFNode, graph: NNCFGraph, tensor_processor: Type[NNCFPruningBaseTensorProcessor]
     ) -> None:
         input_masks = get_input_masks(node, graph)
-        node.data["output_mask"] = cls._get_output_mask(input_masks)
+        node.attributes["output_mask"] = cls._get_output_mask(input_masks)
 
     @classmethod
     def _get_output_mask(cls, input_masks: List[Optional[PropagationMask]]) -> Optional[PropagationMask]:
@@ -284,7 +284,7 @@ class GatherPruningOp(BasePruningOp):
         input_masks = get_input_masks(node, graph)
         assert len(input_masks) == 1
         input_mask = input_masks[0]
-        node.data["output_mask"] = cls._get_output_mask(input_mask, node, graph)
+        node.attributes["output_mask"] = cls._get_output_mask(input_mask, node, graph)
 
     @classmethod
     def _get_output_mask(
@@ -380,7 +380,7 @@ class SplitPruningOp(BasePruningOp):
                     "symbolic mask propagation for split by prune dimension is not implemented, "
                     "just propagate further for now"
                 )
-        node.data["output_mask"] = output_mask
+        node.attributes["output_mask"] = output_mask
 
 
 class ReshapeMode(Enum):
@@ -454,7 +454,7 @@ class ReshapePruningOp(BasePruningOp):
                     grouping[in_map[in_idx][0]].extend(groups)
                 output_mask.dim_groups_map = dict(grouping)
 
-        node.data["output_mask"] = output_mask
+        node.attributes["output_mask"] = output_mask
 
     @staticmethod
     def _can_reach_number_by_multiply(number_to_reach: int, array: List[int], start_idx: int) -> Tuple[bool, int]:
@@ -678,7 +678,7 @@ class TransposePruningOp(BasePruningOp):
         assert len(input_masks) == 1
         input_mask = input_masks[0]
         if not input_mask:
-            node.data["output_mask"] = None
+            node.attributes["output_mask"] = None
             return
 
         if isinstance(node.layer_attributes, TransposeLayerAttributes):
@@ -698,7 +698,7 @@ class TransposePruningOp(BasePruningOp):
             dim_groups_map={new_idx: input_mask.dim_groups_map[old_idx] for old_idx, new_idx in idx_map}
         )
 
-        node.data["output_mask"] = output_mask
+        node.attributes["output_mask"] = output_mask
 
 
 class StopMaskForwardPruningOp(BasePruningOp):
@@ -708,7 +708,7 @@ class StopMaskForwardPruningOp(BasePruningOp):
     ) -> None:
         input_masks = get_input_masks(node, graph)
         cls.invalidate_masks(input_masks)
-        node.data["output_mask"] = None
+        node.attributes["output_mask"] = None
 
 
 class ExpandAsPruningOp(BasePruningOp):
@@ -719,7 +719,7 @@ class ExpandAsPruningOp(BasePruningOp):
         input_edges = graph.get_input_edges(node)
         assert len(input_edges) == 2, "expand should always have 2 inputs"
         input_to_expand = input_edges[0].from_node
-        mask = input_to_expand.data.get("output_mask")
+        mask = input_to_expand.attributes.get("output_mask")
         propagated_mask = None
         if mask:
             nncf_logger.warning(
@@ -728,7 +728,7 @@ class ExpandAsPruningOp(BasePruningOp):
             )
             mask.invalidate_groups()
         input_to_get_shape = input_edges[1].from_node
-        mask: PropagationMask = input_to_get_shape.data.get("output_mask")
+        mask: PropagationMask = input_to_get_shape.attributes.get("output_mask")
         if mask:
             target_shape = input_edges[1].tensor_shape
             source_shape = input_edges[0].tensor_shape
@@ -744,7 +744,7 @@ class ExpandAsPruningOp(BasePruningOp):
             # TODO: (nlyalyus) assume that expand_as is on constant path that does not affect pruning, otherwise pruning
             # of self attention block would be not possible in the general case.
             propagated_mask = mask
-        node.data["output_mask"] = propagated_mask
+        node.attributes["output_mask"] = propagated_mask
 
 
 class ScatterPruningOp(BasePruningOp):
@@ -752,7 +752,7 @@ class ScatterPruningOp(BasePruningOp):
     def mask_propagation(
         cls, node: NNCFNode, graph: NNCFGraph, tensor_processor: Type[NNCFPruningBaseTensorProcessor]
     ) -> None:
-        input_masks = [input_edge.from_node.data.get("output_mask") for input_edge in graph.get_input_edges(node)]
+        input_masks = [input_edge.from_node.attributes.get("output_mask") for input_edge in graph.get_input_edges(node)]
         assert len(input_masks) == 2, "expect that masked_fill should always have 2 inputs"
         i1, i2 = input_masks
         propagated_mask = None
@@ -766,4 +766,4 @@ class ScatterPruningOp(BasePruningOp):
                 i1.invalidate_groups()
         else:
             propagated_mask = i1
-        node.data["output_mask"] = propagated_mask
+        node.attributes["output_mask"] = propagated_mask

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -638,7 +638,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         :param config: map of pruning group id to width value
         """
         for node in self._propagation_graph.get_all_nodes():
-            node.data.pop("output_mask", None)
+            node.attributes.pop("output_mask", None)
 
         names_of_processed_nodes = set()
         for cluster_id, width in config.items():
@@ -649,7 +649,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
                 max_width = elastic_width_info.elastic_op.max_width
                 device = get_model_device(self._target_model)
                 mask = self._width_to_mask(width, max_width, device)
-                node.data["output_mask"] = mask
+                node.attributes["output_mask"] = mask
                 elastic_width_info.elastic_op.set_active_width(width)
                 names_of_processed_nodes.add(node_id)
 
@@ -764,7 +764,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         Reorder output filters in descending order of their importance.
         """
         for node in self._propagation_graph.get_all_nodes():
-            node.data.pop("output_mask", None)
+            node.attributes.pop("output_mask", None)
 
         # 1. Calculate filter importance for all groups of prunable layers
         for group in self._pruned_module_groups_info.get_all_clusters():
@@ -787,7 +787,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
             # 1.2 Setup reorder indexes as output mask to reorganize filters
             for minfo in group.elements:
                 node = self._propagation_graph.get_node_by_id(minfo.nncf_node_id)
-                node.data["output_mask"] = PTNNCFTensor(reorder_indexes)
+                node.attributes["output_mask"] = PTNNCFTensor(reorder_indexes)
 
         # 2. Propagating masks across the graph
         reorder_algo = FilterReorderingAlgorithm(
@@ -809,9 +809,9 @@ class ElasticWidthHandler(SingleElasticityHandler):
         pair_indexes = []
         for idx, (start_node_name, end_node_name) in enumerate(pairs_of_nodes):
             start_node = self._propagation_graph.get_node_by_name(start_node_name)
-            start_mask = start_node.data["output_mask"]
+            start_mask = start_node.attributes["output_mask"]
             end_node = self._propagation_graph.get_node_by_name(end_node_name)
-            end_mask = end_node.data["output_mask"]
+            end_mask = end_node.attributes["output_mask"]
 
             all_start_output_shapes = self._propagation_graph.get_output_shapes_for_node(start_node_name)
             start_output_shape = list(OrderedDict.fromkeys(all_start_output_shapes))

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/visualization.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/visualization.py
@@ -30,9 +30,7 @@ class SubnetGraph:
     def __init__(self, compression_graph: PTNNCFGraph, multi_elasticity_handler: MultiElasticityHandler):
         # TODO: visualize other elastic dimension: depth, kernel (ticket 76870)
         self._width_graph = compression_graph.get_graph_for_structure_analysis(extended=True)
-        for node_key in compression_graph.get_all_node_keys():
-            compression_node = compression_graph.get_node_by_key(node_key)
-
+        for node_key, compression_node in compression_graph.nodes.items():
             operator_name = self._get_operator_name(compression_node, multi_elasticity_handler.width_handler)
 
             metatype = compression_node.metatype
@@ -64,7 +62,7 @@ class SubnetGraph:
             input_widths = None
             if input_masks:
                 input_widths = [ElasticWidthHandler.mask_to_width(input_mask) for input_mask in input_masks]
-            output_width = ElasticWidthHandler.mask_to_width(node.data["output_mask"])
+            output_width = ElasticWidthHandler.mask_to_width(node.attributes["output_mask"])
 
             if input_widths:
                 IW = None

--- a/nncf/experimental/torch/search_building_blocks/search_graph.py
+++ b/nncf/experimental/torch/search_building_blocks/search_graph.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Set
 import networkx as nx
 
 from nncf.common.graph.graph import NNCFGraph
+from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.graph import NNCFNodeName
 from nncf.common.graph.graph_matching import find_subgraphs_matching_pattern
 from nncf.common.graph.patterns.manager import PatternsManager
@@ -50,21 +51,21 @@ class SearchGraphNode:
 
     @property
     def node_name(self) -> NNCFNodeName:
-        return self.data.get(NNCFGraph.NODE_NAME_ATTR)
+        return self.data.get(NNCFNode.NODE_NAME_ATTR)
 
     @property
     def node_type(self) -> str:
         """
         Returns type of node.
         """
-        return self.data.get(NNCFGraph.NODE_TYPE_ATTR)
+        return self.data.get(NNCFNode.NODE_TYPE_ATTR)
 
     @property
     def layer_name(self) -> str:
         """
         Returns the name of the layer to which the node corresponds.
         """
-        return self.data.get(NNCFGraph.LAYER_NAME_ATTR)
+        return self.data.get(NNCFNode.LAYER_NAME_ATTR)
 
     @property
     def main_id(self) -> int:

--- a/nncf/quantization/algorithms/accuracy_control/algorithm.py
+++ b/nncf/quantization/algorithms/accuracy_control/algorithm.py
@@ -281,7 +281,7 @@ class QuantizationAccuracyRestorer:
 
         # Collect original biases and weights because these values are
         # required to undo bias correction and weight correction.
-        # Store this data inside the `node.data` dictionary.
+        # Store this data inside the `node.attributes` dictionary.
         # This data will be used in the `revert_operations_to_floating_point_precision()` method.
         QuantizationAccuracyRestorer._collect_original_biases_and_weights(
             initial_model_graph, quantized_model_graph, initial_model, algo_backend
@@ -452,8 +452,8 @@ class QuantizationAccuracyRestorer:
         algo_backend: AccuracyControlAlgoBackend,
     ) -> None:
         """
-        Collects initial biases and weights and stores them inside the `node.data['original_bias']` and
-        `node.data['original_weight']` where `node` is a node from `quantized_model_graph`.
+        Collects initial biases and weights and stores them inside the `node.attributes['original_bias']` and
+        `node.attributes['original_weight']` where `node` is a node from `quantized_model_graph`.
 
         :param initial_model_graph: Graph for initial model.
         :param quantized_model_graph: Graph for quantized model.

--- a/nncf/tensorflow/graph/converter.py
+++ b/nncf/tensorflow/graph/converter.py
@@ -22,6 +22,7 @@ from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNodeName
 from nncf.common.graph import OperatorMetatype
 from nncf.common.graph.definitions import NNCFGraphNodeType
+from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.layer_attributes import BaseLayerAttributes
 from nncf.common.graph.layer_attributes import ConvertDtypeLayerAttributes
 from nncf.common.graph.layer_attributes import ConvolutionLayerAttributes
@@ -682,7 +683,7 @@ class SequentialConverter(BaseFunctionalSequentialConverter):
 
             layer_attributes = _get_layer_attributes(layer_metatype, model_layer)
             if layer_attributes is not None:
-                attrs.update({NNCFGraph.LAYER_ATTRIBUTES: layer_attributes})
+                attrs.update({NNCFNode.LAYER_ATTRIBUTES: layer_attributes})
 
             node_name = layer_name
             nncf_node = nncf_graph.add_nncf_node(

--- a/nncf/tensorflow/pruning/base_algorithm.py
+++ b/nncf/tensorflow/pruning/base_algorithm.py
@@ -136,7 +136,7 @@ class BasePruningAlgoBuilder(TFCompressionAlgorithmBuilder):
                 # Add output_mask to elements to run mask_propagation
                 # and detect spec_nodes that will be pruned.
                 # It should be done for all elements of shared layer.
-                node.data["output_mask"] = TFNNCFTensor(tf.ones(get_output_channels(node)))
+                node.attributes["output_mask"] = TFNNCFTensor(tf.ones(get_output_channels(node)))
                 if layer_name in shared_layers:
                     continue
                 if node.is_shared():
@@ -175,7 +175,7 @@ class BasePruningAlgoBuilder(TFCompressionAlgorithmBuilder):
         for spec_node in spec_nodes:
             layer_name = get_layer_identifier(spec_node)
             layer = model.get_layer(layer_name)
-            if spec_node.data["output_mask"] is None:
+            if spec_node.attributes["output_mask"] is None:
                 # Skip elements that will not be pruned
                 continue
             if layer_name in shared_layers:

--- a/nncf/tensorflow/pruning/filter_pruning/algorithm.py
+++ b/nncf/tensorflow/pruning/filter_pruning/algorithm.py
@@ -280,7 +280,7 @@ class FilterPruningController(BasePruningAlgoController):
 
         # 0. Removing masks at the elements of the NNCFGraph
         for node in self._original_graph.topological_sort():
-            node.data.pop("output_mask", None)
+            node.attributes.pop("output_mask", None)
 
         # 1. Calculate masks
         for group in self._pruned_layer_groups_info.get_all_clusters():
@@ -298,7 +298,7 @@ class FilterPruningController(BasePruningAlgoController):
             filter_mask = calculate_binary_mask(cumulative_filters_importance, threshold)
             for node in group.elements:
                 nncf_node = self._original_graph.get_node_by_id(node.nncf_node_id)
-                nncf_node.data["output_mask"] = TFNNCFTensor(filter_mask)
+                nncf_node.attributes["output_mask"] = TFNNCFTensor(filter_mask)
 
         # 2. Propagating masks across the graph
         mask_propagator = MaskPropagationAlgorithm(
@@ -310,8 +310,8 @@ class FilterPruningController(BasePruningAlgoController):
         nncf_sorted_nodes = self._original_graph.topological_sort()
         for layer in wrapped_layers:
             nncf_node = [n for n in nncf_sorted_nodes if layer.name == n.layer_name][0]
-            if nncf_node.data["output_mask"] is not None:
-                self._set_operation_masks([layer], nncf_node.data["output_mask"].tensor)
+            if nncf_node.attributes["output_mask"] is not None:
+                self._set_operation_masks([layer], nncf_node.attributes["output_mask"].tensor)
 
         # Calculate actual flops and weights number with new masks
         self._update_benchmark_statistics()
@@ -329,7 +329,7 @@ class FilterPruningController(BasePruningAlgoController):
 
         # 0. Remove masks at the elements of the NNCFGraph
         for node in self._original_graph.topological_sort():
-            node.data.pop("output_mask", None)
+            node.attributes.pop("output_mask", None)
 
         # 1. Calculate masks
         # a. Calculate importances for all groups of filters
@@ -346,7 +346,7 @@ class FilterPruningController(BasePruningAlgoController):
             filter_mask = calculate_binary_mask(filter_importances[group.id], threshold)
             for node in group.elements:
                 nncf_node = self._original_graph.get_node_by_id(node.nncf_node_id)
-                nncf_node.data["output_mask"] = TFNNCFTensor(filter_mask)
+                nncf_node.attributes["output_mask"] = TFNNCFTensor(filter_mask)
 
         # 2. Propagate masks across the graph
         mask_propagator = MaskPropagationAlgorithm(
@@ -358,8 +358,8 @@ class FilterPruningController(BasePruningAlgoController):
         nncf_sorted_nodes = self._original_graph.topological_sort()
         for layer in wrapped_layers:
             nncf_node = [n for n in nncf_sorted_nodes if layer.name == n.layer_name][0]
-            if nncf_node.data["output_mask"] is not None:
-                self._set_operation_masks([layer], nncf_node.data["output_mask"].tensor)
+            if nncf_node.attributes["output_mask"] is not None:
+                self._set_operation_masks([layer], nncf_node.attributes["output_mask"].tensor)
 
         # Calculate actual flops with new masks
         self._update_benchmark_statistics()
@@ -377,7 +377,7 @@ class FilterPruningController(BasePruningAlgoController):
         nncf_sorted_nodes = self._original_graph.topological_sort()
         for layer in wrapped_layers:
             nncf_node = [n for n in nncf_sorted_nodes if layer.name == n.layer_name][0]
-            nncf_node.data["output_mask"] = TFNNCFTensor(tf.ones(get_filters_num(layer)))
+            nncf_node.attributes["output_mask"] = TFNNCFTensor(tf.ones(get_filters_num(layer)))
 
         # 1. Calculate importances for all groups of filters. Initialize masks.
         filter_importances = []
@@ -421,7 +421,7 @@ class FilterPruningController(BasePruningAlgoController):
                 for group in self._pruned_layer_groups_info.get_all_clusters():
                     for node in group.elements:
                         nncf_node = self._original_graph.get_node_by_id(node.nncf_node_id)
-                        nncf_node.data["output_mask"] = TFNNCFTensor(masks[group.id])
+                        nncf_node.attributes["output_mask"] = TFNNCFTensor(masks[group.id])
 
                 mask_propagator = MaskPropagationAlgorithm(
                     self._original_graph, TF_PRUNING_OPERATOR_METATYPES, TFNNCFPruningTensorProcessor
@@ -434,8 +434,8 @@ class FilterPruningController(BasePruningAlgoController):
                 nncf_sorted_nodes = self._original_graph.topological_sort()
                 for layer in wrapped_layers:
                     nncf_node = [n for n in nncf_sorted_nodes if layer.name == n.layer_name][0]
-                    if nncf_node.data["output_mask"] is not None:
-                        self._set_operation_masks([layer], nncf_node.data["output_mask"].tensor)
+                    if nncf_node.attributes["output_mask"] is not None:
+                        self._set_operation_masks([layer], nncf_node.attributes["output_mask"].tensor)
                 return
         raise RuntimeError(f"Unable to prune model to required flops pruning level: {target_flops_pruning_level}")
 

--- a/nncf/tensorflow/pruning/utils.py
+++ b/nncf/tensorflow/pruning/utils.py
@@ -15,7 +15,6 @@ import numpy as np
 import tensorflow as tf
 
 from nncf.common.graph import NNCFGraph
-from nncf.common.graph import NNCFNode
 from nncf.common.graph import NNCFNodeName
 from nncf.common.logging import nncf_logger
 from nncf.tensorflow.graph.metatypes.common import GENERAL_CONV_LAYER_METATYPES
@@ -27,10 +26,6 @@ from nncf.tensorflow.graph.utils import unwrap_layer
 from nncf.tensorflow.layers.data_layout import get_input_channel_axis
 from nncf.tensorflow.layers.data_layout import get_weight_channel_axis
 from nncf.tensorflow.layers.wrapper import NNCFWrapper
-
-
-def is_shared(node: NNCFNode) -> bool:
-    return node.data["is_shared"]
 
 
 def get_filter_axis(layer: NNCFWrapper, weight_attr: str) -> int:

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -699,7 +699,7 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
             if not isinstance(node.layer_attributes, ConvertDtypeLayerAttributes):
                 continue
             if node.layer_attributes.src_dtype == node.layer_attributes.dst_dtype:
-                node.data[NNCFGraph.METATYPE_ATTR] = TFIdentityOpMetatype
+                node.attributes[NNCFNode.METATYPE_ATTR] = TFIdentityOpMetatype
         return nncf_graph
 
     def _get_fake_quantize_name(self, node_name: NNCFNodeName, input_port_id: int = None) -> str:

--- a/nncf/torch/pruning/base_algo.py
+++ b/nncf/torch/pruning/base_algo.py
@@ -156,7 +156,7 @@ class BasePruningAlgoBuilder(PTCompressionAlgorithmBuilder):
 
         all_norm_layers = target_model_graph.get_nodes_by_types(types_to_apply_mask)
         for node in all_norm_layers:
-            if node.data["output_mask"] is None:
+            if node.attributes["output_mask"] is None:
                 # Skip elements that will not be pruned
                 continue
 

--- a/nncf/torch/pruning/filter_pruning/algo.py
+++ b/nncf/torch/pruning/filter_pruning/algo.py
@@ -608,7 +608,7 @@ class FilterPruningController(BasePruningAlgoController):
         for node, pruning_block, node_module in self._pruned_norms_operators:
             if node_module not in pruned_node_modules:
                 # Setting masks for BN nodes
-                pruning_block.binary_filter_pruning_mask = node.data["output_mask"].tensor
+                pruning_block.binary_filter_pruning_mask = node.attributes["output_mask"].tensor
                 pruned_node_modules.append(node_module)
 
     def prepare_for_export(self):

--- a/nncf/torch/pruning/operations.py
+++ b/nncf/torch/pruning/operations.py
@@ -216,7 +216,7 @@ class PTConvolutionPruningOp(ConvolutionPruningOp, PTPruner):
                 node_module.in_channels = new_num_channels
                 node_module.weight = torch.nn.Parameter(node_module.weight[broadcasted_mask].view(new_weight_shape))
                 nncf_logger.debug(
-                    f'Pruned Convolution {node.data["key"]} by input mask. '
+                    f"Pruned Convolution {node.node_key} by input mask. "
                     f"Old input filters number: {old_num_channels}, new filters number: {new_num_channels}."
                 )
         else:
@@ -225,7 +225,7 @@ class PTConvolutionPruningOp(ConvolutionPruningOp, PTPruner):
 
     @classmethod
     def output_prune(cls, model: NNCFNetwork, node: NNCFNode, graph: NNCFGraph, prun_type: PrunType) -> None:
-        mask = node.data["output_mask"]
+        mask = node.attributes["output_mask"]
         if mask is None:
             return
 
@@ -244,7 +244,7 @@ class PTConvolutionPruningOp(ConvolutionPruningOp, PTPruner):
                 node_module.bias = torch.nn.Parameter(node_module.bias[bool_mask])
 
             nncf_logger.debug(
-                f'Pruned Convolution {node.data["key"]} by pruning mask. '
+                f"Pruned Convolution {node.node_key} by pruning mask. "
                 f"Old output filters number: {old_num_channels}, new filters number: {node_module.out_channels}."
             )
         else:
@@ -265,12 +265,12 @@ class PTConvolutionPruningOp(ConvolutionPruningOp, PTPruner):
         conv.weight.data = torch.index_select(conv.weight.data, 1, reorder_indexes)
         nncf_logger.debug(
             f"Reordered input channels (first 10 reorder indexes {reorder_indexes[:10]}) "
-            f'of Convolution: {node.data["key"]} '
+            f"of Convolution: {node.node_key} "
         )
 
     @classmethod
     def output_reorder(cls, model: NNCFNetwork, node: NNCFNode, graph: NNCFGraph):
-        reorder_indexes = node.data["output_mask"]
+        reorder_indexes = node.attributes["output_mask"]
         if reorder_indexes is None:
             return
         conv = model.nncf.get_containing_module(node.node_name)
@@ -280,7 +280,7 @@ class PTConvolutionPruningOp(ConvolutionPruningOp, PTPruner):
             conv.bias.data = torch.index_select(conv.bias.data, 0, reorder_indexes)
         nncf_logger.debug(
             f"Reordered output channels (first 10 reorder indexes {reorder_indexes[:10]}) "
-            f'of Convolution: {node.data["key"]} '
+            f"of Convolution: {node.node_key} "
         )
 
 
@@ -306,7 +306,7 @@ class PTTransposeConvolutionPruningOp(TransposeConvolutionPruningOp, PTPruner):
             node_module.weight = torch.nn.Parameter(node_module.weight[bool_mask])
 
             nncf_logger.debug(
-                f'Pruned ConvTranspose {node.data["key"]} by input mask. '
+                f"Pruned ConvTranspose {node.node_key} by input mask. "
                 f"Old input filters number: {old_num_channels}, new filters number: {node_module.in_channels}."
             )
         else:
@@ -314,7 +314,7 @@ class PTTransposeConvolutionPruningOp(TransposeConvolutionPruningOp, PTPruner):
 
     @classmethod
     def output_prune(cls, model: NNCFNetwork, node: NNCFNode, graph: NNCFGraph, prun_type: PrunType) -> None:
-        output_mask = node.data["output_mask"]
+        output_mask = node.attributes["output_mask"]
         if output_mask is None:
             return
 
@@ -341,7 +341,7 @@ class PTTransposeConvolutionPruningOp(TransposeConvolutionPruningOp, PTPruner):
                 node_module.bias = torch.nn.Parameter(node_module.bias[bool_mask])
 
             nncf_logger.debug(
-                f'Pruned ConvTranspose {node.data["key"]} by pruning mask. '
+                f"Pruned ConvTranspose {node.node_key} by pruning mask. "
                 f"Old output filters number: {old_num_channels}, new filters number: {node_module.out_channels}."
             )
         else:
@@ -377,7 +377,7 @@ class PTLinearPruningOp(LinearPruningOp, PTPruner):
 
             node_module.weight = torch.nn.Parameter(node_module.weight[broadcasted_mask].view(new_weight_shape))
             nncf_logger.debug(
-                f'Pruned Linear {node.data["key"]} by pruning mask. '
+                f"Pruned Linear {node.node_key} by pruning mask. "
                 f"Old input filters number: {in_features}, new filters number: {node_module.in_features}."
             )
         else:
@@ -393,12 +393,12 @@ class PTLinearPruningOp(LinearPruningOp, PTPruner):
         fc = model.nncf.get_containing_module(node.node_name)
         fc.weight.data = torch.index_select(fc.weight.data, 1, reorder_indexes)
         nncf_logger.debug(
-            f"Reordered input channels (first 10 reorder indexes {reorder_indexes[:10]}) of Linear: {node.data['key']}"
+            f"Reordered input channels (first 10 reorder indexes {reorder_indexes[:10]}) of Linear: {node.node_key}"
         )
 
     @classmethod
     def output_prune(cls, model: NNCFNetwork, node: NNCFNode, graph: NNCFGraph, prun_type: PrunType) -> None:
-        output_mask = node.data["output_mask"]
+        output_mask = node.attributes["output_mask"]
         if output_mask is None:
             return
 
@@ -414,7 +414,7 @@ class PTLinearPruningOp(LinearPruningOp, PTPruner):
             node_module.out_features = new_out_features
             node_module.weight = torch.nn.Parameter(node_module.weight[bool_mask])
             nncf_logger.debug(
-                f'Pruned Linear {node.data["key"]} by pruning mask. '
+                f"Pruned Linear {node.node_key} by pruning mask. "
                 f"Old output filters number: {out_features}, new filters number: {node_module.out_features}."
             )
             if node_module.bias is not None:
@@ -426,7 +426,7 @@ class PTLinearPruningOp(LinearPruningOp, PTPruner):
 
     @classmethod
     def output_reorder(cls, model: NNCFNetwork, node: NNCFNode, graph: NNCFGraph):
-        reorder_indexes = node.data["output_mask"]
+        reorder_indexes = node.attributes["output_mask"]
         if reorder_indexes is None:
             return
         fc = model.nncf.get_containing_module(node.node_name)
@@ -435,7 +435,7 @@ class PTLinearPruningOp(LinearPruningOp, PTPruner):
         if fc.bias is not None:
             fc.bias.data = torch.index_select(fc.bias.data, 0, reorder_indexes)
         nncf_logger.debug(
-            f"Reordered output channels (first 10 reorder indexes {reorder_indexes[:10]}) of Linear: {node.data['key']}"
+            f"Reordered output channels (first 10 reorder indexes {reorder_indexes[:10]}) of Linear: {node.node_key}"
         )
 
 
@@ -467,7 +467,7 @@ class PTBatchNormPruningOp(BatchNormPruningOp, PTPruner):
             node_module.running_var = torch.nn.Parameter(node_module.running_var[bool_mask], requires_grad=False)
 
             nncf_logger.debug(
-                f'Pruned BatchNorm {node.data["key"]} by input mask. '
+                f"Pruned BatchNorm {node.node_key} by input mask. "
                 f"Old num features: {old_num_channels}, new num features: {new_num_channels}."
             )
         else:
@@ -497,7 +497,7 @@ class PTBatchNormPruningOp(BatchNormPruningOp, PTPruner):
         bn.running_var.data = torch.index_select(bn.running_var.data, 0, reorder_indexes)
 
         nncf_logger.debug(
-            f'Reordered channels (first 10 reorder indexes {reorder_indexes[:10]}) of BatchNorm: {node.data["key"]} '
+            f"Reordered channels (first 10 reorder indexes {reorder_indexes[:10]}) of BatchNorm: {node.node_key} "
         )
 
 
@@ -528,7 +528,7 @@ class PTGroupNormPruningOp(GroupNormPruningOp, PTPruner):
             node_module.bias = torch.nn.Parameter(node_module.bias[bool_mask])
 
             nncf_logger.debug(
-                f"Pruned GroupNorm {node.data['key']} by input mask. "
+                f"Pruned GroupNorm {node.node_key} by input mask. "
                 f"Old num features: {old_num_channels}, new num features: {new_num_channels}."
             )
         else:
@@ -554,7 +554,7 @@ class PTLayerNormPruningOp(LayerNormPruningOp, PTPruner):
 
         nncf_logger.debug(
             "Reordered channels (first 10 reorder indexes {}) of LayerNorm: {} ".format(
-                reorder_indexes[:10], node.data["key"]
+                reorder_indexes[:10], node.node_key
             )
         )
 
@@ -603,7 +603,7 @@ class PTElementwisePruningOp(ElementwisePruningOp, PTPruner):
                 node_module.n_channels = new_num_channels
 
                 nncf_logger.debug(
-                    f'Pruned Elementwise {node.data["key"]} by input mask. '
+                    f"Pruned Elementwise {node.node_key} by input mask. "
                     f"Old num features: {old_num_channels}, new num features: {new_num_channels}."
                 )
             else:

--- a/nncf/torch/pruning/utils.py
+++ b/nncf/torch/pruning/utils.py
@@ -57,12 +57,12 @@ def init_output_masks_in_graph(graph: NNCFGraph, nodes: List):
     :param nodes: list with pruned nodes
     """
     for node in graph.get_all_nodes():
-        node.data.pop("output_mask", None)
+        node.attributes.pop("output_mask", None)
 
     for minfo in nodes:
         mask = minfo.operand.binary_filter_pruning_mask
         nncf_node = graph.get_node_by_id(minfo.nncf_node_id)
-        nncf_node.data["output_mask"] = PTNNCFTensor(mask)
+        nncf_node.attributes["output_mask"] = PTNNCFTensor(mask)
 
 
 def _calculate_output_shape(graph: NNCFGraph, node: NNCFNode) -> Tuple[int, ...]:

--- a/nncf/torch/quantization/precision_init/bitwidth_graph.py
+++ b/nncf/torch/quantization/precision_init/bitwidth_graph.py
@@ -15,6 +15,7 @@ from typing import Dict
 import networkx as nx
 
 from nncf.common.graph import NNCFGraph
+from nncf.common.graph.graph import NNCFNode
 from nncf.common.logging import nncf_logger
 from nncf.common.quantization.structs import NonWeightQuantizerId
 from nncf.torch.layers import NNCFConv2d
@@ -46,8 +47,7 @@ class BitwidthGraph:
                 flops_vs_node_group[idx] = (flops, node_set)
 
         grouped_mode = bool(groups_of_adjacent_quantizers)
-        for node_key in nncf_graph.get_all_node_keys():
-            node = nncf_graph.get_node_by_key(node_key)
+        for node_key, node in nncf_graph.nodes.items():
             color = ""
             operator_name = node.node_type
             module = model.nncf.get_containing_module(node.node_name)
@@ -161,7 +161,7 @@ class BitwidthGraph:
             bitwidth = quantizer_info.quantizer_module_ref.num_bits
             activation_fq_node["color"] = bitwidth_color_map[bitwidth]
             activation_fq_node["style"] = "filled"
-            node_id = activation_fq_node[NNCFGraph.ID_NODE_ATTR]
+            node_id = activation_fq_node[NNCFNode.ID_NODE_ATTR]
 
             activation_fq_node["label"] = "AFQ_[{}]_#{}".format(
                 quantizer_info.quantizer_module_ref.get_quantizer_config(), str(node_id)

--- a/tests/common/quantization/mock_graphs.py
+++ b/tests/common/quantization/mock_graphs.py
@@ -19,6 +19,7 @@ from nncf.common.graph import BaseLayerAttributes
 from nncf.common.graph import Dtype
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNodeName
+from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.layer_attributes import ConvolutionLayerAttributes
 from nncf.common.graph.operator_metatypes import UnknownMetatype
 from nncf.common.insertion_point_graph import InsertionPointGraph
@@ -88,20 +89,20 @@ def get_nncf_graph_from_mock_nx_graph(nx_graph: nx.DiGraph, nncf_graph_cls=NNCFG
 
     for idx, curr_node_key in enumerate(lexicographical_topological_sort(nx_graph)):
         node = nx_graph.nodes[curr_node_key]
-        if NNCFGraph.NODE_NAME_ATTR in node:
-            node_name = node[NNCFGraph.NODE_NAME_ATTR]
+        if NNCFNode.NODE_NAME_ATTR in node:
+            node_name = node[NNCFNode.NODE_NAME_ATTR]
         else:
             node_name = "/" + curr_node_key + "_0"
 
-        if NNCFGraph.NODE_TYPE_ATTR in node:
-            node_type = node[NNCFGraph.NODE_TYPE_ATTR]
+        if NNCFNode.NODE_TYPE_ATTR in node:
+            node_type = node[NNCFNode.NODE_TYPE_ATTR]
         else:
             node_type = curr_node_key
 
-        layer_attributes = node.get(NNCFGraph.LAYER_ATTRIBUTES)
+        layer_attributes = node.get(NNCFNode.LAYER_ATTRIBUTES)
 
-        if NNCFGraph.METATYPE_ATTR in node:
-            metatype = node[NNCFGraph.METATYPE_ATTR]
+        if NNCFNode.METATYPE_ATTR in node:
+            metatype = node[NNCFNode.METATYPE_ATTR]
         else:
             metatype = METATYPES_FOR_TEST.get_operator_metatype_by_op_name(node_type)
             if metatype is not UnknownMetatype:
@@ -178,10 +179,10 @@ def get_mock_nncf_node_attrs(op_name=None, scope_str=None, metatype=None, type_=
     if scope_str is None:
         scope_str = ""
     output = {
-        NNCFGraph.NODE_NAME_ATTR: f"{scope_str}/{op_name_to_set}_0",
-        NNCFGraph.NODE_TYPE_ATTR: type_,
+        NNCFNode.NODE_NAME_ATTR: f"{scope_str}/{op_name_to_set}_0",
+        NNCFNode.NODE_TYPE_ATTR: type_,
     }
-    for attr_name, attr_val in [(NNCFGraph.METATYPE_ATTR, metatype), (NNCFGraph.LAYER_ATTRIBUTES, layer_attributes)]:
+    for attr_name, attr_val in [(NNCFNode.METATYPE_ATTR, metatype), (NNCFNode.LAYER_ATTRIBUTES, layer_attributes)]:
         if attr_val is not None:
             output[attr_name] = attr_val
 
@@ -194,7 +195,7 @@ def _add_nodes_with_layer_attrs(
     for node_key in node_keys:
         nx_graph.add_node(node_key, **get_mock_nncf_node_attrs(op_name=node_key))
         if node_key in layer_attrs:
-            nx_graph.nodes[node_key][NNCFGraph.LAYER_ATTRIBUTES] = layer_attrs[node_key]
+            nx_graph.nodes[node_key][NNCFNode.LAYER_ATTRIBUTES] = layer_attrs[node_key]
     return nx_graph
 
 
@@ -370,10 +371,10 @@ def get_randomly_connected_model_graph(op_name_keys: Set[str]) -> nx.DiGraph:
     shuffled_op_names = random.sample(op_name_keys, len(op_name_keys))
     for idx, (_, node) in enumerate(mock_graph.nodes.items()):
         op_name = shuffled_op_names[idx]
-        node[NNCFGraph.NODE_NAME_ATTR] = get_node_name(shuffled_op_names[idx])
-        node[NNCFGraph.NODE_TYPE_ATTR] = op_name
+        node[NNCFNode.NODE_NAME_ATTR] = get_node_name(shuffled_op_names[idx])
+        node[NNCFNode.NODE_TYPE_ATTR] = op_name
         if op_name in OP_NAMES_IN_TEST_WITH_MODULE_ATTRIBUTES:
-            node[NNCFGraph.LAYER_ATTRIBUTES] = MagicMock()
+            node[NNCFNode.LAYER_ATTRIBUTES] = MagicMock()
     mark_input_ports_lexicographically_based_on_input_node_key(mock_graph)
     return mock_graph
 
@@ -385,12 +386,12 @@ def get_sequentially_connected_model_graph(op_name_keys: List[str]) -> nx.DiGrap
     actual_keys = []
     for node_key in op_name_keys:
         attrs = {
-            NNCFGraph.NODE_NAME_ATTR: get_node_name(node_key, call_order=node_key_appearances[node_key]),
-            NNCFGraph.NODE_TYPE_ATTR: node_key,
+            NNCFNode.NODE_NAME_ATTR: get_node_name(node_key, call_order=node_key_appearances[node_key]),
+            NNCFNode.NODE_TYPE_ATTR: node_key,
         }
 
         if node_key in OP_NAMES_IN_TEST_WITH_MODULE_ATTRIBUTES:
-            attrs[NNCFGraph.LAYER_ATTRIBUTES] = MagicMock()
+            attrs[NNCFNode.LAYER_ATTRIBUTES] = MagicMock()
         actual_key = node_key + "_{}".format(node_key_appearances[node_key])
         graph.add_node(actual_key, **attrs)
         node_key_appearances[node_key] += 1

--- a/tests/common/quantization/test_filter_constant_nodes.py
+++ b/tests/common/quantization/test_filter_constant_nodes.py
@@ -14,7 +14,7 @@ from collections import Counter
 
 import pytest
 
-from nncf.common.graph.graph import NNCFGraph
+from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.operator_metatypes import InputNoopMetatype
 from nncf.common.graph.operator_metatypes import OutputNoopMetatype
 from nncf.common.insertion_point_graph import ConstantNodesFilter
@@ -227,7 +227,7 @@ def test_constant_nodes_filter(model_to_test):
     quantizable_layer_nodes = [
         QuantizableWeightedLayerNode(weight_node, [QuantizerConfig()]) for weight_node in weight_nodes
     ]
-    quantizable_layer_node_keys = [node.node.data[NNCFGraph.KEY_NODE_ATTR] for node in quantizable_layer_nodes]
+    quantizable_layer_node_keys = [node.node.node_key for node in quantizable_layer_nodes]
 
     ip_graph = get_ip_graph_for_test(nncf_graph, quantizable_layer_nodes)
     filtered_ip_graph = ConstantNodesFilter.filter(ip_graph, quantizable_layer_node_keys)

--- a/tests/common/quantization/test_quantizer_propagation_graph.py
+++ b/tests/common/quantization/test_quantizer_propagation_graph.py
@@ -21,6 +21,7 @@ import pytest
 from nncf.common.graph import Dtype
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNodeName
+from nncf.common.graph.graph import NNCFNode
 from nncf.common.insertion_point_graph import InsertionPointGraph
 from nncf.common.insertion_point_graph import PostHookInsertionPoint
 from nncf.common.insertion_point_graph import PreHookInsertionPoint
@@ -1230,7 +1231,7 @@ class TestUnifinedScaleTypeAfterMergeQuantizers:
             mock_node_attrs = get_mock_nncf_node_attrs(op_name=node_key)
             if node_key == "B":
                 # Split have no POST_HOOK
-                mock_node_attrs[NNCFGraph.NODE_TYPE_ATTR] = "split"
+                mock_node_attrs[NNCFNode.NODE_TYPE_ATTR] = "split"
             mock_graph.add_node(node_key, **mock_node_attrs)
 
         mock_graph.add_edges_from([("A", "B"), ("B", "C"), ("B", "D"), ("C", "E"), ("D", "E")])

--- a/tests/common/quantization/test_quantizer_propagation_solver.py
+++ b/tests/common/quantization/test_quantizer_propagation_solver.py
@@ -22,6 +22,7 @@ from nncf.common.graph import Dtype
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNodeName
 from nncf.common.graph.definitions import MODEL_INPUT_OP_NAME
+from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.operator_metatypes import OutputNoopMetatype
 from nncf.common.graph.operator_metatypes import UnknownMetatype
 from nncf.common.graph.transformations.commands import TargetType
@@ -70,18 +71,18 @@ class TwoFcAfterDropout:
     def get_graph():
         graph = nx.DiGraph()
         dropout_node_attrs = {
-            NNCFGraph.NODE_NAME_ATTR: TwoFcAfterDropout.DROPOUT_NODE_NAME,
-            NNCFGraph.NODE_TYPE_ATTR: TwoFcAfterDropout.DROPOUT_OP_TYPE_STR,
+            NNCFNode.NODE_NAME_ATTR: TwoFcAfterDropout.DROPOUT_NODE_NAME,
+            NNCFNode.NODE_TYPE_ATTR: TwoFcAfterDropout.DROPOUT_OP_TYPE_STR,
         }
 
         fc_1_node_attrs = {
-            NNCFGraph.NODE_NAME_ATTR: TwoFcAfterDropout.FC_1_NODE_NAME,
-            NNCFGraph.NODE_TYPE_ATTR: TwoFcAfterDropout.FC_OP_TYPE_STR,
+            NNCFNode.NODE_NAME_ATTR: TwoFcAfterDropout.FC_1_NODE_NAME,
+            NNCFNode.NODE_TYPE_ATTR: TwoFcAfterDropout.FC_OP_TYPE_STR,
         }
 
         fc_2_node_attrs = {
-            NNCFGraph.NODE_NAME_ATTR: TwoFcAfterDropout.FC_2_NODE_NAME,
-            NNCFGraph.NODE_TYPE_ATTR: TwoFcAfterDropout.FC_OP_TYPE_STR,
+            NNCFNode.NODE_NAME_ATTR: TwoFcAfterDropout.FC_2_NODE_NAME,
+            NNCFNode.NODE_TYPE_ATTR: TwoFcAfterDropout.FC_OP_TYPE_STR,
         }
 
         graph.add_node("dropout", **dropout_node_attrs)
@@ -1124,7 +1125,7 @@ class TestQuantizerPropagationSolver:
         metatypes = {k: v.op_meta for k, v in init_node_to_trait_and_configs_dict.items()}
         for node_key, metatype in metatypes.items():
             node = ip_graph.nodes[node_key]
-            node[InsertionPointGraph.REGULAR_NODE_REF_NODE_ATTR].data[NNCFGraph.METATYPE_ATTR] = metatype
+            node[InsertionPointGraph.REGULAR_NODE_REF_NODE_ATTR].attributes[NNCFNode.METATYPE_ATTR] = metatype
 
         quant_prop_graph = QPSG(ip_graph)
         for node in quant_prop_graph.nodes.values():

--- a/tests/common/test_scopes.py
+++ b/tests/common/test_scopes.py
@@ -32,6 +32,9 @@ from nncf.scopes import IgnoredScope
     ],
 )
 def test_get_not_matched_scopes(scope, ref):
-    node_lists = [NNCFNode(1, "A"), NNCFNode(2, "B")]
+    node_lists = [
+        NNCFNode({NNCFNode.ID_NODE_ATTR: 1, NNCFNode.NODE_NAME_ATTR: "A"}),
+        NNCFNode({NNCFNode.ID_NODE_ATTR: 2, NNCFNode.NODE_NAME_ATTR: "B"}),
+    ]
     not_matched = get_not_matched_scopes(scope, node_lists)
     assert not set(not_matched) - set(ref)

--- a/tests/openvino/native/quantization/test_channel_alignment.py
+++ b/tests/openvino/native/quantization/test_channel_alignment.py
@@ -13,7 +13,6 @@ from typing import Type
 
 import pytest
 
-from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.openvino.graph.layer_attributes import OVLayerAttributes
@@ -32,7 +31,14 @@ from tests.post_training.test_templates.test_channel_alignment import TemplateTe
 
 
 def _get_nncf_node(metatype, layer_attrs):
-    return NNCFNode(0, "test", {NNCFGraph.METATYPE_ATTR: metatype, NNCFGraph.LAYER_ATTRIBUTES: layer_attrs})
+    return NNCFNode(
+        {
+            NNCFNode.ID_NODE_ATTR: 0,
+            NNCFNode.NODE_NAME_ATTR: "test",
+            NNCFNode.METATYPE_ATTR: metatype,
+            NNCFNode.LAYER_ATTRIBUTES: layer_attrs,
+        }
+    )
 
 
 class TestOVChannelAlignment(TemplateTestChannelAlignment):

--- a/tests/openvino/native/test_node_utils.py
+++ b/tests/openvino/native/test_node_utils.py
@@ -13,7 +13,6 @@ import numpy as np
 import pytest
 
 from nncf.common.factory import NNCFGraphFactory
-from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
 from nncf.openvino.graph.layer_attributes import OVLayerAttributes
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVMatMulMetatype
@@ -76,12 +75,14 @@ def test_is_node_with_bias(model_to_create, is_with_bias, node_name):
 )
 def test_get_weight_channel_axes_for_matmul(weights_port_id, transpose, shape, expected_channel_axes):
     attributes = {
-        NNCFGraph.METATYPE_ATTR: OVMatMulMetatype,
-        NNCFGraph.LAYER_ATTRIBUTES: OVLayerAttributes(
+        NNCFNode.ID_NODE_ATTR: 0,
+        NNCFNode.NODE_NAME_ATTR: "test",
+        NNCFNode.METATYPE_ATTR: OVMatMulMetatype,
+        NNCFNode.LAYER_ATTRIBUTES: OVLayerAttributes(
             constant_attributes={weights_port_id: {"transpose": transpose, "shape": shape}}
         ),
     }
-    node = NNCFNode(0, "test", attributes)
+    node = NNCFNode(attributes)
     actual_channel_axes = get_weight_channel_axes(node, weights_port_id)
 
     assert len(actual_channel_axes) == len(expected_channel_axes)

--- a/tests/tensorflow/pruning/test_flops_pruning.py
+++ b/tests/tensorflow/pruning/test_flops_pruning.py
@@ -138,7 +138,7 @@ def test_flops_calulation_for_spec_layers(
     next_nodes = shape_pruner.get_next_nodes(original_graph, pruning_groups)
     # Check output_shapes are empty in graph
     for node in original_graph.get_all_nodes():
-        assert node.data["output_shape"] is None
+        assert node.attributes["output_shape"] is None
 
     assert compression_ctrl._calculate_num_of_sparse_elements_by_node() == ref_num_of_sparse
 

--- a/tests/torch/pruning/filter_pruning/test_algo.py
+++ b/tests/torch/pruning/filter_pruning/test_algo.py
@@ -402,7 +402,7 @@ def test_valid_masks_for_bn_after_concat(prune_bn):
     ref_concat_masks = [[0] * 8 + [1] * 8 + [0] * 8 + [1] * 8, [1] * 8 + [0] * 16 + [1] * 8 + [0] * 8 + [1] * 8]
     graph = pruned_model.nncf.get_original_graph()
     for i, node in enumerate(graph.get_nodes_by_types(["cat"])):
-        assert np.allclose(node.data["output_mask"].tensor.numpy(), ref_concat_masks[i])
+        assert np.allclose(node.attributes["output_mask"].tensor.numpy(), ref_concat_masks[i])
 
 
 @pytest.mark.parametrize('model,ref_output_shapes',
@@ -742,7 +742,7 @@ def test_flops_calculator(model_module, all_weights, pruning_flops_target, ref_f
     pruning_groups_next_nodes = shape_pruning_processor.get_next_nodes(graph, pruning_groups)
     # Check output_shapes are empty in graph
     for node in graph.get_all_nodes():
-        assert node.data["output_shape"] is None
+        assert node.attributes["output_shape"] is None
 
     # Next nodes cluster check
     assert len(pruning_groups_next_nodes) == len(refs["next_nodes"])
@@ -849,7 +849,7 @@ def test_disconnected_graph():
     for name, (shape, mask_sum) in nodes_output_mask_map.items():
         node = graph.get_node_by_name(name)
         if mask_sum is None:
-            assert node.data["output_mask"] is None
+            assert node.attributes["output_mask"] is None
         else:
-            assert sum(node.data["output_mask"].tensor) == mask_sum
+            assert sum(node.attributes["output_mask"].tensor) == mask_sum
         assert collected_shapes[name] == shape

--- a/tests/torch/pruning/test_model_pruning_analysis.py
+++ b/tests/torch/pruning/test_model_pruning_analysis.py
@@ -738,7 +738,7 @@ def test_symbolic_mask_propagation(test_input_info_struct_):
     final_can_prune = algo.symbolic_mask_propagation(pruning_types, test_input_info_struct_.can_prune_after_analysis)
     # Check all output masks are deleted
     for node in graph.get_all_nodes():
-        assert node.data["output_mask"] is None
+        assert node.attributes["output_mask"] is None
 
     # Check ref decisions
     ref_final_can_prune = test_input_info_struct_.final_can_prune

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -270,9 +270,9 @@ def test_nncf_node_attrs_are_consistent():
         node_name="dummy", node_type="dummy", layer_name="dummy", node_metatype=UnknownMetatype
     )
     new_node_saved = nncf_graph.get_node_by_id(new_node.node_id)
-    assert new_node.data is new_node_saved.data
+    assert new_node.attributes is new_node_saved.attributes
     nodes_in_scope = nncf_graph.get_op_nodes_in_scope(nncf_graph.get_scope_by_node_name("dummy"))
-    assert new_node.data is nodes_in_scope[0].data
+    assert new_node.attributes is nodes_in_scope[0].attributes
 
 
 def test_can_collect_scopes_of_train_only_modules():


### PR DESCRIPTION
### Changes

Optimize NNCFGraph. This changes shows speed-up in 10.8x for building NNCFGraph by "hf-internal-testing/tiny-random-GPTNeoXForCausalLM" model from optimum.

### Reason for changes

Speed-up NNCF compression algorithms

### Related tickets

ref: 113245

### Tests

N/A
