### PR TITLE
Add backup precision option

### DIFF
--- a/nncf/common/quantization/quantizer_removal.py
+++ b/nncf/common/quantization/quantizer_removal.py
@@ -17,7 +17,7 @@ from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode
 from nncf.common.graph.operator_metatypes import OperatorMetatype
 from nncf.common.graph.transformations.layout import TransformationLayout
-from nncf.quantization.advanced_parameters import BackupMode
+from nncf.quantization.advanced_parameters import RestoreMode
 
 TModel = TypeVar("TModel")
 
@@ -92,7 +92,7 @@ def revert_operations_to_floating_point_precision(
     quantizers: List[NNCFNode],
     quantized_model: TModel,
     quantized_model_graph: NNCFGraph,
-    backup_mode: BackupMode,
+    restore_mode: RestoreMode,
     weighted_metatypes: List[OperatorMetatype],
 ) -> TModel:
     """
@@ -106,7 +106,7 @@ def revert_operations_to_floating_point_precision(
     :param quantized_model: Quantized model in which provided operations
         should be reverted to floating-point precision.
     :param quantized_model_graph: The graph which was built for `quantized_model`.
-    :param backup_mode: Backup mode.
+    :param restore_mode: Restore mode.
     :param weighted_metatypes: List of operation metatypes that can be reverted to representation
         with int8 weights.
     :return: The model where `operations` were reverted to floating-point precision.
@@ -117,7 +117,7 @@ def revert_operations_to_floating_point_precision(
 
     should_remove_fq = {}
     should_revert_weights_to_fp32 = {}
-    if backup_mode == BackupMode.INT8_WEIGHTS:
+    if restore_mode == RestoreMode.ONLY_ACTIVATIONS:
         for node in operations:
             if (
                 node.metatype in weighted_metatypes

--- a/nncf/common/quantization/quantizer_removal.py
+++ b/nncf/common/quantization/quantizer_removal.py
@@ -93,7 +93,7 @@ def revert_operations_to_floating_point_precision(
     quantized_model: TModel,
     quantized_model_graph: NNCFGraph,
     restore_mode: RestoreMode,
-    weighted_metatypes: List[OperatorMetatype],
+    op_with_weights_metatypes: List[OperatorMetatype],
 ) -> TModel:
     """
     Reverts provided operations to floating-point precision by removing
