### PR TITLE
Hide an irrelevant warning during tune_range call

### DIFF
--- a/nncf/quantization/fake_quantize.py
+++ b/nncf/quantization/fake_quantize.py
@@ -122,11 +122,8 @@ def tune_range(
         qval = fns.round(fval)
 
     ra = fns.where(qval < level_high, qval / (qval - level_high) * right_border, left_border)
-    with warnings.catch_warnings():
-        # If `qval` is 0 `rb` will equal `right_border`, and we don't want to show an unnecessary division by 0 warning
-        warnings.simplefilter("ignore")
-        rb_then_result = (qval - level_high) / qval * left_border
-    rb = fns.where(qval > 0.0, rb_then_result, right_border)
+    qval_ = fns.where(qval == 0.0, fns.ones_like(qval), qval)
+    rb = fns.where(qval > 0.0, (qval - level_high) / qval_ * left_border, right_border)
 
     range_a = right_border - ra
     range_b = rb - left_border

--- a/nncf/quantization/fake_quantize.py
+++ b/nncf/quantization/fake_quantize.py
@@ -121,7 +121,7 @@ def tune_range(
         qval = fns.round(fval)
 
     ra = fns.where(qval < level_high, qval / (qval - level_high) * right_border, left_border)
-    qval_ = fns.where(qval == 0.0, fns.ones_like(qval), qval)
+    qval_ = fns.where(qval == 0.0, 1.0, qval)
     rb = fns.where(qval > 0.0, (qval - level_high) / qval_ * left_border, right_border)
 
     range_a = right_border - ra

--- a/nncf/quantization/fake_quantize.py
+++ b/nncf/quantization/fake_quantize.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from dataclasses import dataclass
 from typing import Tuple
 
@@ -121,8 +122,11 @@ def tune_range(
         qval = fns.round(fval)
 
     ra = fns.where(qval < level_high, qval / (qval - level_high) * right_border, left_border)
-    qval_ = fns.where(qval == 0.0, 1.0, qval)
-    rb = fns.where(qval > 0.0, (qval - level_high) / qval_ * left_border, right_border)
+    with warnings.catch_warnings():
+        # If `qval` is 0 `rb` will equal `right_border`, and we don't want to show an unnecessary division by 0 warning
+        warnings.simplefilter("ignore")
+        rb_then_result = (qval - level_high) / qval * left_border
+    rb = fns.where(qval > 0.0, rb_then_result, right_border)
 
     range_a = right_border - ra
     range_b = rb - left_border

--- a/nncf/quantization/fake_quantize.py
+++ b/nncf/quantization/fake_quantize.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
 from dataclasses import dataclass
 from typing import Tuple
 

--- a/nncf/quantization/fake_quantize.py
+++ b/nncf/quantization/fake_quantize.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from dataclasses import dataclass
 from typing import Tuple
 
@@ -121,7 +122,11 @@ def tune_range(
         qval = fns.round(fval)
 
     ra = fns.where(qval < level_high, qval / (qval - level_high) * right_border, left_border)
-    rb = fns.where(qval > 0.0, (qval - level_high) / qval * left_border, right_border)
+    with warnings.catch_warnings():
+        # If `qval` is 0 `rb` will equal `right_border`, and we don't want to show an unnecessary division by 0 warning
+        warnings.simplefilter("ignore")
+        rb_then_result = (qval - level_high) / qval * left_border
+    rb = fns.where(qval > 0.0, rb_then_result, right_border)
 
     range_a = right_border - ra
     range_b = rb - left_border

--- a/tests/post_training/test_tune_range.py
+++ b/tests/post_training/test_tune_range.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2024 Intel Corporation
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/post_training/test_tune_range.py
+++ b/tests/post_training/test_tune_range.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import warnings
+
+import numpy as np
+
+from nncf.experimental.tensor import Tensor
+from nncf.quantization.fake_quantize import tune_range
+
+
+def test_tune_range_zero_division_warning():
+    with warnings.catch_warnings(record=True) as w:
+        # Calling tune_range should not raise a warning
+        tune_range(Tensor(np.array([0.0])), Tensor(np.array([1.0])), 8, False)
+        assert len(w) == 0


### PR DESCRIPTION
When `tune_range()` is called with a `left_border` being equal to 0. This leads to the following warning
```
/home/nsavel/workspace/nncf/nncf/experimental/tensor/tensor.py:84: RuntimeWarning: invalid value encountered in multiply
  return Tensor(self.data * unwrap_tensor_data(other))
```

at this line:

```
rb = fns.where(qval > 0.0, (qval - level_high) / qval * left_border, right_border)
```

When we divide by `qval` which equals 0, this results in a NaN during computation. At the same time if `qval` is zero then `where` condition does not hold and `rb==right_border`. Seems like numpy computes both results nevertheless of the condition.

### Changes

Do not show the unnecessary warning because it is confusing.

### Reason for changes

Improving UX

### Tests

Added a test for `tune_range`. Not sure about the location, feel free to suggest a better one.
