### PR TITLE
Reverted casting operations in do_integer_quantization function.

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/mixed_precision.py
+++ b/nncf/quantization/algorithms/weight_compression/mixed_precision.py
@@ -171,7 +171,6 @@ class HAWQCriterion(DataBasedCriterion):
 
         orig_shape = weight.shape
         compressed_weights, scale, zero_point = do_integer_quantization(weight, reduction_axis, backup_config)
-        decompressed_weight = compressed_weights.astype(dtype=scale.dtype)
         decompressed_weight = (compressed_weights - zero_point) * scale
         decompressed_weight = decompressed_weight.reshape(orig_shape)
         return fns.linalg.norm(decompressed_weight - weight, ord="fro").item()

--- a/nncf/quantization/algorithms/weight_compression/weight_lowering.py
+++ b/nncf/quantization/algorithms/weight_compression/weight_lowering.py
@@ -136,9 +136,6 @@ def do_integer_quantization(
         scale = scale / level_high_sym
         zero_point = fns.as_tensor_like(scale, [-level_low_sym])
 
-    scale = scale.astype(weight.dtype)
-    zero_point = zero_point.astype(TensorDataType.uint8)
-
     eps = fns.finfo(weight).eps
     # NOTE: adding machine epsilon to avoid division by zero
     scale = fns.where(fns.abs(scale) < eps, eps, scale)
@@ -160,7 +157,6 @@ def get_integer_quantization_error(weight: Tensor, reduction_axis: int, config: 
     orig_shape = weight.shape
     compressed_weights, scale, zero_point = do_integer_quantization(weight, reduction_axis, config)
 
-    compressed_weights = compressed_weights.astype(dtype=weight.dtype)
     decompressed_weight = (compressed_weights - zero_point) * scale
 
     decompressed_weight = decompressed_weight.reshape(orig_shape)


### PR DESCRIPTION
### Changes

Reverted casting operations in do_integer_quantization function.

### Reason for changes

numpy operations with uint8 is very slow.


### Related tickets

ref: 130239

### Tests

N/A
