### PR TITLE
Progress bar visuals enhancement 

### DIFF
--- a/examples/post_training_quantization/openvino/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/openvino/mobilenet_v2/main.py
@@ -102,30 +102,6 @@ val_dataset = datasets.ImageFolder(
 )
 val_data_loader = torch.utils.data.DataLoader(val_dataset, batch_size=1, shuffle=False)
 
-class Loader:
-    def __init__(self, dataloader):
-        self.dataloader = dataloader
-        self.i = 0
-
-    def __iter__(self):
-        self.i = 0
-        self.iter = self.dataloader.__iter__()
-        return self
-
-    def __next__(self):
-        if self.i > 100:
-            raise StopIteration
-        self.i += 1
-        return next(self.iter)
-
-    # def __len__(self):
-    #     return 101
-
-# from time import sleep
-# from nncf.common.logging.track_progress import track
-# for n in track(Loader(val_data_loader)):
-#     sleep(0.1)
-
 path_to_model = download(MODEL_URL, MODEL_PATH)
 ov_model = ov.Core().read_model(path_to_model / "mobilenet_v2_fp32.xml")
 

--- a/examples/post_training_quantization/openvino/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/openvino/mobilenet_v2/main.py
@@ -102,6 +102,30 @@ val_dataset = datasets.ImageFolder(
 )
 val_data_loader = torch.utils.data.DataLoader(val_dataset, batch_size=1, shuffle=False)
 
+class Loader:
+    def __init__(self, dataloader):
+        self.dataloader = dataloader
+        self.i = 0
+
+    def __iter__(self):
+        self.i = 0
+        self.iter = self.dataloader.__iter__()
+        return self
+
+    def __next__(self):
+        if self.i > 100:
+            raise StopIteration
+        self.i += 1
+        return next(self.iter)
+
+    # def __len__(self):
+    #     return 101
+
+# from time import sleep
+# from nncf.common.logging.track_progress import track
+# for n in track(Loader(val_data_loader)):
+#     sleep(0.1)
+
 path_to_model = download(MODEL_URL, MODEL_PATH)
 ov_model = ov.Core().read_model(path_to_model / "mobilenet_v2_fp32.xml")
 

--- a/nncf/common/logging/track_progress.py
+++ b/nncf/common/logging/track_progress.py
@@ -50,13 +50,13 @@ class SeparatorColumn(ProgressColumn):
 class TimeElapsedColumnWithStyle(TimeElapsedColumn):
     def render(self, task: "Task") -> Text:
         text = super().render(task)
-        return Text(text._text[0], style=INTEL_BLUE_COLOR)
+        return Text(text._text[0], style=INTEL_BLUE_COLOR)  # pylint: disable=protected-access
 
 
 class TimeRemainingColumnWithStyle(TimeRemainingColumn):
     def render(self, task: "Task") -> Text:
         text = super().render(task)
-        return Text(text._text[0], style=INTEL_BLUE_COLOR)
+        return Text(text._text[0], style=INTEL_BLUE_COLOR)  # pylint: disable=protected-access
 
 
 class track:

--- a/nncf/common/logging/track_progress.py
+++ b/nncf/common/logging/track_progress.py
@@ -23,7 +23,6 @@ from rich.progress import TextColumn
 from rich.style import StyleType
 from rich.text import Text
 
-# INTEL_BLUE_COLOR = (0, 174, 239)
 INTEL_BLUE_COLOR = (0, 113, 197)
 
 
@@ -51,7 +50,11 @@ class SeparatorColumn(ProgressColumn):
 
 
 class TimeElapsedColumnWithStyle(ProgressColumn):
-    """Renders time elapsed."""
+    """
+    Renders time elapsed.
+
+    Similar to TimeElapsedColumn, but with addition of style parameter.
+    """
 
     def __init__(self, style: Union[str, StyleType]):
         super().__init__()
@@ -67,7 +70,11 @@ class TimeElapsedColumnWithStyle(ProgressColumn):
 
 
 class TimeRemainingColumnWithStyle(ProgressColumn):
-    """Renders estimated time remaining."""
+    """
+    Renders estimated time remaining.
+
+    Similar to TimeRemainingColumn, but with addition of style parameter.
+    """
 
     # Only refresh twice a second to prevent jitter
     max_refresh = 0.5
@@ -157,7 +164,7 @@ class track:
         self.update_period = update_period
         self.task = None
 
-        text_style = f"rgb{INTEL_BLUE_COLOR}".replace(' ', '')
+        text_style = f"rgb({INTEL_BLUE_COLOR[0]},{INTEL_BLUE_COLOR[1]},{INTEL_BLUE_COLOR[2]})"
 
         self.columns: List[ProgressColumn] = (
             [TextColumn("[progress.description]{task.description}")] if description else []
@@ -169,7 +176,7 @@ class track:
                     complete_style=complete_style,
                     finished_style=finished_style,
                     pulse_style=pulse_style,
-                    bar_width=None
+                    bar_width=None,
                 ),
                 TaskProgressColumn(show_speed=show_speed),
                 IterationsColumn(style=text_style),

--- a/nncf/common/logging/track_progress.py
+++ b/nncf/common/logging/track_progress.py
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from datetime import timedelta
+
 from typing import Callable, Iterable, List, Optional, Sequence, Union
 
 from rich.console import Console


### PR DESCRIPTION
### Changes

- Progress bar now extends to screen width
- Iteration count, time spent and time remaining text components are now Intel blue (RGB [0,104,181])

How it looks in terminal (Windows Terminal):
![image](https://github.com/openvinotoolkit/nncf/assets/23343961/cd10196a-ecdc-4b3a-a59e-b89341b6848c)


How it looks in Jupyter:
![image](https://github.com/openvinotoolkit/nncf/assets/23343961/131e2e10-887e-45ac-8640-dd0752f37593)


Please see how it looked before at #2132

Note: I've tried changing color for progress percent too, but couldn't, most probably due to a bug in rich https://github.com/Textualize/rich/issues/3133

### Reason for changes

- Improving user experience

Special thanks to @AlexanderDokuchaev and @kshpv for suggesting these changes.
