### PR TITLE
Fix torch.jit.script wrapper

### DIFF
--- a/nncf/torch/__init__.py
+++ b/nncf/torch/__init__.py
@@ -59,7 +59,7 @@ from nncf.torch.dynamic_graph.context import no_nncf_trace
 from nncf.torch.dynamic_graph.context import forward_nncf_trace
 from nncf.torch.strip import strip
 from nncf.torch.quantization.quantize_model import compress_weights
-from nncf.torch.dynamic_graph.patch_pytorch import disable
+from nncf.torch.dynamic_graph.patch_pytorch import disable_patching
 
 # NNCF relies on tracing PyTorch operations. Each code that uses NNCF
 # should be executed with PyTorch operators wrapped via a call to "patch_torch_operators",

--- a/nncf/torch/__init__.py
+++ b/nncf/torch/__init__.py
@@ -13,6 +13,7 @@
 """
 Base subpackage for NNCF PyTorch functionality.
 """
+
 from nncf import nncf_logger
 from nncf.common.logging.logger import warn_bkc_version_mismatch
 
@@ -58,6 +59,7 @@ from nncf.torch.dynamic_graph.context import no_nncf_trace
 from nncf.torch.dynamic_graph.context import forward_nncf_trace
 from nncf.torch.strip import strip
 from nncf.torch.quantization.quantize_model import compress_weights
+from nncf.torch.dynamic_graph.patch_pytorch import disable
 
 # NNCF relies on tracing PyTorch operations. Each code that uses NNCF
 # should be executed with PyTorch operators wrapped via a call to "patch_torch_operators",

--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -188,7 +188,7 @@ def torch_jit_script_wrapper(*args, **kwargs):
     # so at call of torch.jit.script function we need to
     # un-patch the torch operators
 
-    with disable():
+    with disable_patching():
         signature = inspect.signature(_ORIG_JIT_SCRIPT)
         bound_args = signature.bind(*args, **kwargs).arguments
         # Process the case when the object-to-script is a class as in the original jit.script logic
@@ -218,7 +218,7 @@ def torch_jit_script_wrapper(*args, **kwargs):
 
 
 def torch_jit_trace_make_module_wrapper(*args, **kwargs):
-    with disable():
+    with disable_patching():
         retval = _ORIG_JIT_TRACE_MAKE_MODULE(*args, **kwargs)
     return retval
 
@@ -408,7 +408,7 @@ def unpatch_torch_operators():
 
 
 @contextmanager
-def disable():
+def disable_patching():
     was_patched = _OPERATORS_ALREADY_WRAPPED
     if was_patched:
         unpatch_torch_operators()

--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -201,7 +201,12 @@ def torch_jit_script_wrapper(*args, **kwargs):
             frames_up = bound_args.get("_frames_up", 0)
             rcb = createResolutionCallbackFromFrame(frames_up + 1)
             kwargs["_rcb"] = rcb
-        retval = _ORIG_JIT_SCRIPT(*args, **kwargs)
+        try:
+            retval = _ORIG_JIT_SCRIPT(*args, **kwargs)
+        except Exception as e:
+            if apply_unpatch:
+                patch_torch_operators()
+            raise e
     else:
         # For some reason resolution callback may return patched methods, so we wrap it to avoid this
         if "_rcb" in kwargs:
@@ -215,7 +220,12 @@ def torch_jit_script_wrapper(*args, **kwargs):
 
             kwargs["_rcb"] = rcb_wrapper
 
-        retval = _ORIG_JIT_SCRIPT(*args, **kwargs)
+        try:
+            retval = _ORIG_JIT_SCRIPT(*args, **kwargs)
+        except Exception as e:
+            if apply_unpatch:
+                patch_torch_operators()
+            raise e
 
     if apply_unpatch:
         patch_torch_operators()

--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -11,6 +11,7 @@
 
 import functools
 import inspect
+from contextlib import contextmanager
 from typing import List
 
 import torch
@@ -187,59 +188,38 @@ def torch_jit_script_wrapper(*args, **kwargs):
     # so at call of torch.jit.script function we need to
     # un-patch the torch operators
 
