### PR TITLE
[OV] Apply output insertion transformation first for model with If node 

### DIFF
--- a/nncf/openvino/quantization/quantize_ifmodel.py
+++ b/nncf/openvino/quantization/quantize_ifmodel.py
@@ -246,7 +246,7 @@ class OVBackend:
         ]
         for index in input_indices:
             if not ov_node.inputs()[index].get_tensor().get_names():
-                ov_node.inputs()[index].get_tensor().set_names(set([f"if_{index}_input"]))
+                ov_node.inputs()[index].get_tensor().set_names(set([f"{if_node.node_name}_{index}_input"]))
             input_names.append(ov_node.inputs()[index].get_tensor().get_any_name())
         return input_names
 
@@ -262,7 +262,7 @@ class OVBackend:
         name_to_node_mapping = {op.get_friendly_name(): op for op in model.get_ops()}
         ov_node = name_to_node_mapping[if_node.node_name]
         if not ov_node.inputs()[0].get_tensor().get_names():
-            ov_node.inputs()[0].get_tensor().set_names(set(["if_0_input"]))
+            ov_node.inputs()[0].get_tensor().set_names(set([f"{if_node.node_name}_0_input"]))
         return ov_node.inputs()[0].get_tensor().get_any_name()
 
     @staticmethod

--- a/nncf/openvino/quantization/quantize_ifmodel.py
+++ b/nncf/openvino/quantization/quantize_ifmodel.py
@@ -244,7 +244,10 @@ class OVBackend:
             desc.input_index
             for desc in ov_node.get_input_descriptions(OVBackend._get_if_body_port_id(if_body_condition))
         ]
-        input_names.extend([ov_node.input_values()[index].any_name for index in input_indices])
+        for index in input_indices:
+            if not ov_node.inputs()[index].get_tensor().get_names():
+                ov_node.inputs()[index].get_tensor().set_names(set([f"if_{index}_input"]))
+            input_names.append(ov_node.inputs()[index].get_tensor().get_any_name())
         return input_names
 
     @staticmethod
@@ -258,7 +261,9 @@ class OVBackend:
         """
         name_to_node_mapping = {op.get_friendly_name(): op for op in model.get_ops()}
         ov_node = name_to_node_mapping[if_node.node_name]
-        return ov_node.input_values()[0].any_name
+        if not ov_node.inputs()[0].get_tensor().get_names():
+            ov_node.inputs()[0].get_tensor().set_names(set(["if_0_input"]))
+        return ov_node.inputs()[0].get_tensor().get_any_name()
 
     @staticmethod
     def create_update_body_command(if_node: NNCFNode, if_body_condition: bool, body: ov.Model) -> OVUpdateIfBodyCommand:


### PR DESCRIPTION
### Changes

Apply output transformation first to correctly take the tensor names.

### Reason for changes

This allows to use of these names to collect data from If inputs

### Related tickets

122100

### Tests

Manually model from the ticket was tested.
