### PR TITLE
Dump weight compression params to IR

### DIFF
--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -11,7 +11,7 @@
 
 import importlib
 from copy import deepcopy
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Iterable, List, Optional, Tuple, TypeVar, Union
 
 import openvino.runtime as ov
 from openvino._offline_transformations import compress_quantize_weights_transformation
@@ -24,6 +24,7 @@ from nncf.openvino.graph.node_utils import get_number_if_op
 from nncf.openvino.quantization.backend_parameters import BackendParameters
 from nncf.openvino.quantization.backend_parameters import is_weight_compression_needed
 from nncf.openvino.quantization.quantize_ifmodel import apply_algorithm_if_bodies
+from nncf.openvino.rt_info import dump_parameters
 from nncf.parameters import DropType
 from nncf.parameters import ModelType
 from nncf.parameters import TargetDevice
@@ -69,27 +70,6 @@ def should_use_pot(advanced_parameters: Optional[AdvancedQuantizationParameters]
         )
 
     return True
-
-
-def dump_parameters(model: ov.Model, parameters: Dict, path: Optional[List] = None) -> None:
-    """
-    Dumps input parameters into Model's meta section.
-
-    :param model: ov.Model instance.
-    :param parameters: Incoming dictionary with parameters to save.
-    :param path: Optional list of the paths.
-    """
-    try:
-        path = path if path else []
-        for key, value in parameters.items():
-            # Special condition for composed fields like IgnoredScope
-            if isinstance(value, IgnoredScope):
-                dump_parameters(model, value.__dict__, [key])
-                continue
-            rt_path = ["nncf", "quantization"] + path + [key]
-            model.set_rt_info(str(value), rt_path)
-    except RuntimeError as e:
-        nncf_logger.debug(f"Unable to dump optimization parameters due to error: {e}")
 
 
 @tracked_function(NNCF_OV_CATEGORY, [CompressionStartedWithQuantizeApi(), "target_device", "preset"])

--- a/nncf/openvino/rt_info.py
+++ b/nncf/openvino/rt_info.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, Optional
+
+import openvino.runtime as ov
+
+from nncf.common.logging import nncf_logger
+from nncf.scopes import IgnoredScope
+
+
+def dump_parameters(
+    model: ov.Model, parameters: Dict, algo_name: Optional[str] = "quantization", path: Optional[List] = None
+) -> None:
+    """
+    Dumps the given parameters into Model's meta section.
+
+    :param model: ov.Model instance.
+    :param algo_name: Name of the algorithm, to which the parameters refer.
+    :param parameters: Incoming dictionary with parameters to save.
+    :param path: Optional list of the paths.
+    """
+    try:
+        path = path if path else []
+        for key, value in parameters.items():
+            # Special condition for composed fields like IgnoredScope
+            if isinstance(value, IgnoredScope):
+                dump_parameters(model, value.__dict__, algo_name, [key])
+                continue
+            rt_path = ["nncf", algo_name] + path + [key]
+            model.set_rt_info(str(value), rt_path)
+    except RuntimeError as e:
+        nncf_logger.debug(f"Unable to dump optimization parameters due to error: {e}")

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -25,6 +25,7 @@ from nncf.openvino.graph.metatypes.openvino_metatypes import OVMatMulMetatype
 from nncf.openvino.graph.node_utils import get_channel_agnostic_reduction_axes
 from nncf.openvino.graph.node_utils import get_const_value
 from nncf.openvino.graph.node_utils import get_weight_channel_axes
+from nncf.openvino.rt_info import dump_parameters
 from nncf.parameters import CompressWeightsMode
 from nncf.quantization.algorithms.weight_compression.backend import WeightCompressionAlgoBackend
 from nncf.quantization.fake_quantize import calculate_scale_zero_point
@@ -131,6 +132,16 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
             for target_input in target_inputs:
                 target_input.replace_source_output(last_output)
+
+        dump_parameters(
+            model,
+            parameters={
+                "mode": mode.value,
+                "group_size": group_size,
+                "ratio": ratio,
+            },
+            algo_name="weight_compression",
+        )
         return model
 
 


### PR DESCRIPTION
### Changes

Hyperparameters of weight compression are dumped to IR

### Reason for changes

Useful in cases when different configurations are considered (validation, research experiments, etc)

![image](https://github.com/openvinotoolkit/nncf/assets/4014476/c39ef6c4-7721-4bb8-a146-b81296006639)