-    # If already unpatched, don't perform unpatch/patch
-    apply_unpatch = _OPERATORS_ALREADY_WRAPPED
-    if apply_unpatch:
-        unpatch_torch_operators()
-
-    signature = inspect.signature(_ORIG_JIT_SCRIPT)
-    bound_args = signature.bind(*args, **kwargs).arguments
-    # Process the case when the object-to-script is a class as in the original jit.script logic
-    if inspect.isclass(bound_args["obj"]):
-        # Inserting wrapper alters the call stack, hence we need to change the resolution callback accordingly
-        if "_rcb" not in bound_args:
-            frames_up = bound_args.get("_frames_up", 0)
-            rcb = createResolutionCallbackFromFrame(frames_up + 1)
-            kwargs["_rcb"] = rcb
-        try:
+    with disable():
+        signature = inspect.signature(_ORIG_JIT_SCRIPT)
+        bound_args = signature.bind(*args, **kwargs).arguments
+        # Process the case when the object-to-script is a class as in the original jit.script logic
+        if inspect.isclass(bound_args["obj"]):
+            # Inserting wrapper alters the call stack, hence we need to change the resolution callback accordingly
+            if "_rcb" not in bound_args:
+                frames_up = bound_args.get("_frames_up", 0)
+                rcb = createResolutionCallbackFromFrame(frames_up + 1)
+                kwargs["_rcb"] = rcb
             retval = _ORIG_JIT_SCRIPT(*args, **kwargs)
-        except Exception as e:
-            if apply_unpatch:
-                patch_torch_operators()
-            raise e
-    else:
-        # For some reason resolution callback may return patched methods, so we wrap it to avoid this
-        if "_rcb" in kwargs:
-            rcb = kwargs["_rcb"]
+        else:
+            # For some reason resolution callback may return patched methods, so we wrap it to avoid this
+            if "_rcb" in kwargs:
+                rcb = kwargs["_rcb"]
 
-            def rcb_wrapper(name):
-                value = rcb(name)
-                if hasattr(value, "_original_op"):
-                    value = value._original_op  # pylint: disable=protected-access
-                return value
+                def rcb_wrapper(name):
+                    value = rcb(name)
+                    if hasattr(value, "_original_op"):
+                        value = value._original_op  # pylint: disable=protected-access
+                    return value
 
-            kwargs["_rcb"] = rcb_wrapper
+                kwargs["_rcb"] = rcb_wrapper
 
-        try:
             retval = _ORIG_JIT_SCRIPT(*args, **kwargs)
-        except Exception as e:
-            if apply_unpatch:
-                patch_torch_operators()
-            raise e
 
-    if apply_unpatch:
-        patch_torch_operators()
-
-    return retval
+        return retval
 
 
 def torch_jit_trace_make_module_wrapper(*args, **kwargs):
-    apply_unpatch = _OPERATORS_ALREADY_WRAPPED
-    if apply_unpatch:
-        unpatch_torch_operators()
-    retval = _ORIG_JIT_TRACE_MAKE_MODULE(*args, **kwargs)
-    if apply_unpatch:
-        patch_torch_operators()
+    with disable():
+        retval = _ORIG_JIT_TRACE_MAKE_MODULE(*args, **kwargs)
     return retval
 
 
@@ -425,3 +405,17 @@ def unpatch_torch_operators():
 
     for orig_op_info in ORIGINAL_OPERATORS:
         setattr(orig_op_info.namespace, orig_op_info.name, orig_op_info.op)
+
+
+@contextmanager
+def disable():
+    was_patched = _OPERATORS_ALREADY_WRAPPED
+    if was_patched:
+        unpatch_torch_operators()
+    try:
+        yield
+    finally:
+        # The code in the with statement may raise an exception, which could be expected to be handled elsewhere.
+        # Need to restore the previous state of patching in this case before continuing to the exception handling.
+        if was_patched:
+            patch_torch_operators()

--- a/tests/torch/pytorch_patch_isolated.py
+++ b/tests/torch/pytorch_patch_isolated.py
@@ -48,3 +48,27 @@ def test_jit_if_tracing_script_source_equals():
         "torch.jit.script", "script"
     )
     assert torch_source == nncf_source_corrected
