### PR TITLE
Run OV precommit as a Github action

### DIFF
--- a/.github/workflows/post_pr_merge.yml
+++ b/.github/workflows/post_pr_merge.yml
@@ -35,3 +35,12 @@ jobs:
       coverage_artifact_name_in_pr: coverage_onnx
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  upload-coverage-openvino:
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/upload_coverage_for_develop.yml
+    with:
+      merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      last_sha_in_pr: ${{ github.event.pull_request.head.sha }}
+      coverage_artifact_name_in_pr: coverage_openvino
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -58,4 +58,29 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: coverage_onnx
+  openvino:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.8.10
+      - name: Install NNCF and test requirements
+        run: make install-openvino-test
+      - name: Run OV precommit test scope
+        run: make test-openvino
+        env:
+          NNCF_COVERAGE: 1
+      - name: Upload coverage report as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage_openvino
+          path: ./coverage.xml
+      - name: Upload coverage report to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: coverage_openvino
 


### PR DESCRIPTION
### Changes
As stated in the title

### Reason for changes
Offloading the internal CI jobs to the GH action resources

### Related tickets
N/A

### Tests
OV precommit as run by the github action
