### PR TITLE
Remove legacy external quantizer storage names

### DIFF
--- a/nncf/torch/checkpoint_loading.py
+++ b/nncf/torch/checkpoint_loading.py
@@ -228,7 +228,7 @@ class NormalizedKeys:
     def _key_clipper(key: str) -> str:
         new_key = key
 
-        clip_patterns = ["module.", "|OUTPUT", "|INPUT", "_nncf."]
+        clip_patterns = ["module.", "|OUTPUT", "|INPUT"]
         for pattern in clip_patterns:
             new_key = new_key.replace(pattern, "")
         return new_key
@@ -266,7 +266,6 @@ class NormalizedKeys:
             for key in group_of_keys[1:-1]:
                 result.append(EXTERNAL_QUANTIZERS_STORAGE_PREFIX + "." + key + "." + common_op)
         return result
-
 
 
 class KeyMatcher:

--- a/nncf/torch/checkpoint_loading.py
+++ b/nncf/torch/checkpoint_loading.py
@@ -154,7 +154,6 @@ class NormalizedKeys:
     def __init__(self, keys: List[str], keys_to_ignore: List[str]):
         self._unique_normalized_key_vs_orig_key_map = {}
         self.is_unified_group_detected = False
-        self.has_legacy_storage_keys = False
         unique_clipped_key_vs_orig_key_map, ignored_keys = self._clip_keys_without_collisions(keys, keys_to_ignore)
         self.ignored_orig_keys = ignored_keys
         ignored_keys = self._normalize_keys_without_collisions(unique_clipped_key_vs_orig_key_map, keys_to_ignore)
@@ -228,9 +227,8 @@ class NormalizedKeys:
     @staticmethod
     def _key_clipper(key: str) -> str:
         new_key = key
-        from nncf.torch.nncf_network import LEGACY_MODEL_WRAPPED_BY_NNCF_ATTR_NAME  # pylint: disable=cyclic-import
 
-        clip_patterns = [LEGACY_MODEL_WRAPPED_BY_NNCF_ATTR_NAME + ".", "module.", "|OUTPUT", "|INPUT", "_nncf."]
+        clip_patterns = ["module.", "|OUTPUT", "|INPUT", "_nncf."]
         for pattern in clip_patterns:
             new_key = new_key.replace(pattern, "")
         return new_key
@@ -240,11 +238,6 @@ class NormalizedKeys:
 
         match = re.search("(pre_ops|post_ops)\\.(\\d+?)\\.op", key)
         new_key = new_key if not match else new_key.replace(match.group(), "operation")
-
-        new_key, did_replace = self._replace_legacy_act_quantizer_storage_name(new_key)
-        if did_replace:
-            self.has_legacy_storage_keys = True
-
         result = self._split_unified_parameters(new_key)
         if len(result) > 1:
             self.is_unified_group_detected = True
