### PR TITLE
Move the ranker to a multi-threaded approach

### DIFF
--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -244,7 +244,7 @@ def native_quantize_with_accuracy_control_impl(
             advanced_accuracy_restorer_parameters.max_num_iterations,
             max_drop,
             drop_type,
-            advanced_accuracy_restorer_parameters.num_ranking_processes,
+            advanced_accuracy_restorer_parameters.num_ranking_workers,
         )
         quantized_model = accuracy_restorer.apply(
             model,

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -190,9 +190,9 @@ class AdvancedAccuracyRestorerParameters:
     :param ranking_subset_size: Size of a subset that is used to rank layers by their
         contribution to the accuracy drop.
     :type ranking_subset_size: Optional[int]
-    :param num_ranking_processes: The number of parallel processes that are used to rank
+    :param num_ranking_workers: The number of parallel workers that are used to rank
         quantization operations.
-    :type num_ranking_processes: Optional[int]
+    :type num_ranking_workers: Optional[int]
     :param intermediate_model_dir: Path to the folder where the model, which was fully
         quantized with initial parameters, should be saved.
     :type intermediate_model_dir: Optional[str]
@@ -201,7 +201,7 @@ class AdvancedAccuracyRestorerParameters:
     max_num_iterations: int = sys.maxsize
     tune_hyperparams: bool = False
     ranking_subset_size: Optional[int] = None
-    num_ranking_processes: Optional[int] = None
+    num_ranking_workers: Optional[int] = None
     intermediate_model_dir: Optional[str] = None
 
 

--- a/nncf/quantization/algorithms/accuracy_control/backend.py
+++ b/nncf/quantization/algorithms/accuracy_control/backend.py
@@ -21,19 +21,6 @@ TModel = TypeVar("TModel")
 TPModel = TypeVar("TPModel")
 
 
-class AsyncPreparedModel(ABC):
-    @abstractmethod
-    def get(self, timeout) -> TPModel:
-        """
-        Returns the prepared model for inference when it arrives. If timeout is not None and
-        the result does not arrive within timeout seconds then TimeoutError is raised. If
-        the remote call raised an exception then that exception will be reraised by get().
-
-        :param timeout: timeout
-        :return: A prepared model for inference
-        """
-
-
 class AccuracyControlAlgoBackend(ABC):
     # Metatypes
 
@@ -161,14 +148,4 @@ class AccuracyControlAlgoBackend(ABC):
 
         :param model: A model that should be prepared.
         :return: Prepared model for inference.
-        """
-
-    @staticmethod
-    @abstractmethod
-    def prepare_for_inference_async(model: TModel) -> AsyncPreparedModel:
-        """
-        Prepares model for inference asynchronously.
-
-        :param model: A model that should be prepared.
-        :return: AsyncPreparedModel opbject.
         """


### PR DESCRIPTION
### Changes

- Use multithreading instead of multiprocessing to calculate quantizer ranking score
- Rename num_ranking_process to num_ranking_workers

### Reason for changes

- Support parallel calculations of quantizer ranking score for Windows
- Introducing more general name of parameter of number parallel workers.

### Related tickets

ref: 119274

### Tests

N/A
