### PR TITLE
Adjust timm/crossvit_9_240_backend_TORCH metrics

### DIFF
--- a/tests/post_training/reference_data.yaml
+++ b/tests/post_training/reference_data.yaml
@@ -23,7 +23,7 @@ timm/crossvit_9_240_backend_ONNX:
 timm/crossvit_9_240_backend_OV:
   metric_value: 0.72812
 timm/crossvit_9_240_backend_TORCH:
-  metric_value: 0.72922
+  metric_value: 0.72816
 timm/darknet53_backend_CUDA_TORCH:
   metric_value: 0.79176
 timm/darknet53_backend_FP32:


### PR DESCRIPTION
### Changes

timm/crossvit_9_240_backend_TORCH metrics are adjusted

### Reason for changes

*Validation timeline
 
4.01.24 Tune range fix https://github.com/openvinotoolkit/nncf/pull/2364 validation is green ✅
6.01.24 Weekly post training quantization test is green ✅
9.01.24 Matmul to symmetric mode for transformer https://github.com/openvinotoolkit/nncf/pull/2375 validation is green ✅
11.01.24 Matmul to symmetric mode for transformer https://github.com/openvinotoolkit/nncf/pull/2375 is merged
12.01.24 Tune range fix https://github.com/openvinotoolkit/nncf/pull/2364 is merged
20.01.24 Weekly post training quantization test is red ❌

* timm/crossvit_9_240_backend_TORCH is affected by both PRs  (tune range is calculated differently, some MatMuls were quantized in a wrong mode (asymmetric instead of symmetric) and was never tested on a state where both fixes are present


