### PR TITLE
Data-based mixed-precision for weight compression

### DIFF
--- a/docs/compression_algorithms/CompressWeights.md
+++ b/docs/compression_algorithms/CompressWeights.md
@@ -236,55 +236,46 @@ Here is the word perplexity with data-free and data-based mixed-precision INT4-I
         <td>Model</td>
         <td>Mode</td>
         <td>Word Perplexity (↓)</td>
-        <td></td>
     </tr>
     <tr>
         <td>meta-llama/llama-7b-chat-hf</td>
         <td>int4_sym_g128_r80_data</td>
         <td>11.87</td>
-        <td></td>
     </tr>
     <tr>
         <td>meta-llama/llama-7b-chat-hf</td>
         <td>int4_sym_g128_r80</td>
         <td>11.92</td>
-        <td></td>
     </tr>
     <tr>
         <td>stabilityai_stablelm-3b-4e1t</td>
         <td>int4_sym_g64_r80_data</td>
         <td>10.67</td>
-        <td></td>
     </tr>
     <tr>
         <td>stabilityai_stablelm-3b-4e1t</td>
         <td>int4_sym_g64_r80</td>
         <td>10.83</td>
-        <td></td>
     </tr>
     <tr>
         <td>stable-zephyr-3b-dpo</td>
         <td>int4_sym_g64_r80_data</td>
         <td>21.74</td>
-        <td></td>
     </tr>
     <tr>
         <td>stable-zephyr-3b-dpo</td>
         <td>int4_sym_g64_r80</td>
         <td>23.10</td>
-        <td></td>
     </tr>
     <tr>
         <td>HuggingFaceH4/zephyr-7b-beta</td>
         <td>int4_sym_g128_r80_data</td>
         <td>10.13</td>
-        <td></td>
     </tr>
     <tr>
         <td>HuggingFaceH4/zephyr-7b-beta</td>
         <td>int4_sym_g128</td>
         <td>10.22</td>
-        <td></td>
     </tr>
 </table>
 

--- a/docs/compression_algorithms/CompressWeights.md
+++ b/docs/compression_algorithms/CompressWeights.md
@@ -26,16 +26,14 @@ compressed_model = compress_weights(model)
 - Compress weights symmetrically to 8-bit integer data type.
 
 ```python
-from nncf import compress_weights
-from nncf import CompressWeightsMode
+from nncf import compress_weights, CompressWeightsMode
 compressed_model = compress_weights(model, mode=CompressWeightsMode.INT8_SYM)
 ```
 
 - Compress weights symmetrically to 4-bit integer data type with group size = 128, except embeddings and last linear layers - they are compressed asymmetrically to 8-bit integer data type.
 
 ```python
-from nncf import compress_weights
-from nncf import CompressWeightsMode
+from nncf import compress_weights, CompressWeightsMode
 compressed_model = compress_weights(model, mode=CompressWeightsMode.INT4_SYM)
 ```
 
@@ -47,9 +45,19 @@ compressed_model = compress_weights(model, mode=CompressWeightsMode.INT4_SYM)
   the rest of layers to 8-bit asymmetric integer data type. The same parametrization is applicable for `INT4_SYM` mode.
 
 ```python
-from nncf import compress_weights
-from nncf import CompressWeightsMode
+from nncf import compress_weights, CompressWeightsMode
 compressed_model = compress_weights(model, mode=CompressWeightsMode.INT4_ASYM, group_size=64, ratio=0.9)
+```
+
+- Accuracy of the 4-bit compressed models can be improved by using data-based mixed-precision algorithm. It is capable to find outliers in the input activations and assign different quantization precision to minimize accuracy degradation.
+Below is the example how to compress 80% of layers to 4-bit integer with a default data-based mixed precision algorithm.
+It requires just one extra parameter - a NNCF wrapper of the dataset. If dataset is not specified, data-free mixed precision algorithm works based on weights only.
+Please refer to the second table below for evaluation of data-free and data-based method on the wikitext dataset.
+
+```python
+from nncf import compress_weights, CompressWeightsMode, Dataset
+nncf_dataset = nncf.Dataset(data_source, transform_fn)
+compressed_model = compress_weights(model, mode=CompressWeightsMode.INT4_SYM, ratio=0.8, dataset=nncf_dataset)
 ```
 
 - `NF4` mode can be considered for improving accuracy, but currently models quantized to nf4 should not be faster models
