### PR TITLE
Use transforms from timm

### DIFF
--- a/tests/post_training/reference_data.yaml
+++ b/tests/post_training/reference_data.yaml
@@ -3,266 +3,266 @@ hf/bert-base-uncased_backend_CUDA_TORCH:
 hf/bert-base-uncased_backend_FP32:
   metric_value: null
 hf/bert-base-uncased_backend_ONNX:
-  metric_value: .nan
+  metric_value: null
 hf/bert-base-uncased_backend_OPTIMUM:
-  metric_value: .nan
+  metric_value: null
 hf/bert-base-uncased_backend_OV:
-  metric_value: .nan
+  metric_value: null
 hf/bert-base-uncased_backend_POT:
-  metric_value: .nan
+  metric_value: null
 hf/bert-base-uncased_backend_TORCH:
-  metric_value: .nan
+  metric_value: null
 hf/hf-internal-testing/tiny-random-GPTNeoXForCausalLM_backend_FP32:
   metric_value: null
 hf/hf-internal-testing/tiny-random-GPTNeoXForCausalLM_backend_OPTIMUM:
-  metric_value: .nan
+  metric_value: null
 timm/crossvit_9_240_backend_CUDA_TORCH:
   metric_value: 0.689
 timm/crossvit_9_240_backend_FP32:
-  metric_value: 0.69966
+  metric_value: 0.73982
 timm/crossvit_9_240_backend_ONNX:
-  metric_value: 0.68878
+  metric_value: 0.72854
 timm/crossvit_9_240_backend_OV:
-  metric_value: 0.68882
+  metric_value: 0.72812
 timm/crossvit_9_240_backend_POT:
-  metric_value: 0.68918
+  metric_value: 0.72816
 timm/crossvit_9_240_backend_TORCH:
-  metric_value: 0.6891
+  metric_value: 0.72922
 timm/darknet53_backend_CUDA_TORCH:
   metric_value: 0.79176
 timm/darknet53_backend_FP32:
-  metric_value: 0.79858
+  metric_value: 0.80006
 timm/darknet53_backend_ONNX:
-  metric_value: 0.79224
+  metric_value: 0.79336
 timm/darknet53_backend_OV:
-  metric_value: 0.79242
+  metric_value: 0.79222
 timm/darknet53_backend_POT:
-  metric_value: 0.79192
+  metric_value: 0.79268
 timm/darknet53_backend_TORCH:
-  metric_value: 0.79128
+  metric_value: 0.7916
 timm/deit3_small_patch16_224_backend_CUDA_TORCH:
   metric_value: 0.76816
 timm/deit3_small_patch16_224_backend_FP32:
-  metric_value: 0.76974
+  metric_value: 0.81358
 timm/deit3_small_patch16_224_backend_ONNX:
-  metric_value: 0.76862
+  metric_value: 0.81268
 timm/deit3_small_patch16_224_backend_OV:
-  metric_value: 0.76804
+  metric_value: 0.81276
 timm/deit3_small_patch16_224_backend_POT:
-  metric_value: 0.76806
+  metric_value: 0.8123
 timm/deit3_small_patch16_224_backend_TORCH:
-  metric_value: 0.76816
+  metric_value: 0.81278
 timm/dla34_backend_CUDA_TORCH:
   metric_value: 0.73978
 timm/dla34_backend_FP32:
-  metric_value: 0.74416
+  metric_value: 0.74628
 timm/dla34_backend_ONNX:
-  metric_value: 0.74226
+  metric_value: 0.7455
 timm/dla34_backend_OV:
-  metric_value: 0.74132
+  metric_value: 0.74556
 timm/dla34_backend_POT:
-  metric_value: 0.74232
+  metric_value: 0.74528
 timm/dla34_backend_TORCH:
-  metric_value: 0.73958
+  metric_value: 0.74242
 timm/dpn68_backend_CUDA_TORCH:
   metric_value: 0.75492
 timm/dpn68_backend_FP32:
-  metric_value: 0.75964
+  metric_value: 0.76342
 timm/dpn68_backend_ONNX:
-  metric_value: 0.75488
+  metric_value: 0.7595
 timm/dpn68_backend_OV:
-  metric_value: 0.75492
+  metric_value: 0.75968
 timm/dpn68_backend_POT:
