### PR TITLE
Add common test to GHA precommit workflow and upload coverage for it

### DIFF
--- a/.github/workflows/post_pr_merge.yml
+++ b/.github/workflows/post_pr_merge.yml
@@ -17,24 +17,17 @@ on:
       - closed
 
 jobs:
-  upload-coverage:
+  upload-coverage-common:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3  # codecov uploader demands that the scanned files be present when uploading
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-      - uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: precommit.yml
-          check_artifacts: true
-          commit: ${{ github.event.pull_request.head.sha }}  # this is the latest commit in the PR
-          name: coverage_xml
-      - name: Upload coverage report to Codecov
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-
-          # github.event.pull_request.merge_commit_sha is the fresh commit in the develop,
-          # provided that github.event.pull_request.merged == true
-          ./codecov -f ./coverage.xml -t ${{ secrets.CODECOV_TOKEN }}  -C ${{ github.event.pull_request.merge_commit_sha }} -B develop -n "codecov-onnx"
+    uses: ./.github/workflows/upload_coverage_for_develop.yml
+    with:
+      merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      last_sha_in_pr: ${{ github.event.pull_request.head.sha }}
+      coverage_artifact_name_in_pr: coverage_xml_common
+  upload-coverage-onnx:
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/upload_coverage_for_develop.yml
+    with:
+      merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      last_sha_in_pr: ${{ github.event.pull_request.head.sha }}
+      coverage_artifact_name_in_pr: coverage_xml_onnx

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -8,6 +8,29 @@ on:
       - synchronize
 
 jobs:
+  common:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.8.10
+      - name: Install NNCF and test requirements
+        run: make install-common-test
+      - name: Run common precommit test scope
+        run: make test-common
+      - name: Upload coverage report as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage_xml_common
+          path: ./coverage.xml
+      - name: Upload coverage report to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: codecov-common
   onnx:
     runs-on: ubuntu-20.04
     steps:
@@ -24,10 +47,11 @@ jobs:
       - name: Upload coverage report as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: coverage_xml # optional
+          name: coverage_xml_onnx
           path: ./coverage.xml
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          name: codecov-onnx # optional
+          name: codecov-onnx
+

--- a/.github/workflows/upload_coverage_for_develop.yml
+++ b/.github/workflows/upload_coverage_for_develop.yml
@@ -1,0 +1,37 @@
+name: Upload coverage from an artifact of a merged PR
+
+on:
+  workflow_call:
+    inputs:
+      merge_commit_sha:
+        required: true
+        type: string
+      last_sha_in_pr:
+        required: true
+        type: string
+      coverage_artifact_name_in_pr:
+        required: true
+        type: string
+
+jobs:
+  upload-coverage:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3  # codecov uploader demands that the scanned files be present when uploading
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+      - uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: precommit.yml
+          check_artifacts: true
+          commit: ${{ github.event.pull_request.head.sha }}  # this is the latest commit in the PR
+          name: coverage_xml
+      - name: Upload coverage report to Codecov
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+
+          # github.event.pull_request.merge_commit_sha is the fresh commit in the develop,
+          # provided that github.event.pull_request.merged == true
+          ./codecov -f ./coverage.xml -t ${{ secrets.CODECOV_TOKEN }}  -C ${{ github.event.pull_request.merge_commit_sha }} -B develop -n "codecov-onnx"


### PR DESCRIPTION
### Changes
As stated in the title

### Reason for changes
Allows to observe coverage for common code since currently we run tests for common code on internal hosts and these can't upload coverage results post-merge yet.

### Related tickets
N/A

### Tests
tests/common
