### PR TITLE
[OV] `mean_per_channel` inplace==True mode is enabled by default

### DIFF
--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -311,18 +311,12 @@ def get_inplace_mean_per_ch(op_type: str, axis: int) -> InplaceInsertionFnType:
             transposed_shape = input_shape
 
         keeped_dims = transposed_shape[:2]
+        keeped_dims = [0 if dim < 0 else dim for dim in keeped_dims]
         squized_dims = -1 if -1 in transposed_shape[2:] else np.prod(transposed_shape[2:])
-        if (-1 in keeped_dims and squized_dims == -1) or keeped_dims.count(-1) > 1:
-            raise RuntimeError(
-                f"Could not insert mean_per_ch operation inplace"
-                f" for the node {node} because of"
-                f" input_shape: {input_shape} -> transposed_shape: {transposed_shape}"
-            )
-
         reshape_op = opset.reshape(
             reshape_input_node.output(output_port_id),
             output_shape=np.array((keeped_dims[0], keeped_dims[1], squized_dims)),
-            special_zero=False,
+            special_zero=True,
         )
         return opset.reduce_mean(
             reshape_op,

--- a/nncf/openvino/statistics/collectors.py
+++ b/nncf/openvino/statistics/collectors.py
@@ -255,7 +255,7 @@ class OVMeanPerChanelReducer(MeanPerChReducer):
         return OVNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        return get_inplace_mean_per_ch(self.name, self._reduction_axes)
+        return get_inplace_mean_per_ch(self.name, self._channel_axis)
 
     def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
         return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
@@ -296,9 +296,6 @@ def get_mean_statistic_collector(
     :param inplace: Whether the mean reducer should be calculated inplace or out of place.
     :return: Mean statistic collector.
     """
-    # TODO(dlyakhov): use inplace OVBatchMeanReducer and OVMeanPerChanelReducer
-    # after migration on openvino-dev=2023.0
-    inplace = False
     if channel_axis == 0:
         reducer = OVBatchMeanReducer(inplace)
     else:

--- a/tests/common/experimental/test_reducers_and_aggregators.py
+++ b/tests/common/experimental/test_reducers_and_aggregators.py
@@ -193,12 +193,15 @@ class TemplateTestReducersAggreagtors:
             assert self.all_close(val[i].tensor, self.cast_tensor(ref_, Dtype.FLOAT))
 
     @pytest.mark.parametrize(
-        "reducer_name,ref",
-        [("batch_mean", [[[[-12.5, -11.5, -10.5], [-9.5, -8.5, -7.5], [-6.5, -5.5, -4.5]]]]), ("mean_per_ch", [-8.5])],
+        "reducer_name,ref,kwargs",
+        [
+            ("batch_mean", [[[[-12.5, -11.5, -10.5], [-9.5, -8.5, -7.5], [-6.5, -5.5, -4.5]]]], {}),
+            ("mean_per_ch", [-22.0, -13.0, -4.0, 5.0], {"channel_axis": 0}),
+        ],
     )
-    def test_batch_mean_mean_per_ch_reducers(self, reducer_name, ref, reducers):
+    def test_batch_mean_mean_per_ch_reducers(self, reducer_name, ref, reducers, kwargs):
         input_ = np.arange(-26, 10).reshape((4, 1, 3, 3))
-        reducer = reducers[reducer_name](inplace=False)
+        reducer = reducers[reducer_name](inplace=False, **kwargs)
         val = reducer([self.get_nncf_tensor(input_, Dtype.FLOAT)])
         assert len(val) == 1
         assert self.all_close(val[0].tensor, self.cast_tensor(ref, Dtype.FLOAT))

--- a/tests/common/test_statistics_aggregator.py
+++ b/tests/common/test_statistics_aggregator.py
@@ -828,11 +828,9 @@ class TemplateTestStatisticsAggregator:
             params["reduction_axes"] = [None, (0, 1, 3), (1, 2, 3)]
             params["quantile"] = [[0.01, 0.99], [0.001, 0.999]]
         elif statistics_type == "batch_mean":
-            pytest.skip("Inplace statistic woun't work until openvino==2023.0.0 release")
             params["inplace"] = [False, True]
         elif statistics_type == "mean_per_ch":
-            # TODO(dlyakhov) uncoment when nncf will switch to openvino==2023.0.0
-            # params["inplace"] = [False, True]
+            params["inplace"] = [False, True]
             params["channel_axis"] = [1, 2]
 
         def product_dict(**kwargs):

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -345,35 +345,34 @@ def test_inplace_reduce_fn_zero_rank_output(reduction_axes):
 
 
 DYNAMIC_SHAPE_TEST_CASES = [
-    InplaceOpTestCase("mean_per_ch", 1, get_inplace_mean_per_ch, ["Reshape"], [(-1, 3, 9), (0, 2)]),
+    InplaceOpTestCase("mean_per_ch", 1, get_inplace_mean_per_ch, ["Reshape"], [(0, 3, 9), (0, 2)]),
+    InplaceOpTestCase("mean_per_ch", 1, get_inplace_mean_per_ch, ["Reshape"], [(0, 0, 9), (0, 2)]),
     InplaceOpTestCase("mean_per_ch", 1, get_inplace_mean_per_ch, ["Reshape"], [(1, 3, -1), (0, 2)]),
-    InplaceOpTestCase("mean_per_ch", 3, get_inplace_mean_per_ch, ["Transpose", "Reshape"], [(0, 3, 2, 1), (-1, 3, 9)]),
-    InplaceOpTestCase("mean_per_ch", 3, get_inplace_mean_per_ch, ["Transpose", "Reshape"], [(0, 3, 2, 1), (1, -1, 9)]),
+    InplaceOpTestCase("mean_per_ch", 1, get_inplace_mean_per_ch, ["Reshape"], [(1, 0, -1), (0, 2)]),
+    InplaceOpTestCase("mean_per_ch", 3, get_inplace_mean_per_ch, ["Transpose", "Reshape"], [(0, 3, 2, 1), (0, 3, 9)]),
+    InplaceOpTestCase("mean_per_ch", 3, get_inplace_mean_per_ch, ["Transpose", "Reshape"], [(0, 3, 2, 1), (1, 0, 9)]),
     InplaceOpTestCase("mean_per_ch", 3, get_inplace_mean_per_ch, ["Transpose", "Reshape"], [(0, 3, 2, 1), (1, 3, -1)]),
+    InplaceOpTestCase("mean_per_ch", 3, get_inplace_mean_per_ch, ["Transpose", "Reshape"], [(0, 3, 2, 1), (1, 0, -1)]),
 ]
 
 
 @pytest.mark.parametrize(
-    "test_params,input_shape,raise_error",
+    "test_params,input_shape",
     [
-        (DYNAMIC_SHAPE_TEST_CASES[0], (ov.Dimension(), 3, 3, 3), False),
-        (DYNAMIC_SHAPE_TEST_CASES[1], (1, 3, 3, ov.Dimension()), False),
-        (DYNAMIC_SHAPE_TEST_CASES[0], (ov.Dimension(), ov.Dimension(), 3, 3), True),
-        (DYNAMIC_SHAPE_TEST_CASES[1], (1, 3, ov.Dimension(), ov.Dimension()), False),
-        (DYNAMIC_SHAPE_TEST_CASES[1], (1, ov.Dimension(), ov.Dimension(), 3), True),
-        (DYNAMIC_SHAPE_TEST_CASES[2], (ov.Dimension(), 3, 3, 3), False),
-        (DYNAMIC_SHAPE_TEST_CASES[3], (1, 3, 3, ov.Dimension()), False),
-        (DYNAMIC_SHAPE_TEST_CASES[4], (1, ov.Dimension(), ov.Dimension(), 3), False),
-        (DYNAMIC_SHAPE_TEST_CASES[4], (1, ov.Dimension(), ov.Dimension(), ov.Dimension()), True),
+        (DYNAMIC_SHAPE_TEST_CASES[0], (ov.Dimension(), 3, 3, 3)),
+        (DYNAMIC_SHAPE_TEST_CASES[2], (1, 3, 3, ov.Dimension())),
+        (DYNAMIC_SHAPE_TEST_CASES[1], (ov.Dimension(), ov.Dimension(), 3, 3)),
+        (DYNAMIC_SHAPE_TEST_CASES[2], (1, 3, ov.Dimension(), ov.Dimension())),
+        (DYNAMIC_SHAPE_TEST_CASES[3], (1, ov.Dimension(), ov.Dimension(), 3)),
+        (DYNAMIC_SHAPE_TEST_CASES[4], (ov.Dimension(), 3, 3, 3)),
+        (DYNAMIC_SHAPE_TEST_CASES[5], (1, 3, 3, ov.Dimension())),
+        (DYNAMIC_SHAPE_TEST_CASES[6], (1, ov.Dimension(), ov.Dimension(), 3)),
+        (DYNAMIC_SHAPE_TEST_CASES[7], (1, ov.Dimension(), ov.Dimension(), ov.Dimension())),
     ],
 )
-def test_inplace_mean_per_ch_fn_dynamic_shapes(test_params: InplaceOpTestCase, input_shape, raise_error):
+def test_inplace_mean_per_ch_fn_dynamic_shapes(test_params: InplaceOpTestCase, input_shape):
     input_1 = opset.parameter(input_shape, name="Input")
     fn = test_params.op_builder(test_params.name, test_params.reduce_shape)
-    if raise_error:
-        with pytest.raises(RuntimeError):
-            fn(input_1, 0)
-        return
     last_node = fn(input_1, 0)
     result = opset.result(last_node)
     model = ov.Model([result], [input_1])


### PR DESCRIPTION
### Changes

* Mean per channel reducer inplace==True mode is enabled
* special_zero reshape parameter is used inside mean per channel inplace implementation to make
* Micro bug in `OVMeanPerChanelReducer.get_inplace_fn` is fixed

### Reason for changes

* To use mean_per_channel reducer inplace thus to reduce memory consumption for BiasCorrection algorithm

### Related tickets

113335

### Tests

All related tests are updated with new reference values