-  metric_value: 0.75516
+  metric_value: 0.75842
 timm/dpn68_backend_TORCH:
-  metric_value: 0.75448
+  metric_value: 0.75826
 timm/efficientnet_b0_BC_backend_FP32:
-  metric_value: 0.77292
+  metric_value: 0.77698
 timm/efficientnet_b0_BC_backend_ONNX:
-  metric_value: 0.76856
+  metric_value: 0.77212
 timm/efficientnet_b0_BC_backend_OV:
-  metric_value: 0.76802
+  metric_value: 0.77218
 timm/efficientnet_b0_BC_backend_POT:
-  metric_value: 0.76872
+  metric_value: 0.77288
 timm/efficientnet_b0_backend_CUDA_TORCH:
   metric_value: 0.768
 timm/efficientnet_b0_backend_FP32:
-  metric_value: 0.77292
+  metric_value: 0.77698
 timm/efficientnet_b0_backend_ONNX:
-  metric_value: 0.76862
+  metric_value: 0.77208
 timm/efficientnet_b0_backend_OV:
-  metric_value: 0.76876
+  metric_value: 0.77196
 timm/efficientnet_b0_backend_POT:
-  metric_value: 0.76848
+  metric_value: 0.77196
 timm/efficientnet_b0_backend_TORCH:
-  metric_value: 0.76792
+  metric_value: 0.77124
 timm/efficientnet_lite0_backend_CUDA_TORCH:
   metric_value: 0.74686
 timm/efficientnet_lite0_backend_FP32:
-  metric_value: 0.7496
+  metric_value: 0.75496
 timm/efficientnet_lite0_backend_ONNX:
-  metric_value: 0.74676
+  metric_value: 0.75214
 timm/efficientnet_lite0_backend_OV:
-  metric_value: 0.74658
+  metric_value: 0.7515
 timm/efficientnet_lite0_backend_POT:
-  metric_value: 0.74694
+  metric_value: 0.75252
 timm/efficientnet_lite0_backend_TORCH:
-  metric_value: 0.7469
+  metric_value: 0.75236
 timm/hrnet_w18_backend_CUDA_TORCH:
   metric_value: 0.76712
 timm/hrnet_w18_backend_FP32:
-  metric_value: 0.77504
+  metric_value: 0.78124
 timm/hrnet_w18_backend_ONNX:
-  metric_value: 0.76914
+  metric_value: 0.7747
 timm/hrnet_w18_backend_OV:
-  metric_value: 0.7692
+  metric_value: 0.77526
 timm/hrnet_w18_backend_POT:
-  metric_value: 0.76916
+  metric_value: 0.77516
 timm/hrnet_w18_backend_TORCH:
-  metric_value: 0.7667
+  metric_value: 0.77316
 timm/inception_resnet_v2_backend_CUDA_TORCH:
   metric_value: 0.80024
 timm/inception_resnet_v2_backend_FP32:
-  metric_value: 0.80102
+  metric_value: 0.80448
 timm/inception_resnet_v2_backend_ONNX:
-  metric_value: 0.80142
+  metric_value: 0.804
 timm/inception_resnet_v2_backend_OV:
-  metric_value: 0.80146
+  metric_value: 0.80422
 timm/inception_resnet_v2_backend_TORCH:
-  metric_value: 0.8011
+  metric_value: 0.803
 timm/levit_128_backend_CUDA_TORCH:
   metric_value: 0.7324
 timm/levit_128_backend_FP32:
-  metric_value: 0.7405
+  metric_value: 0.78474
 timm/levit_128_backend_ONNX:
-  metric_value: 0.73244
+  metric_value: 0.7762
 timm/levit_128_backend_OV:
-  metric_value: 0.73382
+  metric_value: 0.77696
 timm/levit_128_backend_TORCH:
-  metric_value: 0.73298
+  metric_value: 0.77752
 timm/mobilenetv2_050_BC_backend_FP32:
-  metric_value: 0.64568
+  metric_value: 0.6594
 timm/mobilenetv2_050_BC_backend_ONNX:
-  metric_value: 0.6451
+  metric_value: 0.65466
 timm/mobilenetv2_050_BC_backend_OV:
-  metric_value: 0.64376
+  metric_value: 0.6543
 timm/mobilenetv2_050_BC_backend_POT:
