### PR TITLE
Added ov_version parameter to the env tests

### DIFF
--- a/tests/cross_fw/examples/conftest.py
+++ b/tests/cross_fw/examples/conftest.py
@@ -29,7 +29,7 @@ def pytest_addoption(parser):
         help="If the parameter is set then the performance metrics will be tested as well",
     )
     parser.addoption(
-        "--ov_module", default=None, help="Parameter to set OpenVINO into the env with the version from PyPI"
+        "--ov_version_override", default=None, help="Parameter to set OpenVINO into the env with the version from PyPI"
     )
 
 
@@ -44,5 +44,5 @@ def is_check_performance(request):
 
 
 @pytest.fixture(scope="module")
-def ov_module(request):
-    return request.config.getoption("--ov_module")
+def ov_version_override(request):
+    return request.config.getoption("--ov_version_override")

--- a/tests/cross_fw/examples/conftest.py
+++ b/tests/cross_fw/examples/conftest.py
@@ -28,6 +28,9 @@ def pytest_addoption(parser):
         default=False,
         help="If the parameter is set then the performance metrics will be tested as well",
     )
+    parser.addoption(
+        "--ov_module", default=None, help="Parameter to set OpenVINO into the env with the version from PyPI"
+    )
 
 
 @pytest.fixture(scope="module")
@@ -38,3 +41,8 @@ def backends_list(request):
 @pytest.fixture(scope="module")
 def is_check_performance(request):
     return request.config.getoption("--check_performance")
+
+
+@pytest.fixture(scope="module")
+def ov_module(request):
+    return request.config.getoption("--ov_module")

--- a/tests/cross_fw/examples/test_examples.py
+++ b/tests/cross_fw/examples/test_examples.py
@@ -42,7 +42,7 @@ def example_test_cases():
 
 
 @pytest.mark.parametrize("example_name, example_params", example_test_cases())
-def test_examples(tmp_path, example_name, example_params, backends_list, is_check_performance):
+def test_examples(tmp_path, example_name, example_params, backends_list, is_check_performance, ov_module):
     backend = example_params["backend"]
     skip_if_backend_not_selected(backend, backends_list)
     venv_path = create_venv_with_nncf(tmp_path, "pip_e_local", "venv", set([backend]))
@@ -51,6 +51,11 @@ def test_examples(tmp_path, example_name, example_params, backends_list, is_chec
         requirements = PROJECT_ROOT / example_params["requirements"]
         run_cmd_line = f"{pip_with_venv} install -r {requirements}"
         subprocess.run(run_cmd_line, check=True, shell=True)
+
+    if ov_module is not None:
+        pip_with_venv = get_pip_executable_with_venv(venv_path)
+        ov_module_cmd_line = f"{pip_with_venv} install {ov_module}"
+        subprocess.run(ov_module_cmd_line, check=True, shell=True)
 
     env = os.environ.copy()
     env["PYTHONPATH"] = str(PROJECT_ROOT)  # need this to be able to import from tests.* in run_example.py

--- a/tests/cross_fw/examples/test_examples.py
+++ b/tests/cross_fw/examples/test_examples.py
@@ -11,6 +11,8 @@
 
 import os
 import subprocess
+from pathlib import Path
+from typing import Any, Dict, List
 
 import pytest
 
@@ -42,7 +44,14 @@ def example_test_cases():
 
 
 @pytest.mark.parametrize("example_name, example_params", example_test_cases())
-def test_examples(tmp_path, example_name, example_params, backends_list, is_check_performance, ov_module):
+def test_examples(
+    tmp_path: Path,
+    example_name: str,
+    example_params: Dict[str, Any],
+    backends_list: List[str],
+    is_check_performance: bool,
+    ov_version_override: str,
+):
     backend = example_params["backend"]
     skip_if_backend_not_selected(backend, backends_list)
     venv_path = create_venv_with_nncf(tmp_path, "pip_e_local", "venv", set([backend]))
@@ -52,10 +61,10 @@ def test_examples(tmp_path, example_name, example_params, backends_list, is_chec
         run_cmd_line = f"{pip_with_venv} install -r {requirements}"
         subprocess.run(run_cmd_line, check=True, shell=True)
 
-    if ov_module is not None:
+    if ov_version_override is not None:
         pip_with_venv = get_pip_executable_with_venv(venv_path)
-        ov_module_cmd_line = f"{pip_with_venv} install {ov_module}"
-        subprocess.run(ov_module_cmd_line, check=True, shell=True)
+        ov_version_cmd_line = f"{pip_with_venv} install {ov_version_override}"
+        subprocess.run(ov_version_cmd_line, check=True, shell=True)
 
     env = os.environ.copy()
     env["PYTHONPATH"] = str(PROJECT_ROOT)  # need this to be able to import from tests.* in run_example.py

--- a/tests/cross_fw/install/conftest.py
+++ b/tests/cross_fw/install/conftest.py
@@ -30,7 +30,7 @@ def pytest_addoption(parser):
         default=["all"],
     )
     parser.addoption(
-        "--ov_module", default=None, help="Parameter to set OpenVINO into the env with the version from PyPI"
+        "--ov_version_override", default=None, help="Parameter to set OpenVINO into the env with the version from PyPI"
     )
 
 
@@ -45,5 +45,5 @@ def host_configuration_clopt(request):
 
 
 @pytest.fixture(scope="module")
-def ov_module(request):
-    return request.config.getoption("--ov_module")
+def ov_version_override(request):
+    return request.config.getoption("--ov_version_override")

--- a/tests/cross_fw/install/conftest.py
+++ b/tests/cross_fw/install/conftest.py
@@ -29,6 +29,9 @@ def pytest_addoption(parser):
         nargs="+",
         default=["all"],
     )
