### PR TITLE
Added option for compressing first and last layers

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -51,7 +51,7 @@ class WeightCompression(Algorithm):
         ratio: float = None,
         group_size: int = None,
         ignored_scope: Optional[IgnoredScope] = None,
-        first_and_last: bool = False,
+        all_layers: bool = False,
     ):
         """
         :param mode: Defines a mode for weight compression.
@@ -73,8 +73,8 @@ class WeightCompression(Algorithm):
             that share quantization parameters (scale). The value -1 means no grouping.
         :param ignored_scope: An ignored scope that defined the list of model control
             flow graph nodes to be ignored during quantization.
-        :param first_and_last: Indicates whether the first and last layers should be compressed to a primary
-            precision. By default, the backup precision is assigned for the first and last layers.
+        :param all_layers: Indicates whether embeddings and last layers should be compressed to a primary
+            precision. By default, the backup precision is assigned for the embeddings and last layers.
         """
         super().__init__()
         self._mode = mode
@@ -83,7 +83,7 @@ class WeightCompression(Algorithm):
         self._ignored_scope = IgnoredScope() if ignored_scope is None else ignored_scope
         self._backend_entity = None
         self._algorithm_key = f"CW_{hash(self)}"
-        self._first_and_last = first_and_last
+        self._all_layers = all_layers
 
     @property
     def available_backends(self) -> List[BackendType]:
@@ -116,7 +116,7 @@ class WeightCompression(Algorithm):
         self._backend_entity.validate_params(self._mode, self._ignored_scope)
         nodes_to_compress = self._get_nodes_to_compress(graph)
         transformed_model = self._backend_entity.do_compression(
-            model, nodes_to_compress, self._mode, self._ratio, self._group_size, self._first_and_last
+            model, nodes_to_compress, self._mode, self._ratio, self._group_size, self._all_layers
         )
         return transformed_model
 

--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -51,6 +51,7 @@ class WeightCompression(Algorithm):
         ratio: float = None,
         group_size: int = None,
         ignored_scope: Optional[IgnoredScope] = None,
+        first_and_last: bool = False,
     ):
         """
         :param mode: Defines a mode for weight compression.
@@ -72,6 +73,8 @@ class WeightCompression(Algorithm):
             that share quantization parameters (scale). The value -1 means no grouping.
         :param ignored_scope: An ignored scope that defined the list of model control
             flow graph nodes to be ignored during quantization.
+        :param first_and_last: Indicates whether the first and last layers should be compressed to a primary
+            precision. By default, the backup precision is assigned for the first and last layers.
         """
         super().__init__()
         self._mode = mode
@@ -80,6 +83,7 @@ class WeightCompression(Algorithm):
         self._ignored_scope = IgnoredScope() if ignored_scope is None else ignored_scope
         self._backend_entity = None
         self._algorithm_key = f"CW_{hash(self)}"
+        self._first_and_last = first_and_last
 
     @property
     def available_backends(self) -> List[BackendType]:
@@ -112,7 +116,7 @@ class WeightCompression(Algorithm):
         self._backend_entity.validate_params(self._mode, self._ignored_scope)
         nodes_to_compress = self._get_nodes_to_compress(graph)
         transformed_model = self._backend_entity.do_compression(
-            model, nodes_to_compress, self._mode, self._ratio, self._group_size
+            model, nodes_to_compress, self._mode, self._ratio, self._group_size, self._first_and_last
         )
         return transformed_model
 

--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -51,7 +51,7 @@ class WeightCompression(Algorithm):
         ratio: float = None,
         group_size: int = None,
         ignored_scope: Optional[IgnoredScope] = None,
-        all_layers: bool = False,
+        all_layers: Optional[bool] = False,
     ):
         """
         :param mode: Defines a mode for weight compression.

--- a/nncf/quantization/algorithms/weight_compression/backend.py
+++ b/nncf/quantization/algorithms/weight_compression/backend.py
@@ -71,6 +71,7 @@ class WeightCompressionAlgoBackend(ABC):
         mode: CompressWeightsMode,
         ratio: float = None,
         group_size: int = None,
+        first_and_last: bool = False,
     ) -> TModel:
         """
         Compress weights of Linear and Embedding layers to 8-bit integer or to nf4
