### PR TITLE
Fix multithreading

### DIFF
--- a/nncf/quantization/algorithms/accuracy_control/ranker.py
+++ b/nncf/quantization/algorithms/accuracy_control/ranker.py
@@ -223,7 +223,7 @@ class Ranker:
                 )
                 ranking_scores.append(float(ranking_score))
 
-        for _ in range(self._num_workers - 1):
+        for _ in range(len(prepared_model_queue)):
             prepared_model = prepared_model_queue.pop(0).result()
             ranking_score = self._calculate_ranking_score(
                 prepared_model, ranking_subset_indices, reference_values_for_each_item

--- a/nncf/quantization/algorithms/accuracy_control/ranker.py
+++ b/nncf/quantization/algorithms/accuracy_control/ranker.py
@@ -223,8 +223,8 @@ class Ranker:
                 )
                 ranking_scores.append(float(ranking_score))
 
-        for _ in range(len(prepared_model_queue)):
-            prepared_model = prepared_model_queue.pop(0).result()
+        for future in prepared_model_queue:
+            prepared_model = future.result()
             ranking_score = self._calculate_ranking_score(
                 prepared_model, ranking_subset_indices, reference_values_for_each_item
             )


### PR DESCRIPTION
### Changes

The `_multithreading_calculation_ranking_score` does not work when len(groups_to_rank) < self._num_workers

### Reason for changes

IndexError: pop from empty list

### Related tickets

N/A

### Tests

N/A
