### PR TITLE
Fix pt sanity tests

### DIFF
--- a/tests/torch/conftest.py
+++ b/tests/torch/conftest.py
@@ -13,6 +13,10 @@ import random
 from pathlib import Path
 
 import pytest
+from pytest import Config
+from pytest import FixtureRequest
+from pytest import MonkeyPatch
+from pytest import Parser
 
 try:
     import torch
@@ -34,7 +38,7 @@ def disable_tf32_precision():
         torch.backends.cudnn.allow_tf32 = False
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser):
     parser.addoption(
         "--data",
         type=str,
@@ -61,14 +65,14 @@ def pytest_addoption(parser):
         help="Enable mixed precision for the nncf weekly test",
     )
     parser.addoption(
-        "--sota-checkpoints-dir", type=str, default=None, help="Path to checkpoints directory for sota accuracy test"
+        "--sota-checkpoints-dir", type=Path, default=None, help="Path to checkpoints directory for sota accuracy test"
     )
     parser.addoption(
-        "--sota-data-dir", type=str, default=None, help="Path to datasets directory for sota accuracy test"
+        "--sota-data-dir", type=Path, default=None, help="Path to datasets directory for sota accuracy test"
     )
     parser.addoption(
         "--metrics-dump-path",
-        type=str,
+        type=Path,
         default=None,
         help="Path to directory to store metrics. "
         "Directory must be empty or should not exist."
@@ -77,7 +81,7 @@ def pytest_addoption(parser):
         "if param not specified",
     )
     parser.addoption(
-        "--ov-data-dir", type=str, default=None, help="Path to datasets directory for OpenVINO accuracy test"
+        "--ov-data-dir", type=Path, default=None, help="Path to datasets directory for OpenVINO accuracy test"
     )
     parser.addoption("--imagenet", action="store_true", default=False, help="Enable tests with imagenet")
     parser.addoption(
@@ -111,116 +115,116 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_configure(config):
+def pytest_configure(config: Config):
     regen_dot = config.getoption("--regen-dot", False)
     if regen_dot:
         os.environ["NNCF_TEST_REGEN_DOT"] = "1"
 
 
 @pytest.fixture(scope="module")
-def dataset_dir(request):
+def dataset_dir(request: FixtureRequest):
     return request.config.getoption("--data")
 
 
 @pytest.fixture(scope="module")
-def enable_imagenet(request):
+def enable_imagenet(request: FixtureRequest):
     return request.config.getoption("--imagenet")
 
 
 @pytest.fixture(scope="module")
-def weekly_models_path(request):
+def weekly_models_path(request: FixtureRequest):
     return request.config.getoption("--weekly-models")
 
 
 @pytest.fixture(scope="module")
-def mixed_precision(request):
+def mixed_precision(request: FixtureRequest):
     return request.config.getoption("--mixed-precision")
 
 
 @pytest.fixture(scope="module")
-def sota_checkpoints_dir(request):
-    return Path(request.config.getoption("--sota-checkpoints-dir"))
+def sota_checkpoints_dir(request: FixtureRequest):
+    return request.config.getoption("--sota-checkpoints-dir")
 
 
 @pytest.fixture(scope="module")
 def sota_data_dir(request):
-    return Path(request.config.getoption("--sota-data-dir"))
+    return request.config.getoption("--sota-data-dir")
 
 
 @pytest.fixture(scope="module")
 def ov_data_dir(request):
-    return Path(request.config.getoption("--ov-data-dir"))
+    return request.config.getoption("--ov-data-dir")
 
 
 @pytest.fixture(scope="module")
-def install_type(request):
+def install_type(request: FixtureRequest):
     return request.config.getoption("--run-install-tests", skip=True)
 
 
 @pytest.fixture(scope="module")
-def backward_compat_models_path(request):
+def backward_compat_models_path(request: FixtureRequest):
     return request.config.getoption("--backward-compat-models")
 
 
 @pytest.fixture(autouse=True)
-def torch_home_dir(request, monkeypatch):
+def torch_home_dir(request: FixtureRequest, monkeypatch: MonkeyPatch):
     torch_home = request.config.getoption("--torch-home")
     if torch_home:
         monkeypatch.setenv("TORCH_HOME", torch_home)
 
 
 @pytest.fixture(scope="session")
-def third_party(request):
+def third_party(request: FixtureRequest):
     return request.config.getoption("--third-party-sanity")
 
 
 @pytest.fixture(scope="session")
-def torch_with_cuda11(request):
+def torch_with_cuda11(request: FixtureRequest):
     return request.config.getoption("--torch-with-cuda11")
 
 
 @pytest.fixture(scope="session")
-def openvino(request):
+def openvino(request: FixtureRequest):
     return request.config.getoption("--run-openvino-eval")
 
 
 @pytest.fixture(scope="module")
-def ov_config_dir(request):
+def ov_config_dir(request: FixtureRequest):
     return request.config.getoption("--ov-config-dir")
 
 
 @pytest.fixture(scope="module")
-def pip_cache_dir(request):
+def pip_cache_dir(request: FixtureRequest):
     return request.config.getoption("--pip-cache-dir")
 
 
 @pytest.fixture(params=[True, False], ids=["per_channel", "per_tensor"])
-def is_per_channel(request):
+def is_per_channel(request: FixtureRequest):
     return request.param
 
 
 @pytest.fixture(params=[True, False], ids=["signed", "unsigned"])
-def is_signed(request):
+def is_signed(request: FixtureRequest):
     return request.param
 
 
 @pytest.fixture(params=[True, False], ids=["weights", "activation"])
-def is_weights(request):
+def is_weights(request: FixtureRequest):
     return request.param
 
 
 @pytest.fixture(params=[True, False], ids=["cuda", "cpu"])
-def use_cuda(request):
+def use_cuda(request: FixtureRequest):
     return request.param
 
 
 @pytest.fixture(params=[True, False], ids=["half_range", "full_range"])
-def is_half_range(request):
+def is_half_range(request: FixtureRequest):
     return request.param
 
 
 @pytest.fixture(params=[QuantizationMode.SYMMETRIC, QuantizationMode.ASYMMETRIC])
-def quantization_mode(request):
+def quantization_mode(request: FixtureRequest):
     return request.param
 
 
@@ -244,8 +248,8 @@ def runs_subprocess_in_precommit():
 
 
 @pytest.fixture(scope="module")
-def distributed_mode_sync_port(request):
-    return request.config.getoption("--distributed-mode-sync-port")
+def distributed_mode_sync_port(request: FixtureRequest):
+    return request.config.getoption("--cuda-ip")
 
 
 @pytest.fixture

--- a/tests/torch/quantization/test_sanity_sample.py
+++ b/tests/torch/quantization/test_sanity_sample.py
@@ -363,7 +363,7 @@ def fixture_export_desc(request):
 def test_export_behavior(export_desc: PrecisionTestCaseDescriptor, tmp_path, mocker, extra_args, is_export_called):
     validator = export_desc.get_validator()
     args = validator.get_default_args(tmp_path)
-    args["--to-onnx"] = tmp_path / "model.onnx"
+    args["--export-model-path"] = tmp_path / "model.onnx"
     if extra_args is not None:
         args.update(extra_args)
     validator.is_export_called = is_export_called

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -11,6 +11,7 @@ pyparsing<3.0
 
 # Required for search_building_blocks tests
 transformers[torch]~=4.30.0
+accelerate==0.24.1
 
 # Required for movement_sparsity tests
 datasets~=2.14.0

--- a/tests/torch/test_sanity_sample.py
+++ b/tests/torch/test_sanity_sample.py
@@ -397,7 +397,7 @@ class TestSanitySample:
             "--mode": "export",
             "--config": config_factory.serialize(),
             "--resume": ckpt_path,
-            "--to-onnx": onnx_path,
+            "--export-model-path": onnx_path,
         }
 
         if not torch.cuda.is_available():
