### PR TITLE
Update Torch to ONNX export in conformance 

### DIFF
--- a/tests/post_training/pipelines/image_classification_timm.py
+++ b/tests/post_training/pipelines/image_classification_timm.py
@@ -54,14 +54,7 @@ class ImageClassificationTimm(BaseTestPipeline):
 
         if self.backend == BackendType.ONNX:
             onnx_path = self.output_model_dir / "model_fp32.onnx"
-            torch.onnx.export(
-                timm_model,
-                self.dummy_tensor,
-                onnx_path,
-                export_params=True,
-                opset_version=13,
-                do_constant_folding=False,
-            )
+            torch.onnx.export(timm_model, self.dummy_tensor, onnx_path, export_params=True, opset_version=13)
             self.model = onnx.load(onnx_path)
             self.input_name = self.model.graph.input[0].name
 

--- a/tests/post_training/reference_data.yaml
+++ b/tests/post_training/reference_data.yaml
@@ -175,7 +175,7 @@ timm/levit_128_backend_TORCH:
     metric_value: 0.73346
     metric_value_fp32: 0.7405
 timm/levit_128_backend_ONNX:
-    metric_value: 0.73184
+    metric_value: 0.73286
     metric_value_fp32: 0.7405
 timm/levit_128_backend_OV:
     metric_value: 0.7334
@@ -321,7 +321,7 @@ timm/visformer_small_backend_TORCH:
     metric_value: 0.77728
     metric_value_fp32: 0.77902
 timm/visformer_small_backend_ONNX:
-    metric_value: 0.77432
+    metric_value: 0.77678
     metric_value_fp32: 0.77902
 timm/visformer_small_backend_OV:
     metric_value: 0.77686


### PR DESCRIPTION
### Changes

Do constant folding while exporting to ONNX from Torch

### Reason for changes

Conformance test regressgion of ONNX after updating torch to 2.1
Model graphs are updated and contain BatchNorm. Therefore bias locates no more as Conv attribute but in BatchNorm layer. It leads to not applying FBC and BC algorithms to these biases.

### Related tickets

125203

### Tests

N/A