-  metric_value: 0.6431
+  metric_value: 0.65422
 timm/mobilenetv2_050_backend_CUDA_TORCH:
   metric_value: 0.64278
 timm/mobilenetv2_050_backend_FP32:
-  metric_value: 0.64568
+  metric_value: 0.6594
 timm/mobilenetv2_050_backend_ONNX:
-  metric_value: 0.64352
+  metric_value: 0.65462
 timm/mobilenetv2_050_backend_OV:
-  metric_value: 0.6413
+  metric_value: 0.65282
 timm/mobilenetv2_050_backend_POT:
-  metric_value: 0.64362
+  metric_value: 0.6522
 timm/mobilenetv2_050_backend_TORCH:
-  metric_value: 0.64288
+  metric_value: 0.65364
 timm/mobilenetv3_small_050_backend_CUDA_TORCH:
   metric_value: 0.41888
 timm/mobilenetv3_small_050_backend_FP32:
-  metric_value: 0.56338
+  metric_value: 0.57906
 timm/mobilenetv3_small_050_backend_ONNX:
-  metric_value: 0.5456
+  metric_value: 0.5617
 timm/mobilenetv3_small_050_backend_OV:
-  metric_value: 0.413
+  metric_value: 0.42184
 timm/mobilenetv3_small_050_backend_POT:
-  metric_value: 0.54106
+  metric_value: 0.55768
 timm/mobilenetv3_small_050_backend_TORCH:
-  metric_value: 0.41842
+  metric_value: 0.43038
 timm/regnetx_002_backend_CUDA_TORCH:
   metric_value: 0.67452
 timm/regnetx_002_backend_FP32:
-  metric_value: 0.67826
+  metric_value: 0.68756
 timm/regnetx_002_backend_ONNX:
-  metric_value: 0.6739
+  metric_value: 0.68476
 timm/regnetx_002_backend_OV:
-  metric_value: 0.6738
+  metric_value: 0.6853
 timm/regnetx_002_backend_POT:
-  metric_value: 0.6748
+  metric_value: 0.68498
 timm/regnetx_002_backend_TORCH:
-  metric_value: 0.67402
+  metric_value: 0.68492
 timm/resnest14d_backend_CUDA_TORCH:
   metric_value: 0.74176
 timm/resnest14d_backend_FP32:
-  metric_value: 0.74862
+  metric_value: 0.75516
 timm/resnest14d_backend_ONNX:
-  metric_value: 0.74326
+  metric_value: 0.74968
 timm/resnest14d_backend_OV:
-  metric_value: 0.7433
+  metric_value: 0.74984
 timm/resnest14d_backend_POT:
-  metric_value: 0.74274
+  metric_value: 0.75044
 timm/resnest14d_backend_TORCH:
-  metric_value: 0.74226
+  metric_value: 0.74838
 timm/resnet18_backend_CUDA_TORCH:
   metric_value: 0.69748
 timm/resnet18_backend_FP32:
-  metric_value: 0.70104
+  metric_value: 0.71502
 timm/resnet18_backend_ONNX:
-  metric_value: 0.69792
+  metric_value: 0.71104
 timm/resnet18_backend_OV:
-  metric_value: 0.69796
+  metric_value: 0.71042
 timm/resnet18_backend_POT:
-  metric_value: 0.69758
+  metric_value: 0.71062
 timm/resnet18_backend_TORCH:
-  metric_value: 0.6974
+  metric_value: 0.71024
 timm/swin_base_patch4_window7_224_backend_CUDA_TORCH:
   metric_value: 0.8131
 timm/swin_base_patch4_window7_224_backend_FP32:
-  metric_value: 0.81462
+  metric_value: 0.85274
 timm/swin_base_patch4_window7_224_backend_ONNX:
-  metric_value: 0.81324
+  metric_value: 0.85158
 timm/swin_base_patch4_window7_224_backend_OV:
-  metric_value: 0.79632
+  metric_value: 0.83636
 timm/swin_base_patch4_window7_224_backend_POT:
-  metric_value: 0.79506
+  metric_value: 0.83614
 timm/swin_base_patch4_window7_224_backend_TORCH:
-  metric_value: 0.81332
+  metric_value: 0.85142
 timm/tf_inception_v3_backend_CUDA_TORCH:
   metric_value: 0.77542
 timm/tf_inception_v3_backend_FP32:
