### PR TITLE
[Fix] Patching nncf_model_inputs

### DIFF
--- a/nncf/torch/dynamic_graph/context.py
+++ b/nncf/torch/dynamic_graph/context.py
@@ -31,7 +31,6 @@ from nncf.torch.dynamic_graph.scope import Scope
 from nncf.torch.dynamic_graph.scope import ScopeElement
 from nncf.torch.dynamic_graph.trace_tensor import TensorMeta
 from nncf.torch.dynamic_graph.trace_tensor import TracedTensor
-from nncf.torch.dynamic_graph.trace_tensor import strip_traced_tensor
 
 
 class ThreadLocalGlobalContext(threading.local):
@@ -135,7 +134,7 @@ class TracingContext:
             if tt is None or not isinstance(tt, TracedTensor):
                 continue
             if previous_context is None:
-                strip_traced_tensor(tt)
+                tt.strip()
             elif previous_context is not self:
                 previous_context.register_traced_tensor(tt)
 

--- a/nncf/torch/dynamic_graph/context.py
+++ b/nncf/torch/dynamic_graph/context.py
@@ -31,6 +31,7 @@ from nncf.torch.dynamic_graph.scope import Scope
 from nncf.torch.dynamic_graph.scope import ScopeElement
 from nncf.torch.dynamic_graph.trace_tensor import TensorMeta
 from nncf.torch.dynamic_graph.trace_tensor import TracedTensor
+from nncf.torch.dynamic_graph.trace_tensor import strip_traced_tensor
 
 
 class ThreadLocalGlobalContext(threading.local):
@@ -71,6 +72,7 @@ class TracingThreadLocals(threading.local):
         self.operator_counters = {}
         self.node_call_tracker = {}
         self.traced_tensor_weakrefs = []
+        self.save_context = []
 
 
 class CopySafeThreadingVars:
@@ -90,7 +92,6 @@ class TracingContext:
     def __init__(self):
         self.graph = DynamicGraph()
 
-        self._save_context = None
         self._post_hooks = {}
         self._pre_hooks: Dict[PreHookId, List[Callable]] = {}
         self._num_nested_hooks = 0
@@ -122,25 +123,29 @@ class TracingContext:
         # all replicas. Otherwise we will have data races on setting and reading the global _CURRENT_CONTEXT
         # variable, which will in turn lead to DP-specific runtime errors such as
         # "'_thread._local' object has no attribute 'scopes'"
-        self._save_context = get_current_context()
+        self._threading.thread_local.save_context.append(get_current_context())
         set_current_context(self)
-        self._reset_thread_local()
-        if is_debug():
-            self.reset_node_call_counters()
 
         return self
 
     def __exit__(self, *args):
-        if self._save_context is not self:  # NNCFNetwork.rebuild_graph() uses the compressed context nested in self
-            for traced_tensor_weakref in self._threading.thread_local.traced_tensor_weakrefs:
-                tt = traced_tensor_weakref()
-                if tt is not None:
-                    tt.nncf_expire()
+        save_context = self._threading.thread_local.save_context.pop(-1)
+        for traced_tensor_weakref in self._threading.thread_local.traced_tensor_weakrefs:
+            tt = traced_tensor_weakref()
+            if tt is None or not isinstance(tt, TracedTensor):
+                continue
+            if save_context is None:
+                strip_traced_tensor(tt)
+            elif save_context is not self:
+                self._save_context.register_traced_tensor(tt)
 
-        self._reset_thread_local()
+        if save_context is not self:
+            self._reset_thread_local()
 
