### PR TITLE
Update ruff to v0.1.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.282
+    rev: v0.1.3
     hooks:
       - id: ruff
 


### PR DESCRIPTION
### Changes
As stated in the title

### Reason for changes
Fixes the following message (spawned when ruff finds an error):
```
panicked at 'byte index 1024 is not a char boundary; it is inside '█' (bytes 1023..1026) of `# Copyright (c) 2023 Intel Corporation
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#      http://www.apache.org/licenses/LICE`[...]', /home/runner/work/ruff/ruff/crates/ruff_source_file/src/locator.rs:382:10
Backtrace:    0: <unknown>
   1: <unknown>
   2: <unknown>
```

### Related tickets
N/A

### Tests
pre-commit linters
