### PR TITLE
[Torch] Fix classification sample metric dumps not in main process

### DIFF
--- a/examples/torch/classification/main.py
+++ b/examples/torch/classification/main.py
@@ -728,20 +728,19 @@ def validate(val_loader, model, criterion, config, epoch=0, log_validation_info=
                     )
                 )
 
-        if is_main_process():
-            if log_validation_info:
-                config.tb.add_scalar("val/loss", losses.avg, len(val_loader) * epoch)
-                config.tb.add_scalar("val/top1", top1.avg, len(val_loader) * epoch)
-                config.tb.add_scalar("val/top5", top5.avg, len(val_loader) * epoch)
-                config.mlflow.safe_call("log_metric", "val/loss", float(losses.avg), epoch)
-                config.mlflow.safe_call("log_metric", "val/top1", float(top1.avg), epoch)
-                config.mlflow.safe_call("log_metric", "val/top5", float(top5.avg), epoch)
+        if is_main_process() and log_validation_info:
+            config.tb.add_scalar("val/loss", losses.avg, len(val_loader) * epoch)
+            config.tb.add_scalar("val/top1", top1.avg, len(val_loader) * epoch)
+            config.tb.add_scalar("val/top5", top5.avg, len(val_loader) * epoch)
+            config.mlflow.safe_call("log_metric", "val/loss", float(losses.avg), epoch)
+            config.mlflow.safe_call("log_metric", "val/top1", float(top1.avg), epoch)
+            config.mlflow.safe_call("log_metric", "val/top5", float(top5.avg), epoch)
 
-                logger.info(" * Acc@1 {top1.avg:.3f} Acc@5 {top5.avg:.3f}\n".format(top1=top1, top5=top5))
+            logger.info(" * Acc@1 {top1.avg:.3f} Acc@5 {top5.avg:.3f}\n".format(top1=top1, top5=top5))
 
-            if config.metrics_dump is not None:
-                acc = top1.avg / 100
-                write_metrics(acc, config.metrics_dump)
+        if is_main_process() and config.metrics_dump is not None:
+            acc = top1.avg / 100
+            write_metrics(acc, config.metrics_dump)
 
     return top1.avg, top5.avg, losses.avg
 

--- a/tests/torch/test_compression_training.py
+++ b/tests/torch/test_compression_training.py
@@ -442,7 +442,7 @@ class TestCompression:
         self._validate_train_metric(desc)
 
     @pytest.mark.dependency(depends=["train"])
-    def test_compression_eval(self, desc: LEGRTrainingTestDescriptor, tmp_path, mocker):
+    def test_compression_eval(self, desc: CompressionTrainingTestDescriptor, tmp_path, mocker):
         validator = desc.get_validator()
         args = validator.get_default_args(tmp_path)
         metric_file_path = self._add_args_for_eval(args, desc, tmp_path)
@@ -497,7 +497,7 @@ class TestCompression:
         self._validate_eval_metric(nas_desc, metric_file_path)
 
     @staticmethod
-    def _validate_eval_metric(desc, metric_file_path):
+    def _validate_eval_metric(desc: CompressionTrainingTestDescriptor, metric_file_path):
         with open(str(metric_file_path), encoding="utf8") as metric_file:
             metrics = json.load(metric_file)
             ref_metric = metrics["Accuracy"]


### PR DESCRIPTION
### Changes
In torch classification sample: `write_metrics` and `mlflow` accuracy logging is called only in main process

### Reason for changes

Torch test_compression_training (build 106) failed due to metric collected by `write_metrics` and metric saved in checkpoint with key "best_acc1" were different

### Tests

Torch test_compression_training build ~~109~~ 111