### PR TITLE
[PTQ] Remove insert_null_biases pass

### DIFF
--- a/nncf/openvino/graph/model_utils.py
+++ b/nncf/openvino/graph/model_utils.py
@@ -16,40 +16,7 @@ from nncf.common.factory import ModelTransformerFactory
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.transformations.layout import TransformationLayout
 from nncf.openvino.graph.metatypes.groups import FAKE_QUANTIZE_OPERATIONS
-from nncf.openvino.graph.metatypes.openvino_metatypes import OVConvolutionBackpropDataMetatype
-from nncf.openvino.graph.metatypes.openvino_metatypes import OVConvolutionMetatype
-from nncf.openvino.graph.metatypes.openvino_metatypes import OVDepthwiseConvolutionMetatype
-from nncf.openvino.graph.metatypes.openvino_metatypes import OVGroupConvolutionBackpropDataMetatype
-from nncf.openvino.graph.metatypes.openvino_metatypes import OVGroupConvolutionMetatype
-from nncf.openvino.graph.node_utils import create_bias_tensor
-from nncf.openvino.graph.node_utils import is_node_with_bias
 from nncf.openvino.graph.transformations.command_creation import OVCommandCreator
-
-
-def insert_null_biases(model: ov.Model, graph: NNCFGraph) -> ov.Model:
-    """
-    This method finds and inserts zero biases for the layers that should have it.
-
-    :param model: ov.Model instance.
-    :param graph: Model graph.
-    :return: Updated ov.Model instance with zero biases
-    """
-    types_to_insert_bias = [
-        OVConvolutionMetatype,
-        OVGroupConvolutionMetatype,
-        OVDepthwiseConvolutionMetatype,
-        OVConvolutionBackpropDataMetatype,
-        OVGroupConvolutionBackpropDataMetatype,
-    ]
-    nodes_without_biases = graph.get_nodes_by_metatypes(types_to_insert_bias)
-    nodes_without_biases = [node for node in nodes_without_biases if not is_node_with_bias(node, graph)]
-    transformation_layout = TransformationLayout()
-    model_transformer = ModelTransformerFactory.create(model)
-    for node_without_bias in nodes_without_biases:
-        const_value = create_bias_tensor(node_without_bias, graph, 0)
-        bias_insertion_command = OVCommandCreator.create_command_to_insert_bias(node_without_bias, const_value)
-        transformation_layout.register(bias_insertion_command)
-    return model_transformer.transform(transformation_layout)
 
 
 def remove_fq_from_inputs(model: ov.Model, graph: NNCFGraph) -> ov.Model:

--- a/nncf/quantization/algorithms/bias_correction/algorithm.py
+++ b/nncf/quantization/algorithms/bias_correction/algorithm.py
@@ -134,7 +134,6 @@ class BiasCorrection(Algorithm):
         dataset: Optional[Dataset] = None,
     ) -> TModel:
         self._set_backend_entity(model)
-        model = self._backend_entity.insert_null_biases(model, graph)
         main_transformations_layout = TransformationLayout()
         main_model_transformer = ModelTransformerFactory.create(model)
 
@@ -488,8 +487,6 @@ class BiasCorrection(Algorithm):
     def get_statistic_points(self, model: TModel, graph: NNCFGraph) -> StatisticPointsContainer:
         self._set_backend_entity(model)
         model_copy = self._backend_entity.remove_fq_from_inputs(copy_model(model), graph)
-        graph_copy = NNCFGraphFactory.create(model_copy)
-        model_copy = self._backend_entity.insert_null_biases(model_copy, graph_copy)
         nncf_graph = NNCFGraphFactory.create(model_copy)
         statistic_container = StatisticPointsContainer()
 

--- a/nncf/quantization/algorithms/bias_correction/backend.py
+++ b/nncf/quantization/algorithms/bias_correction/backend.py
@@ -203,14 +203,3 @@ class BiasCorrectionAlgoBackend(ABC):
         :param nncf_graph: NNCFGraph instance.
         :return: TModel without activation Fake Quantize nodes (or Quantize-Dequantize pairs).
         """
-
-    @staticmethod
-    @abstractmethod
-    def insert_null_biases(model: TModel, nncf_graph: NNCFGraph) -> TModel:
-        """
-        This method finds and inserts zero biases for the layers that should have it.
-
-        :param model: TModel instance.
-        :param nncf_graph: NNCFGraph instance.
-        :return: TModel instance with zero biases
-        """

--- a/nncf/quantization/algorithms/bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/onnx_backend.py
@@ -117,7 +117,3 @@ class ONNXBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
     @staticmethod
     def remove_fq_from_inputs(model: onnx.ModelProto, nncf_graph: NNCFGraph) -> onnx.ModelProto:
         return remove_fq_from_inputs(model, nncf_graph)
-
-    @staticmethod
-    def insert_null_biases(model: onnx.ModelProto, nncf_graph: NNCFGraph) -> onnx.ModelProto:
-        return model

--- a/nncf/quantization/algorithms/bias_correction/openvino_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/openvino_backend.py
@@ -19,7 +19,6 @@ from nncf.common.graph import NNCFNode
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
 from nncf.openvino.graph.metatypes.groups import FAKE_QUANTIZE_OPERATIONS
-from nncf.openvino.graph.model_utils import insert_null_biases
 from nncf.openvino.graph.model_utils import remove_fq_from_inputs
 from nncf.openvino.graph.node_utils import get_bias_value
 from nncf.openvino.graph.node_utils import is_node_with_bias
@@ -132,7 +131,3 @@ class OVBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
     @staticmethod
     def remove_fq_from_inputs(model: ov.Model, nncf_graph: NNCFGraph) -> ov.Model:
         return remove_fq_from_inputs(model, nncf_graph)
-
-    @staticmethod
-    def insert_null_biases(model: ov.Model, nncf_graph: NNCFGraph) -> ov.Model:
-        return insert_null_biases(model, nncf_graph)

--- a/nncf/quantization/passes.py
+++ b/nncf/quantization/passes.py
@@ -14,8 +14,6 @@ from typing import List, Optional, TypeVar
 
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.operator_metatypes import OperatorMetatype
-from nncf.common.utils.backend import BackendType
-from nncf.common.utils.backend import get_backend
 
 TModel = TypeVar("TModel")
 
@@ -173,19 +171,3 @@ def filter_constant_nodes(
     constant_nodes = [node for node in nncf_graph.get_all_nodes() if node not in visited_nodes]
     nncf_graph.remove_nodes_from(constant_nodes)
     return nncf_graph
-
-
-def insert_null_biases_pass(model: TModel, graph: NNCFGraph) -> TModel:
-    """
-    This pass finds and inserts zero biases to the given model for the layers that should have it.
-
-    :param model: Model instance.
-    :param graph: NNCFGraph instance.
-    :return: Updated Model instance with zero biases
-    """
-    model_backend = get_backend(model)
-    if model_backend == BackendType.OPENVINO:
-        from nncf.openvino.graph.model_utils import insert_null_biases
-
-        return insert_null_biases(model, graph)
-    return model


### PR DESCRIPTION
### Changes

- Removed `insert_bull_biases` method

### Reason for changes

- Inserting is not necessary since correcting the null biases is limited by magnitude.
- Inserting of the new increases binary file size.

### Related tickets

- 120843
