### PR TITLE
Constrain filelock package version

### DIFF
--- a/tests/tensorflow/requirements.txt
+++ b/tests/tensorflow/requirements.txt
@@ -10,5 +10,9 @@ pydot
 tensorflow_hub
 virtualenv
 
+# filelock 3.12.3 requires typing-extensions>=4.7.1, but tensorflow 2.12.1 requires typing-extensions<4.6.0,>=3.6.6
+# TODO: remove after upgrade to TF 2.13
+filelock<3.12.3
+
 # Ticket 69520
 pyparsing<3.0


### PR DESCRIPTION
### Changes

Add package constraint `filelock<3.12.3`.

### Reason for changes

Installing tensorflow test environment produces the error:
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
tensorflow 2.12.1 requires typing-extensions<4.6.0,>=3.6.6, but you have typing-extensions 4.7.1 which is incompatible.
```

Starting from `filelock==3.12.3`, it requires `typing-extensions>=4.7.1` so downgrading to `filelock==3.12.2` resolves the issue.

This is temporary measure unless we upgrade to TF 2.13 which does not have `typing-extensions<4.6.0` constraint.

