### PR TITLE
Corrected references for weekly nas tests

### DIFF
--- a/tests/torch/test_compression_training.py
+++ b/tests/torch/test_compression_training.py
@@ -319,7 +319,7 @@ NAS_DESCRIPTORS = [
     NASTrainingTestDescriptor()
     .real_dataset("cifar10")
     .config_name("mobilenet_v2_nas_SMALL.json")
-    .expected_accuracy(80.95)
+    .expected_accuracy(85.1)
     .subnet_expected_accuracy(88.67)
     .weights_filename("mobilenet_v2_cifar10_93.91.pth")
     .absolute_tolerance_train(1.0)
@@ -328,7 +328,7 @@ NAS_DESCRIPTORS = [
     .real_dataset("cifar10")
     .config_name("resnet50_nas_SMALL.json")
     .subnet_expected_accuracy(88.67)
-    .expected_accuracy(87.25)
+    .expected_accuracy(85.19)
     .weights_filename("resnet50_cifar10_93.65.pth")
     .absolute_tolerance_train(2.0)
     .absolute_tolerance_eval(2e-2),


### PR DESCRIPTION
### Changes

as stated in the title

### Reason for changes

failed weekly tests due to latest adjustments in NAS:
https://github.com/openvinotoolkit/nncf/pull/1916
https://github.com/openvinotoolkit/nncf/pull/1903
cc: @jpablomch, @yzheng124

### Related tickets

117724

### Tests

weekly
