### PR TITLE
BootstrapNAS External Weight Reorg.

### DIFF
--- a/nncf/config/schemata/experimental_schema.py
+++ b/nncf/config/schemata/experimental_schema.py
@@ -35,7 +35,9 @@ from nncf.config.schemata.common.targeting import TARGET_SCOPES_DESCRIPTION
 # Experimental Quantization
 ########################################################################################################################
 EXPERIMENTAL_QUANTIZATION_SCHEMA = copy.deepcopy(QUANTIZATION_SCHEMA)
-EXPERIMENTAL_QUANTIZATION_SCHEMA["properties"]["algorithm"]["const"] = EXPERIMENTAL_QUANTIZATION_ALGO_NAME_IN_CONFIG
+EXPERIMENTAL_QUANTIZATION_SCHEMA["properties"]["algorithm"][
+    "const"
+] = EXPERIMENTAL_QUANTIZATION_ALGO_NAME_IN_CONFIG
 
 ########################################################################################################################
 # BootstrapNAS
@@ -155,10 +157,12 @@ ELASTICITY_SCHEMA = {
             "are available - [width, depth, kernel]",
         ),
         "ignored_scopes": with_attributes(
-            make_string_or_array_of_strings_schema(), description=IGNORED_SCOPES_DESCRIPTION
+            make_string_or_array_of_strings_schema(),
+            description=IGNORED_SCOPES_DESCRIPTION,
         ),
         "target_scopes": with_attributes(
-            make_string_or_array_of_strings_schema(), description=TARGET_SCOPES_DESCRIPTION
+            make_string_or_array_of_strings_schema(),
+            description=TARGET_SCOPES_DESCRIPTION,
         ),
     },
     "additionalProperties": False,
@@ -172,7 +176,9 @@ STAGE_DESCRIPTOR_SCHEMA = {
             description="Elasticity dimensions that are enabled for subnet sampling,"
             "the rest elastic dimensions are disabled",
         ),
