### PR TITLE
[Torch] Update metrics for resnet18_imagenet_binarization_xnor

### DIFF
--- a/tests/torch/sota_checkpoints_eval.json
+++ b/tests/torch/sota_checkpoints_eval.json
@@ -256,7 +256,9 @@
                 "model_description": "ResNet-18",
                 "compression_description": "XNOR (weights), scale/threshold (activations)",
                 "diff_fp32_min": -8.5,
-                "diff_fp32_max": 0.1
+                "diff_fp32_max": 0.1,
+                "diff_target_pt_min": -0.3,
+                "diff_target_pt_max": 0.3
             },
             "resnet18_imagenet_binarization_dorefa": {
                 "config": "examples/torch/classification/configs/binarization/resnet18_imagenet_binarization_dorefa.json",

--- a/tests/torch/sota_checkpoints_eval.json
+++ b/tests/torch/sota_checkpoints_eval.json
@@ -250,7 +250,7 @@
                 "config": "examples/torch/classification/configs/binarization/resnet18_imagenet_binarization_xnor.json",
                 "reference": "resnet18_imagenet",
                 "target_ov": 61.82,
-                "target_pt": 61.74,
+                "target_pt": 61.88,
                 "metric_type": "Acc@1",
                 "resume": "resnet18_imagenet_binarization_xnor.pth",
                 "model_description": "ResNet-18",


### PR DESCRIPTION
### Changes

Metrics for resnet18_imagenet_binarization_xnor are updated


### Reason for changes

Green e2e_pytorch

### Related tickets



### Tests

e2e_pytorch_2.0.1/18/
