### PR TITLE
[PTQ] Enable ChannelAlingment algorithm by default

### DIFF
--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -152,7 +152,7 @@ class AdvancedQuantizationParameters:
     overflow_fix: OverflowFix = OverflowFix.FIRST_LAYER
     quantize_outputs: bool = False
     inplace_statistics: bool = True
-    disable_channel_alignment: bool = True
+    disable_channel_alignment: bool = False
     disable_bias_correction: bool = False
     smooth_quant_alpha: float = 0.95
 


### PR DESCRIPTION
### Changes

 ChannelAlingment algorithm enabled by default

### Reason for changes

To increase quantization metrics for models that have patterns, applicable for CA algorithm

### Related tickets



### Tests

### TODO:
Update metrics
