### PR TITLE
Fix torchvision version in the examples

### DIFF
--- a/examples/torch/requirements.txt
+++ b/examples/torch/requirements.txt
@@ -6,5 +6,5 @@ defusedxml>=0.7.0rc1
 mlflow>=2.5.0,<2.7.0
 returns>0.14
 opencv-python>=4.4.0.46
-torchvision>=0.10.0,<0.16  # the minor version should always match the torch minor version that is installed via NNCF's `pip install nncf[torch]`; TV minor version is torch minor version +1
+torchvision>=0.10.0,<0.17  # the minor version should always match the torch minor version that is installed via NNCF's `pip install nncf[torch]`; TV minor version is torch minor version +1
 efficientnet_pytorch


### PR DESCRIPTION
### Changes
Allow torchvision 0.16 in the examples

### Reason for changes
Otherwise the installation of the requirements for the torch examples tries to install torchvision 0.16, which pulls the torch 2.0.1 which is different from the BKC torch v2.1

### Related tickets
N/A

### Tests
torch_nightly, torch E2E
