### PR TITLE
Updated requirements of the ptq tensorflow mobilenet_v2 example

### DIFF
--- a/examples/post_training_quantization/tensorflow/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/tensorflow/mobilenet_v2/main.py
@@ -18,7 +18,6 @@ from typing import List, Optional
 import openvino.runtime as ov
 import tensorflow as tf
 import tensorflow_datasets as tfds
-from keras.utils import data_utils
 from openvino.tools import mo
 from tqdm import tqdm
 
@@ -113,7 +112,7 @@ def preprocess_for_eval(image, label):
 val_dataset = tfds.load("imagenette/320px-v2", split="validation", shuffle_files=False, as_supervised=True)
 val_dataset = val_dataset.map(preprocess_for_eval).batch(128)
 
-weights_path = data_utils.get_file("mobilenet_v2_imagenette_weights.h5", WEIGHTS_URL, cache_subdir="models")
+weights_path = tf.keras.utils.get_file("mobilenet_v2_imagenette_weights.h5", WEIGHTS_URL, cache_subdir="models")
 tf_model = tf.keras.applications.MobileNetV2(weights=weights_path, classes=DATASET_CLASSES)
 
 ###############################################################################

--- a/examples/post_training_quantization/tensorflow/mobilenet_v2/requirements.txt
+++ b/examples/post_training_quantization/tensorflow/mobilenet_v2/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow>=2.7.0,<2.12
+tensorflow~=2.12.0
 tensorflow-datasets
 tqdm
 openvino-dev==2023.0.1


### PR DESCRIPTION
### Changes

tensorflow>=2.7.0,<2.12 => tensorflow~=2.12.0

### Reason for changes

Installation errors:
ERROR: google-auth 2.22.0 has requirement urllib3<2.0, but you'll have urllib3 2.0.4 which is incompatible.
ERROR: tensorflow-metadata 1.14.0 has requirement protobuf<4.21,>=3.20.3, but you'll have protobuf 3.19.6 which is incompatible.
ERROR: tensorflow-datasets 4.9.2 has requirement protobuf>=3.20, but you'll have protobuf 3.19.6 which is incompatible.

### Related tickets

N/A

### Tests

example tests (build 73)