+    parser.addoption(
+        "--ov_module", default=None, help="Parameter to set OpenVINO into the env with the version from PyPI"
+    )
 
 
 @pytest.fixture(scope="module")
@@ -39,3 +42,8 @@ def backend_clopt(request):
 @pytest.fixture(scope="module")
 def host_configuration_clopt(request):
     return request.config.getoption("--host-configuration")
+
+
+@pytest.fixture(scope="module")
+def ov_module(request):
+    return request.config.getoption("--ov_module")

--- a/tests/cross_fw/install/test_install.py
+++ b/tests/cross_fw/install/test_install.py
@@ -107,16 +107,16 @@ class TestInstall:
         package_type: str,
         backend_clopt: List[str],
         host_configuration_clopt: str,
-        ov_module: str,
+        ov_version_override: str,
     ):
         skip_if_backend_not_selected(backend, backend_clopt)
         if "pypi" in package_type:
             pytest.xfail("Disabled until NNCF is exposed in a release")
         venv_path = create_venv_with_nncf(tmp_path, package_type, venv_type, extra_reqs={backend})
-        if ov_module is not None:
+        if ov_version_override is not None:
             pip_with_venv = get_pip_executable_with_venv(venv_path)
-            ov_module_cmd_line = f"{pip_with_venv} install {ov_module}"
-            subprocess.run(ov_module_cmd_line, check=True, shell=True)
+            ov_version_cmd_line = f"{pip_with_venv} install {ov_version_override}"
+            subprocess.run(ov_version_cmd_line, check=True, shell=True)
         run_install_checks(venv_path, tmp_path, package_type, backend=backend, install_type=host_configuration_clopt)
 
     @staticmethod

--- a/tests/cross_fw/install/test_install.py
+++ b/tests/cross_fw/install/test_install.py
@@ -107,11 +107,16 @@ class TestInstall:
         package_type: str,
         backend_clopt: List[str],
         host_configuration_clopt: str,
+        ov_module: str,
     ):
         skip_if_backend_not_selected(backend, backend_clopt)
         if "pypi" in package_type:
             pytest.xfail("Disabled until NNCF is exposed in a release")
         venv_path = create_venv_with_nncf(tmp_path, package_type, venv_type, extra_reqs={backend})
+        if ov_module is not None:
+            pip_with_venv = get_pip_executable_with_venv(venv_path)
+            ov_module_cmd_line = f"{pip_with_venv} install {ov_module}"
+            subprocess.run(ov_module_cmd_line, check=True, shell=True)
         run_install_checks(venv_path, tmp_path, package_type, backend=backend, install_type=host_configuration_clopt)
 
     @staticmethod


### PR DESCRIPTION
### Changes

- Added `ov_version` variable for the pytest in `test_examples`;
- Added `ov_version` variable for the pytest in the `test_install_*`;

### Reason for changes

- More flexible tests

### Related tickets

- 122860

### Tests

- Updated