@@ -422,7 +422,12 @@ class TestSanitySample:
         config_factory = ConfigFactory(config, tmp_path / "config.json")
 
         onnx_path = os.path.join(str(tmp_path), "model.onnx")
-        args = {"--mode": "export", "--config": config_factory.serialize(), "--pretrained": "", "--to-onnx": onnx_path}
+        args = {
+            "--mode": "export",
+            "--config": config_factory.serialize(),
+            "--pretrained": "",
+            "--export-model-path": onnx_path,
+        }
 
         if not torch.cuda.is_available():
             args["--cpu-only"] = True

--- a/tests/torch/test_sota_checkpoints.py
+++ b/tests/torch/test_sota_checkpoints.py
@@ -20,6 +20,7 @@ from typing import List, Optional, Tuple
 
 import pandas as pd
 import pytest
+from pytest import FixtureRequest
 
 from tests.shared.metric_thresholds import DIFF_FP32_MAX_GLOBAL
 from tests.shared.metric_thresholds import DIFF_FP32_MIN_GLOBAL
@@ -223,7 +224,7 @@ def generate_run_examples_command(
 
 
 @pytest.fixture(scope="module")
-def metrics_dump_dir(request):
+def metrics_dump_dir(request: FixtureRequest):
     """
     Path to collect metrics from the tests.
     To set this by pytest argument use '--metrics-dump-path'.
@@ -237,8 +238,7 @@ def metrics_dump_dir(request):
             PROJECT_ROOT / "test_results" / "metrics_dump_"
             f"{'_'.join([str(getattr(data, atr)) for atr in ['year', 'month', 'day', 'hour', 'minute', 'second']])}"
         )
-    else:
-        dump_path = Path(dump_path)
+
     dump_path.mkdir(exist_ok=True, parents=True)
     assert not dump_path.is_dir() or not next(
         dump_path.iterdir(), None
@@ -270,7 +270,7 @@ class TestSotaCheckpoints:
             print(f"Result file: {path}")
 
     @pytest.fixture(params=EVAL_TEST_STRUCT, ids=idfn)
-    def eval_run_param(self, request) -> EvalRunParamsStruct:
+    def eval_run_param(self, request: FixtureRequest) -> EvalRunParamsStruct:
         """
         Returns the test cases that were built from the `tests/torch/sota_checkpoints_eval.json` file.
         """


### PR DESCRIPTION
### Changes

- Update argument name in tests 
- accelerate==0.24.1, 0.25.0 raises exception 
  ```
  NotImplementedError: Using RTX 3090 or 4000 series doesn't support faster communication broadband via P2P or IB. Please set `NCCL_P2P_DISABLE="1"` and `NCCL_IB_DISABLE="1" or use `accelerate launch` which will do this automatically.
  ```
- Path type in addoption