### PR TITLE
[PTQ] Avg pool is added as ignored metatype for TRANSFORMER model_type

### DIFF
--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -184,6 +184,8 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
                 om.ONNXPowMetatype,
                 om.ONNXSqueezeMetatype,
                 om.ONNXSubMetatype,
+                om.ONNXAveragePoolMetatype,
+                om.ONNXGlobalAveragePoolMetatype,
                 om.ONNXReduceMeanMetatype,
                 om.ONNXReduceL2Metatype,
                 om.ONNXReduceSumMetatype,

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -214,6 +214,7 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
                 om.OVPowerMetatype,
                 om.OVSqueezeMetatype,
                 om.OVSubtractMetatype,
+                om.OVAvgPoolMetatype,
                 om.OVReduceMeanMetatype,
                 om.OVReduceL2Metatype,
                 om.OVSumMetatype,

--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -302,6 +302,8 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
                 om.PTAddMetatype,
                 om.PTPowerMetatype,
                 om.PTSubMetatype,
+                om.PTAvgPool2dMetatype,
+                om.PTAvgPool3dMetatype,
                 om.PTMeanMetatype,
                 om.PTSumMetatype,
                 om.PTReduceL2,


### PR DESCRIPTION
### Changes

[PTQ] Avg pool is added as ignored metatype for TRANSFORMER model_type in TORCH/OV/ONNX backends

### Reason for changes

* To align PTQ backends as for example TORCH avg_pool is mapping to reduce_mean in OV, for timm/visformer_small in particular

### Related tickets

110985
119910

### Tests


