### PR TITLE
Fix dump of patterns

### DIFF
--- a/nncf/common/utils/dot_file_rw.py
+++ b/nncf/common/utils/dot_file_rw.py
@@ -101,6 +101,8 @@ def relabel_graph_for_dot_visualization(nx_graph: nx.Graph, from_reference: bool
     hits = defaultdict(lambda: 0)
     mapping = {}
     for original_name in nx_graph.nodes():
+        if not isinstance(original_name, str):
+            continue
         dot_name = original_name.replace(__CHARACTER_REPLACE_FROM, __CHARACTER_REPLACE_TO)
         hits[dot_name] += 1
         if hits[dot_name] > 1:

--- a/tests/common/graph/test_graph_pattern.py
+++ b/tests/common/graph/test_graph_pattern.py
@@ -219,4 +219,5 @@ def test_join_pattern_with_special_input_node():
 def test_dump(tmp_path: Path):
     path_dot = tmp_path / "pattern.dot"
     TestPattern.first_pattern.dump_graph(path_dot)
-    assert path_dot.exists()
+    assert path_dot.is_file()
+    path_dot.unlink()

--- a/tests/common/graph/test_graph_pattern.py
+++ b/tests/common/graph/test_graph_pattern.py
@@ -11,6 +11,7 @@
 
 import copy
 import itertools
+from pathlib import Path
 
 import networkx as nx
 
@@ -215,5 +216,7 @@ def test_join_pattern_with_special_input_node():
     assert pattern == ref_pattern
 
 
-def test_dump(tmp_path):
-    TestPattern.first_pattern.dump_graph(tmp_path / "pattern.dot")
+def test_dump(tmp_path: Path):
+    path_dot = tmp_path / "pattern.dot"
+    TestPattern.first_pattern.dump_graph(path_dot)
+    assert path_dot.exists()

--- a/tests/common/graph/test_graph_pattern.py
+++ b/tests/common/graph/test_graph_pattern.py
@@ -213,3 +213,7 @@ def test_join_pattern_with_special_input_node():
             ref_pattern.add_edge(node, added_node)
 
     assert pattern == ref_pattern
+
+
+def test_dump(tmp_path):
+    TestPattern.first_pattern.dump_graph(tmp_path / "pattern.dot")


### PR DESCRIPTION
### Changes

Replace node name only if node id is string (it can also be `int` like in patterns)

### Reason for changes

```python
        for original_name in nx_graph.nodes():
>           dot_name = original_name.replace(__CHARACTER_REPLACE_FROM, __CHARACTER_REPLACE_TO)
E           AttributeError: 'int' object has no attribute 'replace'

nncf/common/utils/dot_file_rw.py:104: AttributeError
```

### Tests

tests/common/graph/test_graph_pattern.py::test_dump