@@ -96,5 +97,7 @@ class WeightCompressionAlgoBackend(ABC):
             and the rest to INT8_ASYM).
         :param group_size: Number of weights (e.g. 128) in the channel dimension
             that share quantization parameters (scale). The value -1 means no grouping.
+        :param first_and_last: Indicates whether the first and last layers should be compressed to a primary
+            precision. By default, the backup precision is assigned for the first and last layers.
         :return: A resulting model with compressed weights.
         """

--- a/nncf/quantization/algorithms/weight_compression/backend.py
+++ b/nncf/quantization/algorithms/weight_compression/backend.py
@@ -71,7 +71,7 @@ class WeightCompressionAlgoBackend(ABC):
         mode: CompressWeightsMode,
         ratio: float = None,
         group_size: int = None,
-        first_and_last: bool = False,
+        all_layers: bool = False,
     ) -> TModel:
         """
         Compress weights of Linear and Embedding layers to 8-bit integer or to nf4
@@ -97,7 +97,7 @@ class WeightCompressionAlgoBackend(ABC):
             and the rest to INT8_ASYM).
         :param group_size: Number of weights (e.g. 128) in the channel dimension
             that share quantization parameters (scale). The value -1 means no grouping.
-        :param first_and_last: Indicates whether the first and last layers should be compressed to a primary
-            precision. By default, the backup precision is assigned for the first and last layers.
+        :param all_layers: Indicates whether embeddings and last layers should be compressed to a primary
+            precision. By default, the backup precision is assigned for the embeddings and last layers.
         :return: A resulting model with compressed weights.
         """

--- a/nncf/quantization/algorithms/weight_compression/backend.py
+++ b/nncf/quantization/algorithms/weight_compression/backend.py
@@ -71,7 +71,7 @@ class WeightCompressionAlgoBackend(ABC):
         mode: CompressWeightsMode,
         ratio: float = None,
         group_size: int = None,
-        all_layers: bool = False,
+        all_layers: Optional[bool] = False,
     ) -> TModel:
         """
         Compress weights of Linear and Embedding layers to 8-bit integer or to nf4

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -53,7 +53,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
         mode: CompressWeightsMode,
         ratio: float = None,
         group_size: int = None,
-        all_layers: bool = False,
+        all_layers: Optional[bool] = False,
     ) -> ov.Model:
         all_weight_params: List[WeightNodeParams] = []
         quantized_nodes_ids = set()
@@ -103,9 +103,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                 all_weight_params.append(weight_params)
                 quantized_nodes_ids.add(id(weight_node))
 
-        internal_weight_params = _get_internal_weight_params(
-            all_weight_params, mode, is_last_layer_shared, all_layers
-        )
+        internal_weight_params = _get_internal_weight_params(all_weight_params, mode, is_last_layer_shared, all_layers)
         _set_weight_compression_config(internal_weight_params, mode, ratio, group_size)
         nncf_logger.info(_get_bitwidth_distribution_str(all_weight_params, internal_weight_params))
 

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -53,13 +53,14 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
         mode: CompressWeightsMode,
         ratio: float = None,
         group_size: int = None,
+        first_and_last: bool = False,
     ) -> ov.Model:
         all_weight_params: List[WeightNodeParams] = []
         quantized_nodes_ids = set()
 
         friendly_name_to_op_map = {op.get_friendly_name(): op for op in model.get_ops()}
 
-        is_last_layer_compressed = False
+        is_last_layer_shared = False
         n = len(nodes_to_compress)
         for i, nncf_node in enumerate(nodes_to_compress):
             weight_port_ids = nncf_node.layer_attributes.get_const_port_ids()
@@ -70,7 +71,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                     continue
                 if id(weight_node) in quantized_nodes_ids:
                     if i == n - 1:
-                        is_last_layer_compressed = True
+                        is_last_layer_shared = True
                     continue
                 weight_output = weight_node.output(0)
 
@@ -102,7 +103,9 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                 all_weight_params.append(weight_params)
                 quantized_nodes_ids.add(id(weight_node))
 
-        internal_weight_params = _get_internal_weight_params(all_weight_params, mode, is_last_layer_compressed)
+        internal_weight_params = _get_internal_weight_params(
+            all_weight_params, mode, is_last_layer_shared, first_and_last
+        )
         _set_weight_compression_config(internal_weight_params, mode, ratio, group_size)
         nncf_logger.info(_get_bitwidth_distribution_str(all_weight_params, internal_weight_params))
 