-        "epochs": with_attributes(NUMBER, description="Duration of the training stage in epochs"),
+        "epochs": with_attributes(
+            NUMBER, description="Duration of the training stage in epochs"
+        ),
         "depth_indicator": with_attributes(
             NUMBER,
             description="Restricts the maximum number of blocks in each "
@@ -201,7 +207,8 @@ STAGE_DESCRIPTOR_SCHEMA = {
             "beginning of the stage",
         ),
         "bn_adapt": with_attributes(
-            BOOLEAN, description="if True, triggers batchnorm adaptation in the beginning of the stage"
+            BOOLEAN,
+            description="if True, triggers batchnorm adaptation in the beginning of the stage",
         ),
         "init_lr": with_attributes(
             NUMBER,
@@ -210,10 +217,12 @@ STAGE_DESCRIPTOR_SCHEMA = {
             "the beginning of the stage.",
         ),
         "epochs_lr": with_attributes(
-            NUMBER, description="Number of epochs to compute the adjustment of the learning rate."
+            NUMBER,
+            description="Number of epochs to compute the adjustment of the learning rate.",
         ),
         "sample_rate": with_attributes(
-            NUMBER, description="Number of iterations to activate the random subnet. Default value is 1."
+            NUMBER,
+            description="Number of iterations to activate the random subnet. Default value is 1.",
         ),
     },
     "description": "Defines a supernet training stage: how many epochs it takes, which elasticities with which "
@@ -267,7 +276,8 @@ BOOTSTRAP_NAS_TRAINING_SCHEMA = {
         "elasticity": ELASTICITY_SCHEMA,
         "lr_schedule": LR_SCHEDULE_SCHEMA,
         "train_steps": with_attributes(
-            NUMBER, description="Defines the number of samples used for each training epoch."
+            NUMBER,
+            description="Defines the number of samples used for each training epoch.",
         ),
     },
     "additionalProperties": False,
@@ -282,14 +292,17 @@ BOOTSTRAP_NAS_SEARCH_SCHEMA = {
     "type": "object",
     "properties": {
         "algorithm": with_attributes(
-            SEARCH_ALGORITHMS_SCHEMA, description="Defines the search algorithm. Default algorithm is NSGA-II."
+            SEARCH_ALGORITHMS_SCHEMA,
+            description="Defines the search algorithm. Default algorithm is NSGA-II.",
         ),
         "batchnorm_adaptation": BATCHNORM_ADAPTATION_SCHEMA,
         "num_evals": with_attributes(
-            NUMBER, description="Defines the number of evaluations that will be used by the search algorithm."
+            NUMBER,
+            description="Defines the number of evaluations that will be used by the search algorithm.",
         ),
         "population": with_attributes(
-            NUMBER, description="Defines the population size when using an evolutionary search algorithm."
+            NUMBER,
+            description="Defines the population size when using an evolutionary search algorithm.",
         ),
         "acc_delta": with_attributes(
             NUMBER,
@@ -302,7 +315,11 @@ BOOTSTRAP_NAS_SEARCH_SCHEMA = {
             "to generate the super-network.",
         ),
         "compression": make_object_or_array_of_objects_schema(
-            {"oneOf": [{"$ref": f"#/$defs/{KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG}"}]}
+            {
+                "oneOf": [
+                    {"$ref": f"#/$defs/{KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG}"}
+                ]
+            }
         ),
     },
     "additionalProperties": False,
@@ -336,10 +353,12 @@ MOVEMENT_SPARSE_STRUCTURE_BY_SCOPES_SCHEMA = {
             enum=MOVEMENT_SPARSE_STRUCTURE_MODE,
         ),
         "sparse_factors": with_attributes(
-            ARRAY_OF_NUMBERS, description='The block shape for weights to sparsify. Required when `mode`="block".'
+            ARRAY_OF_NUMBERS,
+            description='The block shape for weights to sparsify. Required when `mode`="block".',
         ),
         "axis": with_attributes(
-            NUMBER, description='The dimension for weights to sparsify. Required when `mode`="per_dim".'
+            NUMBER,
+            description='The dimension for weights to sparsify. Required when `mode`="per_dim".',
         ),
         "target_scopes": with_attributes(
             make_string_or_array_of_strings_schema(),
@@ -354,9 +373,12 @@ MOVEMENT_SCHEDULER_PARAMS_SCHEMA = {
     "type": "object",
     "properties": {
         "warmup_start_epoch": with_attributes(
-            NUMBER, description="Index of the starting epoch (include) for warmup stage."
+            NUMBER,
+            description="Index of the starting epoch (include) for warmup stage.",
         ),
-        "warmup_end_epoch": with_attributes(NUMBER, description="Index of the end epoch (exclude) for warmup stage."),
+        "warmup_end_epoch": with_attributes(
+            NUMBER, description="Index of the end epoch (exclude) for warmup stage."
+        ),
         "importance_regularization_factor": with_attributes(
             NUMBER,
             description="The regularization factor on weight importance scores. With a larger "
@@ -396,7 +418,11 @@ MOVEMENT_SCHEDULER_PARAMS_SCHEMA = {
         ),
     },
     "additionalProperties": False,
-    "required": ["warmup_start_epoch", "warmup_end_epoch", "importance_regularization_factor"],
+    "required": [
+        "warmup_start_epoch",
+        "warmup_end_epoch",
+        "importance_regularization_factor",
+    ],
 }
 
 

--- a/nncf/config/schemata/experimental_schema.py
+++ b/nncf/config/schemata/experimental_schema.py
@@ -123,14 +123,14 @@ ELASTIC_WIDTH_SCHEMA = {
         "external_importance_path": with_attributes(
             STRING,
             description="Path to the custom external weight importance (PyTorch tensor) per node "
-                        "that needs to weight reorder. Valid only when filter_importance "
-                        "is `custom`. The file should be loaded via the torch interface "
-                        "torch.load(), represented as a dictionary. It maps NNCF node name "
-                        "to importance tensor with the same shape as the weights in the node "
-                        "module. For example, node `Model/NNCFLinear[fc1]/linear_0` has a "
-                        "3x1 linear module with weight [0.2, 0.3, 0.9], and in the dict"
-                        "{'Model/NNCFLinear[fc1]/linear_0': tensor([0.4, 0.01, 0.2])} represents "
-                        "the corresponding weight importance.",
+            "that needs to weight reorder. Valid only when filter_importance "
+            "is `custom`. The file should be loaded via the torch interface "
+            "torch.load(), represented as a dictionary. It maps NNCF node name "
+            "to importance tensor with the same shape as the weights in the node "
+            "module. For example, node `Model/NNCFLinear[fc1]/linear_0` has a "
+            "3x1 linear module with weight [0.2, 0.3, 0.9], and in the dict"
+            "{'Model/NNCFLinear[fc1]/linear_0': tensor([0.4, 0.01, 0.2])} represents "
+            "the corresponding weight importance.",
         ),
     },
     "additionalProperties": False,

--- a/nncf/config/schemata/experimental_schema.py
+++ b/nncf/config/schemata/experimental_schema.py
@@ -301,6 +301,9 @@ BOOTSTRAP_NAS_SEARCH_SCHEMA = {
             description="Defines the reference accuracy from the pre-trained model used "
             "to generate the super-network.",
         ),
+        "compression": make_object_or_array_of_objects_schema(
+            {"oneOf": [{"$ref": f"#/$defs/{KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG}"}]}
+        ),
     },
     "additionalProperties": False,
 }

--- a/nncf/config/schemata/experimental_schema.py
+++ b/nncf/config/schemata/experimental_schema.py
@@ -13,6 +13,7 @@ import copy
 
 from nncf.config.definitions import BOOTSTRAP_NAS_ALGO_NAME_IN_CONFIG
 from nncf.config.definitions import EXPERIMENTAL_QUANTIZATION_ALGO_NAME_IN_CONFIG
+from nncf.config.definitions import KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG
 from nncf.config.definitions import MOVEMENT_SPARSITY_ALGO_NAME_IN_CONFIG
 from nncf.config.schemata.algo.quantization import QUANTIZATION_SCHEMA
 from nncf.config.schemata.basic import ARRAY_OF_NUMBERS
@@ -20,6 +21,7 @@ from nncf.config.schemata.basic import ARRAY_OF_STRINGS
 from nncf.config.schemata.basic import BOOLEAN
 from nncf.config.schemata.basic import NUMBER
 from nncf.config.schemata.basic import STRING
+from nncf.config.schemata.basic import make_object_or_array_of_objects_schema
 from nncf.config.schemata.basic import make_string_or_array_of_strings_schema
 from nncf.config.schemata.basic import with_attributes
 from nncf.config.schemata.common.compression import BASIC_COMPRESSION_ALGO_SCHEMA

--- a/nncf/config/schemata/experimental_schema.py
+++ b/nncf/config/schemata/experimental_schema.py
@@ -35,9 +35,7 @@ from nncf.config.schemata.common.targeting import TARGET_SCOPES_DESCRIPTION
 # Experimental Quantization
 ########################################################################################################################
 EXPERIMENTAL_QUANTIZATION_SCHEMA = copy.deepcopy(QUANTIZATION_SCHEMA)
-EXPERIMENTAL_QUANTIZATION_SCHEMA["properties"]["algorithm"][
-    "const"
-] = EXPERIMENTAL_QUANTIZATION_ALGO_NAME_IN_CONFIG
+EXPERIMENTAL_QUANTIZATION_SCHEMA["properties"]["algorithm"]["const"] = EXPERIMENTAL_QUANTIZATION_ALGO_NAME_IN_CONFIG
 
 ########################################################################################################################
 # BootstrapNAS
@@ -124,8 +122,7 @@ ELASTIC_WIDTH_SCHEMA = {
         ),
         "filter_importance_path": with_attributes(
             STRING,
-            description="The path of custom weight importance. Valid Only when "
-            "`filter_importance` is `custom`",
+            description="The path of custom weight importance. Valid Only when " "`filter_importance` is `custom`",
         ),
     },
     "additionalProperties": False,
@@ -176,9 +173,7 @@ STAGE_DESCRIPTOR_SCHEMA = {
             description="Elasticity dimensions that are enabled for subnet sampling,"
             "the rest elastic dimensions are disabled",
         ),
-        "epochs": with_attributes(
-            NUMBER, description="Duration of the training stage in epochs"
-        ),
+        "epochs": with_attributes(NUMBER, description="Duration of the training stage in epochs"),
         "depth_indicator": with_attributes(
             NUMBER,
             description="Restricts the maximum number of blocks in each "
@@ -315,11 +310,7 @@ BOOTSTRAP_NAS_SEARCH_SCHEMA = {
             "to generate the super-network.",
         ),
         "compression": make_object_or_array_of_objects_schema(
-            {
-                "oneOf": [
-                    {"$ref": f"#/$defs/{KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG}"}
-                ]
-            }
+            {"oneOf": [{"$ref": f"#/$defs/{KNOWLEDGE_DISTILLATION_ALGO_NAME_IN_CONFIG}"}]}
         ),
     },
     "additionalProperties": False,
@@ -376,9 +367,7 @@ MOVEMENT_SCHEDULER_PARAMS_SCHEMA = {
             NUMBER,
             description="Index of the starting epoch (include) for warmup stage.",
         ),
-        "warmup_end_epoch": with_attributes(
-            NUMBER, description="Index of the end epoch (exclude) for warmup stage."
-        ),
+        "warmup_end_epoch": with_attributes(NUMBER, description="Index of the end epoch (exclude) for warmup stage."),
         "importance_regularization_factor": with_attributes(
             NUMBER,
             description="The regularization factor on weight importance scores. With a larger "

--- a/nncf/config/schemata/experimental_schema.py
+++ b/nncf/config/schemata/experimental_schema.py
@@ -122,7 +122,15 @@ ELASTIC_WIDTH_SCHEMA = {
         ),
         "filter_importance_path": with_attributes(
             STRING,
-            description="The path of custom weight importance. Valid Only when " "`filter_importance` is `custom`",
+            description="Path to the custom weight importance (PyTorch tensor) per node "
+                        "that needs to weight reorder. Valid only when filter_importance "
+                        "is `custom`. The file should be loaded via the torch interface "
+                        "torch.load(), represented as a dictionary. It maps NNCF node name "
+                        "to importance tensor with the same shape as the weights in the node "
+                        "module. For example, node `Model/NNCFLinear[fc1]/linear_0` has a "
+                        "3x1 linear module with weight [0.2, 0.3, 0.9], and in the dict"
+                        "{'Model/NNCFLinear[fc1]/linear_0': tensor([0.4, 0.01, 0.2])} represents "
+                        "the corresponding weight importance.",
         ),
     },
     "additionalProperties": False,

--- a/nncf/config/schemata/experimental_schema.py
+++ b/nncf/config/schemata/experimental_schema.py
@@ -117,12 +117,12 @@ ELASTIC_WIDTH_SCHEMA = {
         "filter_importance": with_attributes(
             STRING,
             description="The type of filter importance metric. Can be"
-            " one of `L1`, `L2`, `geometric_median`, `custom`."
+            " one of `L1`, `L2`, `geometric_median`, `external`."
             " `L2` by default.",
         ),
-        "filter_importance_path": with_attributes(
+        "external_importance_path": with_attributes(
             STRING,
-            description="Path to the custom weight importance (PyTorch tensor) per node "
+            description="Path to the custom external weight importance (PyTorch tensor) per node "
                         "that needs to weight reorder. Valid only when filter_importance "
                         "is `custom`. The file should be loaded via the torch interface "
                         "torch.load(), represented as a dictionary. It maps NNCF node name "

--- a/nncf/config/schemata/experimental_schema.py
+++ b/nncf/config/schemata/experimental_schema.py
@@ -124,7 +124,7 @@ ELASTIC_WIDTH_SCHEMA = {
             STRING,
             description="Path to the custom external weight importance (PyTorch tensor) per node "
             "that needs to weight reorder. Valid only when filter_importance "
-            "is `custom`. The file should be loaded via the torch interface "
+            "is `external`. The file should be loaded via the torch interface "
             "torch.load(), represented as a dictionary. It maps NNCF node name "
             "to importance tensor with the same shape as the weights in the node "
             "module. For example, node `Model/NNCFLinear[fc1]/linear_0` has a "

--- a/nncf/config/schemata/experimental_schema.py
+++ b/nncf/config/schemata/experimental_schema.py
@@ -115,8 +115,13 @@ ELASTIC_WIDTH_SCHEMA = {
         "filter_importance": with_attributes(
             STRING,
             description="The type of filter importance metric. Can be"
-            " one of `L1`, `L2`, `geometric_median`."
+            " one of `L1`, `L2`, `geometric_median`, `custom`."
             " `L2` by default.",
+        ),
+        "filter_importance_path": with_attributes(
+            STRING,
+            description="The path of custom weight importance. Valid Only when "
+            "`filter_importance` is `custom`",
         ),
     },
     "additionalProperties": False,

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -11,7 +11,6 @@
 
 
 import random
-import re
 from collections import OrderedDict
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -806,8 +805,9 @@ class ElasticWidthHandler(SingleElasticityHandler):
         :param node_name: node name
         :return: importance tensor
         """
-        assert should_consider_scope(node_name, ignored_scopes=None, target_scopes=self._external_importance.keys()), \
-            f"Cannot match {node_name} in custom weight importance"
+        assert should_consider_scope(
+            node_name, ignored_scopes=None, target_scopes=self._external_importance.keys()
+        ), f"Cannot match {node_name} in custom weight importance"
         return self._external_importance[node_name]
 
     def reorganize_weights(self) -> None:

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -37,6 +37,7 @@ from nncf.common.pruning.structs import PrunedLayerInfoBase
 from nncf.common.pruning.utils import get_input_masks
 from nncf.common.pruning.utils import get_prunable_layers_in_out_channels
 from nncf.common.pruning.utils import is_prunable_depthwise_conv
+from nncf.common.scopes import should_consider_scope
 from nncf.common.tensor import NNCFTensor
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.base_handler import ELASTICITY_BUILDERS
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.base_handler import ELASTICITY_HANDLERS_MAP
@@ -142,7 +143,7 @@ class EWParamsStateNames:
     WIDTH_STEP = "width_step"
     WIDTH_MULTIPLIERS = "width_multipliers"
     FILTER_IMPORTANCE = "filter_importance"
-    FILTER_IMPORTANCE_PATH = "filter_importance_path"
+    CUSTOM_IMPORTANCE_PATH = "custom_importance_path"
     OVERWRITE_GROUPS = "overwrite_groups"
     OVERWRITE_GROUPS_WIDTHS = "overwrite_groups_widths"
     ADD_DYNAMIC_INPUTS = "add_dynamic_inputs"
@@ -159,7 +160,7 @@ class ElasticWidthParams(BaseElasticityParams):
         width_step: int,
         width_multipliers: List[float],
         filter_importance: str,
-        filter_importance_path: Optional[str] = None,
+        custom_importance_path: Optional[str] = None,
         overwrite_groups: Optional[List[str]] = None,
         overwrite_groups_widths: Optional[List[str]] = None,
         add_dynamic_inputs: Optional[List[str]] = None,
@@ -182,18 +183,18 @@ class ElasticWidthParams(BaseElasticityParams):
         This parameter is mutually exclusive with `width_step`.
         :param filter_importance: The type of filter importance metric. Can be one of `L1`, `L2`, `geometric_median`,
         `custom`. `L1` by default.
-        :param filter_importance_path: Path to custom weight importance. Valid only when `filter_importance`
-        is `custom`.
+        :param custom_importance_path: Path to the custom weight importance (PyTorch tensor) per node that needs
+        to weight reorder. Valid only when filter_importance is `custom`.
         """
         self.min_width = min_width
         self.max_num_widths = max_num_widths
         self.width_step = width_step
         self.width_multipliers = width_multipliers
         assert (
-            filter_importance != "custom" or filter_importance_path is not None
+            filter_importance != "custom" or custom_importance_path is not None
         ), "Missing custom weight importance path."
         self.filter_importance = filter_importance
-        self.filter_importance_path = filter_importance_path
+        self.custom_importance_path = custom_importance_path
 
         self.overwrite_groups = overwrite_groups
         self.overwrite_groups_widths = overwrite_groups_widths
@@ -210,7 +211,7 @@ class ElasticWidthParams(BaseElasticityParams):
             cls._state_names.WIDTH_STEP: config.get(cls._state_names.WIDTH_STEP, 32),
             cls._state_names.WIDTH_MULTIPLIERS: config.get(cls._state_names.WIDTH_MULTIPLIERS),
             cls._state_names.FILTER_IMPORTANCE: config.get(cls._state_names.FILTER_IMPORTANCE, "L1"),
-            cls._state_names.FILTER_IMPORTANCE_PATH: config.get(cls._state_names.FILTER_IMPORTANCE_PATH, None),
+            cls._state_names.CUSTOM_IMPORTANCE_PATH: config.get(cls._state_names.CUSTOM_IMPORTANCE_PATH, None),
             cls._state_names.OVERWRITE_GROUPS: config.get(cls._state_names.OVERWRITE_GROUPS, None),
             cls._state_names.OVERWRITE_GROUPS_WIDTHS: config.get(cls._state_names.OVERWRITE_GROUPS_WIDTHS, None),
             cls._state_names.ADD_DYNAMIC_INPUTS: config.get(cls._state_names.ADD_DYNAMIC_INPUTS, None),
@@ -238,6 +239,7 @@ class ElasticWidthParams(BaseElasticityParams):
             self._state_names.WIDTH_STEP: self.width_step,
             self._state_names.WIDTH_MULTIPLIERS: self.width_multipliers,
             self._state_names.FILTER_IMPORTANCE: self.filter_importance,
+            self._state_names.CUSTOM_IMPORTANCE_PATH: self.custom_importance_path,
             self._state_names.OVERWRITE_GROUPS: self.overwrite_groups,
             self._state_names.OVERWRITE_GROUPS_WIDTHS: self.overwrite_groups_widths,
             self._state_names.ADD_DYNAMIC_INPUTS: self.add_dynamic_inputs,
@@ -525,7 +527,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         self,
         target_model: NNCFNetwork,
         filter_importance_fn: Callable[[torch.Tensor, int], torch.Tensor],
-        filter_importance_path: Optional[str],
+        custom_importance_path: Optional[str],
         weights_normalizer_fn: Optional[Callable[[torch.Tensor], torch.Tensor]],
         node_name_vs_dynamic_input_width_op_map: Dict[NNCFNodeName, ElasticWidthOp],
         pruned_module_groups_info: Clusterization[ElasticWidthInfo](id_fn=lambda x: x.node_name),
@@ -550,9 +552,9 @@ class ElasticWidthHandler(SingleElasticityHandler):
         self._pruned_module_groups_info = pruned_module_groups_info
         self._transformation_commands = transformation_commands
         self._filter_importance_fn = filter_importance_fn
-        self._filter_importance = None
-        if filter_importance_path is not None:
-            self._filter_importance = torch.load(filter_importance_path)
+        self._custom_importance = None
+        if custom_importance_path is not None:
+            self._custom_importance = torch.load(custom_importance_path)
             nncf_logger.debug("Loaded custom weight importance.")
         self._weights_normalizer_fn = weights_normalizer_fn
         self._add_dynamic_inputs = add_dynamic_inputs
@@ -797,17 +799,16 @@ class ElasticWidthHandler(SingleElasticityHandler):
                     group_id = cluster.id
         return group_id
 
-    def get_importance_by_node_name(self, node_name: NNCFNodeName):
+    def get_custom_importance(self, node_name: NNCFNodeName):
         """
         Return custom weight importance for the current node.
 
         :param node_name: node name
         :return: importance tensor
         """
-        # Map node name to module name
-        key = ".".join(re.findall(re.compile(r"[[](.*?)[]]", re.S), node_name)) + ".weight"
-        assert key in self._filter_importance, f"Cannot find the custom weight importance of {node_name}"
-        return self._filter_importance[key]
+        assert should_consider_scope(node_name, ignored_scopes=None, target_scopes=self._custom_importance.keys()), \
+            f"Cannot match {node_name} in custom weight importance"
+        return self._custom_importance[node_name]
 
     def reorganize_weights(self) -> None:
         """
@@ -828,8 +829,8 @@ class ElasticWidthHandler(SingleElasticityHandler):
                 weight = minfo.module.weight
                 if self._weights_normalizer_fn:
                     weight = self._weights_normalizer_fn(minfo.module.weight)
-                if self._filter_importance is not None:
-                    weight = self.get_importance_by_node_name(minfo.node_name).to(device)
+                if self._custom_importance is not None:
+                    weight = self.get_custom_importance(minfo.node_name).to(device)
                 filters_importance = self._filter_importance_fn(weight, minfo.module.target_weight_dim_for_compression)
                 cumulative_filters_importance += filters_importance
 
@@ -997,7 +998,7 @@ class ElasticWidthBuilder(SingleElasticityBuilder):
         """
         filter_importance_str = self._params.filter_importance
         filter_importance = FILTER_IMPORTANCE_FUNCTIONS.get(filter_importance_str, sum_filter)
-        filter_importance_path = self._params.filter_importance_path
+        custom_importance_path = self._params.custom_importance_path
 
         graph = target_model.nncf.get_original_graph()
         device = next(target_model.parameters()).device
@@ -1101,7 +1102,7 @@ class ElasticWidthBuilder(SingleElasticityBuilder):
         return ElasticWidthHandler(
             target_model,
             filter_importance,
-            filter_importance_path,
+            custom_importance_path,
             self._weights_normalizer,
             node_name_vs_dynamic_input_width_op_map,
             pruned_module_groups_info,

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -182,8 +182,8 @@ class ElasticWidthParams(BaseElasticityParams):
         This parameter is mutually exclusive with `width_step`.
         :param filter_importance: The type of filter importance metric. Can be one of `L1`, `L2`, `geometric_median`,
         `external`. `L1` by default.
-        :param external_importance_path: Path to the custom external weight importance (PyTorch tensor) per node that needs
-        to weight reorder. Valid only when filter_importance is `external`.
+        :param external_importance_path: Path to the custom external weight importance (PyTorch tensor) per node
+        that will be used for weight reordering. Valid only when filter_importance is `external`.
         """
         self.min_width = min_width
         self.max_num_widths = max_num_widths

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -182,7 +182,8 @@ class ElasticWidthParams(BaseElasticityParams):
         This parameter is mutually exclusive with `width_step`.
         :param filter_importance: The type of filter importance metric. Can be one of `L1`, `L2`, `geometric_median`,
         `custom`. `L1` by default.
-        :param filter_importance_path: Path of custom weight importance. Valid Only when `filter_importance` is `custom`.
+        :param filter_importance_path: Path to custom weight importance. Valid only when `filter_importance`
+        is `custom`.
         """
         self.min_width = min_width
         self.max_num_widths = max_num_widths

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -206,28 +206,14 @@ class ElasticWidthParams(BaseElasticityParams):
         """
         kwargs = {
             cls._state_names.MIN_WIDTH: config.get(cls._state_names.MIN_WIDTH, 32),
-            cls._state_names.MAX_NUM_WIDTHS: config.get(
-                cls._state_names.MAX_NUM_WIDTHS, -1
-            ),
+            cls._state_names.MAX_NUM_WIDTHS: config.get(cls._state_names.MAX_NUM_WIDTHS, -1),
             cls._state_names.WIDTH_STEP: config.get(cls._state_names.WIDTH_STEP, 32),
-            cls._state_names.WIDTH_MULTIPLIERS: config.get(
-                cls._state_names.WIDTH_MULTIPLIERS
-            ),
-            cls._state_names.FILTER_IMPORTANCE: config.get(
-                cls._state_names.FILTER_IMPORTANCE, "L1"
-            ),
-            cls._state_names.FILTER_IMPORTANCE_PATH: config.get(
-                cls._state_names.FILTER_IMPORTANCE_PATH, None
-            ),
-            cls._state_names.OVERWRITE_GROUPS: config.get(
-                cls._state_names.OVERWRITE_GROUPS, None
-            ),
-            cls._state_names.OVERWRITE_GROUPS_WIDTHS: config.get(
-                cls._state_names.OVERWRITE_GROUPS_WIDTHS, None
-            ),
-            cls._state_names.ADD_DYNAMIC_INPUTS: config.get(
-                cls._state_names.ADD_DYNAMIC_INPUTS, None
-            ),
+            cls._state_names.WIDTH_MULTIPLIERS: config.get(cls._state_names.WIDTH_MULTIPLIERS),
+            cls._state_names.FILTER_IMPORTANCE: config.get(cls._state_names.FILTER_IMPORTANCE, "L1"),
+            cls._state_names.FILTER_IMPORTANCE_PATH: config.get(cls._state_names.FILTER_IMPORTANCE_PATH, None),
+            cls._state_names.OVERWRITE_GROUPS: config.get(cls._state_names.OVERWRITE_GROUPS, None),
+            cls._state_names.OVERWRITE_GROUPS_WIDTHS: config.get(cls._state_names.OVERWRITE_GROUPS_WIDTHS, None),
+            cls._state_names.ADD_DYNAMIC_INPUTS: config.get(cls._state_names.ADD_DYNAMIC_INPUTS, None),
         }
         return cls(**kwargs)
 
@@ -298,9 +284,7 @@ class ElasticOutputWidthOp(ElasticWidthOp):
                     f"Width list for {node_name} contains invalid values: {fixed_width_list}, {max_width}"
                 )
             if fixed_width_list[0] != max_width:
-                raise RuntimeError(
-                    f"Max width for {node_name} is not aligned with pre-trained model"
-                )
+                raise RuntimeError(f"Max width for {node_name} is not aligned with pre-trained model")
             self._width_list = fixed_width_list
         else:
             self._width_list = self._generate_width_list(self._max_width, params)
@@ -473,9 +457,7 @@ class ElasticInputWidthLayerNormOp(ElasticWidthOp, nn.Module):
     Introduces elastic input width for layernorm layer.
     """
 
-    def forward(
-        self, weight: torch.Tensor, bias: torch.Tensor, normalized_shape: torch.Tensor
-    ) -> List[torch.Tensor]:
+    def forward(self, weight: torch.Tensor, bias: torch.Tensor, normalized_shape: torch.Tensor) -> List[torch.Tensor]:
         """
         Trims layernorm parameters according to active number of input channels.
         :param weight: weight tensor to be trimmed
@@ -483,9 +465,7 @@ class ElasticInputWidthLayerNormOp(ElasticWidthOp, nn.Module):
         :param normalized_shape: normalized_shape to be trimmed
         :return: list of trimmed layernorm parameters
         """
-        assert (
-            len(normalized_shape) == 1
-        ), "Currently only 1-dimensional shape is supported."
+        assert len(normalized_shape) == 1, "Currently only 1-dimensional shape is supported."
         return [
             weight[: self._active_width],
             bias[: self._active_width],
@@ -498,9 +478,7 @@ class ElasticOutputWidthConv2DOp(ElasticOutputWidthOp, nn.Module):
     Introduces elastic output width for 2D convolution.
     """
 
-    def forward(
-        self, weight: torch.Tensor, bias: Optional[torch.Tensor]
-    ) -> List[torch.Tensor]:
+    def forward(self, weight: torch.Tensor, bias: Optional[torch.Tensor]) -> List[torch.Tensor]:
         """
         Trims convolution parameters according to active number of output channels.
 
@@ -508,9 +486,7 @@ class ElasticOutputWidthConv2DOp(ElasticOutputWidthOp, nn.Module):
         :param bias: bias tensor to be trimmed
         :return: list of trimmed convolution parameters
         """
-        nncf_logger.debug(
-            f"Conv2d with active width={self._active_width} in scope={self._node_name}"
-        )
+        nncf_logger.debug(f"Conv2d with active width={self._active_width} in scope={self._node_name}")
         num_out_channels = self._active_width
         new_bias = None if bias is None else bias[:num_out_channels]
         new_weights = weight[:num_out_channels, :, :, :]
@@ -522,9 +498,7 @@ class ElasticOutputWidthLinearOp(ElasticOutputWidthOp, nn.Module):
     Introduces elastic output width for linear layer.
     """
 
-    def forward(
-        self, weight: torch.Tensor, bias: Optional[torch.Tensor]
-    ) -> List[torch.Tensor]:
+    def forward(self, weight: torch.Tensor, bias: Optional[torch.Tensor]) -> List[torch.Tensor]:
         """
         Trims linear layer's parameters according to active number of output channels.
 
@@ -554,9 +528,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         filter_importance_path: Optional[str],
         weights_normalizer_fn: Optional[Callable[[torch.Tensor], torch.Tensor]],
         node_name_vs_dynamic_input_width_op_map: Dict[NNCFNodeName, ElasticWidthOp],
-        pruned_module_groups_info: Clusterization[ElasticWidthInfo](
-            id_fn=lambda x: x.node_name
-        ),
+        pruned_module_groups_info: Clusterization[ElasticWidthInfo](id_fn=lambda x: x.node_name),
         transformation_commands: List[TransformationCommand],
         add_dynamic_inputs: Optional[List[str]] = None,
     ):
@@ -574,9 +546,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         """
         super().__init__()
         self._target_model = target_model
-        self._node_name_vs_dynamic_input_width_op_map = (
-            node_name_vs_dynamic_input_width_op_map
-        )
+        self._node_name_vs_dynamic_input_width_op_map = node_name_vs_dynamic_input_width_op_map
         self._pruned_module_groups_info = pruned_module_groups_info
         self._transformation_commands = transformation_commands
         self._filter_importance_fn = filter_importance_fn
@@ -593,9 +563,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
             prunable_types=prunable_types,
             pruning_operations_metatype=PT_PRUNING_OPERATOR_METATYPES,
         )
-        self._next_nodes = self._shape_pruning_processor.get_next_nodes(
-            graph, pruned_module_groups_info
-        )
+        self._next_nodes = self._shape_pruning_processor.get_next_nodes(graph, pruned_module_groups_info)
         # Need a copy because it will be used for adding `output_mask`/`input_masks` to nodes that are relevant to
         # Elastic Width only and therefore it should be isolated to not intercept with other algorithms.
         self._propagation_graph = deepcopy(graph)
@@ -625,9 +593,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         :param state: Output of `get_state()` method.
         """
         super().load_state(state)
-        self.width_num_params_indicator = state[
-            self._width_state_names.WIDTH_NUM_PARAMS_INDICATOR
-        ]
+        self.width_num_params_indicator = state[self._width_state_names.WIDTH_NUM_PARAMS_INDICATOR]
 
     def get_state(self) -> Dict[str, Any]:
         """
@@ -636,9 +602,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         :return: state of the object
         """
         state = super().get_state()
-        state[
-            self._width_state_names.WIDTH_NUM_PARAMS_INDICATOR
-        ] = self.width_num_params_indicator
+        state[self._width_state_names.WIDTH_NUM_PARAMS_INDICATOR] = self.width_num_params_indicator
         return state
 
     def get_transformation_commands(self) -> List[TransformationCommand]:
@@ -654,9 +618,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         if self._width_num_params_indicator == -1:
             return self._collect_ops_data_by_selection_rule(lambda op: op.width_list)
         return self._collect_ops_data_by_selection_rule(
-            lambda op: op.width_list[
-                : min(self._width_num_params_indicator, len(op.width_list))
-            ]
+            lambda op: op.width_list[: min(self._width_num_params_indicator, len(op.width_list))]
         )
 
     def get_active_config(self) -> ElasticWidthConfig:
@@ -665,9 +627,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
 
         :return: map of pruning group id to width value
         """
-        return self._collect_ops_data_by_selection_rule(
-            lambda op: op.get_active_width()
-        )
+        return self._collect_ops_data_by_selection_rule(lambda op: op.get_active_width())
 
     def get_random_config(self) -> ElasticWidthConfig:
         """
@@ -676,9 +636,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         :return: map of pruning group id to width value
         """
         return self._collect_ops_data_by_selection_rule(
-            lambda op: op.width_list[
-                random.randrange(0, self._get_width_list_len(op))
-            ]  # nosec
+            lambda op: op.width_list[random.randrange(0, self._get_width_list_len(op))]  # nosec
         )
 
     def get_minimum_config(self) -> ElasticWidthConfig:
@@ -687,9 +645,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
 
         :return: map of pruning group id to width value
         """
-        return self._collect_ops_data_by_selection_rule(
-            lambda op: min(self._get_width_list(op))
-        )
+        return self._collect_ops_data_by_selection_rule(lambda op: min(self._get_width_list(op)))
 
     def get_maximum_config(self) -> ElasticWidthConfig:
         """
@@ -697,17 +653,13 @@ class ElasticWidthHandler(SingleElasticityHandler):
 
         :return: map of pruning group id to width value
         """
-        return self._collect_ops_data_by_selection_rule(
-            lambda op: max(self._get_width_list(op))
-        )
+        return self._collect_ops_data_by_selection_rule(lambda op: max(self._get_width_list(op)))
 
     def activate_supernet(self) -> None:
         """
         Activates the Supernet - the original network to which elasticity was applied.
         """
-        supernet_config = self._collect_ops_data_by_selection_rule(
-            lambda op: op.max_width
-        )
+        supernet_config = self._collect_ops_data_by_selection_rule(lambda op: op.max_width)
         self.activate_subnet_for_config(supernet_config)
 
     def activate_subnet_for_config(self, config: ElasticWidthConfig) -> None:
@@ -758,28 +710,20 @@ class ElasticWidthHandler(SingleElasticityHandler):
 
             if self._add_dynamic_inputs:
                 if node_name in self._add_dynamic_inputs and not was_set:
-                    nncf_logger.debug(
-                        f"setting input width by user's request for scope={node_name}"
-                    )
+                    nncf_logger.debug(f"setting input width by user's request for scope={node_name}")
                     nodes_to_check = [node]
                     while any(elem is None for elem in input_masks):
                         previous_nodes = []
                         for node in nodes_to_check:
-                            previous_nodes.append(
-                                self._propagation_graph.get_previous_nodes(node)
-                            )
+                            previous_nodes.append(self._propagation_graph.get_previous_nodes(node))
                         nodes_to_check.clear()
-                        previous_nodes = [
-                            item for nodes in previous_nodes for item in nodes
-                        ]
+                        previous_nodes = [item for nodes in previous_nodes for item in nodes]
                         if not previous_nodes:
                             break
                         for previous in previous_nodes:
                             if "output_mask" in previous.attributes:
                                 if previous.attributes["output_mask"] is not None:
-                                    input_masks.append(
-                                        previous.attributes["output_mask"]
-                                    )
+                                    input_masks.append(previous.attributes["output_mask"])
                                     input_masks = [i for i in input_masks if i]
                                 else:
                                     nodes_to_check.append(previous)
@@ -792,9 +736,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
                             dynamic_input_width_op.set_active_width(input_width)
                             was_set = True
                     if was_set:
-                        nncf_logger.debug(
-                            f"Success setting up user's request for dynamic input at scope={node_name}"
-                        )
+                        nncf_logger.debug(f"Success setting up user's request for dynamic input at scope={node_name}")
 
     def get_active_in_out_width_values(
         self,
@@ -812,9 +754,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
 
         for group in self._pruned_module_groups_info.get_all_clusters():
             assert all(
-                out_channels[group.elements[0].node_name]
-                == out_channels[node.node_name]
-                for node in group.elements
+                out_channels[group.elements[0].node_name] == out_channels[node.node_name] for node in group.elements
             )
             first_elastic_width_info: ElasticWidthInfo = group.elements[0]
             first_elastic_op: ElasticOutputWidthOp = first_elastic_width_info.elastic_op
@@ -865,13 +805,8 @@ class ElasticWidthHandler(SingleElasticityHandler):
         :return: importance tensor
         """
         # Map node name to module name
-        key = (
-            ".".join(re.findall(re.compile(r"[[](.*?)[]]", re.S), node_name))
-            + ".weight"
-        )
-        assert (
-            key in self._filter_importance
-        ), f"Cannot find the custom weight importance of {node_name}"
+        key = ".".join(re.findall(re.compile(r"[[](.*?)[]]", re.S), node_name)) + ".weight"
+        assert key in self._filter_importance, f"Cannot find the custom weight importance of {node_name}"
         return self._filter_importance[key]
 
     def reorganize_weights(self) -> None:
@@ -883,9 +818,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
 
         # 1. Calculate filter importance for all groups of prunable layers
         for group in self._pruned_module_groups_info.get_all_clusters():
-            filters_num = torch.tensor(
-                [get_filters_num(minfo.module) for minfo in group.elements]
-            )
+            filters_num = torch.tensor([get_filters_num(minfo.module) for minfo in group.elements])
             assert torch.all(filters_num == filters_num[0])
             device = group.elements[0].module.weight.device
 
@@ -896,17 +829,11 @@ class ElasticWidthHandler(SingleElasticityHandler):
                 if self._weights_normalizer_fn:
                     weight = self._weights_normalizer_fn(minfo.module.weight)
                 if self._filter_importance is not None:
-                    weight = self.get_importance_by_node_name(minfo.node_name).to(
-                        device
-                    )
-                filters_importance = self._filter_importance_fn(
-                    weight, minfo.module.target_weight_dim_for_compression
-                )
+                    weight = self.get_importance_by_node_name(minfo.node_name).to(device)
+                filters_importance = self._filter_importance_fn(weight, minfo.module.target_weight_dim_for_compression)
                 cumulative_filters_importance += filters_importance
 
-            _, reorder_indexes = torch.sort(
-                cumulative_filters_importance, dim=0, descending=True
-            )
+            _, reorder_indexes = torch.sort(cumulative_filters_importance, dim=0, descending=True)
             device = get_model_device(self._target_model)
             reorder_indexes.to(device)
             # 1.2 Setup reorder indexes as output mask to reorganize filters
@@ -923,9 +850,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         )
         reorder_algo.reorder_filters()
 
-    def find_pairs_of_nodes_with_different_width(
-        self, pairs_of_nodes: List[Tuple[str, str]]
-    ) -> List[int]:
+    def find_pairs_of_nodes_with_different_width(self, pairs_of_nodes: List[Tuple[str, str]]) -> List[int]:
         """
         Find pairs of nodes that have different output shapes. It's need to resolve conflict between elastic width and
         elastic depth. The conflicting situation happens when layers are trimmed and skipped independently.
@@ -943,33 +868,19 @@ class ElasticWidthHandler(SingleElasticityHandler):
             end_node = self._propagation_graph.get_node_by_name(end_node_name)
             end_mask = end_node.attributes["output_mask"]
 
-            all_start_output_shapes = (
-                self._propagation_graph.get_output_shapes_for_node(start_node_name)
-            )
+            all_start_output_shapes = self._propagation_graph.get_output_shapes_for_node(start_node_name)
             start_output_shape = list(OrderedDict.fromkeys(all_start_output_shapes))
-            all_end_output_shape = self._propagation_graph.get_output_shapes_for_node(
-                end_node_name
-            )
+            all_end_output_shape = self._propagation_graph.get_output_shapes_for_node(end_node_name)
             end_output_shape = list(OrderedDict.fromkeys(all_end_output_shape))
 
             start_width = ElasticWidthHandler.mask_to_width(start_mask)
             end_width = ElasticWidthHandler.mask_to_width(end_mask)
 
-            if (
-                start_width is None
-                and end_width is None
-                and start_output_shape != end_output_shape
-            ):
+            if start_width is None and end_width is None and start_output_shape != end_output_shape:
                 reason = f"it has a different shapes on boundaries: {start_output_shape} != {end_output_shape}"
-            elif (
-                start_width is not None
-                and end_width is not None
-                and start_width != end_width
-            ):
+            elif start_width is not None and end_width is not None and start_width != end_width:
                 reason = f"it has a different width on boundaries: {start_width} != {end_width}"
-            elif (start_width is None or end_width is None) and not (
-                start_width is None and end_width is None
-            ):
+            elif (start_width is None or end_width is None) and not (start_width is None and end_width is None):
                 reason = (
                     f"it has empty width on one of the boundaries. "
                     f"Width: {start_width} vs {end_width}. Shapes: {start_output_shape} vs {end_output_shape}"
@@ -992,16 +903,12 @@ class ElasticWidthHandler(SingleElasticityHandler):
         width_list_len = self._get_width_list_len(op)
         return op.width_list[:width_list_len]
 
-    def _collect_ops_data_by_selection_rule(
-        self, selection_rule: Callable
-    ) -> Dict[PruningGroupID, Any]:
+    def _collect_ops_data_by_selection_rule(self, selection_rule: Callable) -> Dict[PruningGroupID, Any]:
         elastic_width_config = {}
         for cluster in self._pruned_module_groups_info.get_all_clusters():
             all_max_out_channels = {el.elastic_op.max_width for el in cluster.elements}
             if len(all_max_out_channels) != 1:
-                raise RuntimeError(
-                    "Invalid grouping of layers with different number of output channels"
-                )
+                raise RuntimeError("Invalid grouping of layers with different number of output channels")
 
             first_elastic_width_info = next(iter(cluster.elements))
             op = first_elastic_width_info.elastic_op
@@ -1025,9 +932,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
             mask_len = sum(actual_mask.size())
             width = int(sum(actual_mask))
             device = actual_mask.device
-            ref_mask = ElasticWidthHandler._width_to_mask(
-                width, mask_len, device
-            ).tensor
+            ref_mask = ElasticWidthHandler._width_to_mask(width, mask_len, device).tensor
             assert torch.equal(
                 ref_mask, actual_mask
             ), f"Invalid mask {actual_mask}: the first {width} values must be ones, the rest - zeros."
@@ -1035,9 +940,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
         return result
 
     @staticmethod
-    def _width_to_mask(
-        active_width: int, max_width: int, device: torch.device
-    ) -> PTNNCFTensor:
+    def _width_to_mask(active_width: int, max_width: int, device: torch.device) -> PTNNCFTensor:
         """
         Encodes width to tensor filled by 1 and 0. We intentionally construct mask in a way that first N values are
         equal to 1, and the rest values are 0. The N encodes width value. The mask tensors allows to fully reuse mask
@@ -1093,9 +996,7 @@ class ElasticWidthBuilder(SingleElasticityBuilder):
         :return: a handler object that can manipulate the elastic width.
         """
         filter_importance_str = self._params.filter_importance
-        filter_importance = FILTER_IMPORTANCE_FUNCTIONS.get(
-            filter_importance_str, sum_filter
-        )
+        filter_importance = FILTER_IMPORTANCE_FUNCTIONS.get(filter_importance_str, sum_filter)
         filter_importance_path = self._params.filter_importance_path
 
         graph = target_model.nncf.get_original_graph()
@@ -1114,17 +1015,13 @@ class ElasticWidthBuilder(SingleElasticityBuilder):
                 prune_first=True,
                 prune_downsample_convs=True,
             )
-            groups_of_nodes_to_prune = pruning_node_selector.create_pruning_groups(
-                graph
-            )
+            groups_of_nodes_to_prune = pruning_node_selector.create_pruning_groups(graph)
             for group in groups_of_nodes_to_prune.get_all_clusters():
                 grouped_node_names = [node.node_name for node in group.elements]
                 self._grouped_node_names_to_prune.append(grouped_node_names)
 
         transformation_commands = []
-        pruned_module_groups_info = Clusterization[ElasticWidthInfo](
-            id_fn=lambda x: x.node_name
-        )
+        pruned_module_groups_info = Clusterization[ElasticWidthInfo](id_fn=lambda x: x.node_name)
         node_name_vs_dynamic_input_width_op_map = OrderedDict()
 
         metatype_vs_elastic_op_creator = {
@@ -1149,19 +1046,13 @@ class ElasticWidthBuilder(SingleElasticityBuilder):
                     layer_attrs,
                     node_name,
                     self._params,
-                    self._overwrite_groups_widths[i]
-                    if self._overwriting_pruning_groups
-                    else [],
+                    self._overwrite_groups_widths[i] if self._overwriting_pruning_groups else [],
                 )
                 elastic_width_operation.to(device)
-                update_conv_params_op = UpdateWeightAndOptionalBias(
-                    elastic_width_operation
-                )
+                update_conv_params_op = UpdateWeightAndOptionalBias(elastic_width_operation)
                 transformation_commands.append(
                     PTInsertionCommand(
-                        PTTargetPoint(
-                            TargetType.PRE_LAYER_OPERATION, target_node_name=node_name
-                        ),
+                        PTTargetPoint(TargetType.PRE_LAYER_OPERATION, target_node_name=node_name),
                         update_conv_params_op,
                         TransformationPriority.PRUNING_PRIORITY,
                     )
@@ -1195,19 +1086,13 @@ class ElasticWidthBuilder(SingleElasticityBuilder):
             nodes = graph.get_nodes_by_metatypes([metatype])
             for node in nodes:
                 node_name = node.node_name
-                nncf_logger.debug(
-                    f"Adding Dynamic Input Op for {metatype.name} in scope: {node_name}"
-                )
+                nncf_logger.debug(f"Adding Dynamic Input Op for {metatype.name} in scope: {node_name}")
                 layer_attrs = node.layer_attributes
                 update_module_params = op_creator(layer_attrs, node_name).to(device)
-                node_name_vs_dynamic_input_width_op_map[
-                    node_name
-                ] = update_module_params.op
+                node_name_vs_dynamic_input_width_op_map[node_name] = update_module_params.op
                 transformation_commands.append(
                     PTInsertionCommand(
-                        PTTargetPoint(
-                            TargetType.PRE_LAYER_OPERATION, target_node_name=node_name
-                        ),
+                        PTTargetPoint(TargetType.PRE_LAYER_OPERATION, target_node_name=node_name),
                         update_module_params,
                         priority=TransformationPriority.DEFAULT_PRIORITY,
                     )
@@ -1230,9 +1115,7 @@ class ElasticWidthBuilder(SingleElasticityBuilder):
 
         :param state: Output of `get_state()` method.
         """
-        params_from_state = state[
-            SingleElasticityBuilder._state_names.ELASTICITY_PARAMS
-        ]
+        params_from_state = state[SingleElasticityBuilder._state_names.ELASTICITY_PARAMS]
         params = ElasticWidthParams.from_state(params_from_state)
         if self._params and self._params != params:
             nncf_logger.warning(
@@ -1240,31 +1123,15 @@ class ElasticWidthBuilder(SingleElasticityBuilder):
                 "state. The one from state is taken by ignoring the ones from init."
             )
         self._params = params
-        self._grouped_node_names_to_prune = state[
-            self._state_names.GROUPED_NODE_NAMES_TO_PRUNE
-        ]
+        self._grouped_node_names_to_prune = state[self._state_names.GROUPED_NODE_NAMES_TO_PRUNE]
 
-        if (
-            params_from_state.get(self._state_names.OVERWRITE_GROUP_WIDTHS, None)
-            is not None
-        ):
-            self._overwrite_groups_widths = params_from_state[
-                self._state_names.OVERWRITE_GROUP_WIDTHS
-            ]
+        if params_from_state.get(self._state_names.OVERWRITE_GROUP_WIDTHS, None) is not None:
+            self._overwrite_groups_widths = params_from_state[self._state_names.OVERWRITE_GROUP_WIDTHS]
             self._overwriting_pruning_groups = True
-            if len(self._grouped_node_names_to_prune) != len(
-                self._overwrite_groups_widths
-            ):
-                raise RuntimeError(
-                    "Mismatch between number of groups for pruning and their corresponding widths"
-                )
-        if (
-            params_from_state.get(self._state_names.ADD_DYNAMIC_INPUTS, None)
-            is not None
-        ):
-            self._add_dynamic_inputs = params_from_state[
-                self._state_names.ADD_DYNAMIC_INPUTS
-            ]
+            if len(self._grouped_node_names_to_prune) != len(self._overwrite_groups_widths):
+                raise RuntimeError("Mismatch between number of groups for pruning and their corresponding widths")
+        if params_from_state.get(self._state_names.ADD_DYNAMIC_INPUTS, None) is not None:
+            self._add_dynamic_inputs = params_from_state[self._state_names.ADD_DYNAMIC_INPUTS]
 
     def get_state(self) -> Dict[str, Any]:
         """
@@ -1315,29 +1182,19 @@ class ElasticWidthBuilder(SingleElasticityBuilder):
         )
 
     @staticmethod
-    def _create_dynamic_conv_input_op(
-        conv_layer_attrs: BaseLayerAttributes, node_name: str
-    ) -> UpdateWeight:
+    def _create_dynamic_conv_input_op(conv_layer_attrs: BaseLayerAttributes, node_name: str) -> UpdateWeight:
         assert isinstance(conv_layer_attrs, ConvolutionLayerAttributes)
-        dynamic_conv_input_op = ElasticInputWidthConvOp(
-            max_width=conv_layer_attrs.in_channels, node_name=node_name
-        )
+        dynamic_conv_input_op = ElasticInputWidthConvOp(max_width=conv_layer_attrs.in_channels, node_name=node_name)
         return UpdateWeight(dynamic_conv_input_op)
 
     @staticmethod
-    def _create_dynamic_dw_conv_input_op(
-        conv_layer_attrs: BaseLayerAttributes, node_name: str
-    ) -> UpdateNumGroups:
+    def _create_dynamic_dw_conv_input_op(conv_layer_attrs: BaseLayerAttributes, node_name: str) -> UpdateNumGroups:
         assert isinstance(conv_layer_attrs, ConvolutionLayerAttributes)
-        dynamic_dw_conv_input_op = ElasticInputWidthDWConvOp(
-            max_width=conv_layer_attrs.groups, node_name=node_name
-        )
+        dynamic_dw_conv_input_op = ElasticInputWidthDWConvOp(max_width=conv_layer_attrs.groups, node_name=node_name)
         return UpdateNumGroups(dynamic_dw_conv_input_op)
 
     @staticmethod
-    def _create_dynamic_bn_input_op(
-        generic_layer_attrs: BaseLayerAttributes, node_name: str
-    ) -> UpdateBatchNormParams:
+    def _create_dynamic_bn_input_op(generic_layer_attrs: BaseLayerAttributes, node_name: str) -> UpdateBatchNormParams:
         assert isinstance(generic_layer_attrs, GenericWeightedLayerAttributes)
         dynamic_bn_input_op = ElasticInputWidthBatchNormOp(
             max_width=generic_layer_attrs.get_num_filters(), node_name=node_name
@@ -1345,9 +1202,7 @@ class ElasticWidthBuilder(SingleElasticityBuilder):
         return UpdateBatchNormParams(dynamic_bn_input_op)
 
     @staticmethod
-    def _create_dynamic_ln_input_op(
-        generic_layer_attrs: BaseLayerAttributes, node_name: str
-    ) -> UpdateLayerNormParams:
+    def _create_dynamic_ln_input_op(generic_layer_attrs: BaseLayerAttributes, node_name: str) -> UpdateLayerNormParams:
         assert isinstance(generic_layer_attrs, GenericWeightedLayerAttributes)
         dynamic_ln_input_op = ElasticInputWidthLayerNormOp(
             max_width=generic_layer_attrs.get_num_filters(), node_name=node_name
@@ -1355,9 +1210,7 @@ class ElasticWidthBuilder(SingleElasticityBuilder):
         return UpdateLayerNormParams(dynamic_ln_input_op)
 
     @staticmethod
-    def _create_dynamic_linear_input_op(
-        linear_layer_attrs: BaseLayerAttributes, node_name: str
-    ) -> UpdateWeight:
+    def _create_dynamic_linear_input_op(linear_layer_attrs: BaseLayerAttributes, node_name: str) -> UpdateWeight:
         assert isinstance(linear_layer_attrs, LinearLayerAttributes)
         dynamic_linear_input_op = ElasticInputWidthLinearOp(
             max_width=linear_layer_attrs.in_features, node_name=node_name

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_builder.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/progressive_shrinking_builder.py
@@ -103,7 +103,14 @@ class ProgressiveShrinkingBuilder(PTCompressionAlgorithmBuilder):
             compression_loss_func,
         )
 
-    def _build_compression_loss_function(self, model: NNCFNetwork) -> PTCompressionLoss:
+    def _build_compression_loss_function(self, model: NNCFNetwork) -> "PTCompressionLoss":
+        """
+        Create the compression loss. KnowledgeDistillationLoss is returned when knowledge distillation
+        algorithm is added to the config. By default, ZeroCompressionLoss is returned.
+
+        :param model: The model with additional modifications necessary to enable
+            algorithm-specific compression during fine-tuning.
+        """
         compression_builder = create_compression_algorithm_builder(self._algo_config)
         compressed_model = compression_builder.apply_to(model)
         compression_ctrl = compression_builder.build_controller(compressed_model)

--- a/tests/torch/nas/models/synthetic.py
+++ b/tests/torch/nas/models/synthetic.py
@@ -120,10 +120,12 @@ class TwoSequentialConvBNTestModel(nn.Module):
     w2_max = 2
     w2_min = 1
     IMPORTANCE = {
-        "TwoSequentialConvBNTestModel/Sequential[all_layers]/NNCFConv2d[0]/conv2d_0":
-            torch.Tensor([[[[0.7]]], [[[0.9]]], [[[0.8]]]]),
-        "TwoSequentialConvBNTestModel/Sequential[all_layers]/NNCFConv2d[3]/conv2d_0":
-            torch.Tensor([[[[0.0]], [[0.8]], [[1.0]]], [[[0.8]], [[0.7]], [[1.0]]]]),
+        "TwoSequentialConvBNTestModel/Sequential[all_layers]/NNCFConv2d[0]/conv2d_0": torch.Tensor(
+            [[[[0.7]]], [[[0.9]]], [[[0.8]]]]
+        ),
+        "TwoSequentialConvBNTestModel/Sequential[all_layers]/NNCFConv2d[3]/conv2d_0": torch.Tensor(
+            [[[[0.0]], [[0.8]], [[1.0]]], [[[0.8]], [[0.7]], [[1.0]]]]
+        ),
     }
 
     def __init__(self):

--- a/tests/torch/nas/models/synthetic.py
+++ b/tests/torch/nas/models/synthetic.py
@@ -369,7 +369,7 @@ class TwoSequentialFcLNTestModel(nn.Module):
         assert torch.equal(self.ln1.weight, ref_ln_weights_1)
         assert torch.equal(self.ln1.bias, ref_ln_bias_1)
 
-    def check_custom_reorg(self):
+    def check_custom_external_reorg(self):
         device = get_model_device(self)
         ref_fc_weights_1 = torch.Tensor([[3], [4]]).to(device)
         ref_fc_bias_1 = torch.Tensor([3, 4]).to(device)

--- a/tests/torch/nas/models/synthetic.py
+++ b/tests/torch/nas/models/synthetic.py
@@ -119,6 +119,12 @@ class TwoSequentialConvBNTestModel(nn.Module):
     w1_max = 3
     w2_max = 2
     w2_min = 1
+    IMPORTANCE = {
+        "TwoSequentialConvBNTestModel/Sequential[all_layers]/NNCFConv2d[0]/conv2d_0":
+            torch.Tensor([[[[0.7]]], [[[0.9]]], [[[0.8]]]]),
+        "TwoSequentialConvBNTestModel/Sequential[all_layers]/NNCFConv2d[3]/conv2d_0":
+            torch.Tensor([[[[0.0]], [[0.8]], [[1.0]]], [[[0.8]], [[0.7]], [[1.0]]]]),
+    }
 
     def __init__(self):
         super().__init__()
@@ -175,6 +181,19 @@ class TwoSequentialConvBNTestModel(nn.Module):
         assert torch.equal(self.last_conv.weight, torch.Tensor([2, 2]).reshape(1, 2, 1, 1).to(device))
         assert torch.equal(last_bias, torch.zeros_like(last_bias).to(device))
 
+    def check_custom_external_reorg(self):
+        device = next(self.parameters()).device
+        ref_bias_1 = torch.Tensor([1, 2, self.w1_max]).to(device)
+        ref_weights_1 = ref_bias_1.reshape(3, 1, 1, 1).to(device)
+        ref_bias_2 = torch.Tensor([self.w2_max, 1]).to(device)
+        ref_weights_2 = torch.Tensor([[3, 0, self.w2_max], [2, 0, self.w2_min]]).reshape(2, 3, 1, 1).to(device)
+        TwoSequentialConvBNTestModel.compare_params(ref_bias_1, ref_weights_1, self.conv1, self.bn1)
+        TwoSequentialConvBNTestModel.compare_params(ref_bias_2, ref_weights_2, self.conv2, self.bn2)
+
+        last_bias = self.last_conv.bias
+        assert torch.equal(self.last_conv.weight, torch.Tensor([2, 2]).reshape(1, 2, 1, 1).to(device))
+        assert torch.equal(last_bias, torch.zeros_like(last_bias).to(device))
+
     def get_minimal_subnet_output(self, input_):
         relu1 = self._get_relu1_output(input_)
         return self._get_model_output(relu1, self.w2_max)
@@ -214,6 +233,10 @@ class TwoConvAddConvTestModel(nn.Module):
     V23 = 4
     V11 = 3
     V21 = 1
+    IMPORTANCE = {
+        "TwoConvAddConvTestModel/NNCFConv2d[conv1]/conv2d_0": torch.Tensor([[[[0.7]]], [[[0.9]]], [[[0.8]]]]),
+        "TwoConvAddConvTestModel/NNCFConv2d[conv2]/conv2d_0": torch.Tensor([[[[0.1]]], [[[0.8]]], [[[0.7]]]]),
+    }
 
     def __init__(self):
         super().__init__()
@@ -250,6 +273,22 @@ class TwoConvAddConvTestModel(nn.Module):
         assert torch.equal(self.last_conv.weight, torch.Tensor([2, 2, 2]).reshape(1, 3, 1, 1).to(device))
         assert torch.equal(last_bias, torch.zeros_like(last_bias).to(device))
 
+    def check_custom_external_reorg(self):
+        device = get_model_device(self)
+        ref_bias_1 = torch.Tensor([1, self.V13, self.V11]).to(device)
+        ref_bias_2 = torch.Tensor([2, self.V23, self.V21]).to(device)
+
+        ref_weights_1 = ref_bias_1.reshape(3, 1, 1, 1).to(device)
+        ref_weights_2 = ref_bias_2.reshape(3, 1, 1, 1).to(device)
+
+        assert torch.equal(self.conv1.weight, ref_weights_1)
+        assert torch.equal(self.conv1.bias, ref_bias_1)
+        assert torch.equal(self.conv2.weight, ref_weights_2)
+        assert torch.equal(self.conv2.bias, ref_bias_2)
+        last_bias = self.last_conv.bias
+        assert torch.equal(self.last_conv.weight, torch.Tensor([2, 2, 2]).reshape(1, 3, 1, 1).to(device))
+        assert torch.equal(last_bias, torch.zeros_like(last_bias).to(device))
+
     def get_minimal_subnet_output(self, x):
         o = (self.V13 * x + self.V13) + (self.V23 * x + self.V23)
         ref_weights = self.last_conv.weight[:, :1, :, :]
@@ -274,6 +313,10 @@ class ConvTwoFcTestModel(nn.Module):
     INPUT_SIZE = [1, 1, 1, 1]
     V11 = 2
     V13 = 4
+    IMPORTANCE = {
+        "ConvTwoFcTestModel/NNCFConv2d[conv]/conv2d_0": torch.Tensor([[[[0.9]]], [[[0.1]]], [[[0.2]]]]),
+        "ConvTwoFcTestModel/NNCFLinear[fc1]/linear_0": torch.Tensor([[0.7, 0.9, 0.8], [0.6, 0.4, 0.5]]),
+    }
 
     def __init__(self):
         super().__init__()
@@ -304,6 +347,21 @@ class ConvTwoFcTestModel(nn.Module):
         fc_weights_1 = torch.Tensor([[5, 4, 6], [2, 3, 1]]).to(device)
         fc_bias_1 = torch.Tensor([4, 3]).to(device)
         fc_weights_2 = torch.Tensor([[1, 2], [4, 3], [5, 6]]).to(device)  # last layer don't change the output order
+
+        assert torch.equal(self.conv.weight, ref_weights_1)
+        assert torch.equal(self.conv.bias, ref_bias_1)
+        assert torch.equal(self.fc1.weight, fc_weights_1)
+        assert torch.equal(self.fc1.bias, fc_bias_1)
+        assert torch.equal(self.fc2.weight, fc_weights_2)
+
+    def check_custom_external_reorg(self):
+        device = get_model_device(self)
+        ref_bias_1 = torch.Tensor([self.V11, self.V13, 1]).to(device)
+        ref_weights_1 = ref_bias_1.reshape(3, 1, 1, 1).to(device)
+
+        fc_weights_1 = torch.Tensor([[3, 2, 1], [4, 5, 6]]).to(device)
+        fc_bias_1 = torch.Tensor([3, 4]).to(device)
+        fc_weights_2 = torch.Tensor([[2, 1], [3, 4], [6, 5]]).to(device)  # last layer don't change the output order
 
         assert torch.equal(self.conv.weight, ref_weights_1)
         assert torch.equal(self.conv.bias, ref_bias_1)

--- a/tests/torch/nas/models/synthetic.py
+++ b/tests/torch/nas/models/synthetic.py
@@ -336,7 +336,7 @@ class TwoSequentialFcLNTestModel(nn.Module):
     #
     INPUT_SIZE = [1, 1]
     IMPORTANCE = {
-        "fc1.weight": torch.Tensor([[0.9], [0.1]]),
+        "TwoSequentialFcLNTestModel/NNCFLinear[fc1]/linear_0": torch.Tensor([[0.9], [0.1]]),
     }
 
     def __init__(self):

--- a/tests/torch/nas/models/synthetic.py
+++ b/tests/torch/nas/models/synthetic.py
@@ -335,6 +335,9 @@ class TwoSequentialFcLNTestModel(nn.Module):
     # fc1 -> ln1 -> fc2 -> ln2
     #
     INPUT_SIZE = [1, 1]
+    IMPORTANCE = {
+        "fc1.weight": torch.Tensor([[0.9], [0.1]]),
+    }
 
     def __init__(self):
         super().__init__()
@@ -360,6 +363,19 @@ class TwoSequentialFcLNTestModel(nn.Module):
         ref_ln_weights_1 = torch.Tensor([1, 0]).to(device)
         ref_ln_bias_1 = torch.Tensor([1, 0]).to(device)
         ref_fc_weights_2 = torch.Tensor([[1, 2], [4, 3], [5, 6]]).to(device)
+        assert torch.equal(self.fc1.weight, ref_fc_weights_1)
+        assert torch.equal(self.fc1.bias, ref_fc_bias_1)
+        assert torch.equal(self.fc2.weight, ref_fc_weights_2)
+        assert torch.equal(self.ln1.weight, ref_ln_weights_1)
+        assert torch.equal(self.ln1.bias, ref_ln_bias_1)
+
+    def check_custom_reorg(self):
+        device = get_model_device(self)
+        ref_fc_weights_1 = torch.Tensor([[3], [4]]).to(device)
+        ref_fc_bias_1 = torch.Tensor([3, 4]).to(device)
+        ref_ln_weights_1 = torch.Tensor([0, 1]).to(device)
+        ref_ln_bias_1 = torch.Tensor([0, 1]).to(device)
+        ref_fc_weights_2 = torch.Tensor([[2, 1], [3, 4], [6, 5]]).to(device)
         assert torch.equal(self.fc1.weight, ref_fc_weights_1)
         assert torch.equal(self.fc1.bias, ref_fc_bias_1)
         assert torch.equal(self.fc2.weight, ref_fc_weights_2)

--- a/tests/torch/nas/test_all_elasticity.py
+++ b/tests/torch/nas/test_all_elasticity.py
@@ -262,6 +262,7 @@ REF_COMPRESSION_STATE_FOR_TWO_CONV = {
                             "elasticity_params": {
                                 "add_dynamic_inputs": None,
                                 "filter_importance": "L1",
+                                "external_importance_path": None,
                                 "max_num_widths": -1,
                                 "min_width": 1,
                                 "overwrite_groups": None,

--- a/tests/torch/nas/test_elastic_width.py
+++ b/tests/torch/nas/test_elastic_width.py
@@ -56,6 +56,7 @@ def fixture_basic_model(request):
 
 BASIC_ELASTIC_WIDTH_PARAMS = {
     "filter_importance": "L1",
+    "external_importance_path": None,
     "add_dynamic_inputs": None,
     "max_num_widths": -1,
     "min_width": 1,
@@ -158,17 +159,17 @@ def test_width_custom_reorg(basic_model):
         pytest.skip("Skip test for conv model")
 
     config = get_empty_config(input_sample_sizes=basic_model.INPUT_SIZE)
-    custom_importance = basic_model.IMPORTANCE
-    with tempfile.NamedTemporaryFile() as custom_importance_tempfile:
-        torch.save(custom_importance, custom_importance_tempfile)
+    external_importance = basic_model.IMPORTANCE
+    with tempfile.NamedTemporaryFile() as external_importance_tempfile:
+        torch.save(external_importance, external_importance_tempfile)
         config.update(
             {
                 "bootstrapNAS": {
                     "training": {
                         "elasticity": {
                             "width": {
-                                "filter_importance": "custom",
-                                "custom_importance_path": custom_importance_tempfile.name,
+                                "filter_importance": "external",
+                                "external_importance_path": external_importance_tempfile.name,
                             }
                         },
                     }

--- a/tests/torch/nas/test_elastic_width.py
+++ b/tests/torch/nas/test_elastic_width.py
@@ -158,9 +158,9 @@ def test_width_custom_reorg(basic_model):
         pytest.skip("Skip test for conv model")
 
     config = get_empty_config(input_sample_sizes=basic_model.INPUT_SIZE)
-    importance = basic_model.IMPORTANCE
-    with tempfile.NamedTemporaryFile() as filter_importance_tempfile:
-        torch.save(importance, filter_importance_tempfile)
+    custom_importance = basic_model.IMPORTANCE
+    with tempfile.NamedTemporaryFile() as custom_importance_tempfile:
+        torch.save(custom_importance, custom_importance_tempfile)
         config.update(
             {
                 "bootstrapNAS": {
@@ -168,7 +168,7 @@ def test_width_custom_reorg(basic_model):
                         "elasticity": {
                             "width": {
                                 "filter_importance": "custom",
-                                "filter_importance_path": filter_importance_tempfile.name,
+                                "custom_importance_path": custom_importance_tempfile.name,
                             }
                         },
                     }

--- a/tests/torch/nas/test_elastic_width.py
+++ b/tests/torch/nas/test_elastic_width.py
@@ -95,9 +95,7 @@ def test_elastic_width_with_maximum_value():
 
 
 def test_elastic_width_with_intermediate_value():
-    width_handler, supernet = create_two_conv_width_supernet(
-        elasticity_params={"width": BASIC_ELASTIC_WIDTH_PARAMS}
-    )
+    width_handler, supernet = create_two_conv_width_supernet(elasticity_params={"width": BASIC_ELASTIC_WIDTH_PARAMS})
     device = get_model_device(supernet)
 
     ACTIVE_WIDTH = 1
@@ -196,13 +194,9 @@ def fixture_nas_model_name(request):
 
 def test_weight_reorg(nas_model_name, _seed):
     if nas_model_name in ["inception_v3"]:
-        pytest.skip(
-            "Skip test for Inception-V3 because of invalid padding update in elastic kernel (60990)"
-        )
+        pytest.skip("Skip test for Inception-V3 because of invalid padding update in elastic kernel (60990)")
 
-    compressed_model, training_ctrl, dummy_forward = create_bootstrap_nas_training_algo(
-        nas_model_name
-    )
+    compressed_model, training_ctrl, dummy_forward = create_bootstrap_nas_training_algo(nas_model_name)
     compressed_model.eval()
     before_reorg = dummy_forward(compressed_model)
     width_handler = training_ctrl.multi_elasticity_handler.width_handler

--- a/tests/torch/nas/test_elastic_width.py
+++ b/tests/torch/nas/test_elastic_width.py
@@ -154,7 +154,7 @@ def test_width_reorg(basic_model):
     compare_tensors_ignoring_the_order(after_reorg, before_reorg)
 
 
-def test_width_custom_reorg(basic_model):
+def test_width_custom_external_reorg(basic_model):
     if not isinstance(basic_model, TwoSequentialFcLNTestModel):
         pytest.skip("Skip test for conv model")
 
@@ -184,7 +184,7 @@ def test_width_custom_reorg(basic_model):
     ctrl.multi_elasticity_handler.width_handler.reorganize_weights()
     after_reorg = model(dummy_input)
 
-    model.check_custom_reorg()
+    model.check_custom_external_reorg()
     compare_tensors_ignoring_the_order(after_reorg, before_reorg)
 
 

--- a/tests/torch/nas/test_elastic_width.py
+++ b/tests/torch/nas/test_elastic_width.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 import copy
 import tempfile
+
 import pytest
 import torch
 from torch import nn
@@ -39,7 +40,12 @@ from tests.torch.test_compressed_graph import get_full_path_to_the_graph
 
 @pytest.fixture(
     name="basic_model",
-    params=(TwoSequentialFcLNTestModel, ConvTwoFcTestModel, TwoConvAddConvTestModel, TwoSequentialConvBNTestModel),
+    params=(
+        TwoSequentialFcLNTestModel,
+        ConvTwoFcTestModel,
+        TwoConvAddConvTestModel,
+        TwoSequentialConvBNTestModel,
+    ),
 )
 def fixture_basic_model(request):
     model_cls = request.param
@@ -89,7 +95,9 @@ def test_elastic_width_with_maximum_value():
 
 
 def test_elastic_width_with_intermediate_value():
-    width_handler, supernet = create_two_conv_width_supernet(elasticity_params={"width": BASIC_ELASTIC_WIDTH_PARAMS})
+    width_handler, supernet = create_two_conv_width_supernet(
+        elasticity_params={"width": BASIC_ELASTIC_WIDTH_PARAMS}
+    )
     device = get_model_device(supernet)
 
     ACTIVE_WIDTH = 1
@@ -159,10 +167,12 @@ def test_width_custom_reorg(basic_model):
             {
                 "bootstrapNAS": {
                     "training": {
-                        "elasticity": {"width": {
-                            "filter_importance": "custom",
-                            "filter_importance_path": filter_importance_tempfile.name
-                        }},
+                        "elasticity": {
+                            "width": {
+                                "filter_importance": "custom",
+                                "filter_importance_path": filter_importance_tempfile.name,
+                            }
+                        },
                     }
                 }
             }
@@ -186,9 +196,13 @@ def fixture_nas_model_name(request):
 
 def test_weight_reorg(nas_model_name, _seed):
     if nas_model_name in ["inception_v3"]:
-        pytest.skip("Skip test for Inception-V3 because of invalid padding update in elastic kernel (60990)")
+        pytest.skip(
+            "Skip test for Inception-V3 because of invalid padding update in elastic kernel (60990)"
+        )
 
-    compressed_model, training_ctrl, dummy_forward = create_bootstrap_nas_training_algo(nas_model_name)
+    compressed_model, training_ctrl, dummy_forward = create_bootstrap_nas_training_algo(
+        nas_model_name
+    )
     compressed_model.eval()
     before_reorg = dummy_forward(compressed_model)
     width_handler = training_ctrl.multi_elasticity_handler.width_handler

--- a/tests/torch/nas/test_elastic_width.py
+++ b/tests/torch/nas/test_elastic_width.py
@@ -155,9 +155,6 @@ def test_width_reorg(basic_model):
 
 
 def test_width_custom_external_reorg(basic_model):
-    if not isinstance(basic_model, TwoSequentialFcLNTestModel):
-        pytest.skip("Skip test for conv model")
-
     config = get_empty_config(input_sample_sizes=basic_model.INPUT_SIZE)
     external_importance = basic_model.IMPORTANCE
     with tempfile.NamedTemporaryFile() as external_importance_tempfile:


### PR DESCRIPTION
### Changes

Allow the use of an external weight importance information for reordering weights of the super-network. 

Adds missing info in experimental schema for previously committed KD. 

### Reason for changes

Several advanced algorithms can produce weight importance information that outperform L1/L2 weight reordering strategies. This PR allows the use of external weight importance information to reorder the weights in the super-network. 

### Related tickets

N/A

### Tests

Tests have been included. 