@@ -107,7 +107,7 @@ def revert_operations_to_floating_point_precision(
         should be reverted to floating-point precision.
     :param quantized_model_graph: The graph which was built for `quantized_model`.
     :param restore_mode: Restore mode.
-    :param weighted_metatypes: List of operation metatypes that can be reverted to representation
+    :param op_with_weights_metatypes: List of operation metatypes that can be reverted to representation
         with int8 weights.
     :return: The model where `operations` were reverted to floating-point precision.
     """
@@ -120,7 +120,7 @@ def revert_operations_to_floating_point_precision(
     if restore_mode == RestoreMode.ONLY_ACTIVATIONS:
         for node in operations:
             if (
-                node.metatype in weighted_metatypes
+                node.metatype in op_with_weights_metatypes
                 and node.layer_attributes
                 and node.layer_attributes.constant_attributes
             ):

--- a/nncf/common/quantization/quantizer_removal.py
+++ b/nncf/common/quantization/quantizer_removal.py
@@ -106,6 +106,9 @@ def revert_operations_to_floating_point_precision(
     :param quantized_model: Quantized model in which provided operations
         should be reverted to floating-point precision.
     :param quantized_model_graph: The graph which was built for `quantized_model`.
+    :param backup_mode: Backup mode.
+    :param weighted_metatypes: List of operation metatypes that can be reverted to representation
+        with int8 weights.
     :return: The model where `operations` were reverted to floating-point precision.
     """
     transformation_layout = TransformationLayout()

--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -284,7 +284,7 @@ def native_quantize_with_accuracy_control_impl(
             max_drop,
             drop_type,
             advanced_accuracy_restorer_parameters.num_ranking_workers,
-            advanced_accuracy_restorer_parameters.backup_mode,
+            advanced_accuracy_restorer_parameters.restore_mode,
         )
         quantized_model = accuracy_restorer.apply(
             model,

--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -284,6 +284,7 @@ def native_quantize_with_accuracy_control_impl(
             max_drop,
             drop_type,
             advanced_accuracy_restorer_parameters.num_ranking_workers,
+            advanced_accuracy_restorer_parameters.backup_mode,
         )
         quantized_model = accuracy_restorer.apply(
             model,

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -132,8 +132,12 @@ class AdvancedSmoothQuantParameters:
 
 class BackupMode(Enum):
     """
-    :param FP32:
-    :param INT8_WEIGHTS:
+    Specifies how to revert operations to their original precision.
+
+    :param FP32: Operations will be reverted to floating-point precision.
+    :param INT8_WEIGHTS: Certain operations (such as MatMul and Embedding) will
+        be reverted to representation with int8 weights, while all other operations
+        will revert to floating-point precision.
     """
 
     FP32 = "fp32"
@@ -232,7 +236,7 @@ class AdvancedAccuracyRestorerParameters:
     :param intermediate_model_dir: Path to the folder where the model, which was fully
         quantized with initial parameters, should be saved.
     :type intermediate_model_dir: Optional[str]
-    :param backup_mode:
+    :param backup_mode: Specifies how to revert operations to their original precision.
     :type backup_mode: BackupMode
     """
 

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -135,9 +135,8 @@ class RestoreMode(Enum):
     Specifies how to revert operations to their original precision.
 
     :param ACTIVATIONS_AND_WEIGHTS: Operations will be reverted to floating-point precision.
-    :param ONLY_ACTIVATIONS: Certain operations (such as MatMul and Embedding) will
-        be reverted to representation with int8 weights, while all other operations
-        will revert to floating-point precision.
+    :param ONLY_ACTIVATIONS: Operations with weights will be reverted to representation with int8 weights,
+        while all other operations will revert to floating-point precision.
     """
 
     ACTIVATIONS_AND_WEIGHTS = "activations_and_weights"

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -130,6 +130,16 @@ class AdvancedSmoothQuantParameters:
     matmul: float = 0.95
 
 
+class BackupMode(Enum):
+    """
+    :param FP32:
+    :param INT8_WEIGHTS:
+    """
+
+    FP32 = "fp32"
+    INT8_WEIGHTS = "int8_weights"
+
+
 @api()
 @dataclass
 class AdvancedQuantizationParameters:
@@ -222,6 +232,8 @@ class AdvancedAccuracyRestorerParameters:
     :param intermediate_model_dir: Path to the folder where the model, which was fully
         quantized with initial parameters, should be saved.
     :type intermediate_model_dir: Optional[str]
+    :param backup_mode:
+    :type backup_mode: BackupMode
     """
 
     max_num_iterations: int = sys.maxsize
@@ -229,6 +241,7 @@ class AdvancedAccuracyRestorerParameters:
     ranking_subset_size: Optional[int] = None
     num_ranking_workers: Optional[int] = None
     intermediate_model_dir: Optional[str] = None
+    backup_mode: BackupMode = BackupMode.FP32
 
 
 def changes_asdict(params: Any) -> Dict[str, Any]:

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -130,18 +130,18 @@ class AdvancedSmoothQuantParameters:
     matmul: float = 0.95
 
 
-class BackupMode(Enum):
+class RestoreMode(Enum):
     """
     Specifies how to revert operations to their original precision.
 
-    :param FP32: Operations will be reverted to floating-point precision.
-    :param INT8_WEIGHTS: Certain operations (such as MatMul and Embedding) will
+    :param ACTIVATIONS_AND_WEIGHTS: Operations will be reverted to floating-point precision.
+    :param ONLY_ACTIVATIONS: Certain operations (such as MatMul and Embedding) will
         be reverted to representation with int8 weights, while all other operations
         will revert to floating-point precision.
     """
 
-    FP32 = "fp32"
-    INT8_WEIGHTS = "int8_weights"
+    ACTIVATIONS_AND_WEIGHTS = "activations_and_weights"
+    ONLY_ACTIVATIONS = "only_activations"
 
 
 @api()
@@ -236,8 +236,8 @@ class AdvancedAccuracyRestorerParameters:
     :param intermediate_model_dir: Path to the folder where the model, which was fully
         quantized with initial parameters, should be saved.
     :type intermediate_model_dir: Optional[str]
-    :param backup_mode: Specifies how to revert operations to their original precision.
-    :type backup_mode: BackupMode
+    :param restore_mode: Specifies how to revert operations to their original precision.
+    :type restore_mode: RestoreMode
     """
 
     max_num_iterations: int = sys.maxsize
@@ -245,7 +245,7 @@ class AdvancedAccuracyRestorerParameters:
     ranking_subset_size: Optional[int] = None
     num_ranking_workers: Optional[int] = None
     intermediate_model_dir: Optional[str] = None
-    backup_mode: BackupMode = BackupMode.FP32
+    restore_mode: RestoreMode = RestoreMode.ACTIVATIONS_AND_WEIGHTS
 
 
 def changes_asdict(params: Any) -> Dict[str, Any]:

--- a/nncf/quantization/algorithms/accuracy_control/algorithm.py
+++ b/nncf/quantization/algorithms/accuracy_control/algorithm.py
@@ -24,7 +24,7 @@ from nncf.common.utils.os import get_available_cpu_count
 from nncf.common.utils.os import get_available_memory_amount
 from nncf.data.dataset import Dataset
 from nncf.parameters import DropType
-from nncf.quantization.advanced_parameters import BackupMode
+from nncf.quantization.advanced_parameters import RestoreMode
 from nncf.quantization.algorithms.accuracy_control.backend import AccuracyControlAlgoBackend
 from nncf.quantization.algorithms.accuracy_control.evaluator import Evaluator
 from nncf.quantization.algorithms.accuracy_control.evaluator import MetricResults
@@ -146,7 +146,7 @@ class QuantizationAccuracyRestorer:
         max_drop: float = 0.01,
         drop_type: DropType = DropType.ABSOLUTE,
         num_ranking_workers: Optional[int] = None,
-        backup_mode: BackupMode = BackupMode.FP32,
+        restore_mode: RestoreMode = RestoreMode.ACTIVATIONS_AND_WEIGHTS,
     ):
         """
         :param ranking_subset_size: The number of data items that will be selected from
@@ -158,14 +158,14 @@ class QuantizationAccuracyRestorer:
             calculated.
         :param num_ranking_workers: The number of parallel workers that are used to rank
             quantization operations.
-        :param backup_mode: Backup mode.
+        :param restore_mode: Restore mode.
         """
         self.ranking_subset_size = ranking_subset_size
         self.max_num_iterations = max_num_iterations
         self.max_drop = max_drop
         self.drop_type = drop_type
         self.num_ranking_workers = num_ranking_workers
-        self.backup_mode = backup_mode
+        self.restore_mode = restore_mode
 
     def apply(
         self,
@@ -308,7 +308,7 @@ class QuantizationAccuracyRestorer:
                 current_group.quantizers,
                 previous_model,
                 quantized_model_graph,
-                self.backup_mode,
+                self.restore_mode,
                 algo_backend.get_weighted_metatypes(),
             )
             report.removed_groups.append(current_group)

--- a/nncf/quantization/algorithms/accuracy_control/algorithm.py
+++ b/nncf/quantization/algorithms/accuracy_control/algorithm.py
@@ -23,8 +23,8 @@ from nncf.common.utils.backend import get_backend
 from nncf.common.utils.os import get_available_cpu_count
 from nncf.common.utils.os import get_available_memory_amount
 from nncf.data.dataset import Dataset
-from nncf.quantization.advanced_parameters import BackupMode
 from nncf.parameters import DropType
+from nncf.quantization.advanced_parameters import BackupMode
 from nncf.quantization.algorithms.accuracy_control.backend import AccuracyControlAlgoBackend
 from nncf.quantization.algorithms.accuracy_control.evaluator import Evaluator
 from nncf.quantization.algorithms.accuracy_control.evaluator import MetricResults
@@ -158,6 +158,7 @@ class QuantizationAccuracyRestorer:
             calculated.
         :param num_ranking_workers: The number of parallel workers that are used to rank
             quantization operations.
+        :param backup_mode: Backup mode.
         """
         self.ranking_subset_size = ranking_subset_size
         self.max_num_iterations = max_num_iterations

--- a/nncf/quantization/algorithms/accuracy_control/algorithm.py
+++ b/nncf/quantization/algorithms/accuracy_control/algorithm.py
@@ -309,7 +309,7 @@ class QuantizationAccuracyRestorer:
                 previous_model,
                 quantized_model_graph,
                 self.restore_mode,
-                algo_backend.get_weighted_metatypes(),
+                algo_backend.get_op_with_weights_metatypes(),
             )
             report.removed_groups.append(current_group)
 

--- a/nncf/quantization/algorithms/accuracy_control/backend.py
+++ b/nncf/quantization/algorithms/accuracy_control/backend.py
@@ -27,7 +27,13 @@ class AccuracyControlAlgoBackend(ABC):
     @staticmethod
     @abstractmethod
     def get_weighted_metatypes() -> List[OperatorMetatype]:
-        """ """
+        """
+        Returns a list of operation metatypes that can be reverted to representation
+        with int8 weights.
+
+        :return: The list of operation metatypes that can be reverted to representation
+            with int8 weights.
+        """
 
     @staticmethod
     @abstractmethod

--- a/nncf/quantization/algorithms/accuracy_control/backend.py
+++ b/nncf/quantization/algorithms/accuracy_control/backend.py
@@ -26,7 +26,7 @@ class AccuracyControlAlgoBackend(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_weighted_metatypes() -> List[OperatorMetatype]:
+    def get_op_with_weights_metatypes() -> List[OperatorMetatype]:
         """
         Returns a list of operation metatypes that can be reverted to representation
         with int8 weights.

--- a/nncf/quantization/algorithms/accuracy_control/backend.py
+++ b/nncf/quantization/algorithms/accuracy_control/backend.py
@@ -26,6 +26,11 @@ class AccuracyControlAlgoBackend(ABC):
 
     @staticmethod
     @abstractmethod
+    def get_weighted_metatypes() -> List[OperatorMetatype]:
+        """ """
+
+    @staticmethod
+    @abstractmethod
     def get_quantizer_metatypes() -> List[OperatorMetatype]:
         """
         Returns a list of quantizer metatypes.

--- a/nncf/quantization/algorithms/accuracy_control/openvino_backend.py
+++ b/nncf/quantization/algorithms/accuracy_control/openvino_backend.py
@@ -23,6 +23,7 @@ from nncf.openvino.graph.metatypes.groups import INPUTS_QUANTIZABLE_OPERATIONS
 from nncf.openvino.graph.metatypes.groups import OPERATIONS_WITH_WEIGHTS
 from nncf.openvino.graph.metatypes.groups import QUANTIZE_AGNOSTIC_OPERATIONS
 from nncf.openvino.graph.metatypes.groups import SHAPEOF_OPERATIONS
+from nncf.openvino.graph.metatypes import openvino_metatypes as ov_metatypes
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVConcatMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVOpMetatype
 from nncf.openvino.graph.node_utils import get_bias_value
@@ -37,6 +38,10 @@ class OVAccuracyControlAlgoBackend(AccuracyControlAlgoBackend):
     """
 
     # Metatypes
+
+    @staticmethod
+    def get_weighted_metatypes() -> List[OVOpMetatype]:
+        return [ov_metatypes.OVMatMulMetatype, ov_metatypes.OVEmbeddingMetatype]
 
     @staticmethod
     def get_quantizer_metatypes() -> List[OVOpMetatype]:

--- a/nncf/quantization/algorithms/accuracy_control/openvino_backend.py
+++ b/nncf/quantization/algorithms/accuracy_control/openvino_backend.py
@@ -17,7 +17,6 @@ import openvino.runtime as ov
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode
 from nncf.openvino.graph.layer_attributes import OVLayerAttributes
-from nncf.openvino.graph.metatypes import openvino_metatypes as ov_metatypes
 from nncf.openvino.graph.metatypes.groups import CONSTANT_OPERATIONS
 from nncf.openvino.graph.metatypes.groups import FAKE_QUANTIZE_OPERATIONS
 from nncf.openvino.graph.metatypes.groups import INPUTS_QUANTIZABLE_OPERATIONS
@@ -40,8 +39,8 @@ class OVAccuracyControlAlgoBackend(AccuracyControlAlgoBackend):
     # Metatypes
 
     @staticmethod
-    def get_weighted_metatypes() -> List[OVOpMetatype]:
-        return [ov_metatypes.OVMatMulMetatype, ov_metatypes.OVEmbeddingMetatype]
+    def get_op_with_weights_metatypes() -> List[OVOpMetatype]:
+        return OPERATIONS_WITH_WEIGHTS
 
     @staticmethod
     def get_quantizer_metatypes() -> List[OVOpMetatype]:

--- a/nncf/quantization/algorithms/accuracy_control/openvino_backend.py
+++ b/nncf/quantization/algorithms/accuracy_control/openvino_backend.py
@@ -17,13 +17,13 @@ import openvino.runtime as ov
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode
 from nncf.openvino.graph.layer_attributes import OVLayerAttributes
+from nncf.openvino.graph.metatypes import openvino_metatypes as ov_metatypes
 from nncf.openvino.graph.metatypes.groups import CONSTANT_OPERATIONS
 from nncf.openvino.graph.metatypes.groups import FAKE_QUANTIZE_OPERATIONS
 from nncf.openvino.graph.metatypes.groups import INPUTS_QUANTIZABLE_OPERATIONS
 from nncf.openvino.graph.metatypes.groups import OPERATIONS_WITH_WEIGHTS
 from nncf.openvino.graph.metatypes.groups import QUANTIZE_AGNOSTIC_OPERATIONS
 from nncf.openvino.graph.metatypes.groups import SHAPEOF_OPERATIONS
-from nncf.openvino.graph.metatypes import openvino_metatypes as ov_metatypes
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVConcatMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVOpMetatype
 from nncf.openvino.graph.node_utils import get_bias_value

--- a/nncf/quantization/algorithms/accuracy_control/ranker.py
+++ b/nncf/quantization/algorithms/accuracy_control/ranker.py
@@ -195,7 +195,7 @@ class Ranker:
                 quantized_model,
                 quantized_model_graph,
                 self._restore_mode,
-                self._algo_backend.get_weighted_metatypes(),
+                self._algo_backend.get_op_with_weights_metatypes(),
             )
 
             prepared_model = self._algo_backend.prepare_for_inference(modified_model)
@@ -224,7 +224,7 @@ class Ranker:
                 quantized_model,
                 quantized_model_graph,
                 self._restore_mode,
-                self._algo_backend.get_weighted_metatypes(),
+                self._algo_backend.get_op_with_weights_metatypes(),
             )
 
             prepared_model_queue.append(executor.submit(self._algo_backend.prepare_for_inference, modified_model))

