### PR TITLE
[Experimental tensor statistics] Tensors with different sizes on aggregation axes support

### DIFF
--- a/nncf/experimental/common/tensor_statistics/collectors.py
+++ b/nncf/experimental/common/tensor_statistics/collectors.py
@@ -653,9 +653,30 @@ class OfflineAggregatorBase(AggregatorBase, ABC):
         self._container.append(x)
 
     def _aggregate_impl(self) -> NNCFTensor:
-        stacked_val = self._tensor_processor.stack(self._container)
-        aggregated = self._aggregation_fn(stacked_val, axis=self._aggregation_axes, keepdims=self._keepdims)
-        return self._tensor_processor.squeeze(aggregated, 0).tensor
+        # Case when all registered tensors have identical shape
+        if all(self._container[0].shape == x.shape for x in self._container):
+            stacked_value = self._tensor_processor.stack(self._container)
+            aggregated = self._aggregation_fn(stacked_value, axis=self._aggregation_axes, keepdims=self._keepdims)
+            return self._tensor_processor.squeeze(aggregated, 0).tensor
+        online_axes = tuple(x - 1 for x in self._aggregation_axes if x > 0)
+
+        # Case when some registered tensors have different shapes and
+        # 0 is present in the aggregation axes
+        if 0 in self._aggregation_axes:
+            stacked_value, shape_after_aggregation = _moveaxes_flatten_cat(
+                self._container, online_axes, self._tensor_processor
+            )
+            aggregated = self._aggregation_fn(stacked_value, axis=0, keepdims=False)
+            if self._keepdims:
+                aggregated = self._tensor_processor.reshape(aggregated, shape_after_aggregation)
+            return aggregated.tensor
+
+        # Case when some registered tensors have different shapes and
+        # 0 is not present in the aggregation axes
+        ret_val = []
+        for tensor in self._container:
+            ret_val.append(self._aggregation_fn(tensor, axis=online_axes, keepdims=self._keepdims))
+        return self._tensor_processor.stack(ret_val, axis=0).tensor
 
     @abstractmethod
     def _aggregation_fn(self, stacked_value: NNCFTensor, axis: AggregationAxes, keepdims: bool) -> NNCFTensor:
@@ -686,25 +707,22 @@ class NoOutliersAggregatorBase(OfflineAggregatorBase, ABC):
         self._container = deque(maxlen=window_size)
         self._quantile = quantile
 
-    def _aggregate_impl(self) -> NNCFTensor:
-        stacked_samples = self._tensor_processor.stack(self._container)
+    def _aggregation_fn(self, stacked_value: NNCFTensor, axis: int, keepdims: bool) -> NNCFTensor:
         low_values, high_values = self._tensor_processor.quantile(
-            stacked_samples,
-            quantile=(self._quantile, 1 - self._quantile),
-            axis=self._aggregation_axes,
+            stacked_value, quantile=(self._quantile, 1 - self._quantile), axis=axis
         )
         tp = self._tensor_processor
