### PR TITLE
[Release][Torch][PTQ] Examples are updated for the new PTQ TORCH backend

### DIFF
--- a/examples/post_training_quantization/torch/mobilenet_v2/requirements.txt
+++ b/examples/post_training_quantization/torch/mobilenet_v2/requirements.txt
@@ -1,6 +1,5 @@
-torchvision>=0.10.1,<0.16
-tqdm
-scikit-learn
-fastdownload
+fastdownload==0.0.7
 openvino-dev==2023.1
-onnx
+scikit-learn
+torch==2.1.0
+torchvision==0.16.0

--- a/examples/post_training_quantization/torch/ssd300_vgg16/requirements.txt
+++ b/examples/post_training_quantization/torch/ssd300_vgg16/requirements.txt
@@ -1,7 +1,7 @@
-fastdownload
+fastdownload==0.0.7
+onnx==1.13.1
 openvino-dev==2023.1
+pycocotools==2.0.7
+torch==2.0.1  # ssd300_vgg16 can not be exported with 2.1.0, reference: https://github.com/pytorch/pytorch/issues/113155
 torchmetrics==1.0.1
-pycocotools
-torchvision~=0.15.1
-tqdm
-onnx
+torchvision==0.15.2

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -519,6 +519,7 @@ class MinMaxQuantization(Algorithm):
             self._backend_entity.shapeof_metatypes,
             self._backend_entity.dropout_metatypes,
             self._backend_entity.read_variable_metatypes,
+            nncf_graph_contains_constants=backend != BackendType.TORCH,
         )
 
         quantizer_setup = self._get_quantizer_setup(nncf_graph, inference_nncf_graph, hw_patterns, ignored_patterns)

--- a/nncf/quantization/passes.py
+++ b/nncf/quantization/passes.py
@@ -23,6 +23,7 @@ def transform_to_inference_graph(
     shapeof_metatypes: List[OperatorMetatype],
     dropout_metatypes: List[OperatorMetatype],
     read_variable_metatypes: Optional[List[OperatorMetatype]] = None,
+    nncf_graph_contains_constants: bool = True,
 ) -> NNCFGraph:
     """
     This method contains inplace pipeline of the passes that uses to provide inference graph without constant flows.
@@ -32,11 +33,13 @@ def transform_to_inference_graph(
     :param dropout_metatypes: List of backend-specific Dropout metatypes.
     :param read_variable_metatypes: List of backend-specific metatypes
         that also can be interpreted as inputs (ReadValue).
+    :param nncf_graph_contains_constants: Whether NNCFGraph contains constant nodes or not.
     :return: NNCFGraph in the inference style.
     """
     remove_shapeof_subgraphs(nncf_graph, shapeof_metatypes, read_variable_metatypes)
     remove_nodes_and_reconnect_graph(nncf_graph, dropout_metatypes)
-    filter_constant_nodes(nncf_graph, read_variable_metatypes)
+    if nncf_graph_contains_constants:
+        filter_constant_nodes(nncf_graph, read_variable_metatypes)
     return nncf_graph
 
 

--- a/nncf/torch/quantization/quantize_model.py
+++ b/nncf/torch/quantization/quantize_model.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from copy import deepcopy
 from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
