### PR TITLE
More correct hessian trace calculation

### DIFF
--- a/nncf/torch/quantization/hessian_trace.py
+++ b/nncf/torch/quantization/hessian_trace.py
@@ -141,7 +141,7 @@ class HessianTraceEstimator:
             mean_avg_traces_per_param = self._get_mean(avg_traces_per_iter)
             mean_avg_total_trace = torch.sum(mean_avg_traces_per_param)
 
-            diff_avg = abs(mean_avg_total_trace - avg_total_trace) / (avg_total_trace + self._diff_eps)
+            diff_avg = abs(mean_avg_total_trace - avg_total_trace) / (abs(avg_total_trace) + self._diff_eps)
             if diff_avg < tolerance:
                 return mean_avg_traces_per_param
             avg_total_trace = mean_avg_total_trace


### PR DESCRIPTION
### Changes

Use absolute value of avg_total_trace in denominator, as done in [PyHessian:](https://github.com/amirgholami/PyHessian/blob/master/pyhessian/hessian.py#L186C22-L186C22)

### Reason for changes

more robust mixed precision algo

### Related tickets

resolves #2155 

### Tests

hawq-related tests