### PR TITLE
[Torch] Scale calculation is fixed in the `tune_range` function

### DIFF
--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -58,7 +58,7 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
 
     @property
     def mat_mul_metatypes(self) -> List[OperatorMetatype]:
-        return [om.PTModuleLinearMetatype]
+        return [om.PTModuleLinearMetatype, om.PTLinearMetatype, om.PTMatMulMetatype]
 
     @property
     def post_processing_metatypes(self) -> List[OperatorMetatype]:

--- a/nncf/torch/quantization/quantize_functions.py
+++ b/nncf/torch/quantization/quantize_functions.py
@@ -224,7 +224,7 @@ class TuneRange(torch.autograd.Function):
         input_high[input_high < 0] = 0
         n = levels - 1
         # Need a cast here because fp16 division yields fp32 results sometimes
-        scale = (levels / (input_high - input_low_copy)).to(dtype=input_high.dtype)
+        scale = (n / (input_high - input_low_copy)).to(dtype=input_high.dtype)
         zp = torch.round(-input_low_copy * scale)
 
         new_input_low = torch.where(zp < n, zp / (zp - n) * input_high, input_low_copy)

--- a/nncf/torch/quantization/reference.py
+++ b/nncf/torch/quantization/reference.py
@@ -88,7 +88,7 @@ class ReferenceQuantize:
         input_low[input_low > 0] = 0
         input_high[input_high < 0] = 0
         n = levels - 1
-        scale = levels / (input_high - input_low)
+        scale = n / (input_high - input_low)
         scale = self._astype(scale, input_high.dtype)
         zp = self.backend.round(-input_low * scale)
 

--- a/tests/post_training/reference_data.yaml
+++ b/tests/post_training/reference_data.yaml
@@ -171,7 +171,7 @@ timm/mobilenetv3_small_050_backend_OV:
 timm/mobilenetv3_small_050_backend_POT:
   metric_value: 0.55768
 timm/mobilenetv3_small_050_backend_TORCH:
-  metric_value: 0.43038
+  metric_value: 0.4291
 timm/regnetx_002_backend_CUDA_TORCH:
   metric_value: 0.67452
 timm/regnetx_002_backend_FP32:

--- a/tests/torch/sota_checkpoints_eval.json
+++ b/tests/torch/sota_checkpoints_eval.json
@@ -35,7 +35,7 @@
             "resnet50_imagenet_int4_int8": {
                 "config": "examples/torch/classification/configs/mixed_precision/resnet50_imagenet_mixed_int_hawq.json",
                 "reference": "resnet50_imagenet",
-                "target_ov": 75.5,
+                "target_ov": 75.74,
                 "target_pt": 75.86                ,
                 "metric_type": "Acc@1",
                 "resume": "resnet50_imagenet_int4_int8.pth",
@@ -150,7 +150,7 @@
             "mobilenet_v2_imagenet_int4_int8": {
                 "config": "examples/torch/classification/configs/mixed_precision/mobilenet_v2_imagenet_mixed_int_hawq.json",
                 "reference": "mobilenet_v2_imagenet",
-                "target_ov": 70.44,
+                "target_ov": 70.49,
                 "target_pt": 70.57,
                 "metric_type": "Acc@1",
                 "resume": "mobilenet_v2_imagenet_int4_int8.pth",
@@ -185,7 +185,7 @@
             "mobilenet_v3_small_imagenet_int8": {
                 "config": "examples/torch/classification/configs/quantization/mobilenet_v3_small_imagenet_int8.json",
                 "reference": "mobilenet_v3_small_imagenet",
-                "target_ov": 66.95,
+                "target_ov": 66.92,
                 "target_pt": 66.97,
                 "metric_type": "Acc@1",
                 "resume": "mobilenet_v3_small_imagenet_int8.pth",
@@ -228,7 +228,7 @@
             "squeezenet1_1_imagenet_int4_int8": {
                 "config": "examples/torch/classification/configs/mixed_precision/squeezenet1_1_imagenet_mixed_int_hawq_old_eval.json",
                 "reference": "squeezenet1_1_imagenet",
-                "target_ov": 57.61,
+                "target_ov": 57.53,
                 "target_pt": 57.59,
                 "metric_type": "Acc@1",
                 "resume": "squeezenet1_1_imagenet_int4_int8.pth",


### PR DESCRIPTION
### Changes

Scale in the torch `tune_range` operation uses `(levels - 1)` instead of `levels` in the numerator

### Reason for changes

According to the formula from the [docs ](https://github.com/openvinotoolkit/nncf/blob/develop/docs/compression_algorithms/Quantization.md#asymmetric-quantization) and my understanding of formula: scale := 1 / len of one quant, levels -1  in the nominator of the scale formula should be used in the `tune_range` function.

### Related tickets

128005

### Tests

`test_functions` is updated accordingly 
e2e_pytorch_2.0.1/17/ (Green after #2365 )
post_training_quantization/244 (Metrics for problematic models timm/mobilenetv3_small_050 and timm/crossvit_9_240 for OV and TORCH backends became close)
NNCF/job/nightly/job/TriggerBetta/559
