### PR TITLE
[PTQ] Bump OV opset from 9 to 13

### DIFF
--- a/nncf/openvino/graph/model_transformer.py
+++ b/nncf/openvino/graph/model_transformer.py
@@ -16,7 +16,7 @@ from typing import Callable, Dict, List, Tuple
 import numpy as np
 import openvino.runtime as ov
 from openvino._pyopenvino import DescriptorTensor
-from openvino.runtime import opset9 as opset
+from openvino.runtime import opset13 as opset
 
 from nncf.common.graph.model_transformer import ModelTransformer
 from nncf.common.graph.model_transformer import TModel
@@ -358,8 +358,7 @@ class OVModelTransformer(ModelTransformer):
         const_dtype = const_node.data.dtype
         const_value = np.reshape(const_value, const_shape).astype(const_dtype)
 
-        # TODO(andrey-churkin): Replace on opset13.constant() in a future release
-        new_const_node = ov.op.Constant(const_value, shared_memory=True)
+        new_const_node = opset.constant(const_value, shared_memory=True)
         new_const_node.set_friendly_name(const_node.get_friendly_name())
         const_port.replace_source_output(new_const_node.output(0))
 

--- a/nncf/openvino/graph/model_transformer.py
+++ b/nncf/openvino/graph/model_transformer.py
@@ -358,7 +358,8 @@ class OVModelTransformer(ModelTransformer):
         const_dtype = const_node.data.dtype
         const_value = np.reshape(const_value, const_shape).astype(const_dtype)
 
-        new_const_node = opset.constant(const_value, shared_memory=True)
+        # TODO(andrey-churkin): Replace on opset13.constant() in 2023.3 release
+        new_const_node = ov.op.Constant(const_value, shared_memory=True)
         new_const_node.set_friendly_name(const_node.get_friendly_name())
         const_port.replace_source_output(new_const_node.output(0))
 

--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import numpy as np
 import openvino.runtime as ov
-import openvino.runtime.opset9 as opset
+import openvino.runtime.opset13 as opset
 
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -14,7 +14,7 @@ from typing import List, Optional, Tuple, TypeVar
 
 import numpy as np
 import openvino.runtime as ov
-from openvino.runtime import opset9 as opset
+from openvino.runtime import opset13 as opset
 
 from nncf.common.graph import NNCFNode
 from nncf.common.graph.operator_metatypes import OperatorMetatype

--- a/tests/openvino/native/models.py
+++ b/tests/openvino/native/models.py
@@ -14,9 +14,7 @@ from abc import abstractmethod
 
 import numpy as np
 import openvino.runtime as ov
-from openvino.runtime import opset9 as opset
-from openvino.runtime import opset12
-from openvino.runtime import opset13
+from openvino.runtime import opset13 as opset
 
 from nncf.common.utils.registry import Registry
 
@@ -705,7 +703,7 @@ class GroupNormalizationModel(OVReferenceModel):
 
         scale = self._rng.random(channels).astype(np.float32)
         bias = self._rng.random(channels).astype(np.float32)
-        group_norm = opset12.group_normalization(conv_add, scale, bias, num_groups=channels, epsilon=1e-5)
+        group_norm = opset.group_normalization(conv_add, scale, bias, num_groups=channels, epsilon=1e-5)
 
         relu = opset.relu(group_norm, name="Relu")
 
@@ -833,7 +831,7 @@ class ScaledDotProductAttentionModel(OVReferenceModel):
         value = opset.parameter([1, 1, 1, 64], name="Input_3")
         attn_mask = opset.parameter([1, 1, 1, 1], name="Input_4")
 
-        attn = opset13.scaled_dot_product_attention(query, key, value, attn_mask)
+        attn = opset.scaled_dot_product_attention(query, key, value, attn_mask)
         result = opset.result(attn, name="Result")
         result.get_output_tensor(0).set_names(set(["Result"]))
         model = ov.Model([result], [query, key, value, attn_mask])

--- a/tests/openvino/native/quantization/test_quantize_api.py
+++ b/tests/openvino/native/quantization/test_quantize_api.py
@@ -13,7 +13,7 @@ from openvino.runtime import Model
 from openvino.runtime import Shape
 from openvino.runtime import Type
 from openvino.runtime import op
-from openvino.runtime import opset8
+from openvino.runtime import opset13 as opset
 
 import nncf
 from nncf import Dataset
@@ -25,7 +25,7 @@ INPUT_SHAPE = [2, 1, 1, 1]
 def get_mock_model() -> Model:
     param_node = op.Parameter(Type.f32, Shape(INPUT_SHAPE))
     softmax_axis = 1
-    softmax_node = opset8.softmax(param_node, softmax_axis)
+    softmax_node = opset.softmax(param_node, softmax_axis)
     return Model(softmax_node, [param_node], "mock")
 
 

--- a/tests/openvino/native/test_layer_attributes.py
+++ b/tests/openvino/native/test_layer_attributes.py
@@ -15,7 +15,7 @@ from typing import Callable, Tuple
 import numpy as np
 import openvino.runtime as ov
 import pytest
-from openvino.runtime import opset9 as opset
+from openvino.runtime import opset13 as opset
 
 from nncf.common.graph.layer_attributes import ConvolutionLayerAttributes
 from nncf.common.graph.layer_attributes import GenericWeightedLayerAttributes

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -15,7 +15,7 @@ from typing import Callable, List, Tuple
 import numpy as np
 import openvino.runtime as ov
 import pytest
-from openvino.runtime import opset9 as opset
+from openvino.runtime import opset13 as opset
 
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.transformations.layout import TransformationLayout

--- a/tests/openvino/native/test_node_utils.py
+++ b/tests/openvino/native/test_node_utils.py
@@ -11,7 +11,7 @@
 
 import numpy as np
 import pytest
-from openvino.runtime import opset9 as opset
+from openvino.runtime import opset13 as opset
 
 from nncf.common.factory import NNCFGraphFactory
 from nncf.common.graph.graph import NNCFNode

--- a/tests/openvino/native/test_statistics_aggregator.py
+++ b/tests/openvino/native/test_statistics_aggregator.py
@@ -14,7 +14,7 @@ from typing import List, Type
 import numpy as np
 import openvino.runtime as ov
 import pytest
-from openvino.runtime import opset9 as opset
+from openvino.runtime import opset13 as opset
 
 from nncf import Dataset
 from nncf.common.graph.transformations.commands import TargetPoint

--- a/tests/openvino/test_telemetry.py
+++ b/tests/openvino/test_telemetry.py
@@ -12,7 +12,7 @@ from openvino.runtime import Model
 from openvino.runtime import Shape
 from openvino.runtime import Type
 from openvino.runtime import op
-from openvino.runtime import opset8
+from openvino.runtime import opset13 as opset
 
 import nncf
 from nncf import Dataset
@@ -25,7 +25,7 @@ INPUT_SHAPE = [2, 1, 1, 1]
 def get_mock_model() -> Model:
     param_node = op.Parameter(Type.f32, Shape(INPUT_SHAPE))
     softmax_axis = 1
-    softmax_node = opset8.softmax(param_node, softmax_axis)
+    softmax_node = opset.softmax(param_node, softmax_axis)
     return Model(softmax_node, [param_node], "mock")
 
 


### PR DESCRIPTION
### Changes

Default OV opset has been changed to `opset13`

### Reason for changes

<!--- Why should the change be applied -->

### Related tickets

125777

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
