### PR TITLE
[PTQ][OV] Enable ChannelAlignment algorithm by default

### DIFF
--- a/nncf/common/graph/transformations/command_creation.py
+++ b/nncf/common/graph/transformations/command_creation.py
@@ -49,6 +49,18 @@ class CommandCreator(ABC):
 
     @staticmethod
     @abstractmethod
+    def create_command_to_insert_bias(node_without_bias: NNCFNode, bias_value: Any) -> TransformationCommand:
+        """
+        Creates command to insert bias after given node.
+
+        :param node_without_bias: The node that corresponds to the operation without bias.
+        :param bias_value: Bias value to insert.
+        :param nncf_graph: The NNCF graph.
+        :return: The command to insert bias value.
+        """
+
+    @staticmethod
+    @abstractmethod
     def create_command_to_update_weight(
         node_with_weight: NNCFNode, weight_value: Any, weight_port_id: int
     ) -> TransformationCommand:

--- a/nncf/openvino/graph/model_transformer.py
+++ b/nncf/openvino/graph/model_transformer.py
@@ -479,7 +479,7 @@ class OVModelTransformer(ModelTransformer):
             node_output_port = node.output(transformation.target_point.port_id)
             node_output_source_ports = node_output_port.get_target_inputs()
 
-            bias_const_node = opset.constant(transformation.bias_value, dtype=transformation.bias_value.dtype)
+            bias_const_node = opset.constant(transformation.bias_value, dtype=node.get_element_type().to_dtype())
             bias_const_output_port = bias_const_node.output(0)
 
             add_node = opset.add(node_output_port, bias_const_output_port, name=f"{node_name}/nncf_null_bias_")

--- a/nncf/openvino/graph/transformations/command_creation.py
+++ b/nncf/openvino/graph/transformations/command_creation.py
@@ -18,9 +18,9 @@ from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.transformations.command_creation import CommandCreator
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
+from nncf.openvino.graph.transformations.commands import OVBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVFQNodeRemovingCommand
 from nncf.openvino.graph.transformations.commands import OVMultiplyInsertionCommand
-from nncf.openvino.graph.transformations.commands import OVNullBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVTargetPoint
 from nncf.openvino.graph.transformations.commands import OVWeightUpdateCommand
 
@@ -54,9 +54,9 @@ class OVCommandCreator(CommandCreator):
         return OVWeightUpdateCommand(target_point, weight_value)
 
     @staticmethod
-    def create_command_to_insert_bias(node_without_bias: NNCFNode) -> OVNullBiasInsertionCommand:
+    def create_command_to_insert_bias(node_without_bias: NNCFNode, bias_value: np.ndarray) -> OVBiasInsertionCommand:
         target_point = OVTargetPoint(TargetType.POST_LAYER_OPERATION, node_without_bias.node_name, 0)
-        return OVNullBiasInsertionCommand(target_point)
+        return OVBiasInsertionCommand(target_point, bias_value)
 
     @staticmethod
     def multiply_insertion_command(

--- a/nncf/openvino/graph/transformations/commands.py
+++ b/nncf/openvino/graph/transformations/commands.py
@@ -147,16 +147,17 @@ class OVModelExtractionCommand(Command):
         raise NotImplementedError()
 
 
-class OVNullBiasInsertionCommand(TransformationCommand):
+class OVBiasInsertionCommand(TransformationCommand):
     """
     Inserts null bias for the corresponding node.
     """
 
-    def __init__(self, target_point: OVTargetPoint):
+    def __init__(self, target_point: OVTargetPoint, bias_value: np.ndarray):
         """
         :param target_point: The TargetPoint instance for the insertion that contains layer's information.
         """
         super().__init__(TransformationType.INSERT, target_point)
+        self.bias_value = bias_value
 
     def union(self, other: "TransformationCommand") -> "TransformationCommand":
         # Have a look at nncf/torch/graph/transformations/commands/PTInsertionCommand

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -152,7 +152,7 @@ class AdvancedQuantizationParameters:
     overflow_fix: OverflowFix = OverflowFix.FIRST_LAYER
     quantize_outputs: bool = False
     inplace_statistics: bool = True
-    disable_channel_alignment: bool = True
+    disable_channel_alignment: bool = False
     disable_bias_correction: bool = False
     smooth_quant_alpha: float = 0.95
 

--- a/nncf/quantization/algorithms/channel_alignment/algorithm.py
+++ b/nncf/quantization/algorithms/channel_alignment/algorithm.py
@@ -60,7 +60,6 @@ class ChannelAlignment(Algorithm):
         self,
         subset_size: int = 100,
         inplace_statistics: bool = True,
-        backend_params: Optional[Dict[str, Any]] = None,
     ):
         """
         :param subset_size: Size of a subset for the statistics collection,
@@ -68,12 +67,10 @@ class ChannelAlignment(Algorithm):
         :param inplace_statistics: Defines wheather to calculate quantizers statistics
             by backend graph operations or by default Python implementation, defaults
             to True.
-        :param backend_params: Backend specific parameters.
         """
         super().__init__()
         self.subset_size = subset_size
         self.inplace_statistics = inplace_statistics
