### PR TITLE
[OV][PTQ][Inplace statistics] Always cast dims to np.int to support empty dims case

### DIFF
--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -171,7 +171,7 @@ def get_inplace_reduce_op(
 
         return op(
             op_input.output(output_port_id),
-            reduction_axes=reduction_axes_,
+            reduction_axes=np.array(reduction_axes_, dtype=np.int),
             keep_dims=True,
             name=get_ov_model_reduce_node_name(output_name, reduce_node_name, name_output_port_id),
         )

--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -171,7 +171,7 @@ def get_inplace_reduce_op(
 
         return op(
             op_input.output(output_port_id),
-            reduction_axes=np.array(reduction_axes_, dtype=np.int),
+            reduction_axes=np.array(reduction_axes_, dtype=np.int64),
             keep_dims=True,
             name=get_ov_model_reduce_node_name(output_name, reduce_node_name, name_output_port_id),
         )

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -126,7 +126,7 @@ INPLACE_OPS_TEST_CASES = [
         "abs_max", None, lambda o, r: get_inplace_max_op(o, r, True), ["Abs", "ReduceMax"], [None, (0, 1, 2, 3)]
     ),
     # Batch mean and mean per ch operations
-    InplaceOpTestCase("batch_mean", None, lambda o, r: get_inplace_batch_mean_op(o), ["ReduceMean"], [(0,)]),
+    InplaceOpTestCase("batch_mean", None, lambda o, r: get_inplace_batch_mean_op(o), ["ReduceMean"], [0]),
     InplaceOpTestCase("mean_per_ch", 1, get_inplace_mean_per_ch, ["Reshape", "ReduceMean"], [(1, 3, 16), (0, 2)]),
     InplaceOpTestCase(
         "mean_per_ch",
@@ -135,7 +135,21 @@ INPLACE_OPS_TEST_CASES = [
         ["Transpose", "Reshape", "ReduceMean"],
         [(0, 2, 1, 3), (1, 4, 12), (0, 2)],
     ),
-    InplaceOpTestCase("mean_per_ch", 0, get_inplace_mean_per_ch, ["ReduceMean"], [(0,)], dims="SHORT"),
+    InplaceOpTestCase(
+        "mean_per_ch",
+        0,
+        get_inplace_mean_per_ch,
+        ["ReduceMean"],
+        [
+            0,
+        ],
+        dims="SHORT",
+    ),
+    # EmptyCase
+    InplaceOpTestCase("min", (), get_inplace_min_op, ["ReduceMin"], [()]),
+    InplaceOpTestCase("mean", (), get_inplace_mean_op, ["ReduceMean"], [()]),
+    InplaceOpTestCase("max", (), lambda o, r: get_inplace_max_op(o, r, False), ["ReduceMax"], [()]),
+    InplaceOpTestCase("abs_max", (), lambda o, r: get_inplace_max_op(o, r, True), ["Abs", "ReduceMax"], [None, ()]),
 ]
 
 
@@ -164,9 +178,12 @@ def check_inplace_op(target_node, ref_types, ref_vals, inplace_branches_num, out
             const = get_prev_node(node, 1)
             if ref_val == []:
                 assert const.get_data().shape == (0,)
+            elif not isinstance(ref_val, tuple):
+                assert const.get_data() == ref_val
             else:
                 res = np.equal(const.get_data(), np.array(ref_val))
                 assert all(res)
+                assert const.get_data().shape == np.array(ref_val).shape
 
         nodes = get_next_nodes(node, 0)
         assert len(nodes) == 1


### PR DESCRIPTION
### Changes

Dims are always casted to `np.int` type during creation of an inplace operation, because empty tuple is casted to float type by default and leads to runtime error.

### Reason for changes

To support empty dims inplace reduction operations

### Related tickets

117500

### Tests

* test_model_transformer.py is updated