@@ -57,8 +65,7 @@ compressed_model = compress_weights(model, mode=CompressWeightsMode.INT4_ASYM, g
   Different `group_size` and `ratio` are also supported.
 
 ```python
-from nncf import compress_weights
-from nncf import CompressWeightsMode
+from nncf import compress_weights, CompressWeightsMode
 compressed_model = compress_weights(model, mode=CompressWeightsMode.NF4)
 ```
 
@@ -72,8 +79,8 @@ Here is the perplexity and model size before and after weight compression for di
   <tr>
     <th class="tg-0pky">Model</th>
     <th class="tg-0pky">Mode</th>
-    <th class="tg-0pky">Perplexity</th>
-    <th class="tg-0pky">Perplexity <br>Increase</th>
+    <th class="tg-0pky">Perplexity (↓)</th>
+    <th class="tg-0pky">Perplexity <br>Increase (↓)</th>
     <th class="tg-0pky">Model Size <br>(Gb)</th>
   </tr>
 </thead>
@@ -219,6 +226,66 @@ Here is the perplexity and model size before and after weight compression for di
     <td class="tg-0pky">6.6</td>
   </tr>
 </tbody>
+</table>
+
+Here is the word perplexity with data-free and data-based mixed-precision INT4-INT8 weight compression for different language models on the [wikitext dataset](https://arxiv.org/pdf/1609.07843.pdf).
+`data` suffix refers to the data-based mixed-precision.
+
+<table>
+    <tr>
+        <td>Model</td>
+        <td>Mode</td>
+        <td>Word Perplexity (↓)</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>meta-llama/llama-7b-chat-hf</td>
+        <td>int4_sym_g128_r80_data</td>
+        <td>11.87</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>meta-llama/llama-7b-chat-hf</td>
+        <td>int4_sym_g128_r80</td>
+        <td>11.92</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>stabilityai_stablelm-3b-4e1t</td>
+        <td>int4_sym_g64_r80_data</td>
+        <td>10.67</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>stabilityai_stablelm-3b-4e1t</td>
+        <td>int4_sym_g64_r80</td>
+        <td>10.83</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>stable-zephyr-3b-dpo</td>
+        <td>int4_sym_g64_r80_data</td>
+        <td>21.74</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>stable-zephyr-3b-dpo</td>
+        <td>int4_sym_g64_r80</td>
+        <td>23.10</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>HuggingFaceH4/zephyr-7b-beta</td>
+        <td>int4_sym_g128_r80_data</td>
+        <td>10.13</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>HuggingFaceH4/zephyr-7b-beta</td>
+        <td>int4_sym_g128</td>
+        <td>10.22</td>
+        <td></td>
+    </tr>
 </table>
 
 #### Limitations

--- a/nncf/parameters.py
+++ b/nncf/parameters.py
@@ -89,17 +89,17 @@ class CompressWeightsMode(Enum):
     INT8 = "int8"  # Deprecated mode
 
 
-class MixedPrecisionMode(Enum):
+class SensitivityMetric(Enum):
     """
     Defines a mode for selecting quantization precision.
     :param : TODO:
     """
 
-    INT8_ERROR = "int8_error"
-    HAWQ_IN = "hawq_in"
-    MEAN_VAR = "mean_var"
-    MAX_VAR = "max_var"
-    MEAN_MAX = "mean_max"
+    WEIGHT_QUANTIZATION_ERROR = "int8_error"
+    HESSIAN_INPUT_ACTIVATION = "hawq_in"
+    MEAN_ACTIVATION_VARIANCE = "mean_var"
+    MAX_ACTIVATION_VARIANCE = "max_var"
+    MEAN_ACTIVATION_MAGNITUDE = "mean_max"
 
 
 @api(canonical_alias="nncf.QuantizationMode")

--- a/nncf/parameters.py
+++ b/nncf/parameters.py
@@ -108,11 +108,11 @@ class SensitivityMetric(Enum):
         multiplied by inverted 8-bit quantization noise.
     """
 
-    WEIGHT_QUANTIZATION_ERROR = "int8_error"
-    HESSIAN_INPUT_ACTIVATION = "hawq_in"
-    MEAN_ACTIVATION_VARIANCE = "mean_var"
-    MAX_ACTIVATION_VARIANCE = "max_var"
-    MEAN_ACTIVATION_MAGNITUDE = "mean_max"
+    WEIGHT_QUANTIZATION_ERROR = "weight_quantization_error"
+    HESSIAN_INPUT_ACTIVATION = "hessian_input_activation"
+    MEAN_ACTIVATION_VARIANCE = "mean_activation_variance"
+    MAX_ACTIVATION_VARIANCE = "max_activation_variance"
+    MEAN_ACTIVATION_MAGNITUDE = "mean_activation_magnitude"
 
 
 @api(canonical_alias="nncf.QuantizationMode")

--- a/nncf/parameters.py
+++ b/nncf/parameters.py
@@ -91,8 +91,21 @@ class CompressWeightsMode(Enum):
 
 class SensitivityMetric(Enum):
     """
-    Defines a mode for selecting quantization precision.
-    :param : TODO:
+    Defines a sensitivity metric for assigning quantization precision to layers. In order to
+        preserve the accuracy of the model, the more sensitive layers receives a higher precision.
+
+    :param WEIGHT_QUANTIZATION_ERROR: The inverted 8-bit quantization noise. Weights with highest value
+        of this metric can be accurately quantized channel-wise to 8-bit. The idea is to leave these weights in 8bit,
+        and quantize the rest of layers to 4-bit group-wise. Since group-wise is more accurate than per-channel,
+        accuracy should not degrade.
+    :param HESSIAN_INPUT_ACTIVATION: The average Hessian trace of weights with respect to the layer-wise quantization
+        error multiplied by L2 norm of 8-bit quantization noise.
+    :param MEAN_ACTIVATION_VARIANCE: The mean variance of the layers' inputs
+        multiplied by inverted 8-bit quantization noise.
+    :param MAX_ACTIVATION_VARIANCE: The maximum variance of the layers' inputs
+        multiplied by inverted 8-bit quantization noise.
+    :param MEAN_ACTIVATION_MAGNITUDE: The mean magnitude of the layers' inputs
+        multiplied by inverted 8-bit quantization noise.
     """
 
     WEIGHT_QUANTIZATION_ERROR = "int8_error"

--- a/nncf/parameters.py
+++ b/nncf/parameters.py
@@ -89,6 +89,19 @@ class CompressWeightsMode(Enum):
     INT8 = "int8"  # Deprecated mode
 
 
+class MixedPrecisionMode(Enum):
+    """
+    Defines a mode for selecting quantization precision.
+    :param : TODO:
+    """
+
+    INT8_ERROR = "int8_error"
+    HAWQ_IN = "hawq_in"
+    MEAN_VAR = "mean_var"
+    MAX_VAR = "max_var"
+    MEAN_MAX = "mean_max"
+
+
 @api(canonical_alias="nncf.QuantizationMode")
 class QuantizationMode(Enum):
     """

--- a/nncf/quantization/algorithms/bias_correction/algorithm.py
+++ b/nncf/quantization/algorithms/bias_correction/algorithm.py
@@ -432,6 +432,7 @@ class BiasCorrection(Algorithm):
 
     def _get_fp_inputs(self, statistic_points: StatisticPointsContainer, node_name: str, port_id: int) -> np.ndarray:
         """
+        # TODO: paraphrase
         Makes out pre-layer needed data from the floating-point collected statistics.
 
         :param statistic_points: Filled StatisticPointsContainer.
@@ -565,8 +566,9 @@ class BiasCorrection(Algorithm):
         :return: Tuple with the activation node and port id.
         """
         activation_port = self._backend_entity.get_activation_port_id(node, nncf_graph)
-        activation_node = nncf_graph.get_input_edges(node)[activation_port].from_node
-        port_id = nncf_graph.get_edge(activation_node, node).output_port_id
+        activation_edge = nncf_graph.get_input_edges(node)[activation_port]
+        activation_node = activation_edge.from_node
+        port_id = activation_edge.output_port_id
         return activation_node, port_id
 
     def _get_biased_after_nodes(self, nncf_graph: NNCFGraph, nodes: List[NNCFNode], model: TModel) -> List[NNCFNode]:

--- a/nncf/quantization/algorithms/bias_correction/backend.py
+++ b/nncf/quantization/algorithms/bias_correction/backend.py
@@ -103,7 +103,7 @@ class BiasCorrectionAlgoBackend(ABC):
     def raw_statistic_collector(inplace: bool, num_samples: int = None) -> TensorStatisticCollectorBase:
         """
         Returns backend-specific raw statistic collector.
-        This statistic collector uses for raw data calculation, without aggregating.
+        This statistic collector is used for raw data calculation, without aggregating.
 
         :param inplace: Whether to calculate statistic inplace or not.
         :param num_samples: Maximum number of samples to collect.
@@ -131,7 +131,7 @@ class BiasCorrectionAlgoBackend(ABC):
 
         :param node: Node of NNCFGraph with bias value.
         :param nncf_graph: NNCFGraph instance with the node.
-        :return: boolean port id.
+        :return: target input port id.
         """
 
     @staticmethod

--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -35,7 +35,7 @@ from nncf.common.utils.backend import get_backend
 from nncf.openvino.graph.transformations.commands import TargetType
 from nncf.openvino.statistics.aggregator import OVStatisticsAggregator
 from nncf.parameters import CompressWeightsMode
-from nncf.parameters import MixedPrecisionMode
+from nncf.parameters import SensitivityMetric
 from nncf.quantization.algorithms.algorithm import Algorithm
 from nncf.scopes import IgnoredScope
 from nncf.scopes import get_ignored_node_names_from_ignored_scope
@@ -59,7 +59,7 @@ class WeightCompression(Algorithm):
         group_size: int = None,
         ignored_scope: Optional[IgnoredScope] = None,
         all_layers: Optional[bool] = False,
-        mixed_precision_mode: Optional[MixedPrecisionMode] = MixedPrecisionMode.INT8_ERROR,
+        sensitivity_metric: Optional[SensitivityMetric] = SensitivityMetric.WEIGHT_QUANTIZATION_ERROR,
     ):
         """
         :param mode: Defines a mode for weight compression.
@@ -94,7 +94,7 @@ class WeightCompression(Algorithm):
         self._algorithm_key = f"CW_{hash(self)}"
         self._fp_inputs = defaultdict(list)
         self._all_layers = all_layers
-        self._mixed_precision_mode = mixed_precision_mode
+        self._sensitivity_metric = sensitivity_metric
 
     @property
     def available_backends(self) -> List[BackendType]:
@@ -173,7 +173,7 @@ class WeightCompression(Algorithm):
         nodes_to_compress = self._get_nodes_to_compress(graph)
 
         activations = {}
-        if dataset is not None and self._mixed_precision_mode != MixedPrecisionMode.INT8_ERROR:
+        if dataset is not None and self._sensitivity_metric != SensitivityMetric.WEIGHT_QUANTIZATION_ERROR:
             activations = self.get_activations(dataset, nodes_to_compress, graph, model)
 
         transformed_model = self._backend_entity.do_compression(
@@ -184,7 +184,7 @@ class WeightCompression(Algorithm):
             self._group_size,
             self._all_layers,
             activations,
-            self._mixed_precision_mode,
+            self._sensitivity_metric,
         )
         return transformed_model
 

--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -28,12 +28,12 @@ from nncf import Dataset
 from nncf.common.factory import StatisticsAggregatorFactory
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
+from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.scopes import should_consider_scope
 from nncf.common.tensor_statistics.statistic_point import StatisticPoint
 from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
 from nncf.common.utils.backend import BackendType
 from nncf.common.utils.backend import get_backend
-from nncf.openvino.graph.transformations.commands import TargetType
 from nncf.parameters import CompressWeightsMode
 from nncf.parameters import SensitivityMetric
 from nncf.quantization.algorithms.algorithm import Algorithm

--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -75,7 +75,7 @@ class WeightCompression(Algorithm):
             INT4_ASYM is the same as INT4_SYM mode, but weights are quantized to a primary precision asymmetrically
                 with a typical non-fixed zero point.
             NF4 is the same as INT4_SYM mode, but primary precision is NF4 data type without zero point.
-        :param ratio: the ratio between baseline and backup precisions (e.g. 0.9 means 90% of layers quantized to NF4
+        :param ratio: the ratio between primary and backup precisions (e.g. 0.9 means 90% of layers quantized to NF4
             and the rest to INT8_ASYM).
         :param group_size: number of weights (e.g. 128) in the channel dimension
             that share quantization parameters (scale). The value -1 means no grouping.

--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -55,11 +55,11 @@ class WeightCompression(Algorithm):
     def __init__(
         self,
         mode: CompressWeightsMode,
-        ratio: float = None,
-        group_size: int = None,
-        ignored_scope: Optional[IgnoredScope] = None,
-        all_layers: Optional[bool] = False,
-        sensitivity_metric: Optional[SensitivityMetric] = SensitivityMetric.WEIGHT_QUANTIZATION_ERROR,
+        ratio: float,
+        group_size: int,
+        ignored_scope: IgnoredScope,
+        all_layers: bool,
+        sensitivity_metric: SensitivityMetric,
     ):
         """
         :param mode: Defines a mode for weight compression.
@@ -89,7 +89,7 @@ class WeightCompression(Algorithm):
         self._mode = mode
         self._group_size = group_size
         self._ratio = ratio
-        self._ignored_scope = IgnoredScope() if ignored_scope is None else ignored_scope
+        self._ignored_scope = ignored_scope
         self._backend_entity = None
         self._algorithm_key = f"CW_{hash(self)}"
         self._fp_inputs = defaultdict(list)
@@ -227,7 +227,10 @@ class WeightCompression(Algorithm):
         statistic_container = StatisticPointsContainer()
         all_act_nodes = []
         act_vs_shared_node_names_mapping = {}
-        for node in nodes_to_compress:
+        from nncf.openvino.graph.metatypes.openvino_metatypes import OVMatMulMetatype
+
+        filtered_nodes = filter(lambda node: node.metatype == OVMatMulMetatype, nodes_to_compress)
+        for node in filtered_nodes:
             act_node, output_port_id = self._get_activation_node_and_port(node, graph)
             act_node_name = act_node.node_name
             if act_node_name in all_act_nodes:

--- a/nncf/quantization/algorithms/weight_compression/backend.py
+++ b/nncf/quantization/algorithms/weight_compression/backend.py
@@ -106,6 +106,9 @@ class WeightCompressionAlgoBackend(ABC):
             that share quantization parameters (scale). The value -1 means no grouping.
         :param all_layers: Indicates whether embeddings and last layers should be compressed to a primary
             precision. By default, the backup precision is assigned for the embeddings and last layers.
+        :param activations: The input activations of the layers considered for compression.
+        :param sensitivity_metric: The sensitivity metric for assigning quantization precision to layers. In order to
+            preserve the accuracy of the model, the more sensitive layers receives a higher precision.
         :return: A resulting model with compressed weights.
         """
 
@@ -117,7 +120,7 @@ class WeightCompressionAlgoBackend(ABC):
 
         :param target_type: Type of the location that should be modified.
         :param target_node_name: Name of the located node.
-        :param port_id: id of the port for the statistics disctribution.
+        :param port_id: id of the port for the statistics distribution.
         :return: Backend-specific TargetPoint.
         """
 

--- a/nncf/quantization/algorithms/weight_compression/backend.py
+++ b/nncf/quantization/algorithms/weight_compression/backend.py
@@ -29,9 +29,16 @@ TModel = TypeVar("TModel")
 class WeightCompressionAlgoBackend(ABC):
     @property
     @abstractmethod
-    def weighted_metatypes(self) -> List[OperatorMetatype]:
+    def matmul_metatypes(self) -> List[OperatorMetatype]:
         """
-        Property for the backend-specific metatypes.
+        Property for the backend-specific metatypes for matmul layers.
+        """
+
+    @property
+    @abstractmethod
+    def embedding_metatypes(self) -> List[OperatorMetatype]:
+        """
+        Property for the backend-specific metatypes for embedding layers.
         """
 
     @staticmethod

--- a/nncf/quantization/algorithms/weight_compression/backend.py
+++ b/nncf/quantization/algorithms/weight_compression/backend.py
@@ -13,8 +13,12 @@ from abc import ABC
 from abc import abstractmethod
 from typing import List, Optional, TypeVar
 
+from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode
 from nncf.common.graph.operator_metatypes import OperatorMetatype
+from nncf.common.graph.transformations.commands import TargetPoint
+from nncf.common.graph.transformations.commands import TargetType
+from nncf.common.tensor_statistics.collectors import TensorStatisticCollectorBase
 from nncf.parameters import CompressWeightsMode
 from nncf.scopes import IgnoredScope
 
@@ -71,6 +75,7 @@ class WeightCompressionAlgoBackend(ABC):
         mode: CompressWeightsMode,
         ratio: float = None,
         group_size: int = None,
+        activations=None,
         all_layers: Optional[bool] = False,
     ) -> TModel:
         """
@@ -100,4 +105,41 @@ class WeightCompressionAlgoBackend(ABC):
         :param all_layers: Indicates whether embeddings and last layers should be compressed to a primary
             precision. By default, the backup precision is assigned for the embeddings and last layers.
         :return: A resulting model with compressed weights.
+        """
+
+    @staticmethod
+    @abstractmethod
+    def target_point(target_type: TargetType, target_node_name: str, port_id: int) -> TargetPoint:
+        """
+        Returns backend-specific target point.
+
+        :param target_type: Type of the location that should be modified.
+        :param target_node_name: Name of the located node.
+        :param port_id: id of the port for the statistics disctribution.
+        :return: Backend-specific TargetPoint.
+        """
+
+    @staticmethod
+    @abstractmethod
+    def raw_statistic_collector(inplace: bool, num_samples: int = None) -> TensorStatisticCollectorBase:
+        """
+        Returns backend-specific raw statistic collector.
+        This statistic collector uses for raw data calculation, without aggregating.
+
+        :param inplace: Whether to calculate statistic inplace or not.
+        :param num_samples: Maximum number of samples to collect.
+        :return: Backend-specific TensorStatisticCollectorBase for the statistics calculation.
+        """
+
+    @staticmethod
+    @abstractmethod
+    def get_activation_port_id(node: NNCFNode, nncf_graph: NNCFGraph) -> int:
+        """
+        Returns input port id corresponding to activation input edge for
+        the node.
+        Supports only nodes that could have bias value.
+
+        :param node: Node of NNCFGraph with bias value.
+        :param nncf_graph: NNCFGraph instance with the node.
+        :return: boolean port id.
         """

