### PR TITLE
Fix package detection

### DIFF
--- a/nncf/__init__.py
+++ b/nncf/__init__.py
@@ -11,6 +11,7 @@
 """
 Neural Network Compression Framework (NNCF) for enhanced OpenVINO™ inference.
 """
+
 from nncf.common.logging import nncf_logger
 from nncf.common.logging.logger import disable_logging
 from nncf.common.logging.logger import set_log_level
@@ -32,13 +33,20 @@ _SUPPORTED_FRAMEWORKS = ["torch", "tensorflow", "onnx", "openvino"]
 
 
 from importlib.util import find_spec as _find_spec  # pylint:disable=wrong-import-position
+from pathlib import Path as _Path
 
 _AVAILABLE_FRAMEWORKS = {}
 
 for fw_name in _SUPPORTED_FRAMEWORKS:
     spec = _find_spec(fw_name)
-    # if the framework is not present, spec may still be not None because it found our nncf.*backend_name* subpackage
-    framework_present = spec is not None and spec.origin is not None and "nncf" not in spec.origin
+    framework_present = False
+    if spec is not None and spec.origin is not None:
+        origin_path = _Path(spec.origin)
+        here = _Path(__file__)
+        if origin_path not in here.parents:
+            # if the framework is not present, spec may still be not None because
+            # it found our nncf.*backend_name* subpackage, and spec.origin will point to a folder in NNCF code
+            framework_present = True
     _AVAILABLE_FRAMEWORKS[fw_name] = framework_present
 
 if not any(_AVAILABLE_FRAMEWORKS.values()):

--- a/nncf/__init__.py
+++ b/nncf/__init__.py
@@ -54,7 +54,7 @@ if not any(_AVAILABLE_FRAMEWORKS.values()):
         "Neither PyTorch, TensorFlow, ONNX or OpenVINO Python packages have been found in your Python "
         "environment.\n"
         "Please install one of the supported frameworks above in order to use NNCF on top of it.\n"
-        "See the installation guide at https://github.com/openvinotoolkit/nncf#installation for help."
+        "See the installation guide at https://github.com/openvinotoolkit/nncf#installation-guide for help."
     )
 else:
     nncf_logger.info(

--- a/nncf/__init__.py
+++ b/nncf/__init__.py
@@ -33,7 +33,7 @@ _SUPPORTED_FRAMEWORKS = ["torch", "tensorflow", "onnx", "openvino"]
 
 
 from importlib.util import find_spec as _find_spec  # pylint:disable=wrong-import-position
-from pathlib import Path as _Path
+from pathlib import Path as _Path  # pylint:disable=wrong-import-position
 
 _AVAILABLE_FRAMEWORKS = {}
 

--- a/tests/common/test_framework_detection.py
+++ b/tests/common/test_framework_detection.py
@@ -41,10 +41,10 @@ class FailForModules:
             return ModuleSpec(fullname, loader=MagicMock(), origin=origin)
         return _REAL_FIND_SPEC(fullname, path, target)
 
-def _mock_import_and_check_availability_messages(ref_available_frameworks: List[str],
-                                                 unavailable_frameworks: List[str],
-                                                 failer_obj: FailForModules,
-                                                 nncf_caplog):
+
+def _mock_import_and_check_availability_messages(
+    ref_available_frameworks: List[str], unavailable_frameworks: List[str], failer_obj: FailForModules, nncf_caplog
+):
     with unittest.mock.patch("importlib.util.find_spec", wraps=failer_obj):
         with nncf_caplog.at_level(logging.INFO):
             importlib.reload(nncf)


### PR DESCRIPTION
### Changes
Fixed the package detection to account for cases where backend's `ModuleSpec` origin path can validly contain 'nncf'

### Reason for changes
NNCF would report incorrect package availability when the virtual environment has `nncf` in its path, which can actually happen commonplace.

### Related tickets
119563

### Tests
test_frameworks_detected_if_origin_in_nncf
