### PR TITLE
[PTQ][OV] Move OV precommit to GitHub Actions

### DIFF
--- a/.github/workflows/post_pr_merge.yml
+++ b/.github/workflows/post_pr_merge.yml
@@ -37,3 +37,13 @@ jobs:
       coverage_flags: ONNX
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  upload-coverage-openvino:
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/upload_coverage_for_develop.yml
+    with:
+      merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      last_sha_in_pr: ${{ github.event.pull_request.head.sha }}
+      coverage_artifact_name_in_pr: coverage_openvino
+      coverage_flags: OPENVINO
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -60,4 +60,29 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: coverage_onnx
           flags: ONNX
-
+  openvino:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.8.10
+      - name: Install NNCF and test requirements
+        run: make install-openvino-test
+      - name: Run OV precommit test scope
+        run: make test-openvino
+        env:
+          NNCF_COVERAGE: 1
+      - name: Upload coverage report as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage_openvino
+          path: ./coverage.xml
+      - name: Upload coverage report to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: coverage_openvino
+          flags: OPENVINO

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,9 @@ install-openvino-dev: install-openvino-test install-pre-commit
 	pip install -r examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/requirements.txt
 
 test-openvino:
+	export ONEDNN_MAX_CPU_ISA=AVX2
 	pytest ${COVERAGE_ARGS} tests/openvino $(DATA_ARG) --junitxml ${JUNITXML_PATH}
+	unset ONEDNN_MAX_CPU_ISA
 
 test-install-openvino:
 	pytest tests/cross_fw/install -s        \

--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,7 @@ install-openvino-dev: install-openvino-test install-pre-commit
 	pip install -r examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/requirements.txt
 
 test-openvino:
-	export ONEDNN_MAX_CPU_ISA=AVX2
-	pytest ${COVERAGE_ARGS} tests/openvino $(DATA_ARG) --junitxml ${JUNITXML_PATH}
-	unset ONEDNN_MAX_CPU_ISA
+	ONEDNN_MAX_CPU_ISA=AVX2 pytest ${COVERAGE_ARGS} tests/openvino $(DATA_ARG) --junitxml ${JUNITXML_PATH}
 
 test-install-openvino:
 	pytest tests/cross_fw/install -s        \

--- a/tests/openvino/native/quantization/test_sanity.py
+++ b/tests/openvino/native/quantization/test_sanity.py
@@ -35,7 +35,7 @@ OMZ_MODELS = [
     (
         "mobilenet-v3-small-1.0-224-tf",
         "imagenette2-320",
-        {"accuracy@top1": 0.75, "accuracy@top5": 0.916},
+        {"accuracy@top1": 0.735, "accuracy@top5": 0.925},
         AdvancedQuantizationParameters(disable_channel_alignment=False),
     ),
     ("googlenet-v3-pytorch", "imagenette2-320", {"accuracy@top1": 0.911, "accuracy@top5": 0.994}, None),

--- a/tests/openvino/pot/quantization/test_sanity.py
+++ b/tests/openvino/pot/quantization/test_sanity.py
@@ -24,8 +24,8 @@ from tests.openvino.omz_helpers import convert_model
 from tests.openvino.omz_helpers import download_model
 
 OMZ_MODELS = [
-    ("resnet-18-pytorch", "imagenette2-320", {"accuracy@top1": 0.777, "accuracy@top5": 0.949}),
-    ("mobilenet-v3-small-1.0-224-tf", "imagenette2-320", {"accuracy@top1": 0.744, "accuracy@top5": 0.922}),
+    ("resnet-18-pytorch", "imagenette2-320", {"accuracy@top1": 0.771, "accuracy@top5": 0.949}),
+    ("mobilenet-v3-small-1.0-224-tf", "imagenette2-320", {"accuracy@top1": 0.734, "accuracy@top5": 0.922}),
     ("googlenet-v3-pytorch", "imagenette2-320", {"accuracy@top1": 0.91, "accuracy@top5": 0.994}),
     ("retinaface-resnet50-pytorch", "wider", {"map": 0.91875950512032}),
 ]


### PR DESCRIPTION
### Changes

- Fixed instruction set for openvino precommit.
- Moved openvino precommit to the GitHub Actions (mainly from #2188).

### Reason for changes

- CI improvements.

### Related tickets

- 123702

### Tests

- Manual
