### PR TITLE
Inherit secrets in upload_coverage reusable workflow

### DIFF
--- a/.github/workflows/upload_coverage_for_develop.yml
+++ b/.github/workflows/upload_coverage_for_develop.yml
@@ -12,6 +12,9 @@ on:
       coverage_artifact_name_in_pr:
         required: true
         type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 jobs:
   upload-coverage:


### PR DESCRIPTION
### Changes
As stated in the title

### Reason for changes
Otherwise the `CODECOV_TOKEN` is not available from the `upload_coverage_for_develop.yml` workflow and the upload cannot proceed.

### Related tickets
N/A

### Tests
post-merge