--- a/nncf/quantization/algorithms/accuracy_control/ranker.py
+++ b/nncf/quantization/algorithms/accuracy_control/ranker.py
@@ -24,7 +24,7 @@ from nncf.common.utils.backend import BackendType
 from nncf.common.utils.backend import get_backend
 from nncf.common.utils.timer import timer
 from nncf.data.dataset import Dataset
-from nncf.quantization.advanced_parameters import BackupMode
+from nncf.quantization.advanced_parameters import RestoreMode
 from nncf.quantization.algorithms.accuracy_control.backend import AccuracyControlAlgoBackend
 from nncf.quantization.algorithms.accuracy_control.evaluator import Evaluator
 from nncf.quantization.algorithms.accuracy_control.rank_functions import create_normalized_mse_func
@@ -63,7 +63,7 @@ class Ranker:
         evaluator: Evaluator,
         num_workers: int = 1,
         ranking_fn: Optional[Callable[[Any, Any], float]] = None,
-        backup_mode: BackupMode = BackupMode.FP32,
+        restore_mode: RestoreMode = RestoreMode.ACTIVATIONS_AND_WEIGHTS,
     ):
         """
         :param ranking_subset_size: The number of data items that will be selected from
@@ -84,7 +84,7 @@ class Ranker:
         self._evaluator = evaluator
         self._ranking_fn = ranking_fn
         self._num_workers = num_workers
-        self._backup_mode = backup_mode
+        self._restore_mode = restore_mode
 
     def find_groups_of_quantizers_to_rank(self, quantized_model_graph: NNCFGraph) -> List[GroupToRank]:
         """
