### PR TITLE
Do not install editable NNCF in workflows

### DIFF
--- a/.github/workflows/build_html_doc.yml
+++ b/.github/workflows/build_html_doc.yml
@@ -15,7 +15,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - name: Install NNCF and doc requirements
         run: |
-          pip install -e .
+          pip install .
           pip install -r docs/api/requirements.txt
       - name: Build API docs
         run: |

--- a/.github/workflows/build_schema_page.yml
+++ b/.github/workflows/build_schema_page.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install and Build
         run: |
           pip install json-schema-for-humans
-          pip install -e .
+          pip install .
           python -c 'import jstyleson; from nncf.config import NNCFConfig; jstyleson.dump(NNCFConfig.schema(), open("./schema.json", "w"), indent=2)'
           mkdir schema
           generate-schema-doc --deprecated-from-description schema.json schema/index.html


### PR DESCRIPTION
### Changes
Now doing `pip install .` instead of `pip install -e .` in GH Actions workflow files.

### Reason for changes
Ubuntu 22 and pip/setuptools have a lot of bugs when installing editable packages with the new build isolation flow (e.g. when the pyproject.toml is present). We don't have pyproject.toml yet, but should we need to switch, better to have less failures in the unrelated tests and workflows - we don't really need editability in GH actions we have now.

### Related tickets

N/A

### Tests
Can only test changes in these workflows post-factum.