--- a/nncf/quantization/algorithms/weight_compression/backend.py
+++ b/nncf/quantization/algorithms/weight_compression/backend.py
@@ -11,7 +11,7 @@
 
 from abc import ABC
 from abc import abstractmethod
-from typing import List, Optional, TypeVar
+from typing import Any, Dict, List, Optional, TypeVar
 
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode
@@ -20,6 +20,7 @@ from nncf.common.graph.transformations.commands import TargetPoint
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.tensor_statistics.collectors import TensorStatisticCollectorBase
 from nncf.parameters import CompressWeightsMode
+from nncf.parameters import SensitivityMetric
 from nncf.scopes import IgnoredScope
 
 TModel = TypeVar("TModel")
@@ -75,8 +76,9 @@ class WeightCompressionAlgoBackend(ABC):
         mode: CompressWeightsMode,
         ratio: float = None,
         group_size: int = None,
-        activations=None,
         all_layers: Optional[bool] = False,
+        activations: Optional[Dict[str, Any]] = None,
+        sensitivity_metric: Optional[SensitivityMetric] = SensitivityMetric.WEIGHT_QUANTIZATION_ERROR,
     ) -> TModel:
         """
         Compress weights of Linear and Embedding layers to 8-bit integer or to nf4
@@ -124,7 +126,7 @@ class WeightCompressionAlgoBackend(ABC):
     def raw_statistic_collector(inplace: bool, num_samples: int = None) -> TensorStatisticCollectorBase:
         """
         Returns backend-specific raw statistic collector.
-        This statistic collector uses for raw data calculation, without aggregating.
+        This statistic collector is used for raw data calculation, without aggregating.
 
         :param inplace: Whether to calculate statistic inplace or not.
         :param num_samples: Maximum number of samples to collect.
@@ -141,5 +143,5 @@ class WeightCompressionAlgoBackend(ABC):
 
         :param node: Node of NNCFGraph with bias value.
         :param nncf_graph: NNCFGraph instance with the node.
-        :return: boolean port id.
+        :return: target input port id.
         """

--- a/nncf/quantization/algorithms/weight_compression/compression_info.py
+++ b/nncf/quantization/algorithms/weight_compression/compression_info.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass
+from typing import Optional, TypeVar
+
+import openvino.runtime as ov
+
+from nncf.common.graph.operator_metatypes import OperatorMetatype
+from nncf.parameters import CompressWeightsMode
+
+TWeightType = TypeVar("TWeightType")
+
+
+@dataclass
+class WeightCompressionConfig:
+    """
+    Information on how to compress (quantize) a specific weight.
+
+    :param mode: Defines a mode for weight compression. Defaults to INT8_ASYM mode.
+    :param group_size: Number of weights (e.g. 128) in the channel dimension that share quantization parameters (scale).
+        The value -1 means no grouping. Defaults to -1.
+    """
+
+    mode: Optional[CompressWeightsMode] = CompressWeightsMode.INT8_ASYM
+    group_size: Optional[int] = -1
+
+    @property
+    def num_bits(self):
+        """
+        :return: number of bits that is used for storing a single quantized value in the given mode.
+        """
+        return 8 if self.mode in [CompressWeightsMode.INT8_SYM, CompressWeightsMode.INT8_ASYM] else 4
+
+
+@dataclass
+class WeightNodeParams:
+    """
+    Information about weight node in the ov.Model that is useful for weight compression.
+
+    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
+    :param num_weights: Number of elements in the weight array.
+    :param fq_name: Name for the inserted weight compression operation.
+    :param weight_node: The weight node itself.
+    :param original_weight_dtype: Type of elements in the weight array.
+    :param compression_config: Configuration of weight compression for the weight node.
+    :param metatype: Metatype of the corresponding operation with weight.
+    :param node_name: Unique string representation of the node in the NNCFGraph. It is intended for accessing collected
+        activations.
+    """
+
+    reduction_axis: int
+    num_weights: int
+    fq_name: str
+    weight_node: ov.Node
+    original_weight_dtype: TWeightType
+    compression_config = WeightCompressionConfig()
+    metatype: OperatorMetatype = None
+    node_name: str = None

--- a/nncf/quantization/algorithms/weight_compression/compression_info.py
+++ b/nncf/quantization/algorithms/weight_compression/compression_info.py
@@ -52,7 +52,7 @@ class WeightNodeParams:
     :param original_weight_dtype: Type of elements in the weight array.
     :param compression_config: Configuration of weight compression for the weight node.
     :param metatype: Metatype of the corresponding operation with weight.
-    :param node_name: Unique string representation of the node in the NNCFGraph. It is intended for accessing collected
+    :param node_name: String representation of the node in the NNCFGraph. It is intended for accessing collected
         activations.
     """
 

--- a/nncf/quantization/algorithms/weight_compression/mixed_precision.py
+++ b/nncf/quantization/algorithms/weight_compression/mixed_precision.py
@@ -22,8 +22,8 @@ from nncf.openvino.graph.node_utils import get_const_value
 from nncf.parameters import SensitivityMetric
 from nncf.quantization.algorithms.weight_compression.compression_info import WeightCompressionConfig
 from nncf.quantization.algorithms.weight_compression.compression_info import WeightNodeParams
-from nncf.quantization.algorithms.weight_compression.quantize import _do_integer_quantization
-from nncf.quantization.algorithms.weight_compression.quantize import _get_integer_quantization_error
+from nncf.quantization.algorithms.weight_compression.quantize import do_integer_quantization
+from nncf.quantization.algorithms.weight_compression.quantize import get_integer_quantization_error
 
 MIXED_PRECISION_CRITERIA = Registry("mixed_precision_criteria")
 
