### PR TITLE
Add max_report_age off to codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,7 @@ codecov:
   notify:
      after_n_builds: 2
      wait_for_ci: no
+  max_report_age: off
 
 coverage:
   status:


### PR DESCRIPTION
### Changes
As stated in the title

### Reason for changes
We do post-PR merge uploads of coverage reports to codecov, and it seems that codecov will reject reports [older than 12 hours](https://docs.codecov.com/docs/codecov-yaml#expired-reports) at the time of the upload, which does not work with our appoach and makes PRs merged more than 12 hours after the precommit checks passed break the coverage state on the develop.

### Related tickets
N/A

### Tests
N/A