-        self.backend_params = backend_params
         self._backend_entity = None
         self._quantile = 1e-4
         self._algorithm_key = f"CA_{hash(self)}"

--- a/nncf/quantization/algorithms/channel_alignment/algorithm.py
+++ b/nncf/quantization/algorithms/channel_alignment/algorithm.py
@@ -27,6 +27,7 @@ from nncf.common.tensor_statistics.statistic_point import StatisticPoint
 from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
 from nncf.common.utils.backend import BackendType
 from nncf.common.utils.backend import get_backend
+from nncf.openvino.graph.model_utils import create_bias_constant_value
 from nncf.quantization.algorithms.algorithm import Algorithm
 from nncf.quantization.algorithms.channel_alignment.backend import ALGO_BACKENDS
 from nncf.quantization.algorithms.channel_alignment.backend import ChannelAlignmentAlgoBackend
@@ -120,15 +121,14 @@ class ChannelAlignment(Algorithm):
             conv_in_cont = ConvParamsContainer(conv_in, model, graph, self._backend_entity)
             conv_out_cont = ConvParamsContainer(conv_out, model, graph, self._backend_entity)
 
-            if conv_in_cont.has_bias() and conv_out_cont.has_bias():
-                amean = (stat.max_values + stat.min_values) * 0.5
-                conv_in_cont.bias, conv_out_cont.bias = self._align_means(
-                    conv_in_cont.bias,
-                    conv_out_cont.bias,
-                    conv_out_cont.weight,
-                    amean,
-                    conv_out_cont.dims,
-                )
+            amean = (stat.max_values + stat.min_values) * 0.5
+            conv_in_cont.bias, conv_out_cont.bias = self._align_means(
+                conv_in_cont.bias,
+                conv_out_cont.bias,
+                conv_out_cont.weight,
+                amean,
+                conv_out_cont.dims,
+            )
 
             ascale = (stat.max_values - stat.min_values).astype(np.float32)
             eps = np.finfo(ascale.dtype).eps
@@ -153,9 +153,11 @@ class ChannelAlignment(Algorithm):
                     )
 
                 if container.stated_bias.is_modified():
-                    transformation_layout.register(
-                        command_creator.create_command_to_update_bias(container.op, container.bias, graph),
-                    )
+                    if container.bias_op_exist():
+                        command = command_creator.create_command_to_update_bias(container.op, container.bias, graph)
+                    else:
+                        command = command_creator.create_command_to_insert_bias(container.op, container.bias)
+                    transformation_layout.register(command)
 
         transformed_model = model_transformer.transform(transformation_layout)
         return transformed_model
@@ -239,10 +241,7 @@ class ChannelAlignment(Algorithm):
         scale_in_shape[conv_in_descr.conv_weight_out_channels_dim] = scale_factor.shape[conv_in_descr.bias_channels_dim]
         updated_conv_in_value = conv_in_value / scale_factor.reshape(scale_in_shape)
 