@@ -194,7 +194,7 @@ class Ranker:
                 current_group.quantizers,
                 quantized_model,
                 quantized_model_graph,
-                self._backup_mode,
+                self._restore_mode,
                 self._algo_backend.get_weighted_metatypes(),
             )
 
@@ -223,7 +223,7 @@ class Ranker:
                 current_group.quantizers,
                 quantized_model,
                 quantized_model_graph,
-                self._backup_mode,
+                self._restore_mode,
                 self._algo_backend.get_weighted_metatypes(),
             )
 

--- a/nncf/quantization/algorithms/accuracy_control/ranker.py
+++ b/nncf/quantization/algorithms/accuracy_control/ranker.py
@@ -24,12 +24,12 @@ from nncf.common.utils.backend import BackendType
 from nncf.common.utils.backend import get_backend
 from nncf.common.utils.timer import timer
 from nncf.data.dataset import Dataset
+from nncf.quantization.advanced_parameters import BackupMode
 from nncf.quantization.algorithms.accuracy_control.backend import AccuracyControlAlgoBackend
 from nncf.quantization.algorithms.accuracy_control.evaluator import Evaluator
 from nncf.quantization.algorithms.accuracy_control.rank_functions import create_normalized_mse_func
 from nncf.quantization.algorithms.accuracy_control.subset_selection import select_subset
 from nncf.quantization.passes import remove_shapeof_subgraphs
