### PR TITLE
Fix test_compression_movement_short_train after update transformers to 4.36

### DIFF
--- a/tests/torch/sparsity/movement/test_training.py
+++ b/tests/torch/sparsity/movement/test_training.py
@@ -332,7 +332,7 @@ class TestMovementTraining:
 
     @staticmethod
     def _validate_model_is_saved(desc: MovementTrainingTestDescriptor):
-        assert Path(desc.output_dir, "pytorch_model.bin").is_file()
+        assert Path(desc.output_dir, "model.safetensors").is_file()
 
     @staticmethod
     def _validate_train_metric(desc: MovementTrainingTestDescriptor):


### PR DESCRIPTION
### Changes

Update name of expected output file. 
 
### Reason for changes

Since [4.35.0](https://github.com/huggingface/transformers/tree/v4.35.0) used safetensors serialization by default.

### Tests

tests/torch/sparsity/movement/test_training.py