### PR TITLE
Update links to ONNX models

### DIFF
--- a/tests/onnx/quantization/test_ptq_regression.py
+++ b/tests/onnx/quantization/test_ptq_regression.py
@@ -27,17 +27,17 @@ import nncf
 
 MODELS = [
     (
-        "https://github.com/onnx/models/raw/main/vision/classification/mobilenet/model/mobilenetv2-12.onnx",
+        "https://github.com/onnx/models/raw/5faef4c33eba0395177850e1e31c4a6a9e634c82/vision/classification/mobilenet/model/mobilenetv2-12.onnx",
         "mobilenetv2-12",
         0.7864968152866242,
     ),
     (
-        "https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet50-v1-7.onnx",
+        "https://github.com/onnx/models/raw/5faef4c33eba0395177850e1e31c4a6a9e634c82/vision/classification/resnet/model/resnet50-v1-7.onnx",
         "resnet50-v1-7",
         0.8114649681528663,
     ),
     (
-        "https://github.com/onnx/models/raw/main/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11.onnx",
+        "https://github.com/onnx/models/raw/5faef4c33eba0395177850e1e31c4a6a9e634c82/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11.onnx",
         "efficientnet-lite4-11",
         0.8035668789808917,
     ),


### PR DESCRIPTION
### Changes

Update links to ONNX models

### Reason for changes

`HTTP Error 404: Not Found` after changes in  https://github.com/onnx/models

### Tests

tests/onnx/quantization/test_ptq_regression.py::test_compression