### PR TITLE
Enable codecov/patch status check for onnx code only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,10 +18,18 @@ coverage:
         only_pulls: true
         paths:
           - "nncf"
+    patch:
+      default:
+        branches:
+          - develop
+        informational: true
+        only_pulls: true
+        paths:
+          - "nncf/onnx"  # extend this once we collect coverage reports for more than just onnx part of precommit
+
 comment:
   layout: "diff, flags, files"
-  require_changes: false  # remove me
-  # require_changes: true
+  require_changes: false
 
   require_head: false
   require_base: false


### PR DESCRIPTION
### Changes
As stated in the title

### Reason for changes
Only the ONNX precommit coverage results are currently uploaded, so there is no sense checking and failing on patch coverage being always 0 on non-ONNX PRs.

### Related tickets
N/A

### Tests
coverage/patch check
