### PR TITLE
Upgrade ultralytics to 8.0.170

### DIFF
--- a/examples/post_training_quantization/openvino/yolov8/main.py
+++ b/examples/post_training_quantization/openvino/yolov8/main.py
@@ -17,13 +17,13 @@ import numpy as np
 import openvino.runtime as ov
 import torch
 from tqdm import tqdm
-from ultralytics.models.yolo import YOLO
 from ultralytics.cfg import get_cfg
+from ultralytics.data.converter import coco80_to_coco91_class
 from ultralytics.data.utils import check_det_dataset
 from ultralytics.engine.validator import BaseValidator as Validator
+from ultralytics.models.yolo import YOLO
 from ultralytics.utils import DATASETS_DIR
 from ultralytics.utils import DEFAULT_CFG
-from ultralytics.data.converter import coco80_to_coco91_class
 from ultralytics.utils.metrics import ConfusionMatrix
 
 import nncf

--- a/examples/post_training_quantization/openvino/yolov8/main.py
+++ b/examples/post_training_quantization/openvino/yolov8/main.py
@@ -17,14 +17,14 @@ import numpy as np
 import openvino.runtime as ov
 import torch
 from tqdm import tqdm
-from ultralytics import YOLO
-from ultralytics.yolo.cfg import get_cfg
-from ultralytics.yolo.data.utils import check_det_dataset
-from ultralytics.yolo.engine.validator import BaseValidator as Validator
-from ultralytics.yolo.utils import DATASETS_DIR
-from ultralytics.yolo.utils import DEFAULT_CFG
-from ultralytics.yolo.utils import ops
-from ultralytics.yolo.utils.metrics import ConfusionMatrix
+from ultralytics.models.yolo import YOLO
+from ultralytics.cfg import get_cfg
+from ultralytics.data.utils import check_det_dataset
+from ultralytics.engine.validator import BaseValidator as Validator
+from ultralytics.utils import DATASETS_DIR
+from ultralytics.utils import DEFAULT_CFG
+from ultralytics.data.converter import coco80_to_coco91_class
+from ultralytics.utils.metrics import ConfusionMatrix
 
 import nncf
 
@@ -66,17 +66,17 @@ def print_statistics(stats: np.ndarray, total_images: int, total_objects: int) -
 
 
 def prepare_validation(model: YOLO, args: Any) -> Tuple[Validator, torch.utils.data.DataLoader]:
-    validator = model.ValidatorClass(args)
+    validator = model.smart_load("validator")(args)
     validator.data = check_det_dataset(args.data)
     dataset = validator.data["val"]
     print(f"{dataset}")
 
     data_loader = validator.get_dataloader(f"{DATASETS_DIR}/coco128", 1)
 
-    validator = model.ValidatorClass(args)
+    validator = model.smart_load("validator")(args)
 
     validator.is_coco = True
-    validator.class_map = ops.coco80_to_coco91_class()
+    validator.class_map = coco80_to_coco91_class()
     validator.names = model.model.names
     validator.metrics.names = validator.names
     validator.nc = model.model.model[-1].nc

--- a/examples/post_training_quantization/openvino/yolov8/requirements.txt
+++ b/examples/post_training_quantization/openvino/yolov8/requirements.txt
@@ -1,3 +1,3 @@
-ultralytics==8.0.43
+ultralytics==8.0.170
 onnx>=1.12.0
 openvino-dev==2023.0.1

--- a/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/main.py
+++ b/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/main.py
@@ -18,14 +18,15 @@ import numpy as np
 import openvino.runtime as ov
 import torch
 from tqdm import tqdm
-from ultralytics import YOLO
-from ultralytics.yolo.cfg import get_cfg
-from ultralytics.yolo.data.utils import check_det_dataset
-from ultralytics.yolo.engine.validator import BaseValidator as Validator
-from ultralytics.yolo.utils import DATASETS_DIR
-from ultralytics.yolo.utils import DEFAULT_CFG
-from ultralytics.yolo.utils import ops
-from ultralytics.yolo.utils.metrics import ConfusionMatrix
+from ultralytics.models.yolo import YOLO
+from ultralytics.cfg import get_cfg
+from ultralytics.data.utils import check_det_dataset
+from ultralytics.engine.validator import BaseValidator as Validator
+from ultralytics.utils import DATASETS_DIR
+from ultralytics.utils import DEFAULT_CFG
+from ultralytics.utils import ops
+from ultralytics.data.converter import coco80_to_coco91_class
+from ultralytics.utils.metrics import ConfusionMatrix
 
 import nncf
 
@@ -91,17 +92,17 @@ def print_statistics(stats: np.ndarray, total_images: int, total_objects: int) -
 
 
 def prepare_validation(model: YOLO, args: Any) -> Tuple[Validator, torch.utils.data.DataLoader]:
-    validator = model.ValidatorClass(args)
+    validator = model.smart_load("validator")(args)
     validator.data = check_det_dataset(args.data)
     dataset = validator.data["val"]
     print(f"{dataset}")
 
     data_loader = validator.get_dataloader(f"{DATASETS_DIR}/coco128-seg", 1)
 
-    validator = model.ValidatorClass(args)
+    validator = model.smart_load("validator")(args)
 
     validator.is_coco = True
-    validator.class_map = ops.coco80_to_coco91_class()
+    validator.class_map = coco80_to_coco91_class()
     validator.names = model.model.names
     validator.metrics.names = validator.names
     validator.nc = model.model.model[-1].nc

--- a/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/main.py
+++ b/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/main.py
@@ -18,14 +18,14 @@ import numpy as np
 import openvino.runtime as ov
 import torch
 from tqdm import tqdm
-from ultralytics.models.yolo import YOLO
 from ultralytics.cfg import get_cfg
+from ultralytics.data.converter import coco80_to_coco91_class
 from ultralytics.data.utils import check_det_dataset
 from ultralytics.engine.validator import BaseValidator as Validator
+from ultralytics.models.yolo import YOLO
 from ultralytics.utils import DATASETS_DIR
 from ultralytics.utils import DEFAULT_CFG
 from ultralytics.utils import ops
-from ultralytics.data.converter import coco80_to_coco91_class
 from ultralytics.utils.metrics import ConfusionMatrix
 
 import nncf

--- a/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/requirements.txt
+++ b/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/requirements.txt
@@ -1,3 +1,3 @@
-ultralytics==8.0.43
+ultralytics==8.0.170
 onnx>=1.12.0
 openvino-dev==2023.0.1


### PR DESCRIPTION
### Changes

Upgrade ultralytics to 8.0.170

### Reason for changes

For some reason yolo samples started to fail. Upgrading ultralytics solves this issue because the later version contains these changes: https://github.com/ultralytics/ultralytics/commit/a7419617a6f2f74849161f3faa5b65d2cef92bd5

### Related tickets

120311

### Tests

Build 82 passed
