### PR TITLE
Update patch for roberta-large-mnli in third_party_integration

### DIFF
--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -8,8 +8,8 @@ onnxruntime==1.14.1
 pytest
 pytest-cov
 openvino-dev==2023.2.0
-optimum[onnxruntime,openvino]==1.8.8
-optimum-intel @ git+https://github.com/huggingface/optimum-intel@47428484598986443686b7c8ba825b4a3d7b4f73
+optimum[onnxruntime,openvino]==1.16.0
+optimum-intel @ git+https://github.com/huggingface/optimum-intel@622f585962e5e0ff5f927fd1a96fbc02b60a2e65
 soundfile==0.12.1
 librosa==0.10.0
 memory-profiler==0.61.0

--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -2,7 +2,7 @@
 torch==2.1.0
 --extra-index-url https://download.pytorch.org/whl/cpu
 torchvision==0.16.0
-transformers==4.30.0
+transformers==4.36.0
 onnx==1.13.1
 onnxruntime==1.14.1
 pytest

--- a/tests/torch/data/reference_graphs/pruning_groups/1_layer_BERT.dot
+++ b/tests/torch/data/reference_graphs/pruning_groups/1_layer_BERT.dot
@@ -1,51 +1,51 @@
 strict digraph  {
 0 [color=grey, label="Block: S:1__O:0
-Producers: 8
+Producers: 10
 Consumers: ", style=filled];
 1 [color=grey, label="Block: S:64__O:0
-Producers: 8
+Producers: 10
 Consumers: ", style=filled];
 2 [color=grey, label="Block: S:64__O:0
-Producers: 8,9
+Producers: 10,11
 Consumers: ", style=filled];
 3 [color=green, label="Block: S:64__O:0
-Producers: 8,9,12
-Consumers: 27", style=filled];
+Producers: 10,11,14
+Consumers: 29", style=filled];
 4 [color=grey, label="Block: S:1__O:64
-Producers: 8
+Producers: 10
 Consumers: ", style=filled];
 5 [color=green, label="Block: S:1__O:64
-Producers: 8,9
-Consumers: 18", style=filled];
+Producers: 10,11
+Consumers: 20", style=filled];
 6 [color=grey, label="Block: S:1__O:0
-Producers: 9
+Producers: 11
 Consumers: ", style=filled];
 7 [color=grey, label="Block: S:64__O:0
-Producers: 9
+Producers: 11
 Consumers: ", style=filled];
 8 [color=grey, label="Block: S:1__O:64
-Producers: 9
+Producers: 11
 Consumers: ", style=filled];
 9 [color=grey, label="Block: S:1__O:0
-Producers: 12
+Producers: 14
 Consumers: ", style=filled];
 10 [color=grey, label="Block: S:64__O:0
-Producers: 12
+Producers: 14
 Consumers: ", style=filled];
 11 [color=green, label="Block: S:1__O:64
-Producers: 12
-Consumers: 27", style=filled];
+Producers: 14
+Consumers: 29", style=filled];
 12 [color=red, label="Block: S:1__O:0
-Producers: 27
+Producers: 29
 Consumers: ", style=filled];
 13 [color=green, label="Block: S:1__O:0
-Producers: 31
-Consumers: 33", style=filled];
-14 [color=red, label="Block: S:1__O:0
 Producers: 33
+Consumers: 35", style=filled];
+14 [color=red, label="Block: S:1__O:0
+Producers: 35
 Consumers: ", style=filled];
 15 [color=red, label="Block: S:1__O:0
-Producers: 37
+Producers: 39
 Consumers: ", style=filled];
 0 -> 1;
 0 -> 4;

--- a/tests/torch/data/reference_graphs/pruning_groups/1_layer_BERT_.dot
+++ b/tests/torch/data/reference_graphs/pruning_groups/1_layer_BERT_.dot
@@ -1,0 +1,57 @@
+strict digraph  {
+0 [color=grey, label="Block: S:1__O:0
+Producers: 14
+Consumers: ", style=filled];
+1 [color=grey, label="Block: S:64__O:0
+Producers: 14
+Consumers: ", style=filled];
+2 [color=red, label="Block: S:64__O:0
+Producers: 14,15
+Consumers: ", style=filled];
+3 [color=grey, label="Block: S:1__O:64
+Producers: 14
+Consumers: ", style=filled];
+4 [color=green, label="Block: S:1__O:64
+Producers: 14,15
+Consumers: 24", style=filled];
+5 [color=grey, label="Block: S:1__O:0
+Producers: 15
+Consumers: ", style=filled];
+6 [color=grey, label="Block: S:64__O:0
+Producers: 15
+Consumers: ", style=filled];
+7 [color=grey, label="Block: S:1__O:64
+Producers: 15
+Consumers: ", style=filled];
+8 [color=grey, label="Block: S:1__O:0
+Producers: 18
+Consumers: ", style=filled];
+9 [color=red, label="Block: S:64__O:0
+Producers: 18
+Consumers: ", style=filled];
+10 [color=red, label="Block: S:1__O:64
+Producers: 18
+Consumers: ", style=filled];
+11 [color=red, label="Block: S:1__O:0
+Producers: 33
+Consumers: ", style=filled];
+12 [color=green, label="Block: S:1__O:0
+Producers: 37
+Consumers: 39", style=filled];
+13 [color=red, label="Block: S:1__O:0
+Producers: 39
+Consumers: ", style=filled];
+14 [color=red, label="Block: S:1__O:0
+Producers: 43
+Consumers: ", style=filled];
+0 -> 1;
+0 -> 3;
+1 -> 2;
+3 -> 4;
+5 -> 6;
+5 -> 7;
+6 -> 2;
+7 -> 4;
+8 -> 9;
+8 -> 10;
+}

--- a/tests/torch/data/reference_graphs/pruning_groups/CLIP.dot
+++ b/tests/torch/data/reference_graphs/pruning_groups/CLIP.dot
@@ -1,51 +1,51 @@
 strict digraph  {
 0 [color=grey, label="Block: S:1__O:0
-Producers: 9
+Producers: 10
 Consumers: ", style=filled];
 1 [color=grey, label="Block: S:2__O:0
-Producers: 9
+Producers: 10
 Consumers: ", style=filled];
 2 [color=grey, label="Block: S:2__O:0
-Producers: 9,11
+Producers: 10,12
 Consumers: ", style=filled];
 3 [color=green, label="Block: S:2__O:0
-Producers: 9,11,15
-Consumers: 33", style=filled];
+Producers: 10,12,16
+Consumers: 34", style=filled];
 4 [color=grey, label="Block: S:1__O:2
-Producers: 9
+Producers: 10
 Consumers: ", style=filled];
 5 [color=green, label="Block: S:1__O:2
-Producers: 9,11
-Consumers: 26", style=filled];
+Producers: 10,12
+Consumers: 27", style=filled];
 6 [color=grey, label="Block: S:1__O:0
-Producers: 11
+Producers: 12
 Consumers: ", style=filled];
 7 [color=grey, label="Block: S:2__O:0
-Producers: 11
+Producers: 12
 Consumers: ", style=filled];
 8 [color=grey, label="Block: S:1__O:2
-Producers: 11
+Producers: 12
 Consumers: ", style=filled];
 9 [color=grey, label="Block: S:1__O:0
-Producers: 15
+Producers: 16
 Consumers: ", style=filled];
 10 [color=grey, label="Block: S:2__O:0
-Producers: 15
+Producers: 16
 Consumers: ", style=filled];
 11 [color=green, label="Block: S:1__O:2
-Producers: 15
-Consumers: 33", style=filled];
+Producers: 16
+Consumers: 34", style=filled];
 12 [color=red, label="Block: S:1__O:0
-Producers: 33
+Producers: 34
 Consumers: ", style=filled];
 13 [color=grey, label="Block: S:1__O:0
-Producers: 36
+Producers: 37
 Consumers: ", style=filled];
 14 [color=green, label="Block: S:1__O:0
-Producers: 36
-Consumers: 40", style=filled];
+Producers: 37
+Consumers: 41", style=filled];
 15 [color=red, label="Block: S:1__O:0
-Producers: 40
+Producers: 41
 Consumers: ", style=filled];
 0 -> 1;
 0 -> 4;

--- a/tests/torch/data/reference_graphs/pruning_groups/MobileBERT.dot
+++ b/tests/torch/data/reference_graphs/pruning_groups/MobileBERT.dot
@@ -1,99 +1,99 @@
 strict digraph  {
 0 [color=red, label="Block: S:1__O:0
-Producers: 7
+Producers: 9
 Consumers: ", style=filled];
 1 [color=grey, label="Block: S:1__O:0
-Producers: 15
+Producers: 17
 Consumers: ", style=filled];
 2 [color=grey, label="Block: S:1__O:0
-Producers: 15,40
-Consumers: 44", style=filled];
+Producers: 17,42
+Consumers: 46", style=filled];
 3 [color=grey, label="Block: S:1__O:0
-Producers: 15,40,46
-Consumers: 44,50", style=filled];
+Producers: 17,42,48
+Consumers: 46,52", style=filled];
 4 [color=grey, label="Block: S:1__O:0
-Producers: 15,40,46,52
-Consumers: 44,50,56", style=filled];
+Producers: 17,42,48,54
+Consumers: 46,52,58", style=filled];
 5 [color=grey, label="Block: S:1__O:0
-Producers: 15,40,46,52,58
-Consumers: 44,50,56,62", style=filled];
+Producers: 17,42,48,54,60
+Consumers: 46,52,58,64", style=filled];
 6 [color=green, label="Block: S:1__O:0
-Producers: 15,40,46,52,58,64
-Consumers: 44,50,56,62,68", style=filled];
+Producers: 17,42,48,54,60,66
+Consumers: 46,52,58,64,70", style=filled];
 7 [color=green, label="Block: S:1__O:0
-Producers: 18
-Consumers: 21,22", style=filled];
+Producers: 20
+Consumers: 23,24", style=filled];
 8 [color=grey, label="Block: S:1__O:0
-Producers: 21
+Producers: 23
 Consumers: ", style=filled];
 9 [color=grey, label="Block: S:64__O:0
-Producers: 21
+Producers: 23
 Consumers: ", style=filled];
 10 [color=grey, label="Block: S:64__O:0
-Producers: 21,22
+Producers: 23,24
 Consumers: ", style=filled];
 11 [color=green, label="Block: S:64__O:0
-Producers: 21,22,23
-Consumers: 40", style=filled];
+Producers: 23,24,25
+Consumers: 42", style=filled];
 12 [color=grey, label="Block: S:1__O:64
-Producers: 21
+Producers: 23
 Consumers: ", style=filled];
 13 [color=green, label="Block: S:1__O:64
-Producers: 21,22
-Consumers: 31", style=filled];
+Producers: 23,24
+Consumers: 33", style=filled];
 14 [color=grey, label="Block: S:1__O:0
-Producers: 22
+Producers: 24
 Consumers: ", style=filled];
 15 [color=grey, label="Block: S:64__O:0
-Producers: 22
+Producers: 24
 Consumers: ", style=filled];
 16 [color=grey, label="Block: S:1__O:64
-Producers: 22
+Producers: 24
 Consumers: ", style=filled];
 17 [color=grey, label="Block: S:1__O:0
-Producers: 23
+Producers: 25
 Consumers: ", style=filled];
 18 [color=grey, label="Block: S:64__O:0
-Producers: 23
+Producers: 25
 Consumers: ", style=filled];
 19 [color=green, label="Block: S:1__O:64
-Producers: 23
-Consumers: 40", style=filled];
+Producers: 25
+Consumers: 42", style=filled];
 20 [color=grey, label="Block: S:1__O:0
-Producers: 40
+Producers: 42
 Consumers: ", style=filled];
 21 [color=green, label="Block: S:1__O:0
-Producers: 44
-Consumers: 46", style=filled];
-22 [color=grey, label="Block: S:1__O:0
 Producers: 46
+Consumers: 48", style=filled];
+22 [color=grey, label="Block: S:1__O:0
+Producers: 48
 Consumers: ", style=filled];
 23 [color=green, label="Block: S:1__O:0
-Producers: 50
-Consumers: 52", style=filled];
-24 [color=grey, label="Block: S:1__O:0
 Producers: 52
+Consumers: 54", style=filled];
+24 [color=grey, label="Block: S:1__O:0
+Producers: 54
 Consumers: ", style=filled];
 25 [color=green, label="Block: S:1__O:0
-Producers: 56
-Consumers: 58", style=filled];
-26 [color=grey, label="Block: S:1__O:0
 Producers: 58
+Consumers: 60", style=filled];
+26 [color=grey, label="Block: S:1__O:0
+Producers: 60
 Consumers: ", style=filled];
 27 [color=green, label="Block: S:1__O:0
-Producers: 62
-Consumers: 64", style=filled];
-28 [color=grey, label="Block: S:1__O:0
 Producers: 64
+Consumers: 66", style=filled];
+28 [color=grey, label="Block: S:1__O:0
+Producers: 66
 Consumers: ", style=filled];
 29 [color=red, label="Block: S:1__O:0
-Producers: 68
+Producers: 70
 Consumers: ", style=filled];
 30 [color=green, label="Block: S:1__O:0
-Producers: 74
-Consumers: 77", style=filled];
+Producers: 76
+Consumers: 79", style=filled];
 31 [color=red, label="Block: S:1__O:0
-Producers: 77
+Producers: 79
 Consumers: ", style=filled];
 1 -> 2;
 2 -> 3;

--- a/tests/torch/data/reference_graphs/pruning_groups/RoBERTa.dot
+++ b/tests/torch/data/reference_graphs/pruning_groups/RoBERTa.dot
@@ -1,51 +1,51 @@
 strict digraph  {
 0 [color=grey, label="Block: S:1__O:0
-Producers: 16
+Producers: 18
 Consumers: ", style=filled];
 1 [color=grey, label="Block: S:64__O:0
-Producers: 16
+Producers: 18
 Consumers: ", style=filled];
 2 [color=grey, label="Block: S:64__O:0
-Producers: 16,17
+Producers: 18,19
 Consumers: ", style=filled];
 3 [color=green, label="Block: S:64__O:0
-Producers: 16,17,20
-Consumers: 35", style=filled];
+Producers: 18,19,22
+Consumers: 37", style=filled];
 4 [color=grey, label="Block: S:1__O:64
-Producers: 16
+Producers: 18
 Consumers: ", style=filled];
 5 [color=green, label="Block: S:1__O:64
-Producers: 16,17
-Consumers: 26", style=filled];
+Producers: 18,19
+Consumers: 28", style=filled];
 6 [color=grey, label="Block: S:1__O:0
-Producers: 17
+Producers: 19
 Consumers: ", style=filled];
 7 [color=grey, label="Block: S:64__O:0
-Producers: 17
+Producers: 19
 Consumers: ", style=filled];
 8 [color=grey, label="Block: S:1__O:64
-Producers: 17
+Producers: 19
 Consumers: ", style=filled];
 9 [color=grey, label="Block: S:1__O:0
-Producers: 20
+Producers: 22
 Consumers: ", style=filled];
 10 [color=grey, label="Block: S:64__O:0
-Producers: 20
+Producers: 22
 Consumers: ", style=filled];
 11 [color=green, label="Block: S:1__O:64
-Producers: 20
-Consumers: 35", style=filled];
+Producers: 22
+Consumers: 37", style=filled];
 12 [color=red, label="Block: S:1__O:0
-Producers: 35
+Producers: 37
 Consumers: ", style=filled];
 13 [color=green, label="Block: S:1__O:0
-Producers: 39
-Consumers: 41", style=filled];
-14 [color=red, label="Block: S:1__O:0
 Producers: 41
+Consumers: 43", style=filled];
+14 [color=red, label="Block: S:1__O:0
+Producers: 43
 Consumers: ", style=filled];
 15 [color=red, label="Block: S:1__O:0
-Producers: 45
+Producers: 47
 Consumers: ", style=filled];
 0 -> 1;
 0 -> 4;

--- a/tests/torch/data/reference_graphs/pruning_groups/larger_BERT.dot
+++ b/tests/torch/data/reference_graphs/pruning_groups/larger_BERT.dot
@@ -1,54 +1,54 @@
 strict digraph  {
 0 [color=grey, label="Block: S:1__O:0
-Producers: 8
+Producers: 10
 Consumers: ", style=filled];
 1 [color=grey, label="Block: S:2__O:0
-Producers: 8
+Producers: 10
 Consumers: ", style=filled];
 2 [color=grey, label="Block: S:2__O:0
-Producers: 8,9
+Producers: 10,11
 Consumers: ", style=filled];
 3 [color=green, label="Block: S:2__O:0
-Producers: 8,9,12
-Consumers: 27", style=filled];
+Producers: 10,11,14
+Consumers: 29", style=filled];
 4 [color=grey, label="Block: S:1__O:2
-Producers: 8
+Producers: 10
 Consumers: ", style=filled];
 5 [color=green, label="Block: S:1__O:2
-Producers: 8,9
-Consumers: 18", style=filled];
+Producers: 10,11
+Consumers: 20", style=filled];
 6 [color=grey, label="Block: S:1__O:0
-Producers: 9
+Producers: 11
 Consumers: ", style=filled];
 7 [color=grey, label="Block: S:2__O:0
-Producers: 9
+Producers: 11
 Consumers: ", style=filled];
 8 [color=grey, label="Block: S:1__O:2
-Producers: 9
+Producers: 11
 Consumers: ", style=filled];
 9 [color=grey, label="Block: S:1__O:0
-Producers: 12
+Producers: 14
 Consumers: ", style=filled];
 10 [color=grey, label="Block: S:2__O:0
-Producers: 12
+Producers: 14
 Consumers: ", style=filled];
 11 [color=green, label="Block: S:1__O:2
-Producers: 12
-Consumers: 27", style=filled];
+Producers: 14
+Consumers: 29", style=filled];
 12 [color=red, label="Block: S:1__O:0
-Producers: 27
+Producers: 29
 Consumers: ", style=filled];
 13 [color=green, label="Block: S:1__O:0
-Producers: 31
-Consumers: 33", style=filled];
-14 [color=red, label="Block: S:1__O:0
 Producers: 33
+Consumers: 35", style=filled];
+14 [color=red, label="Block: S:1__O:0
+Producers: 35
 Consumers: ", style=filled];
 15 [color=green, label="Block: S:1__O:0
-Producers: 38
-Consumers: 41", style=filled];
+Producers: 40
+Consumers: 43", style=filled];
 16 [color=red, label="Block: S:1__O:0
-Producers: 41
+Producers: 43
 Consumers: ", style=filled];
 0 -> 1;
 0 -> 4;

--- a/tests/torch/data/search_building_block/bert.json
+++ b/tests/torch/data/search_building_block/bert.json
@@ -30,8 +30,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[0]/BertAttention[attention]/BertSelfOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            7,
-            29
+            9,
+            31
         ]
     },
     {
@@ -49,8 +49,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[0]/BertOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            29,
-            35
+            31,
+            37
         ]
     },
     {
@@ -84,8 +84,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[1]/BertAttention[attention]/BertSelfOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            36,
-            58
+            38,
+            60
         ]
     },
     {
@@ -103,8 +103,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[1]/BertOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            58,
-            64
+            60,
+            66
         ]
     },
     {
@@ -138,8 +138,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[2]/BertAttention[attention]/BertSelfOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            65,
-            87
+            67,
+            89
         ]
     },
     {
@@ -157,8 +157,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[2]/BertOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            87,
-            93
+            89,
+            95
         ]
     },
     {
@@ -192,8 +192,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[3]/BertAttention[attention]/BertSelfOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            94,
-            116
+            96,
+            118
         ]
     },
     {
@@ -211,8 +211,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[3]/BertOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            116,
-            122
+            118,
+            124
         ]
     },
     {
@@ -246,8 +246,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[4]/BertAttention[attention]/BertSelfOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            123,
-            145
+            125,
+            147
         ]
     },
     {
@@ -265,8 +265,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[4]/BertOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            145,
-            151
+            147,
+            153
         ]
     },
     {
@@ -300,8 +300,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[5]/BertAttention[attention]/BertSelfOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            152,
-            174
+            154,
+            176
         ]
     },
     {
@@ -319,8 +319,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[5]/BertOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            174,
-            180
+            176,
+            182
         ]
     },
     {
@@ -354,8 +354,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[6]/BertAttention[attention]/BertSelfOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            181,
-            203
+            183,
+            205
         ]
     },
     {
@@ -373,8 +373,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[6]/BertOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            203,
-            209
+            205,
+            211
         ]
     },
     {
@@ -408,8 +408,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[7]/BertAttention[attention]/BertSelfOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            210,
-            232
+            212,
+            234
         ]
     },
     {
@@ -427,8 +427,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[7]/BertOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            232,
-            238
+            234,
+            240
         ]
     },
     {
@@ -462,8 +462,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[8]/BertAttention[attention]/BertSelfOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            239,
-            261
+            241,
+            263
         ]
     },
     {
@@ -481,8 +481,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[8]/BertOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            261,
-            267
+            263,
+            269
         ]
     },
     {
@@ -516,8 +516,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[9]/BertAttention[attention]/BertSelfOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            268,
-            290
+            270,
+            292
         ]
     },
     {
@@ -535,8 +535,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[9]/BertOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            290,
-            296
+            292,
+            298
         ]
     },
     {
@@ -570,8 +570,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[10]/BertAttention[attention]/BertSelfOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            297,
-            319
+            299,
+            321
         ]
     },
     {
@@ -589,8 +589,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[10]/BertOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            319,
-            325
+            321,
+            327
         ]
     },
     {
@@ -624,8 +624,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[11]/BertAttention[attention]/BertSelfOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            326,
-            348
+            328,
+            350
         ]
     },
     {
@@ -643,8 +643,8 @@
             "BertForQuestionAnswering/BertModel[bert]/BertEncoder[encoder]/ModuleList[layer]/BertLayer[11]/BertOutput[output]/__add___0"
         ],
         "ordinal_ids": [
-            348,
-            354
+            350,
+            356
         ]
     }
 ]

--- a/tests/torch/models_hub_test/requirements.txt
+++ b/tests/torch/models_hub_test/requirements.txt
@@ -2,7 +2,7 @@
 torch==2.1.0
 --extra-index-url https://download.pytorch.org/whl/cpu
 torchvision==0.16.0
-transformers==4.35.0
+transformers==4.36.0
 pytest
 timm==0.9.2
 scikit-learn==1.2.2

--- a/tests/torch/pruning/experimental/test_nodes_grouping.py
+++ b/tests/torch/pruning/experimental/test_nodes_grouping.py
@@ -185,10 +185,10 @@ NLP_DESCS = [
         ref_groups=[
             PruningGroup(
                 block=PruningBlock(size=64, offset=0),
-                producers={ProducerInfo(9), ProducerInfo(12), ProducerInfo(8)},
-                consumers={ConsumerInfo(27)},
+                producers={ProducerInfo(11), ProducerInfo(14), ProducerInfo(10)},
+                consumers={ConsumerInfo(29)},
             ),
-            PruningGroup(block=PruningBlock(), producers={ProducerInfo(31)}, consumers={ConsumerInfo(33)}),
+            PruningGroup(block=PruningBlock(), producers={ProducerInfo(33)}, consumers={ConsumerInfo(35)}),
         ],
     ),
     GroupTestDesc(
@@ -214,11 +214,11 @@ NLP_DESCS = [
         ref_groups=[
             PruningGroup(
                 block=PruningBlock(size=2, offset=0),
-                producers={ProducerInfo(8), ProducerInfo(9), ProducerInfo(12)},
-                consumers={ConsumerInfo(27)},
+                producers={ProducerInfo(10), ProducerInfo(11), ProducerInfo(14)},
+                consumers={ConsumerInfo(29)},
             ),
-            PruningGroup(block=PruningBlock(), producers={ProducerInfo(31)}, consumers={ConsumerInfo(33)}),
-            PruningGroup(block=PruningBlock(), producers={ProducerInfo(38)}, consumers={ConsumerInfo(41)}),
+            PruningGroup(block=PruningBlock(), producers={ProducerInfo(33)}, consumers={ConsumerInfo(35)}),
+            PruningGroup(block=PruningBlock(), producers={ProducerInfo(40)}, consumers={ConsumerInfo(43)}),
         ],
     ),
     GroupTestDesc(
@@ -230,10 +230,10 @@ NLP_DESCS = [
         ref_groups=[
             PruningGroup(
                 block=PruningBlock(size=64, offset=0),
-                producers={ProducerInfo(17), ProducerInfo(20), ProducerInfo(16)},
-                consumers={ConsumerInfo(35)},
+                producers={ProducerInfo(19), ProducerInfo(22), ProducerInfo(18)},
+                consumers={ConsumerInfo(37)},
             ),
-            PruningGroup(block=PruningBlock(), producers={ProducerInfo(39)}, consumers={ConsumerInfo(41)}),
+            PruningGroup(block=PruningBlock(), producers={ProducerInfo(41)}, consumers={ConsumerInfo(43)}),
         ],
     ),
     GroupTestDesc(
@@ -285,28 +285,28 @@ NLP_DESCS = [
             PruningGroup(
                 block=PruningBlock(),
                 producers={
-                    ProducerInfo(15),
-                    ProducerInfo(40),
-                    ProducerInfo(46),
-                    ProducerInfo(52),
-                    ProducerInfo(58),
-                    ProducerInfo(64),
+                    ProducerInfo(17),
+                    ProducerInfo(42),
+                    ProducerInfo(48),
+                    ProducerInfo(54),
+                    ProducerInfo(60),
+                    ProducerInfo(66),
                 },
-                consumers={ConsumerInfo(62), ConsumerInfo(44), ConsumerInfo(56), ConsumerInfo(68), ConsumerInfo(50)},
+                consumers={ConsumerInfo(64), ConsumerInfo(46), ConsumerInfo(58), ConsumerInfo(70), ConsumerInfo(52)},
             ),
             PruningGroup(
                 block=PruningBlock(size=64, offset=0),
-                producers={ProducerInfo(21), ProducerInfo(22), ProducerInfo(23)},
-                consumers={ConsumerInfo(40)},
+                producers={ProducerInfo(23), ProducerInfo(24), ProducerInfo(25)},
+                consumers={ConsumerInfo(42)},
             ),
             PruningGroup(
-                block=PruningBlock(), producers={ProducerInfo(18)}, consumers={ConsumerInfo(21), ConsumerInfo(22)}
+                block=PruningBlock(), producers={ProducerInfo(20)}, consumers={ConsumerInfo(23), ConsumerInfo(24)}
             ),
-            PruningGroup(block=PruningBlock(), producers={ProducerInfo(44)}, consumers={ConsumerInfo(46)}),
-            PruningGroup(block=PruningBlock(), producers={ProducerInfo(50)}, consumers={ConsumerInfo(52)}),
-            PruningGroup(block=PruningBlock(), producers={ProducerInfo(56)}, consumers={ConsumerInfo(58)}),
-            PruningGroup(block=PruningBlock(), producers={ProducerInfo(62)}, consumers={ConsumerInfo(64)}),
-            PruningGroup(block=PruningBlock(), producers={ProducerInfo(74)}, consumers={ConsumerInfo(77)}),
+            PruningGroup(block=PruningBlock(), producers={ProducerInfo(46)}, consumers={ConsumerInfo(48)}),
+            PruningGroup(block=PruningBlock(), producers={ProducerInfo(52)}, consumers={ConsumerInfo(54)}),
+            PruningGroup(block=PruningBlock(), producers={ProducerInfo(58)}, consumers={ConsumerInfo(60)}),
+            PruningGroup(block=PruningBlock(), producers={ProducerInfo(64)}, consumers={ConsumerInfo(66)}),
+            PruningGroup(block=PruningBlock(), producers={ProducerInfo(76)}, consumers={ConsumerInfo(79)}),
         ],
     ),
 ]
@@ -409,10 +409,10 @@ CV_DESCS = [
         ref_groups=[
             PruningGroup(
                 block=PruningBlock(size=2, offset=0),
-                producers={ProducerInfo(9), ProducerInfo(15), ProducerInfo(11)},
-                consumers={ConsumerInfo(33)},
+                producers={ProducerInfo(10), ProducerInfo(16), ProducerInfo(12)},
+                consumers={ConsumerInfo(34)},
             ),
-            PruningGroup(block=PruningBlock(), producers={ProducerInfo(36)}, consumers={ConsumerInfo(40)}),
+            PruningGroup(block=PruningBlock(), producers={ProducerInfo(37)}, consumers={ConsumerInfo(41)}),
         ],
     ),
     GroupTestDesc(
@@ -482,6 +482,11 @@ def test_groups(desc: GroupTestDesc, mocker, tmp_path):
     compare_nx_graph_with_reference(nx_graph, path_to_dot, sort_dot_graph=False)
 
     filtered_groups = select_largest_groups(not_filtered_groups)
+    print(filtered_groups)
+
+    for x in filtered_groups:
+        print(x)
+    # print(desc.ref_groups)
     assert filtered_groups == desc.ref_groups
 
 

--- a/tests/torch/pruning/experimental/test_nodes_grouping.py
+++ b/tests/torch/pruning/experimental/test_nodes_grouping.py
@@ -482,11 +482,6 @@ def test_groups(desc: GroupTestDesc, mocker, tmp_path):
     compare_nx_graph_with_reference(nx_graph, path_to_dot, sort_dot_graph=False)
 
     filtered_groups = select_largest_groups(not_filtered_groups)
-    print(filtered_groups)
-
-    for x in filtered_groups:
-        print(x)
-    # print(desc.ref_groups)
     assert filtered_groups == desc.ref_groups
 
 

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -10,7 +10,7 @@ virtualenv
 pyparsing<3.0
 
 # Required for search_building_blocks tests
-transformers[torch]~=4.30.0
+transformers[torch]~=4.36.0
 accelerate==0.24.1
 
 # Required for movement_sparsity tests

--- a/tests/torch/sparsity/movement/test_model_saving.py
+++ b/tests/torch/sparsity/movement/test_model_saving.py
@@ -445,5 +445,7 @@ class TestCompressionState:
         resumed_trainer.train(str(resume_folder))
 
         PTTensorListComparator.check_equal(
-            list(compressed_model.state_dict().values()), list(resumed_compressed_model.state_dict().values())
+            list(compressed_model.state_dict().values()),
+            list(resumed_compressed_model.state_dict().values()),
+            atol=0.001,
         )

--- a/third_party_integration/huggingface_transformers/0001-Modifications-for-NNCF-usage.patch
+++ b/third_party_integration/huggingface_transformers/0001-Modifications-for-NNCF-usage.patch
@@ -1,6 +1,6 @@
-From 71c900090006c02e94aa46b10da1eb6d16485a07 Mon Sep 17 00:00:00 2001
-From: Nikolay Lyalyushkin <nikolay.lyalyushkin@intel.com>
-Date: Tue, 18 Oct 2022 22:08:16 +0200
+From 76c14db1e3501d03f548d9e9ebc58661443d64e1 Mon Sep 17 00:00:00 2001
+From: Alexander Dokuchaev <alexander.dokuchaev@intel.com>
+Date: Mon, 25 Dec 2023 21:36:16 +0200
 Subject: [PATCH] Modifications for NNCF usage
 
 ---
@@ -17,13 +17,13 @@ Subject: [PATCH] Modifications for NNCF usage
  nncf_distilbert_config_sst2.json              |  33 ++++++
  nncf_gpt2_config_wikitext_hw_config.json      |  49 ++++++++
  nncf_mobilebert_config_squad_int8.json        |  49 ++++++++
- nncf_roberta_config_mnli.json                 |  35 ++++++
+ nncf_roberta_config_mnli.json                 |  29 +++++
  src/transformers/modeling_utils.py            |  24 ++++
  src/transformers/pytorch_utils.py             |   3 +-
  src/transformers/trainer.py                   |  51 +++++++-
  src/transformers/training_args.py             |   6 +
  src/transformers/utils/__init__.py            |   1 +
- 19 files changed, 811 insertions(+), 68 deletions(-)
+ 19 files changed, 805 insertions(+), 68 deletions(-)
  create mode 100644 nncf_bert_config_conll.json
  create mode 100644 nncf_bert_config_mrpc.json
  create mode 100644 nncf_bert_config_squad.json
@@ -40,30 +40,30 @@ index fe03cde7c..3f8cd6d37 100755
 +++ b/examples/pytorch/language-modeling/run_clm.py
 @@ -30,6 +30,8 @@ from itertools import chain
  from typing import Optional
- 
+
  import datasets
 +import onnx
 +import torch
  from datasets import load_dataset
- 
+
  import evaluate
 @@ -51,7 +53,12 @@ from transformers.testing_utils import CaptureLogger
  from transformers.trainer_utils import get_last_checkpoint
  from transformers.utils import check_min_version, send_example_telemetry
  from transformers.utils.versions import require_version
 +from transformers.trainer import get_train_dataloader_for_init
- 
+
 +from nncf import NNCFConfig
 +from nncf.config.structures import QuantizationRangeInitArgs
 +from nncf.config.structures import BNAdaptationInitArgs
 +from nncf.torch.initialization import PTInitializingDataLoader
- 
+
  # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
  check_min_version("4.23.0")
 @@ -373,22 +380,6 @@ def main():
              "You can do it from another script, save it, and load it from here, using --tokenizer_name."
          )
- 
+
 -    if model_args.model_name_or_path:
 -        model = AutoModelForCausalLM.from_pretrained(
 -            model_args.model_name_or_path,
@@ -86,7 +86,7 @@ index fe03cde7c..3f8cd6d37 100755
 @@ -503,6 +494,59 @@ def main():
              preds = preds[:, :-1].reshape(-1)
              return metric.compute(predictions=preds, references=labels)
- 
+
 +    nncf_config = None
 +    if training_args.nncf_config is not None:
 +        nncf_config = NNCFConfig.from_json(training_args.nncf_config)
@@ -149,7 +149,7 @@ index fe03cde7c..3f8cd6d37 100755
          else None,
 +        compression_ctrl=compression_ctrl
      )
- 
+
      # Training
 diff --git a/examples/pytorch/question-answering/run_qa.py b/examples/pytorch/question-answering/run_qa.py
 index 1240623b5..b6136d6e3 100755
@@ -157,11 +157,11 @@ index 1240623b5..b6136d6e3 100755
 +++ b/examples/pytorch/question-answering/run_qa.py
 @@ -25,6 +25,7 @@ from dataclasses import dataclass, field
  from typing import Optional
- 
+
  import datasets
 +import torch
  from datasets import load_dataset
- 
+
  import evaluate
 @@ -42,11 +43,19 @@ from transformers import (
      default_data_collator,
@@ -172,7 +172,7 @@ index 1240623b5..b6136d6e3 100755
  from transformers.utils import check_min_version, send_example_telemetry
  from transformers.utils.versions import require_version
  from utils_qa import postprocess_qa_predictions
- 
+
 +from torch import onnx
 +
 +from nncf import NNCFConfig
@@ -180,7 +180,7 @@ index 1240623b5..b6136d6e3 100755
 +from nncf.config.structures import BNAdaptationInitArgs
 +from nncf.config.structures import QuantizationRangeInitArgs
 +from nncf.common.utils.tensorboard import prepare_for_tensorboard
- 
+
  # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
  check_min_version("4.23.0")
 @@ -327,14 +336,6 @@ def main():
@@ -195,13 +195,13 @@ index 1240623b5..b6136d6e3 100755
 -        revision=model_args.model_revision,
 -        use_auth_token=True if model_args.use_auth_token else None,
 -    )
- 
+
      # Tokenizer check: this script requires a fast tokenizer.
      if not isinstance(tokenizer, PreTrainedTokenizerFast):
 @@ -599,6 +600,51 @@ def main():
      def compute_metrics(p: EvalPrediction):
          return metric.compute(predictions=p.predictions, references=p.label_ids)
- 
+
 +    nncf_config = None
 +    if training_args.nncf_config is not None:
 +        nncf_config = NNCFConfig.from_json(training_args.nncf_config)
@@ -256,14 +256,14 @@ index 1240623b5..b6136d6e3 100755
          compute_metrics=compute_metrics,
 +        compression_ctrl=compression_ctrl
      )
- 
+
      # Training
 diff --git a/examples/pytorch/text-classification/run_glue.py b/examples/pytorch/text-classification/run_glue.py
 index 3eb423f08..f675e7ab4 100755
 --- a/examples/pytorch/text-classification/run_glue.py
 +++ b/examples/pytorch/text-classification/run_glue.py
 @@ -29,6 +29,10 @@ from datasets import load_dataset
- 
+
  import evaluate
  import transformers
 +from nncf import NNCFConfig
@@ -294,7 +294,7 @@ index 3eb423f08..f675e7ab4 100755
 -        use_auth_token=True if model_args.use_auth_token else None,
 -        ignore_mismatched_sizes=model_args.ignore_mismatched_sizes,
 -    )
- 
+
      # Preprocessing the raw_datasets
      if data_args.task_name is not None:
 @@ -400,12 +396,12 @@ def main():
@@ -314,7 +314,7 @@ index 3eb423f08..f675e7ab4 100755
          else:
 @@ -418,11 +414,11 @@ def main():
          label_to_id = {v: i for i, v in enumerate(label_list)}
- 
+
      if label_to_id is not None:
 -        model.config.label2id = label_to_id
 -        model.config.id2label = {id: label for label, id in config.label2id.items()}
@@ -325,13 +325,13 @@ index 3eb423f08..f675e7ab4 100755
 -        model.config.id2label = {id: label for label, id in config.label2id.items()}
 +        config.label2id = {l: i for i, l in enumerate(label_list)}
 +        config.id2label = {id: label for label, id in config.label2id.items()}
- 
+
      if data_args.max_seq_length > tokenizer.model_max_length:
          logger.warning(
 @@ -458,6 +454,87 @@ def main():
              max_train_samples = min(len(train_dataset), data_args.max_train_samples)
              train_dataset = train_dataset.select(range(max_train_samples))
- 
+
 +    nncf_config = None
 +    if training_args.nncf_config is not None:
 +        nncf_config = NNCFConfig.from_json(training_args.nncf_config)
@@ -422,7 +422,7 @@ index 3eb423f08..f675e7ab4 100755
          data_collator=data_collator,
 +        compression_ctrl=compression_ctrl
      )
- 
+
 +    if nncf_config is not None:
 +        if not (training_args.local_rank == -1 or training_args.no_cuda):
 +            compression_ctrl.distributed()
@@ -435,12 +435,12 @@ index 55523edfc..68a3ebe41 100755
 --- a/examples/pytorch/text-classification/run_xnli.py
 +++ b/examples/pytorch/text-classification/run_xnli.py
 @@ -26,10 +26,16 @@ from typing import Optional
- 
+
  import datasets
  import numpy as np
 +import torch
  from datasets import load_dataset
- 
+
  import evaluate
  import transformers
 +from nncf import NNCFConfig
@@ -472,13 +472,13 @@ index 55523edfc..68a3ebe41 100755
 -        use_auth_token=True if model_args.use_auth_token else None,
 -        ignore_mismatched_sizes=model_args.ignore_mismatched_sizes,
 -    )
- 
+
      # Preprocessing the datasets
      # Padding strategy
 @@ -367,6 +365,56 @@ def main():
      else:
          data_collator = None
- 
+
 +    nncf_config = None
 +    if training_args.nncf_config is not None:
 +        nncf_config = NNCFConfig.from_json(training_args.nncf_config)
@@ -538,7 +538,7 @@ index 55523edfc..68a3ebe41 100755
          data_collator=data_collator,
 +        compression_ctrl=compression_ctrl
      )
- 
+
 +    if nncf_config is not None:
 +        if not (training_args.local_rank == -1 or training_args.no_cuda):
 +            compression_ctrl.distributed()
@@ -558,11 +558,11 @@ index 52cbbb87b..30f150580 100755
  from dataclasses import dataclass, field
  from typing import Optional
 +from typing import List
- 
+
  import datasets
  import numpy as np
  from datasets import ClassLabel, load_dataset
- 
+
  import evaluate
 +import torch
  import transformers
@@ -585,8 +585,8 @@ index 52cbbb87b..30f150580 100755
  from transformers.utils.versions import require_version
 @@ -204,6 +214,16 @@ class DataTrainingArguments:
          self.task_name = self.task_name.lower()
- 
- 
+
+
 +def filter_columns(dataset, keep_columns: List[str], remove_columns: List[str]):
 +    if version.parse(datasets.__version__) < version.parse("1.4.0"):
 +        dataset.set_format(
@@ -603,7 +603,7 @@ index 52cbbb87b..30f150580 100755
 @@ -366,16 +386,6 @@ def main():
              use_auth_token=True if model_args.use_auth_token else None,
          )
- 
+
 -    model = AutoModelForTokenClassification.from_pretrained(
 -        model_args.model_name_or_path,
 -        from_tf=bool(".ckpt" in model_args.model_name_or_path),
@@ -619,7 +619,7 @@ index 52cbbb87b..30f150580 100755
          raise ValueError(
 @@ -385,25 +395,25 @@ def main():
          )
- 
+
      # Model has labels -> use them.
 -    if model.config.label2id != PretrainedConfig(num_labels=num_labels).label2id:
 -        if list(sorted(model.config.label2id.keys())) == list(sorted(label_list)):
@@ -642,19 +642,19 @@ index 52cbbb87b..30f150580 100755
 +                f"model labels: {list(sorted(config.label2id.keys()))}, dataset labels:"
                  f" {list(sorted(label_list))}.\nIgnoring the model labels as a result.",
              )
- 
+
      # Set the correspondences label/ID inside the model config
 -    model.config.label2id = {l: i for i, l in enumerate(label_list)}
 -    model.config.id2label = {i: l for i, l in enumerate(label_list)}
 +    config.label2id = {l: i for i, l in enumerate(label_list)}
 +    config.id2label = {i: l for i, l in enumerate(label_list)}
- 
+
      # Map that sends B-Xxx label to its I-Xxx counterpart
      b_to_i_label = []
 @@ -504,6 +514,65 @@ def main():
      # Data collator
      data_collator = DataCollatorForTokenClassification(tokenizer, pad_to_multiple_of=8 if training_args.fp16 else None)
- 
+
 +    nncf_config = None
 +    if training_args.nncf_config is not None:
 +        nncf_config = NNCFConfig.from_json(training_args.nncf_config)
@@ -716,14 +716,14 @@ index 52cbbb87b..30f150580 100755
 +
      # Metrics
      metric = evaluate.load("seqeval")
- 
+
 @@ -549,6 +618,7 @@ def main():
          tokenizer=tokenizer,
          data_collator=data_collator,
          compute_metrics=compute_metrics,
 +        compression_ctrl=compression_ctrl
      )
- 
+
      # Training
 diff --git a/nncf_bert_config_conll.json b/nncf_bert_config_conll.json
 new file mode 100644
@@ -1105,20 +1105,14 @@ index 000000000..4d0e84edf
 +}
 diff --git a/nncf_roberta_config_mnli.json b/nncf_roberta_config_mnli.json
 new file mode 100644
-index 000000000..ff2d462f6
+index 000000000..46f819bca
 --- /dev/null
 +++ b/nncf_roberta_config_mnli.json
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,29 @@
 +{
 +    "input_info": [
 +        {
 +            "keyword": "input_ids",
-+            "sample_size": [1, 128],
-+            "type": "long",
-+            "filler": "ones"
-+        },
-+        {
-+            "keyword": "attention_mask",
 +            "sample_size": [1, 128],
 +            "type": "long",
 +            "filler": "ones"
@@ -1150,17 +1144,17 @@ index 5f4fccd33..7f4cdb3d8 100644
 +++ b/src/transformers/modeling_utils.py
 @@ -27,10 +27,12 @@ from functools import partial
  from typing import Any, Callable, Dict, List, Optional, Tuple, Union
- 
+
  import torch
 +from nncf.torch import create_compressed_model
  from packaging import version
  from torch import Tensor, device, nn
  from torch.nn import CrossEntropyLoss
- 
+
 +from transformers.utils import NNCF_PT_STATE_NAME
  from transformers.utils.hub import convert_file_size_to_int, get_checkpoint_shard_files
  from transformers.utils.import_utils import is_sagemaker_mp_enabled
- 
+
 @@ -1497,6 +1499,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
          push_to_hub: bool = False,
          max_shard_size: Union[int, str] = "10GB",
@@ -1172,7 +1166,7 @@ index 5f4fccd33..7f4cdb3d8 100644
 @@ -1620,6 +1623,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
              else:
                  save_function(shard, os.path.join(save_directory, shard_file))
- 
+
 +        if nncf_compression_state is not None:
 +            nncf_state_output_file = os.path.join(save_directory, NNCF_PT_STATE_NAME)
 +            save_function(nncf_compression_state, nncf_state_output_file)
@@ -1186,13 +1180,13 @@ index 5f4fccd33..7f4cdb3d8 100644
          commit_hash = kwargs.pop("_commit_hash", None)
 +        nncf_config = kwargs.pop("nncf_config", None)
 +        nncf_eval = kwargs.pop("nncf_eval", False)
- 
+
          if trust_remote_code is True:
              logger.warning(
 @@ -2321,6 +2330,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
              if dtype_orig is not None:
                  torch.set_default_dtype(dtype_orig)
- 
+
 +            if nncf_config is not None and nncf_eval:
 +                compression_algo_controller, model = create_compressed_model(model, nncf_config,
 +                                                                             compression_state=state_dict)
@@ -1204,7 +1198,7 @@ index 5f4fccd33..7f4cdb3d8 100644
 @@ -2344,6 +2358,16 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
          # Set model in evaluation mode to deactivate DropOut modules by default
          model.eval()
- 
+
 +        if nncf_config is not None:
 +            compression_state = None
 +            compression_state_file = os.path.join(pretrained_model_name_or_path, NNCF_PT_STATE_NAME)
@@ -1225,7 +1219,7 @@ index d94e049b5..09c99d4dd 100644
 @@ -87,7 +87,8 @@ def prune_linear_layer(layer: nn.Linear, index: torch.LongTensor, dim: int = 0)
          new_layer.bias.requires_grad = True
      return new_layer
- 
+
 -
 +import nncf
 +@nncf.torch.register_module()
@@ -1238,11 +1232,11 @@ index 214e7a978..12a5787cd 100755
 +++ b/src/transformers/trainer.py
 @@ -33,7 +33,7 @@ from pathlib import Path
  from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
- 
+
  from tqdm.auto import tqdm
 -
 +from nncf.torch.nncf_network import NNCFNetwork
- 
+
  # Integrations must be imported before ML frameworks:
  from .integrations import (  # isort: split
 @@ -55,6 +55,8 @@ import numpy as np
@@ -1256,8 +1250,8 @@ index 214e7a978..12a5787cd 100755
  from torch.utils.data.distributed import DistributedSampler
 @@ -206,6 +208,30 @@ SCHEDULER_NAME = "scheduler.pt"
  SCALER_NAME = "scaler.pt"
- 
- 
+
+
 +def get_train_dataloader_for_init(args, train_dataset, data_collator=None):
 +    from torch.utils.data import RandomSampler
 +    from torch.utils.data import DistributedSampler
@@ -1302,7 +1296,7 @@ index 214e7a978..12a5787cd 100755
          enable_full_determinism(self.args.seed) if self.args.full_determinism else set_seed(self.args.seed)
          self.hp_name = None
 @@ -1409,6 +1438,8 @@ class Trainer:
- 
+
              if self.args.ddp_bucket_cap_mb is not None:
                  kwargs["bucket_cap_mb"] = self.args.ddp_bucket_cap_mb
 +            if self.compression_ctrl is not None:
@@ -1312,7 +1306,7 @@ index 214e7a978..12a5787cd 100755
                  device_ids=[self.args.local_rank] if self.args._n_gpu != 0 else None,
 @@ -1687,6 +1718,9 @@ class Trainer:
                      _ = list(train_dataloader.sampler)
- 
+
          for epoch in range(epochs_trained, num_train_epochs):
 +            if self.compression_ctrl is not None:
 +                self.compression_ctrl.scheduler.epoch_step()
@@ -1322,7 +1316,7 @@ index 214e7a978..12a5787cd 100755
              elif hasattr(train_dataloader, "dataset") and isinstance(train_dataloader.dataset, IterableDatasetShard):
 @@ -1790,6 +1824,8 @@ class Trainer:
                              )
- 
+
                      # Optimizer step
 +                    if self.compression_ctrl is not None:
 +                        self.compression_ctrl.scheduler.step()
@@ -1335,12 +1329,12 @@ index 214e7a978..12a5787cd 100755
                      self.state.epoch = epoch + (step + 1) / steps_in_epoch
 +                    self.state.curr_loss = tr_loss_step.cpu().detach().item()
                      self.control = self.callback_handler.on_step_end(args, self.state, self.control)
- 
+
                      self._maybe_log_save_evaluate(tr_loss, model, trial, epoch, ignore_keys_for_eval)
 @@ -2033,6 +2070,14 @@ class Trainer:
              logs["loss"] = round(tr_loss_scalar / (self.state.global_step - self._globalstep_last_logged), 4)
              logs["learning_rate"] = self._get_learning_rate()
- 
+
 +            if self.compression_ctrl is not None:
 +                logs["compression_loss"] = self.compression_ctrl.loss().item()
 +                compression_stats = self.compression_ctrl.statistics()
@@ -1355,7 +1349,7 @@ index 214e7a978..12a5787cd 100755
 @@ -2492,6 +2537,10 @@ class Trainer:
              # deepspeed handles loss scaling by gradient_accumulation_steps in its `backward`
              loss = loss / self.args.gradient_accumulation_steps
- 
+
 +        if self.compression_ctrl is not None:
 +            compression_loss = self.compression_ctrl.loss()
 +            loss += compression_loss
@@ -1370,7 +1364,7 @@ index 170315fe2..daa497c02 100644
 @@ -993,6 +993,12 @@ class TrainingArguments:
          },
      )
- 
+
 +    nncf_config: str = field(default=None,
 +                             metadata={"help": "NNCF configuration .json file for compression-enabled training"})
 +
@@ -1385,13 +1379,12 @@ index 2269f2254..2f3082293 100644
 --- a/src/transformers/utils/__init__.py
 +++ b/src/transformers/utils/__init__.py
 @@ -154,6 +154,7 @@ from .import_utils import (
- 
- 
+
+
  WEIGHTS_NAME = "pytorch_model.bin"
 +NNCF_PT_STATE_NAME = "nncf_state.bin"
  WEIGHTS_INDEX_NAME = "pytorch_model.bin.index.json"
  TF2_WEIGHTS_NAME = "tf_model.h5"
  TF2_WEIGHTS_INDEX_NAME = "tf_model.h5.index.json"
--- 
-2.25.1
-
+--
+2.34.1


### PR DESCRIPTION
### Changes

- Remove `attention_mask` from `input_info` to disable tracing. The placement of the FQ has not changed.
- Bump version of transformers and optimum


### Reason for changes 

After changes in the graph trace, `attention_mask` branch was added in NNCFgraph as result added FQ for mask. 
But since the mask is used values 0 and finfo(float32).min, inf and nan appear at backpropagation, as result parameters xof FQ are set nan.

### Related tickets

127936

### Tests

test_sanity_third_party.TestTransformers.test_glue_train