@@ -263,29 +256,17 @@ class NormalizedKeys:
         Returns original key if there's no ';' and operation doesn't start with EXTERNAL_QUANTIZERS_STORAGE_NAME
         """
         result = [new_key]
-        from nncf.torch.nncf_network import CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX  # pylint: disable=cyclic-import
+        from nncf.torch.nncf_network import EXTERNAL_QUANTIZERS_STORAGE_PREFIX  # pylint: disable=cyclic-import
 
-        if ";" in new_key and new_key.startswith(CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX):
+        if ";" in new_key and new_key.startswith(EXTERNAL_QUANTIZERS_STORAGE_PREFIX):
             group_of_keys = new_key.split(";")
             last_key = group_of_keys[-1]
             common_op = last_key.split(".")[-1]
-            result = [group_of_keys[0] + "." + common_op, CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + "." + last_key]
+            result = [group_of_keys[0] + "." + common_op, EXTERNAL_QUANTIZERS_STORAGE_PREFIX + "." + last_key]
             for key in group_of_keys[1:-1]:
-                result.append(CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + "." + key + "." + common_op)
+                result.append(EXTERNAL_QUANTIZERS_STORAGE_PREFIX + "." + key + "." + common_op)
         return result
 
-    @staticmethod
-    def _replace_legacy_act_quantizer_storage_name(checkpoint_key: str) -> Tuple[str, bool]:
-        did_replace = False
-        splits = checkpoint_key.split(".")
-        from nncf.torch.nncf_network import CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX  # pylint: disable=cyclic-import
-        from nncf.torch.nncf_network import LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX  # pylint: disable=cyclic-import
-
-        if splits[0] == LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX:
-            did_replace = True
-            splits[0] = CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX
-        reconstructed_key = ".".join(splits)
-        return reconstructed_key, did_replace
 
 
 class KeyMatcher:
@@ -339,19 +320,6 @@ class KeyMatcher:
                 "have been deprecated. "
                 "The loader will try to match these entries to the correspoindig `relu` and `relu_` op "
                 "names. The newly exported checkpoints will be adjusted to the new format."
-            )
-
-        if normalized_keys_to_load.has_legacy_storage_keys:
-            from nncf.torch.nncf_network import CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX
-            from nncf.torch.nncf_network import LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX
-
-            warning_deprecated(
-                f"Legacy NNCF-enabled .pth checkpoint has been loaded! "
-                f"The {LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX} storage key is replaced with "
-                f"{CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX} in newer versions of NNCF, and support "
-                f"for the legacy storage key will be dropped in a future release. "
-                f"This checkpoint will be loaded; update your checkpoint file by saving this model's"
-                f"checkpoint file again."
             )
 
         if normalized_model_keys.is_unified_group_detected and not normalized_keys_to_load.is_unified_group_detected:

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -65,11 +65,8 @@ from nncf.torch.utils import get_all_modules_by_type
 from nncf.torch.utils import get_model_device
 from nncf.torch.utils import training_mode_switcher
 
-LEGACY_MODEL_WRAPPED_BY_NNCF_ATTR_NAME = "nncf_module"
-LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX = "external_quantizers"
-
 EXTERNAL_QUANTIZERS_STORAGE_NAME = "external_quantizers"
-CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX = "_nncf." + EXTERNAL_QUANTIZERS_STORAGE_NAME
+EXTERNAL_QUANTIZERS_STORAGE_PREFIX = "_nncf." + EXTERNAL_QUANTIZERS_STORAGE_NAME
 
 Module = TypeVar("Module", bound=nn.Module)
 

--- a/tests/torch/test_backward_compat.py
+++ b/tests/torch/test_backward_compat.py
@@ -25,6 +25,7 @@ from nncf.common.logging.logger import NNCFDeprecationWarning
 from nncf.config import NNCFConfig
 from nncf.torch import register_default_init_args
 from nncf.torch.checkpoint_loading import load_state
+from nncf.torch.nncf_network import EXTERNAL_QUANTIZERS_STORAGE_PREFIX
 from nncf.torch.quantization.algo import QUANTIZER_BUILDER_STATE_VERSION_SAVE_NAME
 from nncf.torch.quantization.algo import QuantizerBuilderStateVersion
 from tests.shared.helpers import get_cli_dict_args
@@ -177,39 +178,41 @@ class ConvBNLayer(torch.nn.Module):
 
 
 sd_without_nncf_bn_wrapping = {
-    "nncf_module.conv.weight": torch.ones([9, 3, 3, 3]),
-    "nncf_module.conv.bias": torch.ones([9]),
-    "nncf_module.conv.nncf_padding_value": torch.ones([1]),
-    "nncf_module.conv.pre_ops.0.op._num_bits": torch.ones([1]),
-    "nncf_module.conv.pre_ops.0.op.signed_tensor": torch.ones([1]),
-    "nncf_module.conv.pre_ops.0.op.enabled": torch.ones([1]),
-    "nncf_module.conv.pre_ops.0.op.scale": torch.ones([9, 1, 1, 1]),
-    "nncf_module.bn.weight": torch.ones([9]),
-    "nncf_module.bn.bias": torch.ones([9]),
-    "nncf_module.bn.running_mean": torch.ones([9]),
-    "nncf_module.bn.running_var": torch.ones([9]),
-    "nncf_module.bn.num_batches_tracked": torch.ones([]),
-    "nncf_module.conv1.weight": torch.ones([3, 9, 3, 3]),
-    "nncf_module.conv1.bias": torch.ones([3]),
-    "nncf_module.conv1.nncf_padding_value": torch.ones([1]),
-    "nncf_module.conv1.pre_ops.0.op._num_bits": torch.ones([1]),
-    "nncf_module.conv1.pre_ops.0.op.signed_tensor": torch.ones([1]),
-    "nncf_module.conv1.pre_ops.0.op.enabled": torch.ones([1]),
-    "nncf_module.conv1.pre_ops.0.op.scale": torch.ones([3, 1, 1, 1]),
-    "nncf_module.bn1.weight": torch.ones([3]),
-    "nncf_module.bn1.bias": torch.ones([3]),
-    "nncf_module.bn1.running_mean": torch.ones([3]),
-    "nncf_module.bn1.running_var": torch.ones([3]),
-    "nncf_module.bn1.num_batches_tracked": torch.ones([]),
-    "external_quantizers./nncf_model_input_0|OUTPUT._num_bits": torch.ones([1]),
-    "external_quantizers./nncf_model_input_0|OUTPUT.signed_tensor": torch.ones([1]),
-    "external_quantizers./nncf_model_input_0|OUTPUT.enabled": torch.ones([1]),
-    "external_quantizers./nncf_model_input_0|OUTPUT.scale": torch.ones([1]),
+    "conv.weight": torch.ones([9, 3, 3, 3]),
+    "conv.bias": torch.ones([9]),
+    "conv.nncf_padding_value": torch.ones([1]),
+    "conv.pre_ops.0.op._num_bits": torch.ones([1]),
+    "conv.pre_ops.0.op.signed_tensor": torch.ones([1]),
+    "conv.pre_ops.0.op.enabled": torch.ones([1]),
+    "conv.pre_ops.0.op.scale": torch.ones([9, 1, 1, 1]),
+    "bn.weight": torch.ones([9]),
+    "bn.bias": torch.ones([9]),
+    "bn.running_mean": torch.ones([9]),
+    "bn.running_var": torch.ones([9]),
+    "bn.num_batches_tracked": torch.ones([]),
+    "conv1.weight": torch.ones([3, 9, 3, 3]),
+    "conv1.bias": torch.ones([3]),
+    "conv1.nncf_padding_value": torch.ones([1]),
+    "conv1.pre_ops.0.op._num_bits": torch.ones([1]),
+    "conv1.pre_ops.0.op.signed_tensor": torch.ones([1]),
+    "conv1.pre_ops.0.op.enabled": torch.ones([1]),
+    "conv1.pre_ops.0.op.scale": torch.ones([3, 1, 1, 1]),
+    "bn1.weight": torch.ones([3]),
+    "bn1.bias": torch.ones([3]),
+    "bn1.running_mean": torch.ones([3]),
+    "bn1.running_var": torch.ones([3]),
+    "bn1.num_batches_tracked": torch.ones([]),
+    f"{EXTERNAL_QUANTIZERS_STORAGE_PREFIX}./nncf_model_input_0|OUTPUT._num_bits": torch.ones([1]),
+    f"{EXTERNAL_QUANTIZERS_STORAGE_PREFIX}./nncf_model_input_0|OUTPUT.signed_tensor": torch.ones([1]),
+    f"{EXTERNAL_QUANTIZERS_STORAGE_PREFIX}./nncf_model_input_0|OUTPUT.enabled": torch.ones([1]),
+    f"{EXTERNAL_QUANTIZERS_STORAGE_PREFIX}./nncf_model_input_0|OUTPUT.scale": torch.ones([1]),
     # Old bn layer names:            |||||||||||
-    "external_quantizers.ConvBNLayer/BatchNorm2d[bn]/batch_norm_0|OUTPUT._num_bits": torch.ones([1]),
-    "external_quantizers.ConvBNLayer/BatchNorm2d[bn]/batch_norm_0|OUTPUT.signed_tensor": torch.ones([1]),
-    "external_quantizers.ConvBNLayer/BatchNorm2d[bn]/batch_norm_0|OUTPUT.enabled": torch.ones([1]),
-    "external_quantizers.ConvBNLayer/BatchNorm2d[bn]/batch_norm_0|OUTPUT.scale": torch.ones([1]),
+    f"{EXTERNAL_QUANTIZERS_STORAGE_PREFIX}.ConvBNLayer/BatchNorm2d[bn]/batch_norm_0|OUTPUT._num_bits": torch.ones([1]),
+    f"{EXTERNAL_QUANTIZERS_STORAGE_PREFIX}.ConvBNLayer/BatchNorm2d[bn]/batch_norm_0|OUTPUT.signed_tensor": torch.ones(
+        [1]
+    ),
+    f"{EXTERNAL_QUANTIZERS_STORAGE_PREFIX}.ConvBNLayer/BatchNorm2d[bn]/batch_norm_0|OUTPUT.enabled": torch.ones([1]),
+    f"{EXTERNAL_QUANTIZERS_STORAGE_PREFIX}.ConvBNLayer/BatchNorm2d[bn]/batch_norm_0|OUTPUT.scale": torch.ones([1]),
 }
 
 compression_state_without_bn_wrapping = {

--- a/tests/torch/test_load_model_state.py
+++ b/tests/torch/test_load_model_state.py
@@ -229,14 +229,12 @@ MATCH_KEY_DESC_LIST = [
         .missing(['2']).matched(['1']),
 
     # wrapping by NNCFNetwork and DataParallel & DistributedDataParallel
-    MatchKeyDesc(num_loaded=2).keys_to_load(['module.1', 'nncf_module.2']).model_keys(['1', '2'])
+    MatchKeyDesc(num_loaded=2).keys_to_load(['1', '2']).model_keys(['module.1', 'module.2'])
         .all_matched(),
-    MatchKeyDesc(num_loaded=2).keys_to_load(['1', '2']).model_keys(['module.1', 'nncf_module.2'])
-        .all_matched(),
-    MatchKeyDesc(num_loaded=2).keys_to_load(['module.nncf_module.1', 'module.2']).model_keys(['1', 'nncf_module.2'])
+    MatchKeyDesc(num_loaded=2).keys_to_load(['module.1', 'module.2']).model_keys(['1', 'module.2'])
         .all_matched(),
     MatchKeyDesc(num_loaded=0, expects_error=True)
-        .keys_to_load(['module.nncf_module.1.1', 'module.2']).model_keys(['1', '2.2'])
+        .keys_to_load(['module.1.1', 'module.2']).model_keys(['1', '2.2'])
         .all_not_matched(),
 
     # collisions after normalization of keys
@@ -252,8 +250,8 @@ MATCH_KEY_DESC_LIST = [
         .model_keys(['pre_ops.0.op.1', 'pre_ops.1.op.1'])
         .all_matched(),
     MatchKeyDesc(num_loaded=2)
-        .keys_to_load(['nncf_module.pre_ops.1.op.1', 'nncf_module.pre_ops.0.op.1'])
-        .model_keys(['module.nncf_module.pre_ops.1.op.1', 'module.nncf_module.pre_ops.0.op.1'])
+        .keys_to_load(['module.pre_ops.1.op.1', 'module.pre_ops.0.op.1'])
+        .model_keys(['module.module.pre_ops.1.op.1', 'module.module.pre_ops.0.op.1'])
         .all_matched(),
     # quantization -> quantization + sparsity: op.1 was first, than
     MatchKeyDesc(num_loaded=2)
@@ -361,9 +359,9 @@ MATCH_KEY_DESC_LIST = [
         .keys_to_ignore(['1'])
         .skipped(['1']),
     MatchKeyDesc(num_loaded=0, expects_error=True)
-        .keys_to_load(['module.nncf_module.1.1', '2.2']).model_keys(['module.1', 'module.2'])
+        .keys_to_load(['module.1.1', '2.2']).model_keys(['module.1', 'module.2'])
         .keys_to_ignore(['1', '2.2'])
-        .skipped(['module.1', '2.2']).missing(['module.2']).unexpected(['module.nncf_module.1.1']),
+        .skipped(['module.1', '2.2']).missing(['module.2']).unexpected(['module.1.1']),
 
     # optional parameter - not necessary in checkpoint can be initialized by default in the model
     # can match unified FQ
@@ -419,9 +417,9 @@ MATCH_KEY_DESC_LIST = [
         .keys_to_ignore(['1'])
         .skipped(['1']),
     MatchKeyDesc(num_loaded=0, expects_error=True)
-        .keys_to_load(['module.nncf_module.1.1', '2.2']).model_keys(['module.1', 'module.2'])
+        .keys_to_load(['module.1.1', '2.2']).model_keys(['module.1', 'module.2'])
         .keys_to_ignore(['1', '2.2'])
-        .skipped(['module.1', '2.2']).missing(['module.2']).unexpected(['module.nncf_module.1.1']),
+        .skipped(['module.1', '2.2']).missing(['module.2']).unexpected(['module.1.1']),
 
     # optional parameter - not necessary in checkpoint can be initialized by default in the model
     # can match unified FQ
@@ -466,12 +464,6 @@ MATCH_KEY_DESC_LIST = [
         .matched([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
         .unexpected(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_3.' + OP1]),
 
-    # can match keys under _nncf in the new style and the keys without _nncf
-    MatchKeyDesc(num_loaded=1)
-        .keys_to_load(['key.op'])
-        .model_keys(['_nncf.key.op'])
-        .all_matched()
-        .with_deprecation_warning(),
 
     OptionalMatchKeyDesc(num_loaded=0)
         .keys_to_load([])

--- a/tests/torch/test_load_model_state.py
+++ b/tests/torch/test_load_model_state.py
@@ -25,8 +25,7 @@ from nncf.torch.checkpoint_loading import ProcessedKeyStatus
 from nncf.torch.checkpoint_loading import load_state
 from nncf.torch.layers import NNCF_PADDING_VALUE_ATTR_NAME
 from nncf.torch.nncf_module_replacement import replace_modules_by_nncf_modules
-from nncf.torch.nncf_network import CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX
-from nncf.torch.nncf_network import LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX
+from nncf.torch.nncf_network import EXTERNAL_QUANTIZERS_STORAGE_PREFIX
 from tests.torch.helpers import BasicConvTestModel
 from tests.torch.helpers import PTTensorListComparator
 
@@ -286,98 +285,70 @@ MATCH_KEY_DESC_LIST = [
         .keys_to_load(['relu_0.' + OP1, 'relu_0.' + OP2]).model_keys(['relu_0|OUTPUT.' + OP1, 'relu_0|INPUT.' + OP2])
         .all_matched(),
 
-    # can match legacy activation quantizer + new format with |INPUT and |OUTPUT
-    MatchKeyDesc(num_loaded=2)
-        .keys_to_load([LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
-                       LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP2])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT.' + OP1,
-                     CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|INPUT.' + OP2])
-        .all_matched()
-        .with_deprecation_warning(),
-
     # can match version agnostic format with the version_specific format
     MatchKeyDesc(num_loaded=4)
         .keys_to_load(["conv2d.weight",
                        "RELUModule.weight",
-                       CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP2])
+                       EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
+                       EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP2])
         .model_keys(["conv2d.weight",
                      "RELUModule.weight",
-                     CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT.' + OP1,
-                     CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|INPUT.' + OP2])
-        .all_matched()
-        .with_deprecation_warning(),
-
-    # can match version agnostic format with the version_specific format + legacy act quant
-    MatchKeyDesc(num_loaded=4)
-        .keys_to_load(["conv2d.weight",
-                       "RELUModule.weight",
-                       LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP2])
-        .model_keys(["conv2d.weight",
-                     "RELUModule.weight",
-                     CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu__0|OUTPUT.' + OP1,
-                     CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu__0|INPUT.' + OP2])
+                     EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT.' + OP1,
+                     EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|INPUT.' + OP2])
         .all_matched()
         .with_deprecation_warning(),
 
     # can match unified FQ
+
     MatchKeyDesc(num_loaded=1)
-        .keys_to_load(['module.' + LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
-                       'module.' + LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_1.' + OP1])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT;relu_1|OUTPUT.' + OP1])
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_1.' + OP1])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT;relu_1|OUTPUT.' + OP1])
         .all_matched()
         .with_warning(r".*Unified parameters.*"),
 
     MatchKeyDesc(num_loaded=1)
-        .keys_to_load(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_1.' + OP1])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT;relu_1|OUTPUT.' + OP1])
-        .all_matched()
-        .with_warning(r".*Unified parameters.*"),
-
-    MatchKeyDesc(num_loaded=1)
-        .keys_to_load(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_1.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_2.' + OP1])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT;relu_2|OUTPUT;relu_1|OUTPUT.' + OP1])
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_1.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_2.' + OP1])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT;relu_2|OUTPUT;relu_1|OUTPUT.' + OP1])
         .all_matched()
         .with_warning(r".*Unified parameters.*"),
 
     # not matched common operation
     MatchKeyDesc(num_loaded=1, expects_error=True)
-        .keys_to_load(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_1.' + OP2,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_2.' + OP1_NOT_PARAM])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT;relu_2|OUTPUT;relu_1|OUTPUT.' + OP1])
-        .matched([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT;relu_2|OUTPUT;relu_1|OUTPUT.' + OP1])
-        .unexpected(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_1.' + OP2,
-                     'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_2.' + OP1_NOT_PARAM]),
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_1.' + OP2,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_2.' + OP1_NOT_PARAM])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT;relu_2|OUTPUT;relu_1|OUTPUT.' + OP1])
+        .matched([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT;relu_2|OUTPUT;relu_1|OUTPUT.' + OP1])
+        .unexpected(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_1.' + OP2,
+                     'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_2.' + OP1_NOT_PARAM]),
 
     # not all unified scopes are matched: relu_3 vs relu_1
     MatchKeyDesc(num_loaded=1, expects_error=True)
-        .keys_to_load(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_3.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_2.' + OP1])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT;relu_2|OUTPUT;relu_1|OUTPUT.' + OP1])
-        .matched([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT;relu_2|OUTPUT;relu_1|OUTPUT.' + OP1])
-        .unexpected(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_3.' + OP1]),
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_3.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_2.' + OP1])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT;relu_2|OUTPUT;relu_1|OUTPUT.' + OP1])
+        .matched([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0|OUTPUT;relu_2|OUTPUT;relu_1|OUTPUT.' + OP1])
+        .unexpected(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_3.' + OP1]),
 
     # won't match relu_ and relu
     MatchKeyDesc(num_loaded=2, expects_error=True)
         .keys_to_load(["conv2d.weight",
                        "RELUModule.weight",
-                       CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
-                       CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP2])
+                       EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
+                       EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP2])
         .model_keys(["conv2d.weight",
                      "RELUModule.weight",
-                     CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu__0|OUTPUT.' + OP1,
-                     CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu__0|INPUT.' + OP2])
+                     EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu__0|OUTPUT.' + OP1,
+                     EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu__0|INPUT.' + OP2])
         .matched(["conv2d.weight", "RELUModule.weight"])
-        .unexpected([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
-                     CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP2])
-        .missing([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu__0|OUTPUT.' + OP1,
-                  CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu__0|INPUT.' + OP2]),
+        .unexpected([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP1,
+                     EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu_0.' + OP2])
+        .missing([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu__0|OUTPUT.' + OP1,
+                  EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.relu__0|INPUT.' + OP2]),
 
     # can skip ignored parameters
     MatchKeyDesc(num_loaded=1).keys_to_load(['1']).model_keys(['1', '2'])
@@ -395,56 +366,47 @@ MATCH_KEY_DESC_LIST = [
         .skipped(['module.1', '2.2']).missing(['module.2']).unexpected(['module.nncf_module.1.1']),
 
     # optional parameter - not necessary in checkpoint can be initialized by default in the model
-    # can match legacy activation quantizer + new format with |INPUT and |OUTPUT
-    MatchKeyDesc(num_loaded=2)
-        .keys_to_load([LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP2])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT.' + OP1,
-                     CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|INPUT.' + OP2])
-        .all_matched()
-        .with_deprecation_warning(),
-
     # can match unified FQ
     MatchKeyDesc(num_loaded=1)
-        .keys_to_load(['module.' + LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       'module.' + LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP1])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP1])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_1|OUTPUT.' + OP1])
         .all_matched()
         .with_warning(r".*Unified parameters.*"),
 
     MatchKeyDesc(num_loaded=1)
-        .keys_to_load(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP1])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP1])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_1|OUTPUT.' + OP1])
         .all_matched()
         .with_warning(r".*Unified parameters.*"),
 
     MatchKeyDesc(num_loaded=1)
-        .keys_to_load(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
         .all_matched()
         .with_warning(r".*Unified parameters.*"),
 
     # not matched common operation
     MatchKeyDesc(num_loaded=1, expects_error=True)
-        .keys_to_load(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP2,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1_NOT_PARAM])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
-        .matched([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
-        .unexpected(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP2,
-                     'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1_NOT_PARAM]),
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP2,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1_NOT_PARAM])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .matched([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .unexpected(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP2,
+                     'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1_NOT_PARAM]),
 
     # not all unified scopes are matched: RELU_3 vs RELU_1
     MatchKeyDesc(num_loaded=1, expects_error=True)
-        .keys_to_load(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_3.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
-        .matched([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
-        .unexpected(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_3.' + OP1]),
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_3.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .matched([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .unexpected(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_3.' + OP1]),
 
     # can skip ignored parameters
     MatchKeyDesc(num_loaded=1).keys_to_load(['1']).model_keys(['1', '2'])
@@ -462,56 +424,47 @@ MATCH_KEY_DESC_LIST = [
         .skipped(['module.1', '2.2']).missing(['module.2']).unexpected(['module.nncf_module.1.1']),
 
     # optional parameter - not necessary in checkpoint can be initialized by default in the model
-    # can match legacy activation quantizer + new format with |INPUT and |OUTPUT
-    MatchKeyDesc(num_loaded=2)
-        .keys_to_load([LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP2])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT.' + OP1,
-                     CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|INPUT.' + OP2])
-        .all_matched()
-        .with_deprecation_warning(),
-
     # can match unified FQ
     MatchKeyDesc(num_loaded=1)
-        .keys_to_load(['module.' + LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       'module.' + LEGACY_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP1])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP1])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_1|OUTPUT.' + OP1])
         .all_matched()
         .with_warning(r".*Unified parameters.*"),
 
     MatchKeyDesc(num_loaded=1)
-        .keys_to_load(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP1])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP1])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_1|OUTPUT.' + OP1])
         .all_matched()
         .with_warning(r".*Unified parameters.*"),
 
     MatchKeyDesc(num_loaded=1)
-        .keys_to_load(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
         .all_matched()
         .with_warning(r".*Unified parameters.*"),
 
     # not matched common operation
     MatchKeyDesc(num_loaded=1, expects_error=True)
-        .keys_to_load(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP2,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1_NOT_PARAM])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
-        .matched([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
-        .unexpected(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP2,
-                     'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1_NOT_PARAM]),
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP2,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1_NOT_PARAM])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .matched([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .unexpected(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_1.' + OP2,
+                     'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1_NOT_PARAM]),
 
     # not all unified scopes are matched: RELU_3 vs RELU_1
     MatchKeyDesc(num_loaded=1, expects_error=True)
-        .keys_to_load(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_3.' + OP1,
-                       'module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1])
-        .model_keys([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
-        .matched([CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
-        .unexpected(['module.' + CURRENT_EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_3.' + OP1]),
+        .keys_to_load(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_3.' + OP1,
+                       'module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_2.' + OP1])
+        .model_keys([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .matched([EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_0|OUTPUT;RELU_2|OUTPUT;RELU_1|OUTPUT.' + OP1])
+        .unexpected(['module.' + EXTERNAL_QUANTIZERS_STORAGE_PREFIX + '.RELU_3.' + OP1]),
 
     # can match keys under _nncf in the new style and the keys without _nncf
     MatchKeyDesc(num_loaded=1)


### PR DESCRIPTION
### Changes
Legacy quantizer storage names in checkpoints were removed

### Reason for changes
The format had changed after the NNCFNetwork rework, and the deprecation warning has been in place for two releases now.

### Related tickets
121535

### Tests
test_load_model_state
