### PR TITLE
[QAT][Torch] Migrate statistic collection to `PTStatisticsAggregator`

### DIFF
--- a/nncf/torch/initialization.py
+++ b/nncf/torch/initialization.py
@@ -173,14 +173,6 @@ class DataLoaderBaseRunner:
         raise NotImplementedError
 
 
-class SimpleDataLoaderRunner(DataLoaderBaseRunner):
-    def _prepare_initialization(self):
-        pass
-
-    def _apply_initializers(self):
-        pass
-
-
 class DataLoaderBNAdaptationRunner(DataLoaderBaseRunner):
     def __init__(self, model, init_device: str):
         super().__init__(model, init_device)

--- a/nncf/torch/initialization.py
+++ b/nncf/torch/initialization.py
@@ -215,13 +215,7 @@ class DataLoaderBNAdaptationRunner(DataLoaderBaseRunner):
 
     def _run_model_inference(self, data_loader, num_init_steps, device):
         with self._bn_training_state_switcher():
-            for i, loaded_item in ProgressBar(
-                enumerate(data_loader), total=num_init_steps, desc=self.progressbar_description
-            ):
-                if num_init_steps is not None and i >= num_init_steps:
-                    break
-                args_kwargs_tuple = data_loader.get_inputs(loaded_item)
-                self._infer_batch(args_kwargs_tuple, device)
+            super()._run_model_inference(data_loader, num_init_steps, device)
 
     def _prepare_initialization(self):
         pass

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -783,9 +783,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
                 is_quantized_on_export=qp.is_weight_quantization_point(),
                 compression_lr_multiplier=compression_lr_multiplier,
             )
-            pt_qp = PTQuantizationPoint(
-                qspec, PTTargetPointTranslator.translate(insertion_point), qp.directly_quantized_operator_node_names
-            )
+            pt_qp = PTQuantizationPoint(qspec, tp, qp.directly_quantized_operator_node_names)
             setup.add_quantization_point(qp_id, pt_qp)
 
         return setup

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -670,9 +670,10 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
         def transform_fn(input_: Tuple[torch.Tensor, torch.Tensor], device: str) -> torch.Tensor:
             return input_[0].to(device)
 
+        target_device = range_init_params.device or get_model_device(target_model)
         dataset = Dataset(
             range_init_params.init_range_data_loader,
-            transform_func=partial(transform_fn, device=range_init_params.device),
+            transform_func=partial(transform_fn, device=target_device),
         )
 
         aggregator = PTStatisticsAggregator(dataset)

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -682,7 +682,8 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
             for collector in scale_shape_vs_collector.values():
                 stat_points_container.add_statistic_point(StatisticPoint(target_point, collector, "QAT"))
         aggregator.register_statistic_points(stat_points_container)
-        aggregator.collect_statistics(target_model, original_nncf_graph)
+        with training_mode_switcher(target_model, is_training=False):
+            aggregator.collect_statistics(target_model, original_nncf_graph)
 
         retval = {}
         for target_point, scale_shape_vs_collector in target_points_vs_collectors_dict.items():

--- a/nncf/torch/tensor_statistics/algo.py
+++ b/nncf/torch/tensor_statistics/algo.py
@@ -8,40 +8,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Callable, Dict, Set, Union
+from typing import Callable, Union
 
 import torch
 
-from nncf.api.compression import CompressionStage
-from nncf.common.schedulers import StubCompressionScheduler
-from nncf.common.statistics import NNCFStatistics
-from nncf.common.tensor_statistics.collectors import ReductionAxes
-from nncf.common.tensor_statistics.collectors import TensorStatisticCollectorBase
-from nncf.config import NNCFConfig
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
-from nncf.torch.algo_selector import ZeroCompressionLoss
-from nncf.torch.compression_method_api import PTCompressionAlgorithmBuilder
-from nncf.torch.compression_method_api import PTCompressionAlgorithmController
 from nncf.torch.dynamic_graph.context import no_nncf_trace
