### PR TITLE
Fix PostprocessingNodeLocator

### DIFF
--- a/nncf/common/quantization/quantizer_propagation/graph.py
+++ b/nncf/common/quantization/quantizer_propagation/graph.py
@@ -165,6 +165,14 @@ class QuantizerPropagationStateGraph(nx.DiGraph):
             self._add_barrier_after_node(barred_node_key)
         self._branch_nodes_directly_dominating_outputs = None
 
+    def get_input_node_keys(self) -> List[str]:
+        """
+        Returns graph input node keys.
+
+        :return: List of the input node keys.
+        """
+        return self._input_node_keys_vs_nncf_nodes.keys()
+
     def get_node_keys_by_metatype(self, metatype: Type[OperatorMetatype]) -> List[str]:
         """
         Returns a list of node keys, whose metatype is corresponding to the 'metatype'.

--- a/nncf/common/quantization/quantizer_propagation/solver.py
+++ b/nncf/common/quantization/quantizer_propagation/solver.py
@@ -237,7 +237,6 @@ class PostprocessingNodeLocator:
         node = self._quant_prop_graph.nodes[node_key]
         return node.get(self._quant_prop_graph.NODE_TYPE_NODE_ATTR) == QuantizerPropagationStateGraphNodeType.OPERATOR
 
-    # pylint:disable=protected-access
     def get_post_processing_node_keys(self) -> Set[str]:
         """
         Finds out the nodes of the QuantizerPropagationStateGraph, which are in post-processing part of the model.
@@ -278,7 +277,7 @@ class PostprocessingNodeLocator:
 
                 if (
                     self._is_node_has_underlying_weights(node_key)
-                    or node_key in self._quant_prop_graph._input_node_keys_vs_nncf_nodes.keys()
+                    or node_key in self._quant_prop_graph.get_input_node_keys()
                 ):
                     if post_proc_encountered:
                         _extend_ignored_operations(path)

--- a/nncf/common/quantization/quantizer_propagation/solver.py
+++ b/nncf/common/quantization/quantizer_propagation/solver.py
@@ -23,7 +23,6 @@ from nncf.common.graph import INPUT_NOOP_METATYPES
 from nncf.common.graph import OUTPUT_NOOP_METATYPES
 from nncf.common.graph import NNCFNodeName
 from nncf.common.graph import OperatorMetatype
-from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.transformations.commands import TargetPoint
 from nncf.common.hardware.config import HWConfig
 from nncf.common.insertion_point_graph import InsertionPointGraph
@@ -238,6 +237,7 @@ class PostprocessingNodeLocator:
         node = self._quant_prop_graph.nodes[node_key]
         return node.get(self._quant_prop_graph.NODE_TYPE_NODE_ATTR) == QuantizerPropagationStateGraphNodeType.OPERATOR
 
+    # pylint:disable=protected-access
     def get_post_processing_node_keys(self) -> Set[str]:
         """
         Finds out the nodes of the QuantizerPropagationStateGraph, which are in post-processing part of the model.
@@ -276,7 +276,10 @@ class PostprocessingNodeLocator:
                 ):
                     post_proc_encountered = True
 
-                if self._is_node_has_underlying_weights(node_key):
+                if (
+                    self._is_node_has_underlying_weights(node_key)
+                    or node_key in self._quant_prop_graph._input_node_keys_vs_nncf_nodes.keys()
+                ):
                     if post_proc_encountered:
                         _extend_ignored_operations(path)
                 else:

--- a/tests/common/quantization/test_ignore_post_processing.py
+++ b/tests/common/quantization/test_ignore_post_processing.py
@@ -94,6 +94,8 @@ class ModelToTest1:
             "TopK_1",
             "NMS_1",
             "NMS_2",
+            "Identity_3",
+            "Input_2",
         ]
 
 
@@ -463,7 +465,7 @@ class ModelToTest9:
         ]
         original_mock_graph = create_mock_graph(nodes, node_edges)
         self.nncf_graph = get_nncf_graph_from_mock_nx_graph(original_mock_graph)
-        self.reference_ignored_scopes = []
+        self.reference_ignored_scopes = ["Input_1", "Identity_1", "TopK_1", "Identity_2"]
 
 
 @pytest.mark.parametrize("model_to_test", ALL_SYNTHETIC_NNCF_GRAPH.values())


### PR DESCRIPTION
### Changes

- Fixed PostprocessingNodeLocator algorithm to ignore `Input -> ... -> TopK/NMS -> ... -> Output` pattern (without Conv/MatMul).

### Reason for changes

- Accuracy degradation

### Related tickets

- 117437

### Tests

- Updated `tests/common/quantization/test_ignore_post_processing.py`