-        set_current_context(self._save_context)
-        self._save_context = None
+            if is_debug():
+                self.reset_node_call_counters()
+
+        set_current_context(save_context)
 
     def find_operator_node(
         self, tensor_metas: List[Optional[TensorMeta]], op_address: OperationAddress

--- a/nncf/torch/dynamic_graph/io_handling.py
+++ b/nncf/torch/dynamic_graph/io_handling.py
@@ -38,7 +38,7 @@ from nncf.torch.utils import is_traced_tensor
 @api(canonical_alias="nncf.torch.nncf_model_input")
 @register_operator(name=MODEL_INPUT_OP_NAME)
 def nncf_model_input(tensor: "torch.Tensor"):
-    return tensor
+    return torch.Tensor(tensor)
 
 
 @api(canonical_alias="nncf.torch.nncf_model_output")

--- a/nncf/torch/dynamic_graph/io_handling.py
+++ b/nncf/torch/dynamic_graph/io_handling.py
@@ -38,7 +38,7 @@ from nncf.torch.utils import is_traced_tensor
 @api(canonical_alias="nncf.torch.nncf_model_input")
 @register_operator(name=MODEL_INPUT_OP_NAME)
 def nncf_model_input(tensor: "torch.Tensor"):
-    return torch.Tensor(tensor)
+    return tensor
 
 
 @api(canonical_alias="nncf.torch.nncf_model_output")

--- a/nncf/torch/dynamic_graph/trace_tensor.py
+++ b/nncf/torch/dynamic_graph/trace_tensor.py
@@ -174,7 +174,7 @@ def strip_traced_tensor(tensor: TracedTensor) -> torch.Tensor:
     return tensor
 
 
-def strip_traced_tensors_in_inpputs(args: Tuple, kwargs: Dict) -> Tuple[Tuple, Dict]:
+def strip_traced_tensors_in_inputs(args: Tuple, kwargs: Dict) -> Tuple[Tuple, Dict]:
     """
     Required to guard against new forward calls on tensors that have already passed
     through NNCF's forward once and got turned into TracedTensors by reference access.

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -61,7 +61,6 @@ from nncf.torch.graph.operator_metatypes import PTSplitMetatype
 from nncf.torch.graph.transformations.commands import PTTargetPoint
 from nncf.torch.knowledge_distillation.knowledge_distillation_handler import KnowledgeDistillationLossHandler
 from nncf.torch.layer_utils import _NNCFModuleMixin
-from nncf.torch.nested_objects_traversal import objwalk
 from nncf.torch.nncf_module_replacement import replace_modules_by_nncf_modules
 from nncf.torch.quantization.external_quantizer import EXTERNAL_QUANTIZERS_STORAGE_NAME
 from nncf.torch.utils import compute_FLOPs_hook

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -51,7 +51,7 @@ from nncf.torch.dynamic_graph.operation_address import OperationAddress
 from nncf.torch.dynamic_graph.patch_pytorch import ORIGINAL_CALL
 from nncf.torch.dynamic_graph.scope import Scope
 from nncf.torch.dynamic_graph.scope_access import get_module_by_scope
-from nncf.torch.dynamic_graph.trace_tensor import strip_traced_tensors_in_inpputs
+from nncf.torch.dynamic_graph.trace_tensor import strip_traced_tensors_in_inputs
 from nncf.torch.dynamic_graph.wrappers import wrap_module_call
 from nncf.torch.graph.graph import PTNNCFGraph
 from nncf.torch.graph.graph_builder import GraphBuilder
@@ -920,7 +920,7 @@ class NNCFNetwork(torch.nn.Module, metaclass=NNCFNetworkMeta):
             if not self.nncf._in_user_dummy_forward:
                 # If a user supplies own dummy forward, he is responsible for
                 # correctly wrapping inputs inside it as well.
-                args, kwargs = strip_traced_tensors_in_inpputs(args, kwargs)
+                args, kwargs = strip_traced_tensors_in_inputs(args, kwargs)
                 args, kwargs = self.nncf._wrap_inputs_fn(args, kwargs)
 
             # For purposes of scope tracking, need the original forward call to occur as if it were

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -51,7 +51,7 @@ from nncf.torch.dynamic_graph.operation_address import OperationAddress
 from nncf.torch.dynamic_graph.patch_pytorch import ORIGINAL_CALL
 from nncf.torch.dynamic_graph.scope import Scope
 from nncf.torch.dynamic_graph.scope_access import get_module_by_scope
-from nncf.torch.dynamic_graph.trace_tensor import strip_traced_tensors_in_inputs
+from nncf.torch.dynamic_graph.trace_tensor import strip_traced_tensors
 from nncf.torch.dynamic_graph.wrappers import wrap_module_call
 from nncf.torch.graph.graph import PTNNCFGraph
 from nncf.torch.graph.graph_builder import GraphBuilder
@@ -920,7 +920,7 @@ class NNCFNetwork(torch.nn.Module, metaclass=NNCFNetworkMeta):
             if not self.nncf._in_user_dummy_forward:
                 # If a user supplies own dummy forward, he is responsible for
                 # correctly wrapping inputs inside it as well.
-                args, kwargs = strip_traced_tensors_in_inputs(args, kwargs)
+                args, kwargs = strip_traced_tensors(args, kwargs)
                 args, kwargs = self.nncf._wrap_inputs_fn(args, kwargs)
 
             # For purposes of scope tracking, need the original forward call to occur as if it were

--- a/tests/torch/ptq/test_wrap_model.py
+++ b/tests/torch/ptq/test_wrap_model.py
@@ -15,6 +15,7 @@ from torch import nn
 
 from nncf.torch.dynamic_graph.context import no_nncf_trace
 from nncf.torch.model_creation import wrap_model
+from nncf.torch.nested_objects_traversal import objwalk
 
 
 class ArgumentModel(nn.Module):
@@ -64,9 +65,15 @@ class KeyWordArgumentsModel(nn.Module):
 def test_wrap_model_with_example_input(example_input, model_cls):
     model = model_cls(example_input)
     nncf_network = wrap_model(model, example_input)
+
+    def check_type(x):
+        assert type(x) == torch.Tensor
+        return x
+
+    objwalk(example_input, lambda x: True, check_type)
+
     nncf_graph = nncf_network.nncf.get_original_graph()
     all_nodes = nncf_graph.get_all_nodes()
-
     num_nodes = 2
     if isinstance(example_input, (tuple, dict)):
         num_nodes *= len(example_input)

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -839,3 +839,11 @@ def test_multidevice_model():
     input_info = ExampleInputInfo.from_example_input(example_input)
     nncf_model = NNCFNetwork(model, input_info)
     nncf_model(*example_input)
+
+
+def test_access_to_input_info():
+    model = SimplestModel()
+    example_input = torch.ones(SimplestModel.INPUT_SIZE)
+    input_info = ExampleInputInfo.from_example_input(example_input)
+    nncf_model = NNCFNetwork(model, input_info)
+    nncf_model.nncf.input_infos

--- a/tests/torch/test_tracing_context.py
+++ b/tests/torch/test_tracing_context.py
@@ -93,7 +93,7 @@ class ModuleForTest(torch.nn.Module):
         return self.conv2d(x)
 
 
-def test_traced_tensors_are_striped_on_context_exit():
+def test_traced_tensors_are_stripped_on_context_exit():
     module = ModuleForTest()
     module.train()
     tensor = torch.ones([1, 1, 1, 1])
@@ -120,20 +120,29 @@ def test_no_cross_forward_run_dependency():
         ctx.disable_trace_dynamic_graph()
 
 
-def test_nested_context():
-    ctx = TracingContext()
+@pytest.mark.parametrize(
+    "contexts",
+    [3 * [TracingContext()], [TracingContext(), TracingContext(), TracingContext()]],
+    ids=["same", "different"],
+)
+def test_nested_contexts(contexts):
     module = ModuleForTest()
     module.train()
     tensor = torch.ones([1, 1, 1, 1])
-    with ctx:
-        with ctx:
-            with ctx:
+    nesting_count = [1]
+    with contexts[0]:
+        with contexts[1]:
+            count = contexts[:2].count(contexts[1])
+            nesting_count.append(count)
+            with contexts[2]:
+                count = contexts.count(contexts[2])
+                nesting_count.append(count)
                 module(tensor)
-                assert len(ctx._threading.thread_local.save_context) == 3
-                assert len(ctx._threading.thread_local.traced_tensor_weakrefs) > 0
-            assert len(ctx._threading.thread_local.save_context) == 2
-            assert len(ctx._threading.thread_local.traced_tensor_weakrefs) > 0
-        assert len(ctx._threading.thread_local.save_context) == 1
-        assert ctx._threading.thread_local.save_context[0] is None
-        assert len(ctx._threading.thread_local.traced_tensor_weakrefs) > 0
-    assert len(ctx._threading.thread_local.traced_tensor_weakrefs) == 0
+                assert len(contexts[2]._threading.thread_local.nested_contexts_stack) == nesting_count[2]
+                assert len(contexts[2]._threading.thread_local.traced_tensor_weakrefs) > 0
+            assert len(contexts[1]._threading.thread_local.nested_contexts_stack) == nesting_count[1]
+            assert len(contexts[1]._threading.thread_local.traced_tensor_weakrefs) > 0
+        assert len(contexts[0]._threading.thread_local.nested_contexts_stack) == nesting_count[0]
+        assert contexts[0]._threading.thread_local.nested_contexts_stack[0] is None
+        assert len(contexts[0]._threading.thread_local.traced_tensor_weakrefs) > 0
+    assert len(contexts[0]._threading.thread_local.traced_tensor_weakrefs) == 0

--- a/tests/torch/test_tracing_context.py
+++ b/tests/torch/test_tracing_context.py
@@ -134,6 +134,6 @@ def test_nested_context():
             assert len(ctx._threading.thread_local.save_context) == 2
             assert len(ctx._threading.thread_local.traced_tensor_weakrefs) > 0
         assert len(ctx._threading.thread_local.save_context) == 1
-        assert ctx._threading.thread_local.save_context[0] == None
+        assert ctx._threading.thread_local.save_context[0] is None
         assert len(ctx._threading.thread_local.traced_tensor_weakrefs) > 0
     assert len(ctx._threading.thread_local.traced_tensor_weakrefs) == 0


### PR DESCRIPTION
### Changes
Strip traced tensors when exit from the tracing context

### Reason for changes

`nncf_model_input` patched `torch.Tensor` with `TracedTensor` which does not support deepcopy.

### Related tickets

125357

### Tests
test_wrap_model_with_example_input
e2e 506
test_examples 154