-        outliers_mask = tp.logical_or(tp.less(stacked_samples, low_values), tp.less(high_values, stacked_samples))
-        aggregated = self._aggregation_fn(
-            stacked_samples=stacked_samples,
+        outliers_mask = tp.logical_or(tp.less(stacked_value, low_values), tp.less(high_values, stacked_value))
+        aggregated = self._masked_aggregation_fn(
+            stacked_samples=stacked_value,
             mask=outliers_mask,
-            axis=self._aggregation_axes,
-            keepdims=self._keepdims,
+            axis=axis,
+            keepdims=keepdims,
         )
-        return self._tensor_processor.squeeze(aggregated, 0).tensor
+        return aggregated
 
     @abstractmethod
-    def _aggregation_fn(
+    def _masked_aggregation_fn(
         self, stacked_samples: NNCFTensor, mask: NNCFTensor, axis: AggregationAxes, keepdims: bool
     ) -> NNCFTensor:
         pass
@@ -717,14 +735,14 @@ class NoOutliersAggregatorBase(OfflineAggregatorBase, ABC):
 
 
 class MeanNoOutliersAggregator(NoOutliersAggregatorBase):
-    def _aggregation_fn(
+    def _masked_aggregation_fn(
         self, stacked_samples: NNCFTensor, mask: NNCFTensor, axis: AggregationAxes, keepdims: bool
     ) -> NNCFTensor:
         return self._tensor_processor.masked_mean(stacked_samples, axis=axis, mask=mask, keepdims=keepdims)
 
 
 class MedianNoOutliersAggregator(NoOutliersAggregatorBase):
-    def _aggregation_fn(
+    def _masked_aggregation_fn(
         self, stacked_samples: NNCFTensor, mask: NNCFTensor, axis: AggregationAxes, keepdims: bool
     ) -> NNCFTensor:
         return self._tensor_processor.masked_median(stacked_samples, axis=axis, mask=mask, keepdims=keepdims)

--- a/nncf/torch/tensor_statistics/collectors.py
+++ b/nncf/torch/tensor_statistics/collectors.py
@@ -85,7 +85,7 @@ class PTNNCFCollectorTensorProcessor(NNCFCollectorTensorProcessor):
 
     @classmethod
     def masked_mean(
-        cls, x: NNCFTensor, axis: Union[int, Tuple[int, ...], List[int]], mask: NNCFTensor, keepdims=False
+        cls, x: NNCFTensor, axis: Union[int, Tuple[int, ...]], mask: NNCFTensor, keepdims: bool = False
     ) -> NNCFTensor:
         if mask is None:
             return cls.mean(x, axis=axis, keepdims=keepdims)
@@ -98,7 +98,7 @@ class PTNNCFCollectorTensorProcessor(NNCFCollectorTensorProcessor):
 
     @classmethod
     def masked_median(
-        cls, x: NNCFTensor, axis: Union[int, Tuple[int, ...], List[int]], mask: NNCFTensor, keepdims=False
+        cls, x: NNCFTensor, axis: Union[int, Tuple[int, ...]], mask: NNCFTensor, keepdims: bool = False
     ) -> NNCFTensor:
         # Implemented in numy as torch.masked.median is not implemented yet
         if mask is None:

--- a/tests/common/experimental/test_reducers_and_aggregators.py
+++ b/tests/common/experimental/test_reducers_and_aggregators.py
@@ -13,12 +13,13 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from functools import partial
 from itertools import product
-from typing import Any, List, Optional, Tuple
+from typing import Any, Iterator, List, Optional, Tuple
 
 import numpy as np
 import pytest
 
 from nncf.common.graph.layer_attributes import Dtype
+from nncf.common.tensor import NNCFTensor
 from nncf.common.tensor_statistics.collectors import NNCFCollectorTensorProcessor
 from nncf.experimental.common.tensor_statistics.collectors import AggregationAxes
 from nncf.experimental.common.tensor_statistics.collectors import MaxAggregator
@@ -32,10 +33,10 @@ from nncf.experimental.common.tensor_statistics.collectors import NoopAggregator
 from nncf.experimental.common.tensor_statistics.collectors import PercentileAggregator
 from nncf.experimental.common.tensor_statistics.collectors import ShapeAggregator
 
-DEFALUT_3D_MEAN_VALUE = [[2503.125, -2493.75, 5009.375], [-4987.5, 7515.625, -7481.25], [10021.875, -9975.0, 12528.125]]
+DEFAULT_3D_MEAN_VALUE = [[2503.125, -2493.75, 5009.375], [-4987.5, 7515.625, -7481.25], [10021.875, -9975.0, 12528.125]]
 
 
-DEFALUT_3D_MEDIAN_VALUE = [[4.5, 5.0, 13.5], [10.0, 22.5, 15.0], [31.5, 20.0, 40.5]]
+DEFAULT_3D_MEDIAN_VALUE = [[4.5, 5.0, 13.5], [10.0, 22.5, 15.0], [31.5, 20.0, 40.5]]
 
 
 NO_OUTLIERS_DEFAULT_3D_MEAN_VALUE = [
@@ -77,28 +78,48 @@ OFFLINE_AGGREGATORS_TEST_CASES = [
         min_ref=np.array(
             [
                 [[[-50000, 5, 10]]],
+                [[[-50000, 5, 10]]],
+                [[[-40000, 4, 8]]],
                 [[[-40000, 4, 8]]],
                 [[[-30000, 3, 6]]],
+                [[[-30000, 3, 6]]],
+                [[[-20000, 2, 4]]],
                 [[[-20000, 2, 4]]],
                 [[[-10000, 1, 2]]],
+                [[[-10000, 1, 2]]],
+                [[[0, 0, 0]]],
                 [[[0, 0, 0]]],
                 [[[-6, -7, -8]]],
+                [[[-6, -7, -8]]],
+                [[[-12, -14, -16]]],
                 [[[-12, -14, -16]]],
                 [[[-18, -21, -24]]],
+                [[[-18, -21, -24]]],
+                [[[-24, -28, -32]]],
                 [[[-24, -28, -32]]],
             ]
         ),
         max_ref=np.array(
             [
                 [[[50000, -5, -10]]],
+                [[[50000, -5, -10]]],
+                [[[40000, -4, -8]]],
                 [[[40000, -4, -8]]],
                 [[[30000, -3, -6]]],
+                [[[30000, -3, -6]]],
+                [[[20000, -2, -4]]],
                 [[[20000, -2, -4]]],
                 [[[10000, -1, -2]]],
+                [[[10000, -1, -2]]],
+                [[[0, 0, 0]]],
                 [[[0, 0, 0]]],
                 [[[6, 7, 8]]],
+                [[[6, 7, 8]]],
+                [[[12, 14, 16]]],
                 [[[12, 14, 16]]],
                 [[[18, 21, 24]]],
+                [[[18, 21, 24]]],
+                [[[24, 28, 32]]],
                 [[[24, 28, 32]]],
             ]
         ),
@@ -243,53 +264,68 @@ class TemplateTestReducersAggreagtors:
             min_aggregator.register_reduced_input(self.get_nncf_tensor(input_ * (-i)))
             max_aggregator.register_reduced_input(self.get_nncf_tensor(input_ * i))
 
+            for axis in aggregation_axes:
+                if axis:
+                    concatted_input = tensor_processor.cat([self.get_nncf_tensor(input_)] * 2, axis - 1).tensor
+                    min_aggregator.register_reduced_input(self.get_nncf_tensor(concatted_input * (-i)))
+                    max_aggregator.register_reduced_input(self.get_nncf_tensor(concatted_input * i))
+
         min_ref = offline_aggregators_test_desc.min_ref
         max_ref = offline_aggregators_test_desc.max_ref
-        assert self.all_close(
-            min_aggregator.aggregate(),
-            min_ref,
-        )
+
+        assert self.all_close(min_aggregator.aggregate(), min_ref)
         assert self.all_close(max_aggregator.aggregate(), max_ref)
 
     NO_OUTLIERS_TEST_PARAMS = [
-        (MeanAggregator, True, 1, [1404.5138888888905]),
-        (MedianAggregator, True, 1, [24.0]),
+        (MeanAggregator, (0, 1), 1, [1404.5138888888905]),
+        (MedianAggregator, (0, 1), 1, [24.0]),
         (
             MeanAggregator,
-            False,
+            (0,),
             1,
             [2503.125, -2493.75, 5009.375, -4987.5, 7515.625, -7481.25, 10021.875, -9975.0, 12528.125],
         ),
-        (MedianAggregator, False, 1, [4.5, 5.0, 13.5, 10.0, 22.5, 15.0, 31.5, 20.0, 40.5]),
-        (MeanAggregator, True, 2, [[2512.5, -1651.04166667, 3352.08333333]]),
-        (MedianAggregator, True, 2, [[13.0, 12.5, 21.0]]),
-        (MeanAggregator, False, 2, DEFALUT_3D_MEAN_VALUE),
-        (MedianAggregator, False, 2, DEFALUT_3D_MEDIAN_VALUE),
-        (MeanAggregator, True, 3, [DEFALUT_3D_MEAN_VALUE]),
-        (MedianAggregator, True, 3, [DEFALUT_3D_MEDIAN_VALUE]),
-        (MeanAggregator, False, 3, [DEFALUT_3D_MEAN_VALUE]),
-        (MedianAggregator, False, 3, [DEFALUT_3D_MEDIAN_VALUE]),
-        (default_test_mean_no_outlier, True, 1, [20.0893]),
-        (default_test_median_no_outlier, True, 1, [30.0]),
+        (MedianAggregator, (0,), 1, [4.5, 5.0, 13.5, 10.0, 22.5, 15.0, 31.5, 20.0, 40.5]),
+        ############################################################
+        (MeanAggregator, (0, 1), 2, [[2512.5, -1651.04166667, 3352.08333333]]),
+        (MedianAggregator, (0, 1), 2, [[13.0, 12.5, 21.0]]),
+        (MeanAggregator, (0,), 2, DEFAULT_3D_MEAN_VALUE),
+        (MedianAggregator, (0,), 2, DEFAULT_3D_MEDIAN_VALUE),
+        ############################################################
+        (MeanAggregator, (0, 1), 3, [DEFAULT_3D_MEAN_VALUE]),
+        (MedianAggregator, (0, 1), 3, [DEFAULT_3D_MEDIAN_VALUE]),
+        (MeanAggregator, (0,), 3, [DEFAULT_3D_MEAN_VALUE]),
+        (MedianAggregator, (0,), 3, [DEFAULT_3D_MEDIAN_VALUE]),
+        ############################################################
+        (default_test_mean_no_outlier, (0, 1), 1, [20.0893]),
+        (default_test_median_no_outlier, (0, 1), 1, [30.0]),
         (
             default_test_mean_no_outlier,
-            False,
+            (0,),
             1,
             [4.16666667, 8.33333333, 12.5, 16.66666667, 20.83333333, 25.0, 29.16666667, 33.33333333, 37.5],
         ),
-        (default_test_median_no_outlier, False, 1, [5.0, 4.0, 15.0, 8.0, 25.0, 12.0, 35.0, 16.0, 45.0]),
-        (default_test_mean_no_outlier, True, 2, [[16.66666667, 20.83333333, 25.0]]),
-        (default_test_median_no_outlier, True, 2, [[14.0, 10.0, 24.0]]),
-        (default_test_mean_no_outlier, False, 2, NO_OUTLIERS_DEFAULT_3D_MEAN_VALUE),
-        (default_test_median_no_outlier, False, 2, NO_OUTLIERS_DEFAULT_3D_MEDIAN_VALUE),
-        (default_test_mean_no_outlier, True, 3, [NO_OUTLIERS_DEFAULT_3D_MEAN_VALUE]),
-        (default_test_median_no_outlier, True, 3, [NO_OUTLIERS_DEFAULT_3D_MEDIAN_VALUE]),
-        (default_test_mean_no_outlier, False, 3, [NO_OUTLIERS_DEFAULT_3D_MEAN_VALUE]),
-        (default_test_median_no_outlier, False, 3, [NO_OUTLIERS_DEFAULT_3D_MEDIAN_VALUE]),
+        (default_test_median_no_outlier, (0,), 1, [5.0, 4.0, 15.0, 8.0, 25.0, 12.0, 35.0, 16.0, 45.0]),
+        ############################################################
+        (default_test_mean_no_outlier, (0, 1), 2, [[16.66666667, 20.83333333, 25.0]]),
+        (default_test_median_no_outlier, (0, 1), 2, [[14.0, 10.0, 24.0]]),
+        (default_test_mean_no_outlier, (0,), 2, NO_OUTLIERS_DEFAULT_3D_MEAN_VALUE),
+        (default_test_median_no_outlier, (0,), 2, NO_OUTLIERS_DEFAULT_3D_MEDIAN_VALUE),
+        ############################################################
+        (default_test_mean_no_outlier, (0, 1), 3, [NO_OUTLIERS_DEFAULT_3D_MEAN_VALUE]),
+        (default_test_median_no_outlier, (0, 1), 3, [NO_OUTLIERS_DEFAULT_3D_MEDIAN_VALUE]),
+        (default_test_mean_no_outlier, (0,), 3, [NO_OUTLIERS_DEFAULT_3D_MEAN_VALUE]),
+        (default_test_median_no_outlier, (0,), 3, [NO_OUTLIERS_DEFAULT_3D_MEDIAN_VALUE]),
     ]
 
-    @pytest.mark.parametrize("aggregator_cls,use_per_sample_stats,dims,refs", NO_OUTLIERS_TEST_PARAMS)
-    def test_mean_median_agggregators(self, aggregator_cls, refs, tensor_processor, dims, use_per_sample_stats):
+    def _get_inputs_for_mean_median_aggregators(
+        self,
+        dims: int,
+        aggregation_axes: Tuple[int, ...],
+        is_median: bool,
+        tensor_processor: NNCFCollectorTensorProcessor,
+        different_sizes: bool = False,
+    ) -> Iterator[NNCFTensor]:
         input_ = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9])
         input_with_outliers = np.array(
             [100_000, -100_000, 200_000, -200_000, 300_000, -300_000, 400_000, -400_000, 500_000]
@@ -301,25 +337,69 @@ class TemplateTestReducersAggreagtors:
             input_ = input_.reshape((1, 3, 3))
             input_with_outliers = input_with_outliers.reshape((1, 3, 3))
 
-        aggregation_axes = (0, 1) if use_per_sample_stats else (0,)
-        aggregator = aggregator_cls(tensor_processor=tensor_processor, aggregation_axes=aggregation_axes)
         for i in range(1, 6):
-            aggregator.register_reduced_input(self.get_nncf_tensor(input_ * i, Dtype.FLOAT))
+            yield self.get_nncf_tensor(input_ * i, Dtype.FLOAT)
         # this registration is to make diff between mean and median bigger
-        aggregator.register_reduced_input(self.get_nncf_tensor(input_ * 10, Dtype.FLOAT))
-        is_median = isinstance(aggregator, (MedianAggregator, MedianNoOutliersAggregator))
+        yield self.get_nncf_tensor(input_ * 10, Dtype.FLOAT)
         # Outliers registration
         for i in range(2):
             # mult is needed to make outlier and no outlier aggreagators differs
             mult = 2.2 * i - 1 if not is_median else 1
-            aggregator.register_reduced_input(self.get_nncf_tensor(input_with_outliers * mult, Dtype.FLOAT))
-            if is_median and dims == 1 and use_per_sample_stats:
+            yield self.get_nncf_tensor(input_with_outliers * mult, Dtype.FLOAT)
+            if is_median and dims == 1 and aggregation_axes == (0, 1):
                 # To make no outliers and outliers versions return different output
-                aggregator.register_reduced_input(
-                    self.get_nncf_tensor(np.full(input_with_outliers.shape, input_with_outliers[-1]), Dtype.FLOAT)
-                )
-        ret_val = aggregator.aggregate()
+                yield self.get_nncf_tensor(np.full(input_with_outliers.shape, input_with_outliers[-1]), Dtype.FLOAT)
 
+        if different_sizes:
+            # Different size input registration:
+            cat_input = self.get_nncf_tensor(input_, Dtype.FLOAT)
+            for axis in aggregation_axes:
+                if axis:
+                    yield tensor_processor.cat([cat_input] * 2, axis=axis - 1)
+
+    @pytest.mark.parametrize("aggregator_cls,aggregation_axes,dims,refs", NO_OUTLIERS_TEST_PARAMS)
+    def test_mean_median_agggregators(self, aggregator_cls, refs, tensor_processor, dims, aggregation_axes):
+        aggregator = aggregator_cls(tensor_processor=tensor_processor, aggregation_axes=aggregation_axes)
+        is_median = isinstance(aggregator, (MedianAggregator, MedianNoOutliersAggregator))
+        for input_ in self._get_inputs_for_mean_median_aggregators(dims, aggregation_axes, is_median, tensor_processor):
+            aggregator.register_reduced_input(input_)
+
+        ret_val = aggregator.aggregate()
+        assert self.all_close(ret_val, self.cast_tensor(refs, Dtype.FLOAT))
+
+    NO_OUTLIERS_DIFFERENT_SIZES_TEST_PARAMS = [
+        (MeanAggregator, (1,), 1, [[5.0], [10.0], [15.0], [20.0], [25.0], [50.0], [-55556.0], [66667.0], [5.0]]),
+        (MedianAggregator, (1,), 1, [[5.0], [10.0], [15.0], [20.0], [25.0], [50.0], [100_000.0], [100_000.0], [5.0]]),
+        (MeanAggregator, (0, 1), 1, [1124.6111]),
+        (MedianAggregator, (0, 1), 1, [15.5]),
+        (
+            default_test_mean_no_outlier,
+            (1,),
+            1,
+            [[5.0], [10.0], [15.0], [20.0], [25.0], [50.0], [-57143.0], [68571.0], [5.0]],
+        ),
+        (
+            default_test_median_no_outlier,
+            (1,),
+            1,
+            [[5.0], [10.0], [15.0], [20.0], [25.0], [50.0], [100_000.0], [100_000.0], [5.0]],
+        ),
+        (default_test_mean_no_outlier, (0, 1), 1, [16.8750]),
+        (default_test_median_no_outlier, (0, 1), 1, [20]),
+    ]
+
+    @pytest.mark.parametrize("aggregator_cls,aggregation_axes,dims,refs", NO_OUTLIERS_DIFFERENT_SIZES_TEST_PARAMS)
+    def test_mean_median_agggregators_different_sizes(
+        self, aggregator_cls, refs, tensor_processor, dims, aggregation_axes
+    ):
+        aggregator = aggregator_cls(tensor_processor=tensor_processor, aggregation_axes=aggregation_axes)
+        is_median = isinstance(aggregator, (MedianAggregator, MedianNoOutliersAggregator))
+        for input_ in self._get_inputs_for_mean_median_aggregators(
+            dims, aggregation_axes, is_median, tensor_processor, different_sizes=True
+        ):
+            aggregator.register_reduced_input(input_)
+
+        ret_val = aggregator.aggregate()
         assert self.all_close(ret_val, self.cast_tensor(refs, Dtype.FLOAT))
 
     @pytest.fixture(


### PR DESCRIPTION
### Changes

Support for tensors with different sizes on aggregation axes in `TensorCollector`

### Reason for changes

Previous implementation of tensor collectors was able to aggregate tensors with different batch size in the `per_sample` mode.
As this functional was not tested, this feature was missed in new implementation

### Related tickets

125669

### Tests

Tests with different sizes for online and offline tensor aggregators in `tests/common/experimental/test_reducers_and_aggregators.py`
MaskRCNN-EfficientNetB2B PTQ is checked locally 