-from nncf.quantization.advanced_parameters import BackupMode
 
 TModel = TypeVar("TModel")
 TPModel = TypeVar("TPModel")

--- a/tests/openvino/native/quantization/test_quantizer_removal.py
+++ b/tests/openvino/native/quantization/test_quantizer_removal.py
@@ -18,7 +18,7 @@ import pytest
 from nncf.common.factory import NNCFGraphFactory
 from nncf.common.quantization.quantizer_removal import revert_operations_to_floating_point_precision
 from nncf.openvino.graph.metatypes import openvino_metatypes as ov_metatypes
-from nncf.quantization.advanced_parameters import BackupMode
+from nncf.quantization.advanced_parameters import RestoreMode
 from tests.openvino.native.models import LinearQuantizedModel
 
 
@@ -30,14 +30,14 @@ class InputTestData:
     :param operations: List of operation names to revert to floating-point precision.
     :param quantizers: List of quantizer names that need to be removed in order to revert
         operations to floating-point precision.
-    :param backup_mode: Backup mode.
+    :param restore_mode: Restore mode.
     :param expected_remaining_quantizers: List of remaining quantizer names.
     """
 
     quantized_model: ov.Model
     operations: List[str]
     quantizers: List[str]
-    backup_mode: BackupMode
+    restore_mode: RestoreMode
     expected_remaining_quantizers: List[str]
 
 
@@ -51,7 +51,7 @@ TEST_CASES = [
             "FQ_ReLu_0",
             "FQ_Weights_1",
         ],
-        backup_mode=BackupMode.FP32,
+        restore_mode=RestoreMode.ACTIVATIONS_AND_WEIGHTS,
         expected_remaining_quantizers=[
             "FQ_Inputs",
             "FQ_Weights_0",
@@ -66,7 +66,7 @@ TEST_CASES = [
             "FQ_ReLu_0",
             "FQ_Weights_1",
         ],
-        backup_mode=BackupMode.INT8_WEIGHTS,
+        restore_mode=RestoreMode.ONLY_ACTIVATIONS,
         expected_remaining_quantizers=[
             "FQ_Weights_0",
             "FQ_Weights_1",
@@ -86,7 +86,7 @@ def test_revert_operations_to_floating_point_precision(test_case: InputTestData)
         quantizers,
         test_case.quantized_model,
         quantized_model_graph,
-        test_case.backup_mode,
+        test_case.restore_mode,
         [ov_metatypes.OVMatMulMetatype, ov_metatypes.OVEmbeddingMetatype],
     )
 

--- a/tests/openvino/native/quantization/test_quantizer_removal.py
+++ b/tests/openvino/native/quantization/test_quantizer_removal.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import List
+
+import openvino.runtime as ov
+import pytest
+
+from nncf.common.factory import NNCFGraphFactory
+from nncf.common.quantization.quantizer_removal import revert_operations_to_floating_point_precision
+from nncf.openvino.graph.metatypes import openvino_metatypes as ov_metatypes
+from nncf.quantization.advanced_parameters import BackupMode
+from tests.openvino.native.models import LinearQuantizedModel
+
+
+@dataclass
+class InputTestData:
+    """
+    :param quantized_model: A quantized model in which specified operations need
+        to be reverted to floating-point precision.
+    :param operations: List of operation names to revert to floating-point precision.
+    :param quantizers: List of quantizer names that need to be removed in order to revert
+        operations to floating-point precision.
+    :param backup_mode: Backup mode.
+    :param expected_remaining_quantizers: List of remaining quantizer names.
+    """
+
+    quantized_model: ov.Model
+    operations: List[str]
+    quantizers: List[str]
+    backup_mode: BackupMode
+    expected_remaining_quantizers: List[str]
+
+
+TEST_CASES = [
+    InputTestData(
+        quantized_model=LinearQuantizedModel().ov_model,
+        operations=[
+            "MatMul_1",
+        ],
+        quantizers=[
+            "FQ_ReLu_0",
+            "FQ_Weights_1",
+        ],
+        backup_mode=BackupMode.FP32,
+        expected_remaining_quantizers=[
+            "FQ_Inputs",
+            "FQ_Weights_0",
+        ],
+    ),
+    InputTestData(
+        quantized_model=LinearQuantizedModel().ov_model,
+        operations=["MatMul_0", "MatMul_1"],
+        quantizers=[
+            "FQ_Inputs",
+            "FQ_Weights_0",
+            "FQ_ReLu_0",
+            "FQ_Weights_1",
+        ],
+        backup_mode=BackupMode.INT8_WEIGHTS,
+        expected_remaining_quantizers=[
+            "FQ_Weights_0",
+            "FQ_Weights_1",
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize("test_case", TEST_CASES)
+def test_revert_operations_to_floating_point_precision(test_case: InputTestData):
+    quantized_model_graph = NNCFGraphFactory.create(test_case.quantized_model)
+    operations = [quantized_model_graph.get_node_by_name(name) for name in test_case.operations]
+    quantizers = [quantized_model_graph.get_node_by_name(name) for name in test_case.quantizers]
+
+    updated_model = revert_operations_to_floating_point_precision(
+        operations,
+        quantizers,
+        test_case.quantized_model,
+        quantized_model_graph,
+        test_case.backup_mode,
+        [ov_metatypes.OVMatMulMetatype, ov_metatypes.OVEmbeddingMetatype],
+    )
+
+    updated_model_graph = NNCFGraphFactory.create(updated_model)
+    actual_remaining_quantizers = [
+        x.node_name for x in updated_model_graph.get_nodes_by_metatypes([ov_metatypes.OVFakeQuantizeMetatype])
+    ]
+
+    assert sorted(actual_remaining_quantizers) == sorted(test_case.expected_remaining_quantizers)


### PR DESCRIPTION
### Changes

- Add a backup precision option that allows for preserving FQs on weights during the accuracy-aware algorithm.

### Reason for changes

See description in Ref: 123999

### Related tickets

Ref: 123999

### Tests

tests/openvino/native/quantization/test_quantizer_removal.py

