### PR TITLE
Bump `numpy` version upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ INSTALL_REQUIRES = [
     "natsort>=7.1.0",
     "networkx>=2.6, <=2.8.2",  # see ticket 94048 or https://github.com/networkx/networkx/issues/5962
     "ninja>=1.10.0.post2, <1.11",
-    "numpy>=1.19.1, <1.25",
+    "numpy>=1.19.1, <1.27",
     "openvino-telemetry>=2023.2.0",
     "packaging>=20.0",
     "pandas>=1.1.5,<2.1",


### PR DESCRIPTION
### Changes

Bump `numpy` version.

### Reason for changes

Current version causes issues in OpenVINO CI: https://github.com/intel-innersource/frameworks.ai.openvino.ci.product-configs/pull/2803

### Related tickets

122802

