### PR TITLE
Fix TypeError: Object of type RestoreMode is not JSON serializable

### DIFF
--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -46,6 +46,7 @@ from nncf.quantization.advanced_parameters import AdvancedAccuracyRestorerParame
 from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
 from nncf.quantization.advanced_parameters import AggregatorType
 from nncf.quantization.advanced_parameters import OverflowFix
+from nncf.quantization.advanced_parameters import RestoreMode
 from nncf.quantization.advanced_parameters import StatisticsType
 from nncf.scopes import IgnoredScope
 
@@ -126,6 +127,7 @@ class CustomJSONEncoder(json.JSONEncoder):
                 AggregatorType,
                 DropType,
                 QuantizationMode,
+                RestoreMode,
             ),
         ):
             return o.value


### PR DESCRIPTION
### Changes

Fix TypeError: Object of type RestoreMode is not JSON serializable

### Reason for changes

TypeError: Object of type RestoreMode is not JSON serializable

### Related tickets

N/A

### Tests

N/A
