### PR TITLE
Revert "[TF] Disable MaskRCNN and RetinaNet graph tests (#2119)"

### DIFF
--- a/tests/tensorflow/test_compressed_graph.py
+++ b/tests/tensorflow/test_compressed_graph.py
@@ -194,15 +194,11 @@ SKIP_MAP = {
         "nasnet_mobile": pytest.mark.skip(reason="gitlab issue #18"),
         "mobilenet_v2_slim": pytest.mark.skip(reason="ticket #46349"),
         "xception": pytest.mark.skip(reason="gitlab issue #28"),
-        "retinanet": pytest.mark.skip(reason="ticket #119664"),
-        "mask_rcnn": pytest.mark.skip(reason="ticket #119664"),
     },
     "magnitude_sparsity": {
         "inception_resnet_v2": pytest.mark.skip(reason="gitlab issue #17"),
         "nasnet_mobile": pytest.mark.skip(reason="gitlab issue #18"),
         "xception": pytest.mark.skip(reason="gitlab issue #28"),
-        "retinanet": pytest.mark.skip(reason="ticket #119664"),
-        "mask_rcnn": pytest.mark.skip(reason="ticket #119664"),
     },
     "filter_pruning": {
         "densenet121": pytest.mark.skip(reason="ticket #50604"),
@@ -212,13 +208,8 @@ SKIP_MAP = {
         "mask_rcnn": pytest.mark.skip(reason="ticket #50605"),
         "resnet50v2": pytest.mark.skip(reason="Several masks on one weight"),
         "mobilenet_v2_slim": pytest.mark.skip(reason="ticket #46349"),
-        "retinanet": pytest.mark.skip(reason="ticket #119664"),
     },
-    "rb_sparsity": {
-        "mobilenet_v2_slim": pytest.mark.skip(reason="ticket #46349"),
-        "retinanet": pytest.mark.skip(reason="ticket #119664"),
-        "mask_rcnn": pytest.mark.skip(reason="ticket #119664"),
-    },
+    "rb_sparsity": {"mobilenet_v2_slim": pytest.mark.skip(reason="ticket #46349")},
 }
 
 
@@ -480,8 +471,7 @@ class TestModelsGraph:
 
 QUANTIZE_OUTPUTS_MODELS = [
     ModelDesc("mobilenet_v2_quantize_outputs.pb", test_models.MobileNetV2, [1, 96, 96, 3]),
-    # Skip this model due to #119664
-    # ModelDesc("retinanet_quantize_outputs.pb", test_models.RetinaNet, [1, 603, 603, 3]),
+    ModelDesc("retinanet_quantize_outputs.pb", test_models.RetinaNet, [1, 603, 603, 3]),
     ModelDesc("sequential_model_quantize_outputs.pb", test_models.SequentialModel, [1, 224, 224, 3]),
     ModelDesc("shared_layers_model_quantize_outputs.pb", test_models.SharedLayersModel, [1, 30, 30, 3]),
 ]


### PR DESCRIPTION
### Changes

This reverts #2119

### Reason for changes

It seems that the problem is only reproduced on a single machine. This machine is excluded from test scope.

### Related tickets

119664
