### PR TITLE
Skipping CUDA tests for CPU setup

### DIFF
--- a/tests/torch/ptq/test_fast_bias_correction.py
+++ b/tests/torch/ptq/test_fast_bias_correction.py
@@ -62,17 +62,14 @@ class TestTorchFBCAlgorithm(TemplateTestFBCAlgorithm):
         raise ValueError("Not found node with bias")
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Skipping for CPU-only setups")
 class TestTorchCudaFBCAlgorithm(TestTorchFBCAlgorithm):
     @staticmethod
     def list_to_backend_type(data: List) -> torch.Tensor:
-        if not torch.cuda.is_available():
-            pytest.skip("Skipping for CPU-only setups")
         return torch.Tensor(data).cuda()
 
     @staticmethod
     def backend_specific_model(model: bool, tmp_dir: str):
-        if not torch.cuda.is_available():
-            pytest.skip("Skipping for CPU-only setups")
         return get_nncf_network(model.cuda(), model.INPUT_SIZE)
 
     @staticmethod

--- a/tests/torch/ptq/test_fast_bias_correction.py
+++ b/tests/torch/ptq/test_fast_bias_correction.py
@@ -11,6 +11,7 @@
 
 from typing import List
 
+import pytest
 import torch
 
 from nncf.common.factory import NNCFGraphFactory
@@ -64,10 +65,14 @@ class TestTorchFBCAlgorithm(TemplateTestFBCAlgorithm):
 class TestTorchCudaFBCAlgorithm(TestTorchFBCAlgorithm):
     @staticmethod
     def list_to_backend_type(data: List) -> torch.Tensor:
+        if not torch.cuda.is_available():
+            pytest.skip("Skipping for CPU-only setups")
         return torch.Tensor(data).cuda()
 
     @staticmethod
     def backend_specific_model(model: bool, tmp_dir: str):
+        if not torch.cuda.is_available():
+            pytest.skip("Skipping for CPU-only setups")
         return get_nncf_network(model.cuda(), model.INPUT_SIZE)
 
     @staticmethod

--- a/tests/torch/test_tensor.py
+++ b/tests/torch/test_tensor.py
@@ -22,11 +22,10 @@ class TestPTNNCFTensorOperators(TemplateTestNNCFTensorOperators):
         return torch.tensor(x)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Skipping for CPU-only setups")
 class TestCudaPTNNCFTensorOperators(TemplateTestNNCFTensorOperators):
     @staticmethod
     def to_tensor(x):
-        if not torch.cuda.is_available():
-            pytest.skip("Skipping for CPU-only setups")
         return torch.tensor(x).cuda()
 
     def test_device(self):


### PR DESCRIPTION
### Changes

Add check `torch.cuda.is_available` to `TestTorchCudaFBCAlgorithm` test.

### Related tickets

122537


