### PR TITLE
[Torch] Workaroud for torch.quantile function

### DIFF
--- a/nncf/torch/tensor_statistics/collectors.py
+++ b/nncf/torch/tensor_statistics/collectors.py
@@ -173,17 +173,10 @@ class PTNNCFCollectorTensorProcessor(NNCFCollectorTensorProcessor):
     ) -> List[NNCFTensor]:
         device = tensor.device
         # See https://github.com/pytorch/pytorch/issues/61582
-        if not isinstance(axis, int):
-            result = torch.tensor(
-                np.quantile(tensor.tensor.detach().cpu().numpy(), q=quantile, axis=axis, keepdims=keepdims)
-            )
-        else:
-            result = torch.quantile(
-                tensor.tensor,
-                torch.tensor(quantile, dtype=tensor.tensor.dtype, device=tensor.tensor.device),
-                axis,
-                keepdims,
-            )
+        # https://github.com/pytorch/pytorch/issues/64947
+        result = torch.tensor(
+            np.quantile(tensor.tensor.detach().cpu().numpy(), q=quantile, axis=axis, keepdims=keepdims)
+        )
         result = result.type(tensor.tensor.dtype).to(device)
         return [PTNNCFTensor(x) for x in result]
 

--- a/tests/torch/ptq/test_reducers_and_aggregators.py
+++ b/tests/torch/ptq/test_reducers_and_aggregators.py
@@ -101,3 +101,24 @@ class TestCudaReducersAggregators(BaseTestReducersAggregators):
     def all_close(self, val: torch.Tensor, ref) -> bool:
         assert val.is_cuda
         return super().all_close(val, ref)
+
+
+@pytest.mark.parametrize("device", ["cuda", "cpu"])
+@pytest.mark.parametrize("size,ref", [(16_000_000, 1_600_000.8750), (17_000_000, 1_700_000.7500)])
+def test_quantile_percentile_function(device, size, ref):
+    tensor = PTNNCFTensor(torch.arange(1, size, 1).float().to(device))
+    res_quantile = PTNNCFCollectorTensorProcessor.quantile(tensor, [0.1], axis=0)
+    res_percentile = PTNNCFCollectorTensorProcessor.percentile(tensor, [10], axis=0)
+    assert len(res_quantile) == len(res_percentile) == 1
+    for tensor in [res_quantile[0].tensor, res_percentile[0].tensor]:
+        assert tensor == ref
+        assert tensor.is_cuda == (device == "cuda")
+
+
+@pytest.mark.parametrize("device", ["cuda", "cpu"])
+@pytest.mark.parametrize("size,ref", [(16_000_000, 8_000_000), (17_000_000, 8_500_000)])
+def test_median_function(device, size, ref):
+    tensor = PTNNCFTensor(torch.arange(1, size, 1).float().to(device))
+    res = PTNNCFCollectorTensorProcessor.median(tensor, axis=0)
+    assert res.tensor == ref
+    assert res.tensor.is_cuda == (device == "cuda")


### PR DESCRIPTION
### Changes

torch quantile is always using numpy realization

### Reason for changes

Bug https://github.com/pytorch/pytorch/issues/64947

third party test 237 has failed

```
       RuntimeError: quantile() input tensor is too large
 ```
### Related tickets


### Tests
Build test third party 239 is finished successfully