-        if bias_in_value is not None:
-            updated_bias_in_value = bias_in_value / scale_factor.reshape(bias_in_value.shape)
-        else:
-            updated_bias_in_value = None
+        updated_bias_in_value = bias_in_value / scale_factor.reshape(bias_in_value.shape)
 
         scale_out_shape = np.ones(len(conv_out_value.shape), dtype=int)
         scale_out_shape[conv_out_descr.conv_weight_in_channels_dim] = scale_factor.shape[
@@ -433,18 +432,23 @@ class ConvParamsContainer:
     Convolution container class which is incapsulating common convolutional parameters collection.
     """
 
-    def __init__(self, conv_op, model, nncf_graph, backend_entity: ChannelAlignmentAlgoBackend):
+    def __init__(
+        self, conv_op: NNCFNode, model: TModel, nncf_graph: NNCFGraph, backend_entity: ChannelAlignmentAlgoBackend
+    ):
         """
-        :param conv_op: Backend-specific conv node.
+        :param conv_op: NNCF conv node.
         :param model: Backend-specific model instance.
         :param nncf_graph: NNCFGraph of given backend-specific model.
         :param backend_entity: Current backend entity to retrieve parameters from given conv node
         """
         _, self._weights_port_id = backend_entity.get_weights_port_ids_for_node(conv_op)
         self.stated_weight = StatedTensor(backend_entity.get_weight_value(conv_op, model, self._weights_port_id))
-        bias = None
+        self._bias_op_exist = False
         if backend_entity.is_node_with_bias(conv_op, nncf_graph):
             bias = backend_entity.get_bias_value(conv_op, model, nncf_graph)
+            self._bias_op_exist = True
+        else:
+            bias = create_bias_constant_value(conv_op, nncf_graph, 0)
         self.stated_bias = StatedTensor(bias)
         self._op = conv_op
         self._dims = backend_entity.get_dims_descriptor(conv_op)
@@ -477,5 +481,5 @@ class ConvParamsContainer:
     def dims(self) -> LayoutDescriptor:
         return self._dims
 
-    def has_bias(self) -> bool:
-        return self.bias is not None
+    def bias_op_exist(self) -> bool:
+        return self._bias_op_exist

--- a/nncf/quantization/algorithms/post_training/algorithm.py
+++ b/nncf/quantization/algorithms/post_training/algorithm.py
@@ -100,7 +100,6 @@ class PostTrainingQuantization(Algorithm):
             channel_alignment = ChannelAlignment(
                 subset_size=subset_size,
                 inplace_statistics=advanced_parameters.inplace_statistics,
-                backend_params=advanced_parameters.backend_params,
             )
             self.first_stage_algorithms.append(channel_alignment)
 

--- a/nncf/quantization/algorithms/post_training/algorithm.py
+++ b/nncf/quantization/algorithms/post_training/algorithm.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, TypeVar
 
 from nncf import Dataset
@@ -34,7 +33,6 @@ from nncf.quantization.algorithms.fast_bias_correction.algorithm import FAST_BIA
 from nncf.quantization.algorithms.fast_bias_correction.algorithm import FastBiasCorrection
 from nncf.quantization.algorithms.min_max.algorithm import MinMaxQuantization
 from nncf.quantization.algorithms.smooth_quant.algorithm import SmoothQuant
-from nncf.quantization.passes import insert_null_biases_pass
 from nncf.scopes import IgnoredScope
 
 TModel = TypeVar("TModel")
@@ -48,11 +46,6 @@ class PostTrainingQuantization(Algorithm):
     2) MinMaxQuantization
     3) FastBiasCorrection or BiasCorrection
     """
-
-    @dataclass
-    class FirstStageAlgorithm:
-        algorithm: "Algorithm"
-        pre_passes: List[TPass]
 
     def __init__(
         self,
@@ -87,7 +80,7 @@ class PostTrainingQuantization(Algorithm):
         """
         super().__init__()
         self.algorithms = []
-        self.first_stage_algorithms: List[self.FirstStageAlgorithm] = []
+        self.first_stage_algorithms: List[Algorithm] = []
 
         if target_device is TargetDevice.VPU:
             warning_deprecated("VPU device is deprecated and will no longer be supported in the future.")
@@ -101,7 +94,7 @@ class PostTrainingQuantization(Algorithm):
                 inplace_statistics=advanced_parameters.inplace_statistics,
                 alpha=advanced_parameters.smooth_quant_alpha,
             )
-            self.first_stage_algorithms.append(self.FirstStageAlgorithm(smooth_quant_algorithm, []))
+            self.first_stage_algorithms.append(smooth_quant_algorithm)
 
         if not advanced_parameters.disable_channel_alignment:
             channel_alignment = ChannelAlignment(
@@ -109,7 +102,7 @@ class PostTrainingQuantization(Algorithm):
                 inplace_statistics=advanced_parameters.inplace_statistics,
                 backend_params=advanced_parameters.backend_params,
             )
-            self.first_stage_algorithms.append(self.FirstStageAlgorithm(channel_alignment, [insert_null_biases_pass]))
+            self.first_stage_algorithms.append(channel_alignment)
 
         min_max_quantization = MinMaxQuantization(
             preset=preset,
@@ -187,9 +180,7 @@ class PostTrainingQuantization(Algorithm):
         modified_model_graph = graph
         backend = get_backend(modified_model)
 
-        for first_stage_algorithm in self.first_stage_algorithms:
-            algorithm = first_stage_algorithm.algorithm
-
+        for algorithm in self.first_stage_algorithms:
             if isinstance(algorithm, SmoothQuant) and backend != BackendType.OPENVINO:
                 nncf_logger.debug(f"{backend.name} does not support SmoothQuant algorithm yet.")
                 continue
@@ -197,10 +188,6 @@ class PostTrainingQuantization(Algorithm):
             if isinstance(algorithm, ChannelAlignment) and backend != BackendType.OPENVINO:
                 nncf_logger.debug(f"{backend.name} does not support ChannelAlignment algorithm yet.")
                 continue
-
-            for pre_pass in first_stage_algorithm.pre_passes:
-                modified_model = pre_pass(modified_model, modified_model_graph)
-                modified_model_graph = NNCFGraphFactory.create(modified_model)
 
             statistics_aggregator = StatisticsAggregatorFactory.create(modified_model, dataset)
             algo_statistic_points = algorithm.get_statistic_points(modified_model, modified_model_graph)

--- a/tests/openvino/native/quantization/test_channel_alignment.py
+++ b/tests/openvino/native/quantization/test_channel_alignment.py
@@ -23,6 +23,7 @@ from nncf.openvino.graph.metatypes.openvino_metatypes import OVGroupConvolutionM
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVMatMulMetatype
 from nncf.openvino.graph.transformations.command_creation import OVCommandCreator
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
+from nncf.openvino.graph.transformations.commands import OVBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVTargetPoint
 from nncf.openvino.graph.transformations.commands import OVWeightUpdateCommand
 from nncf.quantization.algorithms.channel_alignment.backend import LayoutDescriptor
@@ -64,7 +65,7 @@ class TestOVChannelAlignment(TemplateTestChannelAlignment):
         return OVConstantMetatype
 
     def get_transformation_commands(self):
-        return OVBiasCorrectionCommand, OVWeightUpdateCommand
+        return OVBiasInsertionCommand, OVBiasCorrectionCommand, OVWeightUpdateCommand
 
     def mock_command_creation_factory(self, mocker) -> None:
         mocker.patch("nncf.common.factory.CommandCreatorFactory.create", return_value=OVCommandCreator)

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -568,7 +568,7 @@ def test_null_biases_insertion(model_with_parameters):
         TargetType.LAYER,
         OVBiasInsertionCommand,
         port_id=0,
-        command_kwargs=[{"bias_value": np.zeros(shape, dtype=np.float32)} for shape in layers[1]],
+        command_kwargs=[{"bias_value": np.zeros(shape, dtype=np.int8)} for shape in layers[1]],
     )
     ops_dict = {op.get_friendly_name(): op for op in transformed_model.get_ops()}
 

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -28,11 +28,11 @@ from nncf.openvino.graph.node_utils import get_inplace_min_op
 from nncf.openvino.graph.node_utils import get_ov_model_reduce_node_name
 from nncf.openvino.graph.node_utils import get_result_node_name
 from nncf.openvino.graph.transformations.commands import OVBiasCorrectionCommand
+from nncf.openvino.graph.transformations.commands import OVBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVFQNodeRemovingCommand
 from nncf.openvino.graph.transformations.commands import OVInplaceFnInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVModelExtractionCommand
 from nncf.openvino.graph.transformations.commands import OVMultiplyInsertionCommand
-from nncf.openvino.graph.transformations.commands import OVNullBiasInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVOutputInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVQuantizerInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVTargetPoint
@@ -56,9 +56,12 @@ TARGET_POST_LAYER_FQS = [["Add/fq_output_0"], ["MatMul/fq_output_0"], ["Add/fq_o
 TARGET_WEIGHTS_FQS = [["Add/fq_weights_1"], ["MatMul/fq_weights_1"], ["Add/fq_weights_1", "MatMul/fq_weights_1"]]
 
 
-def create_transformed_model(model, target_layers, target_type, command_type, port_id=0, **kwargs):
+def create_transformed_model(model, target_layers, target_type, command_type, port_id=0, command_kwargs=None):
     transformation_layout = TransformationLayout()
-    for target_layer in target_layers:
+    command_kwargs = command_kwargs or {}
+    if isinstance(command_kwargs, dict):
+        command_kwargs = [command_kwargs] * len(target_layers)
+    for target_layer, kwargs in zip(target_layers, command_kwargs):
         target_point = OVTargetPoint(target_type, target_layer, port_id=port_id)
         command = command_type(target_point, **kwargs)
         transformation_layout.register(command)
@@ -204,9 +207,11 @@ def test_inplace_fn_insertion(test_params: InplaceOpTestCase, target_type, targe
         target_layers,
         target_type,
         OVInplaceFnInsertionCommand,
-        port_id=port_id,
-        inplace_op_fn=test_params.op_builder(test_params.name, test_params.reduce_shape),
-        fn_output_port_id=0,
+        port_id,
+        {
+            "inplace_op_fn": test_params.op_builder(test_params.name, test_params.reduce_shape),
+            "fn_output_port_id": 0,
+        },
     )
 
     inplace_branches_num = 1
@@ -255,9 +260,11 @@ def test_split_inplace_fn_insertion(test_params: InplaceOpTestCase):
         [target_layer],
         TargetType.POST_LAYER_OPERATION,
         OVInplaceFnInsertionCommand,
-        port_id=port_id,
-        inplace_op_fn=test_params.op_builder(test_params.name, test_params.reduce_shape),
-        fn_output_port_id=0,
+        port_id,
+        {
+            "inplace_op_fn": test_params.op_builder(test_params.name, test_params.reduce_shape),
+            "fn_output_port_id": 0,
+        },
     )
 
     target_node = get_node_by_name(transformed_model, target_layer)
@@ -301,9 +308,11 @@ def test_inplace_reduce_fn_zero_rank_output(reduction_shape):
         [target_layer],
         TargetType.OPERATION_WITH_WEIGHTS,
         OVInplaceFnInsertionCommand,
-        port_id=port_id,
-        inplace_op_fn=get_inplace_min_op(name, reduction_shape=reduction_shape),
-        fn_output_port_id=0,
+        port_id,
+        {
+            "inplace_op_fn": get_inplace_min_op(name, reduction_shape=reduction_shape),
+            "fn_output_port_id": 0,
+        },
     )
     target_node = get_prev_node(get_node_by_name(transformed_model, target_layer), 1)
     check_inplace_op(target_node, ["ReduceMin"], [[]], 1, 0)
@@ -354,9 +363,7 @@ def test_inplace_mean_per_ch_fn_dynamic_shapes(test_params: InplaceOpTestCase, i
 def test_output_insertion(target_type, target_layers):
     model = LinearModel().ov_model
     port_id = 1 if target_type == TargetType.OPERATION_WITH_WEIGHTS else 0
-    transformed_model = create_transformed_model(
-        model, target_layers, target_type, OVOutputInsertionCommand, port_id=port_id
-    )
+    transformed_model = create_transformed_model(model, target_layers, target_type, OVOutputInsertionCommand, port_id)
 
     if target_type == TargetType.PRE_LAYER_OPERATION:
         target_layers = ["Reshape"]
@@ -386,7 +393,7 @@ def test_split_output_insertion(test_params: InplaceOpTestCase):
     target_layer = "Split"
     port_id = 1
     transformed_model = create_transformed_model(
-        model, [target_layer], TargetType.POST_LAYER_OPERATION, OVOutputInsertionCommand, port_id=port_id
+        model, [target_layer], TargetType.POST_LAYER_OPERATION, OVOutputInsertionCommand, port_id
     )
 
     target_node = get_node_by_name(transformed_model, target_layer)
@@ -431,7 +438,7 @@ def test_fq_insertion_pre_layer(target_layers, ref_fq_names):
         target_layers,
         TargetType.PRE_LAYER_OPERATION,
         OVQuantizerInsertionCommand,
-        quantizer_parameters=quantizer_parameters,
+        command_kwargs={"quantizer_parameters": quantizer_parameters},
     )
     fq_nodes = get_fq_nodes(transformed_model)
 
@@ -452,7 +459,7 @@ def test_fq_insertion_post_layer(target_layers, ref_fq_names):
         target_layers,
         TargetType.POST_LAYER_OPERATION,
         OVQuantizerInsertionCommand,
-        quantizer_parameters=quantizer_parameters,
+        command_kwargs={"quantizer_parameters": quantizer_parameters},
     )
     fq_nodes = get_fq_nodes(transformed_model)
 
@@ -473,8 +480,8 @@ def test_fq_insertion_weights(target_layers, ref_fq_names):
         target_layers,
         TargetType.OPERATION_WITH_WEIGHTS,
         OVQuantizerInsertionCommand,
-        port_id=1,
-        quantizer_parameters=quantizer_parameters,
+        1,
+        {"quantizer_parameters": quantizer_parameters},
     )
     fq_nodes = get_fq_nodes(transformed_model)
 
@@ -507,7 +514,7 @@ def test_bias_correction(model_with_parameters):
     refs = model_with_parameters["refs"]
 
     transformed_model = create_transformed_model(
-        model, layers, TargetType.LAYER, OVBiasCorrectionCommand, port_id=1, **{"bias_value": values}
+        model, layers, TargetType.LAYER, OVBiasCorrectionCommand, 1, {"bias_value": values}
     )
     ops_dict = {op.get_friendly_name(): op for op in transformed_model.get_ops()}
 
@@ -545,8 +552,8 @@ def test_no_transformations():
 
 
 MODELS_WITH_PARAMETERS = [
-    {"model": ConvNotBiasModel().ov_model, "layers": ["Conv"]},
-    {"model": WeightsModel().ov_model, "layers": ["Conv", "Conv_backprop"]},
+    {"model": ConvNotBiasModel().ov_model, "layers": [["Conv"], [(1, 3, 1, 1)]]},
+    {"model": WeightsModel().ov_model, "layers": [["Conv", "Conv_backprop"], [(1, 3, 1, 1), (1, 3, 1, 1)]]},
 ]
 
 
@@ -555,10 +562,17 @@ def test_null_biases_insertion(model_with_parameters):
     model = model_with_parameters["model"]
     layers = model_with_parameters["layers"]
 
-    transformed_model = create_transformed_model(model, layers, TargetType.LAYER, OVNullBiasInsertionCommand, port_id=0)
+    transformed_model = create_transformed_model(
+        model,
+        layers[0],
+        TargetType.LAYER,
+        OVBiasInsertionCommand,
+        port_id=0,
+        command_kwargs=[{"bias_value": np.zeros(shape, dtype=np.float32)} for shape in layers[1]],
+    )
     ops_dict = {op.get_friendly_name(): op for op in transformed_model.get_ops()}
 
-    for layer_name in layers:
+    for layer_name in layers[0]:
         node = ops_dict[layer_name]
         layer_shape = ops_dict[layer_name].shape
         bias_dtype = node.get_element_type().to_dtype()
@@ -626,7 +640,7 @@ def test_multiply_insertion(model_with_parameters):
         TargetType.POST_LAYER_OPERATION,
         OVMultiplyInsertionCommand,
         port_id=output_port_id,
-        **{"scale_value": scale, "destination_node_names": dest_nodes, "multiply_node_name": "test_name"},
+        command_kwargs={"scale_value": scale, "destination_node_names": dest_nodes, "multiply_node_name": "test_name"},
     )
     ops_dict = {op.get_friendly_name(): op for op in transformed_model.get_ops()}
 

--- a/tests/openvino/native/test_model_utils.py
+++ b/tests/openvino/native/test_model_utils.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+from openvino.runtime import opset9 as opset
+
+from nncf.openvino.graph.model_utils import create_bias_constant_value
+
+
+def get_conv_node(input_shape, dtype):
+    input_node = opset.parameter(input_shape, dtype=dtype)
+    strides = [1, 1]
+    pads = [0, 0]
+    dilations = [1, 1]
+    return opset.convolution(
+        input_node, np.zeros((4, input_shape[1], 1, 1), dtype=dtype), strides, pads, pads, dilations
+    )
+
+
+@pytest.mark.parametrize(
+    "input_shape,dtype",
+    [((2, 3, 4, 5), np.float32), ((1, 1, 1, 1), np.float64)],
+)
+def test_create_bias_constant_value(input_shape, dtype):
+    conv = get_conv_node(input_shape, dtype)
+    val = create_bias_constant_value(conv, 5)
+    assert val.shape == (1, 4, 1, 1)
+    assert np.equal(val, np.full((1, 4, 1, 1), 5)).all()


### PR DESCRIPTION
On top of #2056
### Changes

* ChannelAlignment algorithm is enabled by default
* Biases are added only for operations that are affected by CA algorithm

### Reason for changes

* To increase models mertics by using ChannelAlignment algorithm by default

### Related tickets

114328
114583

### Tests

tests/post_training/test_templates/test_channel_alignment.py is updated
