### PR TITLE
Fix docs deps version

### DIFF
--- a/docs/api/requirements.txt
+++ b/docs/api/requirements.txt
@@ -1,3 +1,4 @@
+astroid==2.15.8
 Sphinx==6.1.3
 sphinx-autoapi==2.1.0
 furo==2023.3.27


### PR DESCRIPTION
### Changes

- Fixed the `astroid` version (`shpinx-autoapi` dependence)

### Reason for changes

- The 3.0.0 version breaks our pipeline
