### PR TITLE
Added a SensitivityMetric enum to API

### DIFF
--- a/nncf/__init__.py
+++ b/nncf/__init__.py
@@ -22,6 +22,7 @@ from nncf.parameters import CompressWeightsMode as CompressWeightsMode
 from nncf.parameters import DropType as DropType
 from nncf.parameters import ModelType as ModelType
 from nncf.parameters import QuantizationMode as QuantizationMode
+from nncf.parameters import SensitivityMetric as SensitivityMetric
 from nncf.parameters import TargetDevice as TargetDevice
 from nncf.quantization import QuantizationPreset as QuantizationPreset
 from nncf.quantization import compress_weights as compress_weights

--- a/nncf/parameters.py
+++ b/nncf/parameters.py
@@ -89,6 +89,7 @@ class CompressWeightsMode(Enum):
     INT8 = "int8"  # Deprecated mode
 
 
+@api(canonical_alias="nncf.SensitivityMetric")
 class SensitivityMetric(Enum):
     """
     Defines a sensitivity metric for assigning quantization precision to layers. In order to

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -18,10 +18,10 @@ import pytest
 from attr import dataclass
 
 from nncf import CompressWeightsMode
+from nncf import SensitivityMetric
 from nncf.data.dataset import Dataset
 from nncf.openvino.graph.node_utils import get_const_value
 from nncf.openvino.quantization.mixed_precision import MIXED_PRECISION_CRITERIA
-from nncf.parameters import SensitivityMetric
 from nncf.quantization import compress_weights
 from nncf.quantization.algorithms.weight_compression.compression_info import WeightCompressionConfig
 from nncf.quantization.algorithms.weight_compression.quantize import get_integer_quantization_error

--- a/tests/torch/ptq/test_weights_compression.py
+++ b/tests/torch/ptq/test_weights_compression.py
@@ -13,7 +13,7 @@ import pytest
 import torch
 
 from nncf import CompressWeightsMode
-from nncf.parameters import SensitivityMetric
+from nncf import SensitivityMetric
 from nncf.quantization import compress_weights
 
 DATA_BASED_SENSITIVITY_METRICS = (


### PR DESCRIPTION
### Changes

as stated in title

### Reason for changes

`nncf.parameters.SensitivityMetric` is an argument for `compress_weights` API 
it should be accessible in the folllowing way:
```python
from nncf import SensitivityMetric
#or 
nncf.SensitivityMetric.HESSIAN_INPUT_ACTIVATION
```