@@ -377,20 +380,25 @@ def _get_bitwidth_distribution_str(all_params: List[WeightNodeParams], internal_
 
 
 def _get_internal_weight_params(
-    all_weight_params: List[WeightNodeParams], mode: CompressWeightsMode, is_last_layer_compressed: bool
+    all_weight_params: List[WeightNodeParams],
+    mode: CompressWeightsMode,
+    is_last_layer_shared: bool,
+    first_and_last: bool,
 ) -> List[WeightNodeParams]:
     """
     Returns the internal weight parameters.
 
     :param all_weight_params: List of all weight parameters.
     :param mode: Weight compression mode.
-    :param is_last_layer_compressed: Indicates whether the last layer is compressed.
+    :param is_last_layer_shared: Indicates whether the last layer shares the weight to be quantized.
+    :param first_and_last: Indicates whether the first and last layers should be compressed to a primary
+        precision. By default, the backup precision is assigned for the first and last layers.
     :return: List of information about weight nodes that are considered for mixed precision.
     """
     internal_weight_params = all_weight_params
-    if mode not in [CompressWeightsMode.INT8_SYM, CompressWeightsMode.INT8_ASYM]:
+    if mode not in [CompressWeightsMode.INT8_SYM, CompressWeightsMode.INT8_ASYM] and not first_and_last:
         internal_weight_params = list(filter(lambda wp: wp.metatype != OVEmbeddingMetatype, internal_weight_params))
-        if not is_last_layer_compressed:
+        if not is_last_layer_shared:
             internal_weight_params = internal_weight_params[:-1]
     return internal_weight_params
 

--- a/nncf/quantization/quantize_model.py
+++ b/nncf/quantization/quantize_model.py
@@ -291,7 +291,7 @@ def compress_weights(
                 "Default values of `ratio` (1) and `group_size` (-1) parameters can not be overridden"
             )
         if all_layers is not None:
-            raise AttributeError("INT8 modes does not support `all_layers` option, set it to None.")
+            raise AttributeError("INT8 modes do not support `all_layers` option, set it to None.")
     else:
         if ratio is None:
             ratio = 1

--- a/nncf/quantization/quantize_model.py
+++ b/nncf/quantization/quantize_model.py
@@ -246,6 +246,7 @@ def compress_weights(
     ratio: Optional[float] = None,
     group_size: Optional[int] = None,
     ignored_scope: Optional[IgnoredScope] = None,
+    first_and_last: bool = False,
 ) -> TModel:
     """
     Compress model weights.
@@ -269,6 +270,8 @@ def compress_weights(
         The value -1 means no grouping.
     :param ignored_scope: An ignored scope that defined the list of model control
         flow graph nodes to be ignored during quantization.
+    :param first_and_last: Indicates whether the first and last layers should be compressed to a primary
+        precision. By default, the backup precision is assigned for the first and last layers.
     :return: The non-trainable model with compressed weights.
     """
     if mode == CompressWeightsMode.INT8:
@@ -299,7 +302,7 @@ def compress_weights(
 
         return compress_weights_impl(model, mode, ratio, group_size, ignored_scope)
 
-    compression_algorithm = WeightCompression(mode, ratio, group_size, ignored_scope)
+    compression_algorithm = WeightCompression(mode, ratio, group_size, ignored_scope, first_and_last)
     graph = NNCFGraphFactory.create(model)
     return compression_algorithm.apply(model, graph)
 

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -209,9 +209,9 @@ def test_mixed_precision(ratio, group_size, ref_nf4_nodes):
     assert ref_nf4_nodes == names
 
 
-def test_compress_first_and_last():
+def test_compress_all_layers():
     model = SequentialMatmulModel().ov_model
-    compressed_model = compress_weights(model, mode=CompressWeightsMode.NF4, ratio=1, group_size=1, first_and_last=True)
+    compressed_model = compress_weights(model, mode=CompressWeightsMode.NF4, ratio=1, group_size=1, all_layers=True)
     num_int4 = sum(1 for op in compressed_model.get_ordered_ops() if op.get_element_type() == ov.Type.nf4)
     assert num_int4 == 5
 


### PR DESCRIPTION
### Changes

as stated in the title

### Reason for changes

some models, e.g. Qwen, may benefit from quantization of the first and last layers to 4-bit
but by default, they were always quantized to 8-bit

### Tests

test_compress_first_and_last
test_mixed_precision
