### PR TITLE
Deprecation note for the git patch to Transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ NNCF may be straightforwardly integrated into training/evaluation pipelines of t
 
 ### Git patches for third-party repository
 
+_Note that this git patch is deprecated and will be removed from NNCF repository in future releases.
+_
 See [third_party_integration](./third_party_integration) for examples of code modifications (Git patches and base commit IDs are provided) that are necessary to integrate NNCF into the following repositories:
 
 - [huggingface-transformers](third_party_integration/huggingface_transformers/README.md)

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ NNCF may be straightforwardly integrated into training/evaluation pipelines of t
 
 ### Git patches for third-party repository
 
-**NOTE (PyTorch)**: this patch is deprecated and will be removed from NNCF repository in future releases.
+**NOTE**: this patch is deprecated and will be removed from NNCF repository in future releases.
 
 See [third_party_integration](./third_party_integration) for examples of code modifications (Git patches and base commit IDs are provided) that are necessary to integrate NNCF into the following repositories:
 

--- a/README.md
+++ b/README.md
@@ -339,11 +339,10 @@ NNCF may be straightforwardly integrated into training/evaluation pipelines of t
 
 ### Git patches for third-party repository
 
-**NOTE**: this patch is deprecated and will be removed from NNCF repository in future releases.
-
 See [third_party_integration](./third_party_integration) for examples of code modifications (Git patches and base commit IDs are provided) that are necessary to integrate NNCF into the following repositories:
 
 - [huggingface-transformers](third_party_integration/huggingface_transformers/README.md)
+**NOTE**: this patch is deprecated and will be removed from NNCF repository in future releases.
 
 ## Installation Guide
 

--- a/README.md
+++ b/README.md
@@ -339,8 +339,8 @@ NNCF may be straightforwardly integrated into training/evaluation pipelines of t
 
 ### Git patches for third-party repository
 
-_Note that this git patch is deprecated and will be removed from NNCF repository in future releases.
-_
+**NOTE (PyTorch)**: this patch is deprecated and will be removed from NNCF repository in future releases.
+
 See [third_party_integration](./third_party_integration) for examples of code modifications (Git patches and base commit IDs are provided) that are necessary to integrate NNCF into the following repositories:
 
 - [huggingface-transformers](third_party_integration/huggingface_transformers/README.md)

--- a/third_party_integration/huggingface_transformers/README.md
+++ b/third_party_integration/huggingface_transformers/README.md
@@ -4,6 +4,8 @@ https://github.com/huggingface/transformers
 
 This folder contains a git patch to enable NNCF-based quantization for XNLI, SQuAD and GLUE training pipelines of the huggingface transformers repository.
 
+**NOTE**: this patch is deprecated and will be removed from NNCF repository in future releases.
+
 Instructions:
 
 1. Apply the `0001-Modifications-for-NNCF-usage.patch` file to the huggingface transformers repository checked out at commit id: `bd469c40659ce76c81f69c7726759d249b4aef49`


### PR DESCRIPTION
### Changes

Added a deprecation note for the git patch to Transformers

### Reason for changes

optimum-intel is recommended way to apply NNCF optimizations for HF Transformers

### Related tickets

na

### Tests

na