@@ -108,7 +109,8 @@ def quantize_impl(
     if target_device == TargetDevice.CPU_SPR:
         raise RuntimeError("target_device == CPU_SPR is not supported")
 
-    nncf_network = create_nncf_network(model.eval(), calibration_dataset)
+    copied_model = deepcopy(model)
+    nncf_network = create_nncf_network(copied_model.eval(), calibration_dataset)
 
     quantization_algorithm = PostTrainingQuantization(
         preset=preset,

--- a/tests/common/data/reference_graphs/passes/test_constant_filtering_model_after.dot
+++ b/tests/common/data/reference_graphs/passes/test_constant_filtering_model_after.dot
@@ -1,0 +1,12 @@
+strict digraph  {
+"0 /Input_1_0" [id=0, type=Input_1];
+"1 /ReadVariable_0" [id=1, type=ReadVariable];
+"4 /Conv_0" [id=4, type=Conv];
+"6 /Conv2_0" [id=6, type=Conv2];
+"7 /Add_0" [id=7, type=Add];
+"8 /Final_node_0" [id=8, type=Final_node];
+"0 /Input_1_0" -> "4 /Conv_0";
+"1 /ReadVariable_0" -> "7 /Add_0";
+"6 /Conv2_0" -> "7 /Add_0";
+"7 /Add_0" -> "8 /Final_node_0";
+}

--- a/tests/common/data/reference_graphs/passes/test_constant_filtering_model_before.dot
+++ b/tests/common/data/reference_graphs/passes/test_constant_filtering_model_before.dot
@@ -1,0 +1,18 @@
+strict digraph  {
+"0 /Input_1_0" [id=0, type=Input_1];
+"1 /ReadVariable_0" [id=1, type=ReadVariable];
+"2 /Weights_0" [id=2, type=Weights];
+"3 /AnyNodeBetweenWeightAndConv_0" [id=3, type=AnyNodeBetweenWeightAndConv];
+"4 /Conv_0" [id=4, type=Conv];
+"5 /Weights2_0" [id=5, type=Weights2];
+"6 /Conv2_0" [id=6, type=Conv2];
+"7 /Add_0" [id=7, type=Add];
+"8 /Final_node_0" [id=8, type=Final_node];
+"0 /Input_1_0" -> "4 /Conv_0";
+"1 /ReadVariable_0" -> "7 /Add_0";
+"2 /Weights_0" -> "3 /AnyNodeBetweenWeightAndConv_0";
+"3 /AnyNodeBetweenWeightAndConv_0" -> "4 /Conv_0";
+"5 /Weights2_0" -> "6 /Conv2_0";
+"6 /Conv2_0" -> "7 /Add_0";
+"7 /Add_0" -> "8 /Final_node_0";
+}

--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -110,7 +110,7 @@
         "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
         "accuracy_metrics": {
             "fp32_top1": 0.9864968152866243,
-            "int8_top1": 0.9829299363057324,
+            "int8_top1": 0.9836942675159236,
             "accuracy_drop": 0.0035668789808918078
         },
         "performance_metrics": {
@@ -129,8 +129,8 @@
         "requirements": "examples/post_training_quantization/torch/ssd300_vgg16/requirements.txt",
         "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
         "accuracy_metrics": {
-            "fp32_mAP": 0.5232756733894348,
-            "int8_mAP": 0.5140125155448914,
+            "fp32_mAP": 0.5228869318962097,
+            "int8_mAP": 0.5148677825927734,
             "accuracy_drop": 0.009263157844543457
         },
         "performance_metrics": {

--- a/tests/cross_fw/examples/test_examples.py
+++ b/tests/cross_fw/examples/test_examples.py
@@ -34,7 +34,7 @@ MODEL_SIZE_RELATIVE_TOLERANCE = 0.05
 
 ACCURACY_METRICS = "accuracy_metrics"
 MODEL_SIZE_METRICS = "model_size_metrics"
-PERFORMNACE_METRICS = "performance_metrics"
+PERFORMANCE_METRICS = "performance_metrics"
 
 
 def example_test_cases():
@@ -85,6 +85,6 @@ def test_examples(
         for name, value in example_params[MODEL_SIZE_METRICS].items():
             assert measured_metrics[name] == pytest.approx(value, rel=MODEL_SIZE_RELATIVE_TOLERANCE)
 
-    if is_check_performance and PERFORMNACE_METRICS in example_params:
-        for name, value in example_params[PERFORMNACE_METRICS].items():
+    if is_check_performance and PERFORMANCE_METRICS in example_params:
+        for name, value in example_params[PERFORMANCE_METRICS].items():
             assert measured_metrics[name] == pytest.approx(value, rel=PERFORMANCE_RELATIVE_TOLERANCE)

--- a/tests/post_training/test_templates/models.py
+++ b/tests/post_training/test_templates/models.py
@@ -297,3 +297,30 @@ class NNCFGraphDropoutRemovingCase:
                 dtype=Dtype.FLOAT,
                 parallel_input_port_ids=list(range(1, 10)),
             )
+
+
+class NNCFGraphToTestConstantFiltering:
+    def __init__(self, constant_metatype, read_variable_metatype, nncf_graph_cls=NNCFGraph) -> None:
+        nodes = [
+            NodeWithType("Input_1", InputNoopMetatype),
+            NodeWithType("Conv", None),
+            NodeWithType("Weights", constant_metatype),
+            NodeWithType("AnyNodeBetweenWeightAndConv", None),
+            NodeWithType("Weights2", constant_metatype),
+            NodeWithType("Conv2", None),
+            NodeWithType("ReadVariable", read_variable_metatype),
+            NodeWithType("Add", None),
+            NodeWithType("Final_node", None),
+        ]
+
+        edges = [
+            ("Input_1", "Conv"),
+            ("Weights", "AnyNodeBetweenWeightAndConv"),
+            ("AnyNodeBetweenWeightAndConv", "Conv"),
+            ("Weights2", "Conv2"),
+            ("Conv2", "Add"),
+            ("ReadVariable", "Add"),
+            ("Add", "Final_node"),
+        ]
+        original_mock_graph = create_mock_graph(nodes, edges)
+        self.nncf_graph = get_nncf_graph_from_mock_nx_graph(original_mock_graph, nncf_graph_cls)


### PR DESCRIPTION
Cherry-pick of 1493149ae35987442a13a60de151e7842159955f

### Changes

- Do not filter constant nodes for torch backend in the inference graph
- Fix version in requarements.txt for examples of post_training_quantization
    - for ssd300_vgg16 is not available to use torch 2.1.0 (failed on export to onnx Unsupported: ONNX export of operator get_pool_ceil_padding, tracing is not supporting too)
    - Update metrics
- Add to PTEngine convert inputs to model's device to sync behavior with `create_compress_model` 
- Mobilenet_v2 example converting PyTorch model to IR by tracing (without onnx).
- nncf.quantize for PyTorch works with copy of the target model

### Reason for changes

To make PTQ work properly with disconnected graphs (like in  [example](https://github.com/openvinotoolkit/nncf/blob/develop/examples/post_training_quantization/torch/ssd300_vgg16/main.py))

### Related tickets
124417

### Tests

test_examples build 128