### PR TITLE
Fix parameters in coverage workflows

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -24,13 +24,13 @@ jobs:
       - name: Upload coverage report as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: coverage_xml_common
+          name: coverage_common
           path: ./coverage.xml
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          name: codecov-common
+          name: coverage_common
   onnx:
     runs-on: ubuntu-20.04
     steps:
@@ -47,11 +47,11 @@ jobs:
       - name: Upload coverage report as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: coverage_xml_onnx
+          name: coverage_onnx
           path: ./coverage.xml
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          name: codecov-onnx
+          name: coverage_onnx
 

--- a/.github/workflows/upload_coverage_for_develop.yml
+++ b/.github/workflows/upload_coverage_for_develop.yml
@@ -20,13 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3  # codecov uploader demands that the scanned files be present when uploading
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ inputs.merge_commit_sha }}
       - uses: dawidd6/action-download-artifact@v2
         with:
           workflow: precommit.yml
           check_artifacts: true
-          commit: ${{ github.event.pull_request.head.sha }}  # this is the latest commit in the PR
-          name: coverage_xml
+          commit: ${{ inputs.last_sha_in_pr }}  # this is the latest commit in the PR
+          name: ${{ inputs.coverage_artifact_name_in_pr }}
       - name: Upload coverage report to Codecov
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov
@@ -34,4 +34,4 @@ jobs:
 
           # github.event.pull_request.merge_commit_sha is the fresh commit in the develop,
           # provided that github.event.pull_request.merged == true
-          ./codecov -f ./coverage.xml -t ${{ secrets.CODECOV_TOKEN }}  -C ${{ github.event.pull_request.merge_commit_sha }} -B develop -n "codecov-onnx"
+          ./codecov -f ./coverage.xml -t ${{ secrets.CODECOV_TOKEN }}  -C ${{ inputs.merge_commit_sha }} -B develop -n "${{ inputs.coverage_artifact_name_in_pr }}"


### PR DESCRIPTION
### Changes
Fixed workflow script to correctly use passed input parameters

### Reason for changes
Current version does not send out coverage reports at all.

### Related tickets
N/A

### Tests
post-merge action run, can't be tested before merging