-from nncf.torch.graph.transformations.commands import PTInsertionCommand
-from nncf.torch.graph.transformations.commands import PTTargetPoint
-from nncf.torch.graph.transformations.commands import TransformationPriority
-from nncf.torch.graph.transformations.layout import PTTransformationLayout
-from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.return_types import maybe_get_values_from_torch_return_type
 from nncf.torch.tensor import PTNNCFTensor
-
-
-class TensorStatisticObservationPoint:
-    def __init__(self, target_point: PTTargetPoint, reduction_shapes: Set[ReductionAxes] = None):
-        self.target_point = target_point
-        self.reduction_shapes = reduction_shapes
-
-    def __hash__(self):
-        return hash(self.target_point)
-
-    def __eq__(self, other: "TensorStatisticObservationPoint"):
-        return self.target_point == other.target_point
 
 
 def create_register_input_hook(collector: TensorCollector) -> Callable[[torch.Tensor], torch.Tensor]:
@@ -65,74 +39,3 @@ def create_register_input_hook(collector: TensorCollector) -> Callable[[torch.Te
         return x
 
     return register_inputs_hook
-
-
-class TensorStatisticsCollectionBuilder(PTCompressionAlgorithmBuilder):
-    def __init__(
-        self,
-        config: NNCFConfig,
-        observation_points_vs_collectors: Dict[TensorStatisticObservationPoint, TensorStatisticCollectorBase],
-    ):
-        super().__init__(config)
-        self._observation_points_vs_collectors = observation_points_vs_collectors
-
-    def _get_transformation_layout(self, target_model: NNCFNetwork) -> PTTransformationLayout:
-        # Will it really suffice to use a single collector for all threads? After all, each of the threads
-        # receives its own data, and should we use a thread-local collector, there would have to be a
-        # separate thread reduction step involved. Still, is there a better option here than to rely on GIL?
-        layout = PTTransformationLayout()
-        for op, rs_vs_collector in self._observation_points_vs_collectors.items():
-            for collector in rs_vs_collector.values():
-                command = PTInsertionCommand(
-                    op.target_point,
-                    create_register_input_hook(collector=collector),
-                    TransformationPriority.FP32_TENSOR_STATISTICS_OBSERVATION,
-                )
-                layout.register(command)
-        return layout
-
-    def _build_controller(self, model: NNCFNetwork) -> "TensorStatisticsCollectionController":
-        return TensorStatisticsCollectionController(
-            model, {k.target_point: v for k, v in self._observation_points_vs_collectors.items()}
-        )
-
-    def _handle_frozen_layers(self, target_model: NNCFNetwork):
-        pass
-
-    def initialize(self, model: NNCFNetwork) -> None:
-        pass
-
-    def _get_algo_specific_config_section(self) -> Dict:
-        return {}
-
-
-class TensorStatisticsCollectionController(PTCompressionAlgorithmController):
-    def __init__(
-        self, target_model: NNCFNetwork, ip_vs_collector_dict: Dict[PTTargetPoint, TensorStatisticCollectorBase]
-    ):
-        super().__init__(target_model)
-        self.ip_vs_collector_dict = ip_vs_collector_dict
-        self._scheduler = StubCompressionScheduler()
-        self._loss = ZeroCompressionLoss("cpu")
-
-    @property
-    def loss(self) -> ZeroCompressionLoss:
-        return self._loss
-
-    @property
-    def scheduler(self) -> StubCompressionScheduler:
-        return self._scheduler
-
-    def start_collection(self):
-        for collector in self.ip_vs_collector_dict.values():
-            collector.enable()
-
-    def stop_collection(self):
-        for collector in self.ip_vs_collector_dict.values():
-            collector.disable()
-
-    def compression_stage(self) -> CompressionStage:
-        return CompressionStage.FULLY_COMPRESSED
-
-    def statistics(self, quickly_collected_only: bool = False) -> NNCFStatistics:
-        return NNCFStatistics()


### PR DESCRIPTION
### Changes

* PT QAT statistic collection is using `PTStatisticsAggregator` to aggregate statistics
* `generate_collectors_for_range_init_statistics_collection` function is simplified
* `get_input_shape_and_channel_idx` is introduced to remove code duplicates

### Reason for changes

Part of activity for QAT migration to PTQ quantization implementation

### Related tickets



### Tests

Updated accordingly