-  metric_value: 0.77728
+  metric_value: 0.7786
 timm/tf_inception_v3_backend_ONNX:
-  metric_value: 0.77764
+  metric_value: 0.77766
 timm/tf_inception_v3_backend_OV:
-  metric_value: 0.77736
+  metric_value: 0.77742
 timm/tf_inception_v3_backend_POT:
-  metric_value: 0.77746
+  metric_value: 0.77758
 timm/tf_inception_v3_backend_TORCH:
-  metric_value: 0.77526
+  metric_value: 0.77642
 timm/vgg11_backend_CUDA_TORCH:
   metric_value: 0.6809
 timm/vgg11_backend_FP32:
-  metric_value: 0.68344
+  metric_value: 0.6904
 timm/vgg11_backend_ONNX:
-  metric_value: 0.68102
+  metric_value: 0.68754
 timm/vgg11_backend_OV:
-  metric_value: 0.6809
+  metric_value: 0.68732
 timm/vgg11_backend_TORCH:
-  metric_value: 0.68106
+  metric_value: 0.68754
 timm/visformer_small_backend_CUDA_TORCH:
   metric_value: 0.77728
 timm/visformer_small_backend_FP32:
-  metric_value: 0.77902
+  metric_value: 0.82098
 timm/visformer_small_backend_ONNX:
-  metric_value: 0.77688
+  metric_value: 0.81604
 timm/visformer_small_backend_OV:
-  metric_value: 0.7769
+  metric_value: 0.81692
 timm/visformer_small_backend_POT:
-  metric_value: 0.77718
+  metric_value: 0.81684
 timm/visformer_small_backend_TORCH:
-  metric_value: 0.77682
+  metric_value: 0.81624
 timm/wide_resnet50_2_backend_CUDA_TORCH:
   metric_value: 0.81186
 timm/wide_resnet50_2_backend_FP32:
-  metric_value: 0.81414
+  metric_value: 0.81454
 timm/wide_resnet50_2_backend_ONNX:
-  metric_value: 0.81208
+  metric_value: 0.81228
 timm/wide_resnet50_2_backend_OV:
-  metric_value: 0.81168
+  metric_value: 0.8125
 timm/wide_resnet50_2_backend_POT:
-  metric_value: 0.81148
+  metric_value: 0.81278
 timm/wide_resnet50_2_backend_TORCH:
-  metric_value: 0.8121
+  metric_value: 0.81234

--- a/tests/post_training/reference_data.yaml
+++ b/tests/post_training/reference_data.yaml
@@ -3,31 +3,31 @@ hf/bert-base-uncased_backend_CUDA_TORCH:
 hf/bert-base-uncased_backend_FP32:
   metric_value: null
 hf/bert-base-uncased_backend_ONNX:
-  metric_value: null
+  metric_value: .nan
 hf/bert-base-uncased_backend_OPTIMUM:
-  metric_value: null
+  metric_value: .nan
 hf/bert-base-uncased_backend_OV:
-  metric_value: null
+  metric_value: .nan
 hf/bert-base-uncased_backend_POT:
-  metric_value: null
+  metric_value: .nan
 hf/bert-base-uncased_backend_TORCH:
-  metric_value: null
+  metric_value: .nan
 hf/hf-internal-testing/tiny-random-GPTNeoXForCausalLM_backend_FP32:
   metric_value: null
 hf/hf-internal-testing/tiny-random-GPTNeoXForCausalLM_backend_OPTIMUM:
-  metric_value: null
+  metric_value: .nan
 timm/crossvit_9_240_backend_CUDA_TORCH:
   metric_value: 0.689
 timm/crossvit_9_240_backend_FP32:
   metric_value: 0.69966
 timm/crossvit_9_240_backend_ONNX:
-  metric_value: 0.68906
+  metric_value: 0.68878
 timm/crossvit_9_240_backend_OV:
-  metric_value: 0.68912
+  metric_value: 0.68882
 timm/crossvit_9_240_backend_POT:
-  metric_value: 0.68862
+  metric_value: 0.68918
 timm/crossvit_9_240_backend_TORCH:
-  metric_value: 0.689
+  metric_value: 0.6891
 timm/darknet53_backend_CUDA_TORCH:
   metric_value: 0.79176
 timm/darknet53_backend_FP32:
@@ -35,21 +35,21 @@ timm/darknet53_backend_FP32:
 timm/darknet53_backend_ONNX:
   metric_value: 0.79224
 timm/darknet53_backend_OV:
-  metric_value: 0.79192
+  metric_value: 0.79242
 timm/darknet53_backend_POT:
-  metric_value: 0.79206
+  metric_value: 0.79192
 timm/darknet53_backend_TORCH:
-  metric_value: 0.79176
+  metric_value: 0.79128
 timm/deit3_small_patch16_224_backend_CUDA_TORCH:
   metric_value: 0.76816
 timm/deit3_small_patch16_224_backend_FP32:
   metric_value: 0.76974
 timm/deit3_small_patch16_224_backend_ONNX:
-  metric_value: 0.76806
+  metric_value: 0.76862
 timm/deit3_small_patch16_224_backend_OV:
-  metric_value: 0.76786
+  metric_value: 0.76804
 timm/deit3_small_patch16_224_backend_POT:
-  metric_value: 0.7676
+  metric_value: 0.76806
 timm/deit3_small_patch16_224_backend_TORCH:
   metric_value: 0.76816
 timm/dla34_backend_CUDA_TORCH:
@@ -57,13 +57,13 @@ timm/dla34_backend_CUDA_TORCH:
 timm/dla34_backend_FP32:
   metric_value: 0.74416
 timm/dla34_backend_ONNX:
-  metric_value: 0.74202
+  metric_value: 0.74226
 timm/dla34_backend_OV:
-  metric_value: 0.74224
+  metric_value: 0.74132
 timm/dla34_backend_POT:
-  metric_value: 0.74222
+  metric_value: 0.74232
 timm/dla34_backend_TORCH:
-  metric_value: 0.73978
+  metric_value: 0.73958
 timm/dpn68_backend_CUDA_TORCH:
   metric_value: 0.75492
 timm/dpn68_backend_FP32:
@@ -71,17 +71,17 @@ timm/dpn68_backend_FP32:
 timm/dpn68_backend_ONNX:
   metric_value: 0.75488
 timm/dpn68_backend_OV:
-  metric_value: 0.75544
-timm/dpn68_backend_POT:
-  metric_value: 0.7554
-timm/dpn68_backend_TORCH:
   metric_value: 0.75492
+timm/dpn68_backend_POT:
+  metric_value: 0.75516
+timm/dpn68_backend_TORCH:
+  metric_value: 0.75448
 timm/efficientnet_b0_BC_backend_FP32:
   metric_value: 0.77292
 timm/efficientnet_b0_BC_backend_ONNX:
-  metric_value: 0.7686
+  metric_value: 0.76856
 timm/efficientnet_b0_BC_backend_OV:
-  metric_value: 0.76794
+  metric_value: 0.76802
 timm/efficientnet_b0_BC_backend_POT:
   metric_value: 0.76872
 timm/efficientnet_b0_backend_CUDA_TORCH:
@@ -89,63 +89,63 @@ timm/efficientnet_b0_backend_CUDA_TORCH:
 timm/efficientnet_b0_backend_FP32:
   metric_value: 0.77292
 timm/efficientnet_b0_backend_ONNX:
-  metric_value: 0.7686
+  metric_value: 0.76862
 timm/efficientnet_b0_backend_OV:
-  metric_value: 0.7688
+  metric_value: 0.76876
 timm/efficientnet_b0_backend_POT:
-  metric_value: 0.76866
+  metric_value: 0.76848
 timm/efficientnet_b0_backend_TORCH:
-  metric_value: 0.768
+  metric_value: 0.76792
 timm/efficientnet_lite0_backend_CUDA_TORCH:
   metric_value: 0.74686
 timm/efficientnet_lite0_backend_FP32:
   metric_value: 0.7496
 timm/efficientnet_lite0_backend_ONNX:
-  metric_value: 0.7468
+  metric_value: 0.74676
 timm/efficientnet_lite0_backend_OV:
-  metric_value: 0.74704
+  metric_value: 0.74658
 timm/efficientnet_lite0_backend_POT:
-  metric_value: 0.74686
+  metric_value: 0.74694
 timm/efficientnet_lite0_backend_TORCH:
-  metric_value: 0.74686
+  metric_value: 0.7469
 timm/hrnet_w18_backend_CUDA_TORCH:
   metric_value: 0.76712
 timm/hrnet_w18_backend_FP32:
   metric_value: 0.77504
 timm/hrnet_w18_backend_ONNX:
-  metric_value: 0.76916
+  metric_value: 0.76914
 timm/hrnet_w18_backend_OV:
-  metric_value: 0.76926
+  metric_value: 0.7692
 timm/hrnet_w18_backend_POT:
-  metric_value: 0.76968
+  metric_value: 0.76916
 timm/hrnet_w18_backend_TORCH:
-  metric_value: 0.76712
+  metric_value: 0.7667
 timm/inception_resnet_v2_backend_CUDA_TORCH:
   metric_value: 0.80024
 timm/inception_resnet_v2_backend_FP32:
   metric_value: 0.80102
 timm/inception_resnet_v2_backend_ONNX:
-  metric_value: 0.80108
+  metric_value: 0.80142
 timm/inception_resnet_v2_backend_OV:
-  metric_value: 0.80152
+  metric_value: 0.80146
 timm/inception_resnet_v2_backend_TORCH:
-  metric_value: 0.80024
+  metric_value: 0.8011
 timm/levit_128_backend_CUDA_TORCH:
   metric_value: 0.7324
 timm/levit_128_backend_FP32:
   metric_value: 0.7405
 timm/levit_128_backend_ONNX:
-  metric_value: 0.73286
+  metric_value: 0.73244
 timm/levit_128_backend_OV:
-  metric_value: 0.7334
+  metric_value: 0.73382
 timm/levit_128_backend_TORCH:
-  metric_value: 0.73346
+  metric_value: 0.73298
 timm/mobilenetv2_050_BC_backend_FP32:
   metric_value: 0.64568
 timm/mobilenetv2_050_BC_backend_ONNX:
-  metric_value: 0.64498
+  metric_value: 0.6451
 timm/mobilenetv2_050_BC_backend_OV:
-  metric_value: 0.64412
+  metric_value: 0.64376
 timm/mobilenetv2_050_BC_backend_POT:
   metric_value: 0.6431
 timm/mobilenetv2_050_backend_CUDA_TORCH:
@@ -153,13 +153,13 @@ timm/mobilenetv2_050_backend_CUDA_TORCH:
 timm/mobilenetv2_050_backend_FP32:
   metric_value: 0.64568
 timm/mobilenetv2_050_backend_ONNX:
-  metric_value: 0.64358
+  metric_value: 0.64352
 timm/mobilenetv2_050_backend_OV:
-  metric_value: 0.64134
+  metric_value: 0.6413
 timm/mobilenetv2_050_backend_POT:
   metric_value: 0.64362
 timm/mobilenetv2_050_backend_TORCH:
-  metric_value: 0.64278
+  metric_value: 0.64288
 timm/mobilenetv3_small_050_backend_CUDA_TORCH:
   metric_value: 0.41888
 timm/mobilenetv3_small_050_backend_FP32:
@@ -169,7 +169,7 @@ timm/mobilenetv3_small_050_backend_ONNX:
 timm/mobilenetv3_small_050_backend_OV:
   metric_value: 0.413
 timm/mobilenetv3_small_050_backend_POT:
-  metric_value: 0.54104
+  metric_value: 0.54106
 timm/mobilenetv3_small_050_backend_TORCH:
   metric_value: 0.41842
 timm/regnetx_002_backend_CUDA_TORCH:
@@ -177,92 +177,92 @@ timm/regnetx_002_backend_CUDA_TORCH:
 timm/regnetx_002_backend_FP32:
   metric_value: 0.67826
 timm/regnetx_002_backend_ONNX:
-  metric_value: 0.67394
+  metric_value: 0.6739
 timm/regnetx_002_backend_OV:
   metric_value: 0.6738
 timm/regnetx_002_backend_POT:
-  metric_value: 0.67472
+  metric_value: 0.6748
 timm/regnetx_002_backend_TORCH:
-  metric_value: 0.67452
+  metric_value: 0.67402
 timm/resnest14d_backend_CUDA_TORCH:
   metric_value: 0.74176
 timm/resnest14d_backend_FP32:
   metric_value: 0.74862
 timm/resnest14d_backend_ONNX:
-  metric_value: 0.74316
+  metric_value: 0.74326
 timm/resnest14d_backend_OV:
-  metric_value: 0.74358
+  metric_value: 0.7433
 timm/resnest14d_backend_POT:
-  metric_value: 0.74352
+  metric_value: 0.74274
 timm/resnest14d_backend_TORCH:
-  metric_value: 0.74176
+  metric_value: 0.74226
 timm/resnet18_backend_CUDA_TORCH:
   metric_value: 0.69748
 timm/resnet18_backend_FP32:
   metric_value: 0.70104
 timm/resnet18_backend_ONNX:
-  metric_value: 0.6979
-timm/resnet18_backend_OV:
-  metric_value: 0.69774
-timm/resnet18_backend_POT:
   metric_value: 0.69792
+timm/resnet18_backend_OV:
+  metric_value: 0.69796
+timm/resnet18_backend_POT:
+  metric_value: 0.69758
 timm/resnet18_backend_TORCH:
-  metric_value: 0.69748
+  metric_value: 0.6974
 timm/swin_base_patch4_window7_224_backend_CUDA_TORCH:
   metric_value: 0.8131
 timm/swin_base_patch4_window7_224_backend_FP32:
   metric_value: 0.81462
 timm/swin_base_patch4_window7_224_backend_ONNX:
-  metric_value: 0.81294
+  metric_value: 0.81324
 timm/swin_base_patch4_window7_224_backend_OV:
-  metric_value: 0.79582
+  metric_value: 0.79632
 timm/swin_base_patch4_window7_224_backend_POT:
-  metric_value: 0.79514
+  metric_value: 0.79506
 timm/swin_base_patch4_window7_224_backend_TORCH:
-  metric_value: 0.8131
+  metric_value: 0.81332
 timm/tf_inception_v3_backend_CUDA_TORCH:
   metric_value: 0.77542
 timm/tf_inception_v3_backend_FP32:
   metric_value: 0.77728
 timm/tf_inception_v3_backend_ONNX:
-  metric_value: 0.77748
+  metric_value: 0.77764
 timm/tf_inception_v3_backend_OV:
   metric_value: 0.77736
 timm/tf_inception_v3_backend_POT:
-  metric_value: 0.77792
+  metric_value: 0.77746
 timm/tf_inception_v3_backend_TORCH:
-  metric_value: 0.77542
+  metric_value: 0.77526
 timm/vgg11_backend_CUDA_TORCH:
   metric_value: 0.6809
 timm/vgg11_backend_FP32:
   metric_value: 0.68344
 timm/vgg11_backend_ONNX:
-  metric_value: 0.681
+  metric_value: 0.68102
 timm/vgg11_backend_OV:
   metric_value: 0.6809
 timm/vgg11_backend_TORCH:
-  metric_value: 0.6809
+  metric_value: 0.68106
 timm/visformer_small_backend_CUDA_TORCH:
   metric_value: 0.77728
 timm/visformer_small_backend_FP32:
   metric_value: 0.77902
 timm/visformer_small_backend_ONNX:
-  metric_value: 0.77678
+  metric_value: 0.77688
 timm/visformer_small_backend_OV:
-  metric_value: 0.77686
+  metric_value: 0.7769
 timm/visformer_small_backend_POT:
-  metric_value: 0.77736
+  metric_value: 0.77718
 timm/visformer_small_backend_TORCH:
-  metric_value: 0.77728
+  metric_value: 0.77682
 timm/wide_resnet50_2_backend_CUDA_TORCH:
   metric_value: 0.81186
 timm/wide_resnet50_2_backend_FP32:
   metric_value: 0.81414
 timm/wide_resnet50_2_backend_ONNX:
-  metric_value: 0.81214
+  metric_value: 0.81208
 timm/wide_resnet50_2_backend_OV:
-  metric_value: 0.81136
+  metric_value: 0.81168
 timm/wide_resnet50_2_backend_POT:
-  metric_value: 0.8114
+  metric_value: 0.81148
 timm/wide_resnet50_2_backend_TORCH:
-  metric_value: 0.81186
+  metric_value: 0.8121


### PR DESCRIPTION
### Changes

Use transformers from timm.

### Reason for changes

Use incorrect transformers to validate models from timm.

### Related tickets

128005

### Tests

tests/post_training/test_quantize_conformance.py


