### PR TITLE
Added non-vnni test make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,11 @@ install-openvino-dev: install-openvino-test install-pre-commit
 test-openvino:
 	pytest ${COVERAGE_ARGS} tests/openvino $(DATA_ARG) --junitxml ${JUNITXML_PATH}
 
+test-openvino-avx2:
+	export ONEDNN_MAX_CPU_ISA=AVX2
+	make test-openvino
+	unset ONEDNN_MAX_CPU_ISA
+
 test-install-openvino:
 	pytest tests/cross_fw/install -s        \
 		--backend openvino                  \

--- a/tests/openvino/native/quantization/test_sanity.py
+++ b/tests/openvino/native/quantization/test_sanity.py
@@ -24,22 +24,42 @@ from tests.openvino.datasets_helpers import get_nncf_dataset_from_ac_config
 from tests.openvino.omz_helpers import calculate_metrics
 from tests.openvino.omz_helpers import convert_model
 from tests.openvino.omz_helpers import download_model
+from tests.shared.helpers import get_env_instruction_set
 
 OMZ_MODELS = [
     (
         "resnet-18-pytorch",
         "imagenette2-320",
-        {"accuracy@top1": 0.777, "accuracy@top5": 0.948},
+        {
+            "VNNI": {"accuracy@top1": 0.777, "accuracy@top5": 0.948},
+            "AVX2": {"accuracy@top1": 0.777, "accuracy@top5": 0.948},
+        },
         None,
     ),
     (
         "mobilenet-v3-small-1.0-224-tf",
         "imagenette2-320",
-        {"accuracy@top1": 0.75, "accuracy@top5": 0.916},
+        {
+            "VNNI": {"accuracy@top1": 0.75, "accuracy@top5": 0.916},
+            "AVX2": {"accuracy@top1": 0.735, "accuracy@top5": 0.925},
+        },
         AdvancedQuantizationParameters(disable_channel_alignment=False),
     ),
-    ("googlenet-v3-pytorch", "imagenette2-320", {"accuracy@top1": 0.911, "accuracy@top5": 0.994}, None),
-    ("retinaface-resnet50-pytorch", "wider", {"map": 0.917961898320335}, None),
+    (
+        "googlenet-v3-pytorch",
+        "imagenette2-320",
+        {
+            "VNNI": {"accuracy@top1": 0.911, "accuracy@top5": 0.994},
+            "AVX2": {"accuracy@top1": 0.911, "accuracy@top5": 0.994},
+        },
+        None,
+    ),
+    (
+        "retinaface-resnet50-pytorch",
+        "wider",
+        {"VNNI": {"map": 0.917961898320335}, "AVX2": {"map": 0.917961898320335}},
+        None,
+    ),
 ]
 
 
@@ -76,5 +96,6 @@ def test_compression(data_dir, tmp_path, model, dataset, ref_metrics, advanced_p
 
     report_path = tmp_path / f"{model}.csv"
     metrics = calculate_metrics(int8_ir_path, config_path, extracted_data_dir, report_path, eval_size=1000)
-    for metric_name, metric_val in ref_metrics.items():
+    reference = ref_metrics[get_env_instruction_set()]
+    for metric_name, metric_val in reference.items():
         assert metrics[metric_name] == pytest.approx(metric_val, abs=0.006)

--- a/tests/openvino/pot/quantization/test_sanity.py
+++ b/tests/openvino/pot/quantization/test_sanity.py
@@ -22,12 +22,34 @@ from tests.openvino.datasets_helpers import get_nncf_dataset_from_ac_config
 from tests.openvino.omz_helpers import calculate_metrics
 from tests.openvino.omz_helpers import convert_model
 from tests.openvino.omz_helpers import download_model
+from tests.shared.helpers import get_env_instruction_set
 
 OMZ_MODELS = [
-    ("resnet-18-pytorch", "imagenette2-320", {"accuracy@top1": 0.777, "accuracy@top5": 0.949}),
-    ("mobilenet-v3-small-1.0-224-tf", "imagenette2-320", {"accuracy@top1": 0.744, "accuracy@top5": 0.922}),
-    ("googlenet-v3-pytorch", "imagenette2-320", {"accuracy@top1": 0.91, "accuracy@top5": 0.994}),
-    ("retinaface-resnet50-pytorch", "wider", {"map": 0.91875950512032}),
+    (
+        "resnet-18-pytorch",
+        "imagenette2-320",
+        {
+            "VNNI": {"accuracy@top1": 0.777, "accuracy@top5": 0.949},
+            "AVX2": {"accuracy@top1": 0.771, "accuracy@top5": 0.949},
+        },
+    ),
+    (
+        "mobilenet-v3-small-1.0-224-tf",
+        "imagenette2-320",
+        {
+            "VNNI": {"accuracy@top1": 0.744, "accuracy@top5": 0.922},
+            "AVX2": {"accuracy@top1": 0.734, "accuracy@top5": 0.922},
+        },
+    ),
+    (
+        "googlenet-v3-pytorch",
+        "imagenette2-320",
+        {
+            "VNNI": {"accuracy@top1": 0.91, "accuracy@top5": 0.994},
+            "AVX2": {"accuracy@top1": 0.91, "accuracy@top5": 0.994},
+        },
+    ),
+    ("retinaface-resnet50-pytorch", "wider", {"VNNI": {"map": 0.91875950512032}, "AVX2": {"map": 0.91875950512032}}),
 ]
 
 
@@ -55,5 +77,6 @@ def test_compression(data_dir, tmp_path, omz_cache_dir, model, dataset, ref_metr
 
     report_path = tmp_path / f"{model}.csv"
     metrics = calculate_metrics(int8_ir_path, config_path, extracted_data_dir, report_path, eval_size=1000)
-    for metric_name, metric_val in ref_metrics.items():
+    reference = ref_metrics[get_env_instruction_set()]
+    for metric_name, metric_val in reference.items():
         assert metrics[metric_name] == pytest.approx(metric_val, abs=0.006)

--- a/tests/shared/helpers.py
+++ b/tests/shared/helpers.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import os
 import subprocess
 import sys
 from abc import ABC
@@ -216,3 +217,11 @@ def get_pip_executable_with_venv(venv_path: Path) -> str:
 
 def remove_line_breaks(s: str) -> str:
     return s.replace("\r\n", "").replace("\n", "")
+
+
+def get_env_instruction_set() -> bool:
+    instruction_set = "VNNI"
+    onednn_max_cpu_isa = os.getenv("ONEDNN_MAX_CPU_ISA")
+    if onednn_max_cpu_isa is not None:
+        instruction_set = onednn_max_cpu_isa
+    return instruction_set


### PR DESCRIPTION
### Changes

- Updated Makefile with the `test-openvino-avx2` command.
- Updated sanity tests with AVX2 metrics.

### Reason for changes

- More robust testing pipeline.

### Related tickets

- 123702

### Tests

 - CI should use the new Makefile command.