+
+
+class DummyModel(torch.nn.Module):
+    def forward(self, x):
+        return x
+
+
+@pytest.mark.skipif(ISOLATION_RUN_ENV_VAR not in os.environ, reason="Should be run via isolation proxy")
+def test_jit_script_exception_preserves_patching_isolated():
+    from nncf.torch import create_compressed_model
+    from nncf import NNCFConfig
+    _, compressed_model = create_compressed_model(DummyModel(), NNCFConfig.from_dict({
+        "input_info": {"sample_size": [1, 3, 32, 32]},
+        "compression": {"algorithm": "quantization"}
+    }))
+
+    try:
+        torch.jit.script(compressed_model)  # supposed to fail since torch.jit.script does not support NNCF models
+    except:
+        pass
+
+    # torch.nn.Module.__call__ is one of the fundamental patched functions, if the code object points to NNCF code,
+    # then it means patching is still present
+    assert 'nncf' in torch.nn.Module.__call__.__code__.co_filename

--- a/tests/torch/pytorch_patch_isolated.py
+++ b/tests/torch/pytorch_patch_isolated.py
@@ -57,18 +57,21 @@ class DummyModel(torch.nn.Module):
 
 @pytest.mark.skipif(ISOLATION_RUN_ENV_VAR not in os.environ, reason="Should be run via isolation proxy")
 def test_jit_script_exception_preserves_patching_isolated():
-    from nncf.torch import create_compressed_model
     from nncf import NNCFConfig
-    _, compressed_model = create_compressed_model(DummyModel(), NNCFConfig.from_dict({
-        "input_info": {"sample_size": [1, 3, 32, 32]},
-        "compression": {"algorithm": "quantization"}
-    }))
+    from nncf.torch import create_compressed_model
+
+    _, compressed_model = create_compressed_model(
+        DummyModel(),
+        NNCFConfig.from_dict(
+            {"input_info": {"sample_size": [1, 3, 32, 32]}, "compression": {"algorithm": "quantization"}}
+        ),
+    )
 
     try:
         torch.jit.script(compressed_model)  # supposed to fail since torch.jit.script does not support NNCF models
-    except:
+    except:  # pylint:disable=bare-except
         pass
 
     # torch.nn.Module.__call__ is one of the fundamental patched functions, if the code object points to NNCF code,
     # then it means patching is still present
-    assert 'nncf' in torch.nn.Module.__call__.__code__.co_filename
+    assert "nncf" in torch.nn.Module.__call__.__code__.co_filename

--- a/tests/torch/test_pytorch_patch.py
+++ b/tests/torch/test_pytorch_patch.py
@@ -25,6 +25,7 @@ from tests.torch.helpers import BasicConvTestModel
 from tests.torch.helpers import create_compressed_model_and_algo_for_test
 from tests.torch.helpers import register_bn_adaptation_init_args
 from tests.torch.pytorch_patch_isolated import test_jit_if_tracing_script_source_equals
+from tests.torch.pytorch_patch_isolated import test_jit_script_exception_preserves_patching_isolated
 
 
 def test_get_all_aliases_is_valid():
@@ -83,6 +84,11 @@ def test_jit_if_tracing_script_patching(tmp_path):
 def test_jit_if_tracing_script_source():
     # Run test case in a separate process to track patching of torch by NNCF
     run_pytest_case_function_in_separate_process(test_jit_if_tracing_script_source_equals)
+
+
+def test_jit_script_exception_preserves_patching():
+    # Run test case in a separate process to track patching of torch by NNCF
+    run_pytest_case_function_in_separate_process(test_jit_script_exception_preserves_patching_isolated)
 
 
 def test_jit_script_signature():


### PR DESCRIPTION
### Changes
`torch.jit.script` wrapper fixed to catch exceptions in the original `torch.jit.script` call in order to keep torch state patched if an exception from the user's `torch.jit.script` invocation was expected to fail (by handling the original exception) and the process should have continued.

### Reason for changes
If the user has the following code:
```python
_, nncf_model = create_compressed_model(...)
try:
    _ = torch.jit.script(nncf_model)
except:
    pass
```
then, since `torch.jit.script` will fail for NNCF models and the wrapper had to unpatch torch ops in the meanwhile, we end up in a state where the script continues, but torch ops are unpatched, and further interaction with `nncf_model` will fail.

### Related tickets
118468

### Tests
tests.torch.test_pytorch_patch.test_jit_script_exception_preserves_patching