### PR TITLE
Add `cleanup_torchscript_cache` to test_quantize_conformance.py

### DIFF
--- a/tests/post_training/pipelines/base.py
+++ b/tests/post_training/pipelines/base.py
@@ -278,6 +278,18 @@ class BaseTestPipeline(ABC):
         self.save_quantized_model()
         self.get_num_fq()
         self.validate()
+        self.cleanup_torchscript_cache()
+
+    @staticmethod
+    def cleanup_torchscript_cache():
+        """
+        Helper for removing cached model representation.
+
+        After run torch.jit.trace in convert_model, PyTorch does not clear the trace cache automatically.
+        """
+        torch._C._jit_clear_class_registry()
+        torch.jit._recursive.concrete_type_store = torch.jit._recursive.ConcreteTypeStore()
+        torch.jit._state._clear_class_state()
 
     def get_run_info(self) -> RunInfo:
         return self.run_info

--- a/tests/post_training/pipelines/base.py
+++ b/tests/post_training/pipelines/base.py
@@ -287,6 +287,7 @@ class BaseTestPipeline(ABC):
 
         After run torch.jit.trace in convert_model, PyTorch does not clear the trace cache automatically.
         """
+        # pylint: disable=protected-access
         torch._C._jit_clear_class_registry()
         torch.jit._recursive.concrete_type_store = torch.jit._recursive.ConcreteTypeStore()
         torch.jit._state._clear_class_state()


### PR DESCRIPTION
### Changes

Add `cleanup_torchscript_cache` function to test_quantize_conformance.py

### Reason for changes

After run torch.jit.trace in convert_model, PyTorch does not clear the trace cache automatically.

Same function in torch test and openvino notebok:
https://github.com/pytorch/pytorch/blob/main/torch/testing/_internal/jit_utils.py#L59
https://github.com/openvinotoolkit/openvino_notebooks/blob/1932d4b4e99116bdedaa620c9dc92069fbb1f05e/notebooks/236-stable-diffusion-v2/implementation/conversion_helper_utils.py#L8


