### PR TITLE
Adjust codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,10 +3,10 @@ ignore:
   - "tests"
   - "tools"
 
-#codecov:
-#  notify:
-#     after_n_builds: 4
-#     wait_for_ci: yes
+codecov:
+  notify:
+     after_n_builds: 2
+     wait_for_ci: no
 
 coverage:
   status:
@@ -25,7 +25,8 @@ coverage:
         informational: true
         only_pulls: true
         paths:
-          - "nncf/onnx"  # extend this once we collect coverage reports for more than just onnx part of precommit
+          - "nncf/onnx"
+          - "nncf/common"  # extend this once we collect coverage reports for more than just onnx and common part of precommit
 
 comment:
   layout: "diff, flags, files"


### PR DESCRIPTION
### Changes
Makes Codecov wait for 2 reports being uploaded before printing a comment, since we have both onnx and common precommits submitting coverage reports now via GH action runs.

### Reason for changes
Currently the common precommit finishes much faster than the ONNX, and Codecov posts coverage based off that run before waiting for the ONNX precommit to finish, which is necessarily lower and confusing.

### Related tickets
N/A

### Tests
N/A
