### PR TITLE
[Torch][PTQ] MatMul metatypes are updated

### DIFF
--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -58,7 +58,7 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
 
     @property
     def mat_mul_metatypes(self) -> List[OperatorMetatype]:
-        return [om.PTModuleLinearMetatype]
+        return [om.PTModuleLinearMetatype, om.PTLinearMetatype, om.PTMatMulMetatype]
 
     @property
     def post_processing_metatypes(self) -> List[OperatorMetatype]:


### PR DESCRIPTION
### Changes

MatMul metatypes are updated for the TORCH PTQ backend

### Reason for changes

To align quantization setup between OV and TORCH PTQ backends

### Related tickets

128005

### Tests