@@ -31,7 +31,6 @@ MIXED_PRECISION_CRITERIA = Registry("mixed_precision_criteria")
 class MixedPrecisionCriterion:
     """
     Assigns mixed quantization scheme (e.g. uniform int8 or non-uniform nf4) for weights based on some criteria.
-
     """
 
     def __init__(
@@ -83,7 +82,7 @@ class DataFreeCriterion(MixedPrecisionCriterion):
         weight = get_const_value(weight_param.weight_node)
         backup_config = weight_param.compression_config
         reduction_axis = weight_param.reduction_axis
-        int_error = _get_integer_quantization_error(weight, reduction_axis, backup_config)
+        int_error = get_integer_quantization_error(weight, reduction_axis, backup_config)
         eps = np.finfo(weight.dtype).eps
         return 1 / (int_error + eps)
 
@@ -139,7 +138,7 @@ class HAWQCriterion(DataBasedCriterion):
         reduction_axis = weight_param.reduction_axis
 
         orig_shape = weight.shape
-        compressed_weights, scale, zero_point = _do_integer_quantization(weight, reduction_axis, backup_config)
+        compressed_weights, scale, zero_point = do_integer_quantization(weight, reduction_axis, backup_config)
         decompressed_weight = compressed_weights.astype(dtype=scale.dtype)
         decompressed_weight = (compressed_weights - zero_point) * scale
         decompressed_weight = decompressed_weight.reshape(orig_shape)

--- a/nncf/quantization/algorithms/weight_compression/mixed_precision.py
+++ b/nncf/quantization/algorithms/weight_compression/mixed_precision.py
@@ -17,6 +17,7 @@ from numpy import linalg
 
 from nncf.common.logging.track_progress import track
 from nncf.common.utils.registry import Registry
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVEmbeddingMetatype
 from nncf.openvino.graph.node_utils import get_const_value
 from nncf.parameters import SensitivityMetric
 from nncf.quantization.algorithms.weight_compression.compression_info import WeightCompressionConfig
@@ -107,6 +108,10 @@ class DataBasedCriterion(DataFreeCriterion):
         pass
 
     def _calc_score_per_node(self, weight_param: WeightNodeParams):
+        # NOTE: TODO: data-based metrics are valid for Matmul operations only. If gathers also considered for mixed
+        # precision, define a minimal metric value to be select 4-bit precision for gathers in the first order.
+        if weight_param.metatype == OVEmbeddingMetatype:
+            return 0
         weight_score = self._calc_weight_score(weight_param)
         activation_score = self._calc_activation_score(self._activations[weight_param.node_name])
         return weight_score * activation_score

--- a/nncf/quantization/algorithms/weight_compression/mixed_precision.py
+++ b/nncf/quantization/algorithms/weight_compression/mixed_precision.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import abstractmethod
+from typing import Dict, List, Optional
+
+import numpy as np
+from numpy import linalg
+
+from nncf.common.logging.track_progress import track
+from nncf.common.utils.registry import Registry
+from nncf.openvino.graph.node_utils import get_const_value
+from nncf.parameters import MixedPrecisionMode
+from nncf.quantization.algorithms.weight_compression.compression_info import WeightCompressionConfig
+from nncf.quantization.algorithms.weight_compression.compression_info import WeightNodeParams
+from nncf.quantization.algorithms.weight_compression.quantize import _do_integer_quantization
+from nncf.quantization.algorithms.weight_compression.quantize import _get_integer_quantization_error
+
+MIXED_PRECISION_CRITERIA = Registry("mixed_precision_criteria")
+
+
+class MixedPrecisionCriterion:
+    """
+    Assigns mixed quantization scheme (e.g. uniform int8 or non-uniform nf4) for weights based on some criteria.
+
+    """
+
+    def __init__(
+        self,
+        weight_params: List[WeightNodeParams],
+        primary_config: WeightCompressionConfig,
+        ratio: float,
+        activations: Optional[Dict[str, np.ndarray]] = None,
+    ):
+        """
+        :param weight_params: List of information about internal weight nodes. Only internal nodes are considered
+            for mixed precision. The quantization scheme is added to this info.
+        :param ratio: The ratio between primary and backup precisions (e.g. 0.9 means 90% of layers quantized to NF4
+            and the rest to INT8_ASYM).
+        :param primary_config: Information on how to compress (quantize) weights to primary precision.
+        """
+        self._weight_params = weight_params
+        self._activations = activations
+        self._primary_config = primary_config
+        self._ratio = ratio
+
+    @abstractmethod
+    def _calc_scores(self):
+        """TODO:_summary_
+        smallest values are chosen to 4-bit first
+        """
+
+    def assign_mixed_precision(self) -> None:
+        scores = self._calc_scores()
+        num_internal_weights = sum(wp.num_weights for wp in self._weight_params)
+
+        indexes_of_layers_in_ascending_order_of_scores = [
+            i[0] for i in sorted(enumerate(scores), reverse=False, key=lambda x: x[1])
+        ]
+        num_weights_in_4bit = 0
+        for index in indexes_of_layers_in_ascending_order_of_scores:
+            weight_param = self._weight_params[index]
+            current_ratio = (num_weights_in_4bit + weight_param.num_weights) / num_internal_weights
+            if current_ratio >= self._ratio:
+                break
+            weight_param.compression_config = self._primary_config
+            num_weights_in_4bit += weight_param.num_weights
+
+
+@MIXED_PRECISION_CRITERIA.register(MixedPrecisionMode.INT8_ERROR)
+class DataFreeCriterion(MixedPrecisionCriterion):
+    @staticmethod
+    def _calc_weight_score(weight_param: WeightNodeParams):
+        weight = get_const_value(weight_param.weight_node)
+        backup_config = weight_param.compression_config
+        reduction_axis = weight_param.reduction_axis
+        int_error = _get_integer_quantization_error(weight, reduction_axis, backup_config)
+        eps = np.finfo(weight.dtype).eps
+        return 1 / (int_error + eps)
+
+    def _calc_score_per_node(self, weight_param: WeightNodeParams):
+        weight_score = self._calc_weight_score(weight_param)
+        return weight_score
+
+    def _calc_scores(self):
+        scores = []
+        for weight_param in track(self._weight_params, description="Searching for Mixed-Precision Configuration"):
+            scores.append(self._calc_score_per_node(weight_param))
+        return scores
+
+
+class DataBasedCriterion(DataFreeCriterion):
+    @staticmethod
+    @abstractmethod
+    def _calc_activation_score(activations: np.ndarray):
+        """
+        activation shape = [seq_length, hidden_dim]
+        """
+        pass
+
+    def _calc_score_per_node(self, weight_param: WeightNodeParams):
+        weight_score = self._calc_weight_score(weight_param)
+        activation_score = self._calc_activation_score(self._activations[weight_param.node_name])
+        return weight_score * activation_score
+
+
+@MIXED_PRECISION_CRITERIA.register(MixedPrecisionMode.HAWQ_IN)
+class HAWQCriterion(DataBasedCriterion):
+    @staticmethod
+    def _calc_activation_score(activations: np.ndarray):
+        htrace = 0
+        nsamples = len(activations)
+        for inp in activations:
+            # NOTE: average trace?? divide by number of diagonal elements
+            htrace += np.sum(np.multiply(inp, inp))
+            # normalize by sequence_length - the same for all activations
+            # normalize by hidden dimension
+            htrace /= inp.size
+        htrace *= 2 / nsamples
+        return htrace
+
+    @staticmethod
+    def _calc_weight_score(weight_param: WeightNodeParams):
+        weight = get_const_value(weight_param.weight_node)
+        backup_config = weight_param.compression_config
+        reduction_axis = weight_param.reduction_axis
+
+        orig_shape = weight.shape
+        compressed_weights, scale, zero_point = _do_integer_quantization(weight, reduction_axis, backup_config)
+        decompressed_weight = compressed_weights.astype(dtype=scale.dtype)
+        decompressed_weight = (compressed_weights - zero_point) * scale
+        decompressed_weight = decompressed_weight.reshape(orig_shape)
+        return linalg.norm(decompressed_weight - weight, ord="fro")
+
+
+@MIXED_PRECISION_CRITERIA.register(MixedPrecisionMode.MEAN_VAR)
+class MeanVarianceCriterion(DataBasedCriterion):
+    @staticmethod
+    def _calc_activation_score(activations: np.ndarray):
+        return float(np.mean([np.mean(np.var(inp, axis=0)) for inp in activations]))
+
+
+@MIXED_PRECISION_CRITERIA.register(MixedPrecisionMode.MAX_VAR)
+class MaxVarianceCriterion(DataBasedCriterion):
+    @staticmethod
+    def _calc_activation_score(activations: np.ndarray):
+        return float(np.mean([np.max(np.var(inp, axis=0)) for inp in activations]))
+
+
+@MIXED_PRECISION_CRITERIA.register(MixedPrecisionMode.MEAN_MAX)
+class MeanMaxCriterion(DataBasedCriterion):
+    @staticmethod
+    def _calc_activation_score(activations: np.ndarray):
+        return float(np.mean([np.mean(np.max(inp, axis=0)) for inp in activations]))

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -139,9 +139,6 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
         _set_weight_compression_config(ratio_defining_params, mode, ratio, group_size, activations, sensitivity_metric)
         nncf_logger.info(_get_bitwidth_distribution_str(all_weight_params, ratio_defining_params))
 
-        for wp in all_weight_params:
-            print(f"mode={wp.compression_config.mode.value} g{wp.compression_config.group_size} {wp.fq_name}")
-
         for wp in track(all_weight_params, description="Applying Weight Compression"):
             weight_node = wp.weight_node
             original_weight_dtype = wp.original_weight_dtype

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -44,8 +44,12 @@ from nncf.scopes import IgnoredScope
 
 class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
     @property
-    def weighted_metatypes(self) -> List[OperatorMetatype]:
-        return [OVMatMulMetatype, OVEmbeddingMetatype]
+    def matmul_metatypes(self) -> List[OperatorMetatype]:
+        return [OVMatMulMetatype]
+
+    @property
+    def embedding_metatypes(self) -> List[OperatorMetatype]:
+        return [OVEmbeddingMetatype]
 
     @staticmethod
     def is_node_with_weights(node: NNCFNode) -> bool:
@@ -170,13 +174,14 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
             for target_input in target_inputs:
                 target_input.replace_source_output(last_output)
-
         dump_parameters(
             model,
             parameters={
                 "mode": mode.value,
                 "group_size": group_size,
                 "ratio": ratio,
+                "all_layers": all_layers,
+                "sensitivity_metric": sensitivity_metric.value,
             },
             algo_name="weight_compression",
         )

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -37,8 +37,8 @@ from nncf.quantization.algorithms.weight_compression.backend import WeightCompre
 from nncf.quantization.algorithms.weight_compression.compression_info import WeightCompressionConfig
 from nncf.quantization.algorithms.weight_compression.compression_info import WeightNodeParams
 from nncf.quantization.algorithms.weight_compression.mixed_precision import MIXED_PRECISION_CRITERIA
-from nncf.quantization.algorithms.weight_compression.quantize import _do_integer_quantization
-from nncf.quantization.algorithms.weight_compression.quantize import _get_norm_weight_and_nf4_scale
+from nncf.quantization.algorithms.weight_compression.quantize import do_integer_quantization
+from nncf.quantization.algorithms.weight_compression.quantize import get_norm_weight_and_nf4_scale
 from nncf.scopes import IgnoredScope
 
 
@@ -150,12 +150,12 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
             config = wp.compression_config
             original_shape = weight.shape
             if config.mode == CompressWeightsMode.NF4:
-                norm_weight, scale = _get_norm_weight_and_nf4_scale(weight, wp.reduction_axis, group_size)
+                norm_weight, scale = get_norm_weight_and_nf4_scale(weight, wp.reduction_axis, group_size)
                 compressed_const = opset.constant(norm_weight, dtype=ov.Type.nf4, name=weight_name)
                 convert = opset.convert(compressed_const, original_weight_dtype)
                 mul = opset.multiply(convert, scale.astype(original_weight_dtype), name=wp.fq_name)
             else:
-                compressed_weights, scale, zero_point = _do_integer_quantization(weight, wp.reduction_axis, config)
+                compressed_weights, scale, zero_point = do_integer_quantization(weight, wp.reduction_axis, config)
                 compression_type = ov.Type.u8 if config.num_bits == 8 else ov.Type.u4
                 compressed_weights_node = opset.constant(compressed_weights, dtype=compression_type, name=weight_name)
                 convert_weights_node = opset.convert(compressed_weights_node, original_weight_dtype)
@@ -228,7 +228,7 @@ def _get_bitwidth_distribution_str(all_params: List[WeightNodeParams], internal_
     return pretty_string
 
 
-# TODO: rename to mixed precision params
+# TODO: rename to mixed precision params. Everywhere!! or just put a comment!
 # ratio considered params
 # non-fixed precision
 # params for mixed precision

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -228,6 +228,10 @@ def _get_bitwidth_distribution_str(all_params: List[WeightNodeParams], internal_
     return pretty_string
 
 
+# TODO: rename to mixed precision params
+# ratio considered params
+# non-fixed precision
+# params for mixed precision
 def _get_internal_weight_params(
     all_weight_params: List[WeightNodeParams],
     mode: CompressWeightsMode,

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -9,27 +9,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import OrderedDict
-from dataclasses import dataclass
-from typing import List, Optional, Tuple, TypeVar
+from typing import Dict, List, Optional
 
 import numpy as np
 import openvino.runtime as ov
 from openvino.runtime import opset13 as opset
 
+from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode
 from nncf.common.graph.operator_metatypes import OperatorMetatype
+from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.logging import nncf_logger
 from nncf.common.logging.track_progress import track
 from nncf.common.utils.helpers import create_table
+from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVEmbeddingMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVMatMulMetatype
 from nncf.openvino.graph.node_utils import get_channel_agnostic_reduction_axes
 from nncf.openvino.graph.node_utils import get_const_value
 from nncf.openvino.graph.node_utils import get_weight_channel_axes
+from nncf.openvino.graph.transformations.commands import OVTargetPoint
 from nncf.openvino.rt_info import dump_parameters
+from nncf.openvino.statistics.collectors import get_raw_stat_collector
 from nncf.parameters import CompressWeightsMode
+from nncf.parameters import MixedPrecisionMode
 from nncf.quantization.algorithms.weight_compression.backend import WeightCompressionAlgoBackend
-from nncf.quantization.fake_quantize import calculate_scale_zero_point
+from nncf.quantization.algorithms.weight_compression.compression_info import WeightCompressionConfig
+from nncf.quantization.algorithms.weight_compression.compression_info import WeightNodeParams
+from nncf.quantization.algorithms.weight_compression.mixed_precision import MIXED_PRECISION_CRITERIA
+from nncf.quantization.algorithms.weight_compression.quantize import _do_integer_quantization
+from nncf.quantization.algorithms.weight_compression.quantize import _get_norm_weight_and_nf4_scale
 from nncf.scopes import IgnoredScope
 
 
@@ -47,6 +56,23 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
         pass
 
     @staticmethod
+    def target_point(target_type: TargetType, target_node_name: str, port_id: int) -> OVTargetPoint:
+        return OVTargetPoint(target_type, target_node_name, port_id)
+
+    @staticmethod
+    def raw_statistic_collector(inplace: bool, num_samples: int = None) -> TensorCollector:
+        return get_raw_stat_collector(num_samples, inplace)
+
+    @staticmethod
+    def get_activation_port_id(node: NNCFNode, nncf_graph: NNCFGraph) -> int:
+        constant_ports = node.layer_attributes.get_const_port_ids()
+        activation_ports = [
+            e.input_port_id for e in nncf_graph.get_input_edges(node) if e.input_port_id not in constant_ports
+        ]
+        assert len(activation_ports) == 1
+        return activation_ports[0]
+
+    @staticmethod
     def do_compression(
         model: ov.Model,
         nodes_to_compress: List[NNCFNode],
@@ -54,15 +80,16 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
         ratio: float = None,
         group_size: int = None,
         all_layers: Optional[bool] = False,
+        activations: Optional[Dict[str, np.ndarray]] = None,
+        mixed_precision_mode: Optional[MixedPrecisionMode] = MixedPrecisionMode.INT8_ERROR,
     ) -> ov.Model:
         all_weight_params: List[WeightNodeParams] = []
         quantized_nodes_ids = set()
-
         friendly_name_to_op_map = {op.get_friendly_name(): op for op in model.get_ops()}
-
         is_last_layer_shared = False
         n = len(nodes_to_compress)
         for i, nncf_node in enumerate(nodes_to_compress):
+            node_name = nncf_node.node_name
             weight_port_ids = nncf_node.layer_attributes.get_const_port_ids()
             for weight_port_id in weight_port_ids:
                 weight_op_friendly_name = nncf_node.layer_attributes.constant_attributes[weight_port_id]["name"]
@@ -85,7 +112,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                     nncf_logger.warning(
                         f"Weight compression expects a single reduction axes, but given {len(reduction_axes)}. "
                         f"Weight shape: {const_shape}, reduction axes: {reduction_axes}, "
-                        f"node name: {nncf_node.node_name}. The node won't be quantized."
+                        f"node name: {node_name}. The node won't be quantized."
                     )
                     continue
                 reduction_axis = reduction_axes[0] if isinstance(reduction_axes, tuple) else reduction_axes
@@ -99,13 +126,19 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                     weight_node,
                     original_weight_dtype,
                     metatype=nncf_node.metatype,
+                    node_name=node_name,
                 )
                 all_weight_params.append(weight_params)
                 quantized_nodes_ids.add(id(weight_node))
 
         internal_weight_params = _get_internal_weight_params(all_weight_params, mode, is_last_layer_shared, all_layers)
-        _set_weight_compression_config(internal_weight_params, mode, ratio, group_size)
+        _set_weight_compression_config(
+            internal_weight_params, mode, ratio, group_size, activations, mixed_precision_mode
+        )
         nncf_logger.info(_get_bitwidth_distribution_str(all_weight_params, internal_weight_params))
+
+        for wp in all_weight_params:
+            print(f"mode={wp.compression_config.mode.value} g{wp.compression_config.group_size} {wp.fq_name}")
 
         for wp in track(all_weight_params, description="Applying Weight Compression"):
             weight_node = wp.weight_node
@@ -150,186 +183,6 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
             algo_name="weight_compression",
         )
         return model
-
-
-TWeightType = TypeVar("TWeightType")
-
-
-@dataclass
-class WeightCompressionConfig:
-    """
-    Information on how to compress (quantize) a specific weight.
-
-    :param mode: Defines a mode for weight compression. Defaults to INT8_ASYM mode.
-    :param group_size: Number of weights (e.g. 128) in the channel dimension that share quantization parameters (scale).
-        The value -1 means no grouping. Defaults to -1.
-    """
-
-    mode: Optional[CompressWeightsMode] = CompressWeightsMode.INT8_ASYM
-    group_size: Optional[int] = -1
-
-    @property
-    def num_bits(self):
-        """
-        :return: number of bits that is used for storing a single quantized value in the given mode.
-        """
-        return 8 if self.mode in [CompressWeightsMode.INT8_SYM, CompressWeightsMode.INT8_ASYM] else 4
-
-
-@dataclass
-class WeightNodeParams:
-    """
-    Information about weight node in the ov.Model that is useful for weight compression.
-
-    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
-    :param num_weights: Number of elements in the weight array.
-    :param fq_name: Name for the inserted weight compression operation.
-    :param weight_node: The weight node itself.
-    :param original_weight_dtype: Type of elements in the weight array.
-    :param compression_config: Configuration of weight compression for the weight node.
-    :param metatype: Metatype of the corresponding operation with weight.
-    """
-
-    reduction_axis: int
-    num_weights: int
-    fq_name: str
-    weight_node: ov.Node
-    original_weight_dtype: TWeightType
-    compression_config = WeightCompressionConfig()
-    metatype: OperatorMetatype = None
-
-
-def _do_integer_quantization(
-    weight: np.ndarray, reduction_axis: int, config: WeightCompressionConfig
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """
-    The method quantizes the given weights to integer data type in accordance with the compression config.
-    The config defines a quantization mode:
-        INT8_SYM mode refers to unsigned int8 symmetric weight compression with a fixed zero point equals to 128 -
-            quantization to [0, 255] range.
-        INT8_ASYM mode refers to unsigned int8 asymmetric weight compression with a typical non-fixed zero-point -
-            quantization to [0, 255] range.
-        INT4_ASYM mode refers to unsigned int4 asymmetric weight compression with a typical non-fixed zero-point -
-            quantization to [0, 15] range.
-        INT4_SYM mode refers to unsigned int4 symmetric weight compression with a fixed zero point equals to 8 -
-            quantization to [0, 15] range.
-        NF4 mode requires a dedicated procedure and it is not supported in this method.
-    One of the parameter of compression config is a group size. Quantization is per-channel, if group size equals to -1,
-    otherwise it's per-group, i.e. group size number of weights in the channel dimension share quantization parameters
-    (scales).
-
-    :param weight: Weight array to compress.
-    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
-    :param config: Information on how to compress (quantize) a specific weight.
-    :return: The compressed weights, scale and zero point that was used for its quantization.
-    """
-    mode = config.mode
-    assert mode != CompressWeightsMode.NF4, "The function supports integer quantization only"
-    group_size = config.group_size
-    num_bits = config.num_bits
-
-    level_low = 0
-    level_high = 2**num_bits - 1
-
-    if group_size != -1:
-        # weights are reshaped from [a1, r, a2] to [a1, r//gs, gs, a2]
-        weight, reduction_axis = _reshape_weights_for_grouped_quantization(weight, reduction_axis, group_size)
-
-    if mode in [CompressWeightsMode.INT8_ASYM, CompressWeightsMode.INT4_ASYM]:
-        min_values = np.min(weight, axis=reduction_axis, keepdims=True)  # [a1, r, a2] -> [a1, 1, a2]
-        max_values = np.max(weight, axis=reduction_axis, keepdims=True)  # [a1, r, a2] -> [a1, 1, a2]
-        scale, zero_point = calculate_scale_zero_point(
-            min_values, max_values, level_low, level_high, narrow_range=False
-        )
-    else:
-        scale = np.max(np.abs(weight), axis=reduction_axis, keepdims=True)  # [a1, r//gs, 1, a2]
-        level_low_sym = -(2 ** (num_bits - 1))
-        level_high_sym = 2 ** (num_bits - 1) - 1
-        scale = scale / level_high_sym
-        zero_point = np.array([-level_low_sym])
-
-    eps = np.finfo(weight.dtype).eps
-    # NOTE: adding machine epsilon to avoid division by zero
-    scale[np.abs(scale) < eps] = eps
-    compressed_weights = np.round(weight / scale + zero_point)
-    compressed_weights = np.clip(compressed_weights, level_low, level_high).astype(np.uint8)
-    return compressed_weights, scale, zero_point
-
-
-def _get_integer_quantization_error(weight: np.ndarray, reduction_axis: int, config: WeightCompressionConfig) -> float:
-    """
-    Calculates a quantity characterizing the difference between floating point weights and fake quantized
-    (compressed and decompressed) to integer ones.
-
-    :param weight: Weight array to compress.
-    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
-    :param config: Information on how to compress (quantize) a specific weight.
-    :return: The quantity characterizing the error of integer quantization.
-    """
-    orig_shape = weight.shape
-    compressed_weights, scale, zero_point = _do_integer_quantization(weight, reduction_axis, config)
-
-    decompressed_weight = compressed_weights.astype(dtype=scale.dtype)
-    decompressed_weight = (compressed_weights - zero_point) * scale
-
-    decompressed_weight = decompressed_weight.reshape(orig_shape)
-    diff = (decompressed_weight - weight) ** 2
-    layer_err = np.mean(diff, axis=reduction_axis)
-    val = np.max(layer_err)
-    return val
-
-
-def _reshape_weights_for_grouped_quantization(
-    weight: np.ndarray, reduction_axis: int, group_size: int
-) -> Tuple[np.ndarray, int]:
-    """
-    Reshapes weights for group-wise quantization and return a new reduction axis for collecting statistics per group
-    dimension. Having weights with shapes [c_out, c_in] and group size = 128, shape of reshaped weights is
-    [c_out, c_in // 128, 128].
-
-    :param weight: Weight array to compress.
-    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
-    :param group_size: Number of weights (e.g. 128) in the channel dimension that share quantization parameters (scale).
-    :return: reshaped weights and new reduction axis.
-    """
-    assert group_size != -1
-    assert isinstance(reduction_axis, int)
-    channel_size = weight.shape[reduction_axis]
-    if channel_size % group_size != 0:
-        raise RuntimeError(f"Channel size {channel_size} should be divisible by size of group {group_size}")
-
-    num_groups_per_channel = channel_size // group_size
-    shape = list(weight.shape)  # [a1, r, a2] - "r" refers to number of channels along reduction axis
-    shape[reduction_axis : reduction_axis + 1] = (num_groups_per_channel, group_size)
-    reshaped_weight = weight.reshape(shape)
-    reduction_axis += 1
-    return reshaped_weight, reduction_axis
-
-
-def _get_norm_weight_and_nf4_scale(
-    weight: np.ndarray, reduction_axis: int, group_size: int = -1
-) -> Tuple[np.ndarray, np.ndarray]:
-    """
-    Calculates scale for nf4 quantization and normalizes weights by the scale.
-    Weights are reshaped in case of positive value of group size.
-
-    :param weight: Weight array to compress.
-    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
-    :param group_size: Number of weights (e.g. 128) in the channel dimension that share quantization parameters (scale).
-        The value -1 means no grouping. Defaults to -1.
-    :return: Normalized weights and nf4 scale.
-    """
-    if group_size != -1:
-        # weights are reshaped: [a1, r, a2] -> [a1, r//gs, gs, a2]
-        weight, reduction_axis = _reshape_weights_for_grouped_quantization(weight, reduction_axis, group_size)
-        scale = np.max(np.abs(weight), axis=reduction_axis, keepdims=True)  # [a1, r//gs, 1, a2]
-    else:
-        scale = np.max(np.abs(weight), axis=reduction_axis, keepdims=True)  # [a1, 1, a2]
-    eps = np.finfo(weight.dtype).eps
-    # NOTE: adding machine epsilon to avoid division by zero
-    scale[np.abs(scale) < eps] = eps
-    norm_weight = weight / scale
-    return norm_weight, scale
 
 
 def _proportion_str(num_weights_list: List[int], total_num_weights: int, total_num_params: int) -> str:
@@ -401,44 +254,13 @@ def _get_internal_weight_params(
     return internal_weight_params
 
 
-def _assign_mixed_precision(
-    internal_weight_params: List[WeightNodeParams], ratio: float, primary_config: WeightCompressionConfig
-) -> None:
-    """
-    Assigns mixed quantization scheme (e.g. uniform int8 or non-uniform nf4) for weights based on some criteria.
-    :param internal_weight_params: List of information about internal weight nodes. Only internal nodes are considered
-        for mixed precision. The quantization scheme is added to this info.
-    :param ratio: The ratio between primary and backup precisions (e.g. 0.9 means 90% of layers quantized to NF4
-        and the rest to INT8_ASYM).
-    :param primary_config: Information on how to compress (quantize) weights to primary precision.
-    :return: None.
-    """
-    errors = []
-    num_internal_weights = 0
-    for weight_param in track(internal_weight_params, description="Searching for Mixed-Precision Configuration"):
-        weight = get_const_value(weight_param.weight_node)
-        backup_config = weight_param.compression_config
-        reduction_axis = weight_param.reduction_axis
-        backup_error = _get_integer_quantization_error(weight, reduction_axis, backup_config)
-        eps = np.finfo(weight.dtype).eps
-        error = 1 / (backup_error + eps)
-        errors.append(error)
-        num_internal_weights += weight_param.num_weights
-    indexes_of_layers_in_ascending_order_of_errors = [
-        i[0] for i in sorted(enumerate(errors), reverse=False, key=lambda x: x[1])
-    ]
-    num_weights_in_4bit = 0
-    for index in indexes_of_layers_in_ascending_order_of_errors:
-        weight_param = internal_weight_params[index]
-        current_ratio = (num_weights_in_4bit + weight_param.num_weights) / num_internal_weights
-        if current_ratio >= ratio:
-            break
-        weight_param.compression_config = primary_config
-        num_weights_in_4bit += weight_param.num_weights
-
-
 def _set_weight_compression_config(
-    internal_weight_params: List[WeightNodeParams], mode: CompressWeightsMode, ratio: float, group_size: int
+    internal_weight_params: List[WeightNodeParams],
+    mode: CompressWeightsMode,
+    ratio: float,
+    group_size: int,
+    activations: Optional[Dict[str, np.ndarray]] = None,
+    mixed_precision_mode: Optional[MixedPrecisionMode] = MixedPrecisionMode.INT8_ERROR,
 ) -> None:
     """
     Set the appropriate compression configuration for weights based on some criteria.
@@ -454,4 +276,6 @@ def _set_weight_compression_config(
         for weight_param in internal_weight_params:
             weight_param.compression_config = primary_config
     else:
-        _assign_mixed_precision(internal_weight_params, ratio, primary_config)
+        criterion_cls = MIXED_PRECISION_CRITERIA.get(mixed_precision_mode)
+        criterion = criterion_cls(internal_weight_params, primary_config, ratio, activations)
+        criterion.assign_mixed_precision()

--- a/nncf/quantization/algorithms/weight_compression/quantize.py
+++ b/nncf/quantization/algorithms/weight_compression/quantize.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Tuple
+
+import numpy as np
+
+from nncf.parameters import CompressWeightsMode
+from nncf.quantization.algorithms.weight_compression.compression_info import WeightCompressionConfig
+from nncf.quantization.fake_quantize import calculate_scale_zero_point
+
+
+def _do_integer_quantization(
+    weight: np.ndarray, reduction_axis: int, config: WeightCompressionConfig
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    The method quantizes the given weights to integer data type in accordance with the compression config.
+    The config defines a quantization mode:
+        INT8_SYM mode refers to unsigned int8 symmetric weight compression with a fixed zero point equals to 128 -
+            quantization to [0, 255] range.
+        INT8_ASYM mode refers to unsigned int8 asymmetric weight compression with a typical non-fixed zero-point -
+            quantization to [0, 255] range.
+        INT4_ASYM mode refers to unsigned int4 asymmetric weight compression with a typical non-fixed zero-point -
+            quantization to [0, 15] range.
+        INT4_SYM mode refers to unsigned int4 symmetric weight compression with a fixed zero point equals to 8 -
+            quantization to [0, 15] range.
+        NF4 mode requires a dedicated procedure and it is not supported in this method.
+    One of the parameter of compression config is a group size. Quantization is per-channel, if group size equals to -1,
+    otherwise it's per-group, i.e. group size number of weights in the channel dimension share quantization parameters
+    (scales).
+
+    :param weight: Weight array to compress.
+    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
+    :param config: Information on how to compress (quantize) a specific weight.
+    :return: The compressed weights, scale and zero point that was used for its quantization.
+    """
+    mode = config.mode
+    assert mode != CompressWeightsMode.NF4, "The function supports integer quantization only"
+    group_size = config.group_size
+    num_bits = config.num_bits
+
+    level_low = 0
+    level_high = 2**num_bits - 1
+
+    if group_size != -1:
+        # weights are reshaped from [a1, r, a2] to [a1, r//gs, gs, a2]
+        weight, reduction_axis = _reshape_weights_for_grouped_quantization(weight, reduction_axis, group_size)
+
+    if mode in [CompressWeightsMode.INT8_ASYM, CompressWeightsMode.INT4_ASYM]:
+        min_values = np.min(weight, axis=reduction_axis, keepdims=True)  # [a1, r, a2] -> [a1, 1, a2]
+        max_values = np.max(weight, axis=reduction_axis, keepdims=True)  # [a1, r, a2] -> [a1, 1, a2]
+        scale, zero_point = calculate_scale_zero_point(
+            min_values, max_values, level_low, level_high, narrow_range=False
+        )
+    else:
+        scale = np.max(np.abs(weight), axis=reduction_axis, keepdims=True)  # [a1, r//gs, 1, a2]
+        level_low_sym = -(2 ** (num_bits - 1))
+        level_high_sym = 2 ** (num_bits - 1) - 1
+        scale = scale / level_high_sym
+        zero_point = np.array([-level_low_sym])
+
+    eps = np.finfo(weight.dtype).eps
+    # NOTE: adding machine epsilon to avoid division by zero
+    scale[np.abs(scale) < eps] = eps
+    compressed_weights = np.round(weight / scale + zero_point)
+    compressed_weights = np.clip(compressed_weights, level_low, level_high).astype(np.uint8)
+    return compressed_weights, scale, zero_point
+
+
+def _get_integer_quantization_error(weight: np.ndarray, reduction_axis: int, config: WeightCompressionConfig) -> float:
+    """
+    Calculates a quantity characterizing the difference between floating point weights and fake quantized
+    (compressed and decompressed) to integer ones.
+
+    :param weight: Weight array to compress.
+    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
+    :param config: Information on how to compress (quantize) a specific weight.
+    :return: The quantity characterizing the error of integer quantization.
+    """
+    orig_shape = weight.shape
+    compressed_weights, scale, zero_point = _do_integer_quantization(weight, reduction_axis, config)
+
+    decompressed_weight = compressed_weights.astype(dtype=scale.dtype)
+    decompressed_weight = (compressed_weights - zero_point) * scale
+
+    decompressed_weight = decompressed_weight.reshape(orig_shape)
+    diff = (decompressed_weight - weight) ** 2
+    layer_err = np.mean(diff, axis=reduction_axis)
+    val = np.max(layer_err)
+    return val
+
+
+def _reshape_weights_for_grouped_quantization(
+    weight: np.ndarray, reduction_axis: int, group_size: int
+) -> Tuple[np.ndarray, int]:
+    """
+    Reshapes weights for group-wise quantization and return a new reduction axis for collecting statistics per group
+    dimension. Having weights with shapes [c_out, c_in] and group size = 128, shape of reshaped weights is
+    [c_out, c_in // 128, 128].
+
+    :param weight: Weight array to compress.
+    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
+    :param group_size: Number of weights (e.g. 128) in the channel dimension that share quantization parameters (scale).
+    :return: reshaped weights and new reduction axis.
+    """
+    assert group_size != -1
+    assert isinstance(reduction_axis, int)
+    channel_size = weight.shape[reduction_axis]
+    if channel_size % group_size != 0:
+        raise RuntimeError(f"Channel size {channel_size} should be divisible by size of group {group_size}")
+
+    num_groups_per_channel = channel_size // group_size
+    shape = list(weight.shape)  # [a1, r, a2] - "r" refers to number of channels along reduction axis
+    shape[reduction_axis : reduction_axis + 1] = (num_groups_per_channel, group_size)
+    reshaped_weight = weight.reshape(shape)
+    reduction_axis += 1
+    return reshaped_weight, reduction_axis
+
+
+def _get_norm_weight_and_nf4_scale(
+    weight: np.ndarray, reduction_axis: int, group_size: int = -1
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Calculates scale for nf4 quantization and normalizes weights by the scale.
+    Weights are reshaped in case of positive value of group size.
+
+    :param weight: Weight array to compress.
+    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
+    :param group_size: Number of weights (e.g. 128) in the channel dimension that share quantization parameters (scale).
+        The value -1 means no grouping. Defaults to -1.
+    :return: Normalized weights and nf4 scale.
+    """
+    if group_size != -1:
+        # weights are reshaped: [a1, r, a2] -> [a1, r//gs, gs, a2]
+        weight, reduction_axis = _reshape_weights_for_grouped_quantization(weight, reduction_axis, group_size)
+        scale = np.max(np.abs(weight), axis=reduction_axis, keepdims=True)  # [a1, r//gs, 1, a2]
+    else:
+        scale = np.max(np.abs(weight), axis=reduction_axis, keepdims=True)  # [a1, 1, a2]
+    eps = np.finfo(weight.dtype).eps
+    # NOTE: adding machine epsilon to avoid division by zero
+    scale[np.abs(scale) < eps] = eps
+    norm_weight = weight / scale
+    return norm_weight, scale

--- a/nncf/quantization/quantize_model.py
+++ b/nncf/quantization/quantize_model.py
@@ -255,8 +255,8 @@ def compress_weights(
     ratio: Optional[float] = None,
     group_size: Optional[int] = None,
     ignored_scope: Optional[IgnoredScope] = None,
-    dataset: Dataset = None,
     all_layers: Optional[bool] = None,
+    dataset: Optional[Dataset] = None,
     sensitivity_metric: Optional[SensitivityMetric] = None,
 ) -> TModel:
     """
@@ -283,6 +283,7 @@ def compress_weights(
         flow graph nodes to be ignored during quantization.
     :param all_layers: Indicates whether embeddings and last layers should be compressed to a primary
         precision. By default, the backup precision is assigned for the embeddings and last layers.
+    :param dataset: Dataset used for assigning different quantization precision by finding outliers in activations.
     :param sensitivity_metric: The sensitivity metric for assigning quantization precision to layers. In order to
         preserve the accuracy of the model, the more sensitive layers receives a higher precision.
     :return: The non-trainable model with compressed weights.

--- a/nncf/quantization/quantize_model.py
+++ b/nncf/quantization/quantize_model.py
@@ -21,9 +21,9 @@ from nncf.common.utils.backend import get_backend
 from nncf.data import Dataset
 from nncf.parameters import CompressWeightsMode
 from nncf.parameters import DropType
-from nncf.parameters import MixedPrecisionMode
 from nncf.parameters import ModelType
 from nncf.parameters import QuantizationMode
+from nncf.parameters import SensitivityMetric
 from nncf.parameters import TargetDevice
 from nncf.quantization.advanced_parameters import AdvancedAccuracyRestorerParameters
 from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
@@ -257,7 +257,7 @@ def compress_weights(
     ignored_scope: Optional[IgnoredScope] = None,
     dataset: Dataset = None,
     all_layers: Optional[bool] = None,
-    mixed_precision_mode: Optional[MixedPrecisionMode] = MixedPrecisionMode.INT8_ERROR,
+    sensitivity_metric: Optional[SensitivityMetric] = SensitivityMetric.WEIGHT_QUANTIZATION_ERROR,
 ) -> TModel:
     """
     Compress model weights.
@@ -286,9 +286,11 @@ def compress_weights(
     # TODO:
     :return: The non-trainable model with compressed weights.
     """
-    if not dataset and mixed_precision_mode != MixedPrecisionMode.INT8_ERROR:
+    if not dataset and sensitivity_metric != SensitivityMetric.WEIGHT_QUANTIZATION_ERROR:
         # TODO: correct
-        raise AttributeError("mixed precision mode except INT8_ERROR requires dataset, but it's not provided")
+        raise AttributeError(
+            "mixed precision mode except WEIGHT_QUANTIZATION_ERROR requires dataset, but it's not provided"
+        )
 
     if mode == CompressWeightsMode.INT8:
         warning_deprecated(
@@ -324,7 +326,7 @@ def compress_weights(
 
     if all_layers is None:
         all_layers = False
-    compression_algorithm = WeightCompression(mode, ratio, group_size, ignored_scope, all_layers, mixed_precision_mode)
+    compression_algorithm = WeightCompression(mode, ratio, group_size, ignored_scope, all_layers, sensitivity_metric)
     graph = NNCFGraphFactory.create(model)
     return compression_algorithm.apply(model, graph, dataset=dataset)
 

--- a/nncf/quantization/quantize_model.py
+++ b/nncf/quantization/quantize_model.py
@@ -283,7 +283,8 @@ def compress_weights(
         flow graph nodes to be ignored during quantization.
     :param all_layers: Indicates whether embeddings and last layers should be compressed to a primary
         precision. By default, the backup precision is assigned for the embeddings and last layers.
-    # TODO:
+    :param sensitivity_metric: The sensitivity metric for assigning quantization precision to layers. In order to
+        preserve the accuracy of the model, the more sensitive layers receives a higher precision.
     :return: The non-trainable model with compressed weights.
     """
     if mode == CompressWeightsMode.INT8:
@@ -304,7 +305,6 @@ def compress_weights(
             )
         options = [all_layers, sensitivity_metric, dataset]
         if any(option is not None for option in options):
-            # TODO: warning or better error?
             raise AttributeError(
                 "INT8 modes do not support `all_layers`, `sensitivity_metric` and `dataset` options."
                 "Set them to None."
@@ -332,8 +332,8 @@ def compress_weights(
         )
     if ratio != 1 and dataset is None and sensitivity_metric != SensitivityMetric.WEIGHT_QUANTIZATION_ERROR:
         raise AttributeError(
-            # TODO: correct message
-            "mixed precision mode except WEIGHT_QUANTIZATION_ERROR requires dataset, but it's not provided"
+            f"Mixed precision selection based on the given sensitivity metric={sensitivity_metric.value} requires "
+            "a dataset, but it's not provided."
         )
     compression_algorithm = WeightCompression(mode, ratio, group_size, ignored_scope, all_layers, sensitivity_metric)
     graph = NNCFGraphFactory.create(model)

--- a/tests/openvino/native/models.py
+++ b/tests/openvino/native/models.py
@@ -769,7 +769,7 @@ class SequentialMatmulModel(OVReferenceModel):
 
     def _create_ov_model(self):
         input_node = opset.parameter([3, 3], name="Input_1")
-        main_values = [100, 1000, 10000, 10, 1]
+        main_values = [10000, 1000, 1, 10, 10000]
 
         last_node = input_node
         for i, main_value in enumerate(main_values):
@@ -782,6 +782,18 @@ class SequentialMatmulModel(OVReferenceModel):
             last_node = current_node
 
         result = opset.result(last_node, name="Result")
+        result.get_output_tensor(0).set_names(set(["Result"]))
+        model = ov.Model([result], [input_node])
+        return model
+
+
+class IdentityMatmul(OVReferenceModel):
+    def _create_ov_model(self):
+        input_node = opset.parameter([3, 3], name="Input_1")
+        weights_data = np.eye(3) * 255
+        current_weights = opset.constant(weights_data, dtype=np.float32, name="weights")
+        matmul_node = opset.matmul(input_node, current_weights, transpose_a=False, transpose_b=True, name="MatMul")
+        result = opset.result(matmul_node, name="Result")
         result.get_output_tensor(0).set_names(set(["Result"]))
         model = ov.Model([result], [input_node])
         return model

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -332,8 +332,8 @@ def test_data_based_criterion(mode, ref_scores, ref_act_scores, mocker):
     model = IdentityMatmul().ov_model
     dataset = Dataset([ACTIVATION])
     criterion_cls = MIXED_PRECISION_CRITERIA.get(mode)
-    scores_spy = mocker.spy(criterion_cls, "_calc_scores")
-    act_scores_spy = mocker.spy(criterion_cls, "_calc_activation_score")
+    scores_spy = mocker.spy(criterion_cls, "_calc_sensitivity")
+    act_scores_spy = mocker.spy(criterion_cls, "_calc_activation_sensitivity")
 
     compress_weights(
         model,
@@ -592,7 +592,7 @@ def test_call_max_var_criterion_with_dataset_by_default(mocker, mode):
     model = IntegerModel().ov_model
     dataset = Dataset([np.ones([1, 7, 1])])
     criterion_cls = MIXED_PRECISION_CRITERIA.get(SensitivityMetric.MAX_ACTIVATION_VARIANCE)
-    scores_spy = mocker.spy(criterion_cls, "_calc_scores")
+    scores_spy = mocker.spy(criterion_cls, "_calc_sensitivity")
 
     compress_weights(model, mode=mode, ratio=0.8, group_size=-1, dataset=dataset)
 

--- a/tests/torch/ptq/test_weights_compression.py
+++ b/tests/torch/ptq/test_weights_compression.py
@@ -13,7 +13,25 @@ import pytest
 import torch
 
 from nncf import CompressWeightsMode
+from nncf.parameters import SensitivityMetric
 from nncf.quantization import compress_weights
+
+DATA_BASED_SENSITIVITY_METRICS = (
+    SensitivityMetric.HESSIAN_INPUT_ACTIVATION,
+    SensitivityMetric.MEAN_ACTIVATION_VARIANCE,
+    SensitivityMetric.MAX_ACTIVATION_VARIANCE,
+    SensitivityMetric.MEAN_ACTIVATION_MAGNITUDE,
+)
+
+ALL_SENSITIVITY_METRICS = DATA_BASED_SENSITIVITY_METRICS + (SensitivityMetric.WEIGHT_QUANTIZATION_ERROR,)
+
+SUPPORTED_MODES = (CompressWeightsMode.INT8, CompressWeightsMode.INT8_ASYM)
+UNSUPPORTED_MODES = (
+    CompressWeightsMode.INT4_SYM,
+    CompressWeightsMode.INT4_ASYM,
+    CompressWeightsMode.NF4,
+    CompressWeightsMode.INT8_SYM,
+)
 
 
 class ShortTransformer(torch.nn.Module):
@@ -74,32 +92,27 @@ def test_compress_shared_weights():
         assert compressed_model.lm_head.get_pre_op(key) is val
 
 
+@pytest.mark.parametrize("mode", SUPPORTED_MODES)
 @pytest.mark.parametrize(
-    "mode", [CompressWeightsMode.INT8, CompressWeightsMode.INT8_ASYM, CompressWeightsMode.INT8_SYM]
+    "params",
+    (
+        {"ratio": 0.5},
+        {"group_size": 64},
+        {"all_layers": True},
+        {"all_layers": False},
+        *({"sensitivity_metric": metric} for metric in ALL_SENSITIVITY_METRICS),
+        {"dataset": "anything"},
+        {"ignored_scope": "anything"},
+    ),
 )
-def test_raise_error_with_int8_and_non_default_ratio(mocker, mode):
+def test_raise_error_with_unsupported_params_for_int8(mode, params):
+    dummy_torch_model = torch.nn.Module()
     with pytest.raises(AttributeError):
-        compress_weights(mocker.Mock(), mode=mode, ratio=0.5)
+        compress_weights(dummy_torch_model, mode=mode, **params)
 
 
-@pytest.mark.parametrize(
-    "mode", [CompressWeightsMode.INT8, CompressWeightsMode.INT8_ASYM, CompressWeightsMode.INT8_SYM]
-)
-def test_raise_error_with_int8_and_non_default_group_size(mocker, mode):
-    with pytest.raises(AttributeError):
-        compress_weights(mocker.Mock(), mode=mode, group_size=64)
-
-
-@pytest.mark.parametrize(
-    "mode",
-    [
-        CompressWeightsMode.NF4,
-        CompressWeightsMode.INT4_ASYM,
-        CompressWeightsMode.INT4_SYM,
-        CompressWeightsMode.INT8_SYM,
-    ],
-)
+@pytest.mark.parametrize("mode", UNSUPPORTED_MODES)
 def test_raise_error_with_not_int8_asym(mode):
+    dummy_torch_model = torch.nn.Module()
     with pytest.raises(AttributeError):
-        dummy_torch_model = torch.nn.Module()
         compress_weights(dummy_torch_model, mode=mode)


### PR DESCRIPTION
### Changes

Introduced 4 new criteria (HAWQ_IN, MEAN_VAR, MEAN_MAX, MAX_VAR) for assigning different quantization precision based on the given dataset

### Reason for changes

determine more accurate configuration by taking into account activations

### Related tickets

126378

### Tests

test_data_based_criterion
test_mixed_precision

- [x] proper docstrings and typehints
- [x] final check of accuracy on llama, qwen

the MAX_ACTIVATION_VARIANCE metric shows improvement on wikitext and who-what-benchmark for the 4 considered models.
![image](https://github.com/openvinotoolkit/nncf/assets/4014476/ac833188-5d5d-45de-a770-2dd2e2e11d86)

Manual validation on llama-2 shows that output is without German words.
![image](https://github.com/openvinotoolkit/nncf/assets/4014476/eca1f5e4-5b0f-4b8f-9201-94cee72ceb2f)

MEAN_VAR
![image](https://github.com/openvinotoolkit/nncf/assets/4014476/fa65c1c1-f435-434e-92a6-7ca50d4650d7)
MAX_VAR
![image](https://github.com/openvinotoolkit/nncf/assets/4014476/5c013ccf-0282-4da4-8a07-304e093e7d95)
HAWQ_IN
![image](https://github.com/openvinotoolkit/nncf/assets/4014476/259d918d-7037-4e0f-9dd7-5ba59f71fe9c)
INT8_ERROR
![image](https://github.com/openvinotoolkit/nncf/assets/4014476/886c09b9-a2ee-4c4f-a8e2-92782aa168b7)
