### PR TITLE
Compress weights of Conv layers to 8 bit

### DIFF
--- a/docs/compression_algorithms/CompressWeights.md
+++ b/docs/compression_algorithms/CompressWeights.md
@@ -4,14 +4,14 @@
 
 #### The algorithm description
 
-The Weights Compression algorithm is aimed at compressing the weights of the models and can be used to optimize the model footprint and performance of large models where the size of weights is relatively larger than the size of activations, for example, Large Language Models (LLM). The algorithm compresses weights only for Linear and Embedding layers.
+The Weights Compression algorithm is aimed at compressing the weights of the models and can be used to optimize the model footprint and performance of large models where the size of weights is relatively larger than the size of activations, for example, Large Language Models (LLM). The algorithm compresses weights for Linear, Convolution and Embedding layers.
 
 #### Supported modes
 
 By default, weights are compressed asymmetrically to 8-bit integer data type - "INT8_ASYM" mode.
 OpenVINO backend also supports 3 modes of mixed precision weight quantization with a 4-bit data type as a primary precision - INT4_SYM, INT4_ASYM and NF4. The primary precision in case of INT4_SYM mode is unsigned 4-bit integer and weights are quantized to it [symmetrically](https://github.com/openvinotoolkit/nncf/blob/develop/docs/compression_algorithms/Quantization.md#symmetric-quantization) with a fixed zero point equals to 8. In case of INT4_ASYM mode - also unsigned 4-bit integer, but weight are quantized to it [asymmetrically](https://github.com/openvinotoolkit/nncf/blob/develop/docs/compression_algorithms/Quantization.md#asymmetric-quantization) with a typical non-fixed zero point. In case of NF4 mode - [nf4](https://arxiv.org/pdf/2305.14314v1.pdf) data type without zero point.
 All 4-bit modes have a grouped quantization support, when small group of weights (e.g. 128) in the channel dimension share quantization parameters (scale).
-All embeddings and last linear layers are always compressed to 8-bit integer data type.
+All embeddings, convolutions and last linear layers are always compressed to 8-bit integer data type. To quantize embeddings and last linear layers to 4-bit, use `all_layers=True`.
 Percent of the rest layers compressed to 4-bit can be configured by "ratio" parameter. E.g. ratio=0.9 means 90% of layers compressed to the corresponding 4-bit data type and the rest to 8-bit asymmetric integer data type.
 
 #### User guide
@@ -30,7 +30,7 @@ from nncf import compress_weights, CompressWeightsMode
 compressed_model = compress_weights(model, mode=CompressWeightsMode.INT8_SYM) # model is openvino.Model object
 ```
 
-- Compress weights symmetrically to 4-bit integer data type with group size = 128, except embeddings and last linear layers - they are compressed asymmetrically to 8-bit integer data type.
+- Compress weights symmetrically to 4-bit integer data type with group size = 128, except embeddings, convolutions and last linear layers - they are compressed asymmetrically to 8-bit integer data type.
 
 ```python
 from nncf import compress_weights, CompressWeightsMode

--- a/nncf/common/tensor_statistics/collectors.py
+++ b/nncf/common/tensor_statistics/collectors.py
@@ -21,7 +21,7 @@ from nncf.common.tensor import TensorElementsType
 from nncf.common.tensor import TensorType
 from nncf.common.tensor_statistics.reduction import get_per_channel_history
 
-ReductionAxes = Tuple[int]
+ReductionAxes = Tuple[int, ...]
 
 
 class TensorStatisticCollectorBase(ABC):

--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -139,7 +139,11 @@ class WeightCompression(Algorithm):
         :param nncf_graph: NNCFGraph instance.
         :return: List with the data for each layer.
         """
-        weighted_metatypes = self._backend_entity.matmul_metatypes + self._backend_entity.embedding_metatypes
+        weighted_metatypes = \
+            self._backend_entity.matmul_metatypes + \
+            self._backend_entity.embedding_metatypes + \
+            self._backend_entity.convolution_metatypes
+
         ordered_nodes_to_compress = []
         ignored_names = get_ignored_node_names_from_ignored_scope(
             self._ignored_scope, nncf_graph, strict=self._ignored_scope.validate

--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -172,7 +172,7 @@ class WeightCompression(Algorithm):
             return all_weight_params
 
         if self._all_layers:
-            return list(filter(lambda wp: len(wp.reduction_axis) == 1, all_weight_params))
+            return list(filter(lambda wp: len(wp.reduction_axes) == 1, all_weight_params))
 
         ratio_defining_params = list(
             filter(

--- a/nncf/quantization/algorithms/weight_compression/awq.py
+++ b/nncf/quantization/algorithms/weight_compression/awq.py
@@ -198,7 +198,8 @@ class AWQ(Algorithm):
             weight = self._backend_entity.get_weight(
                 wp.node_with_weight, weight_port_id, model, graph
             )  # get_const_value(wp.weight_node)
-            reduction_axis = wp.reduction_axis
+            assert isinstance(wp.reduction_axes, tuple) and len(wp.reduction_axes) == 1
+            reduction_axis = wp.reduction_axes[0]
 
             if reduction_axis == 0:
                 weight = fns.transpose(weight)
@@ -247,7 +248,7 @@ class AWQ(Algorithm):
 
             a_scale = scale
             w_scale = scale
-            if wp.reduction_axis == 0:
+            if wp.reduction_axes[0] == 0:
                 w_scale = fns.unsqueeze(w_scale, 1)
                 a_scale = fns.unsqueeze(1.0 / a_scale, 0)
             else:

--- a/nncf/quantization/algorithms/weight_compression/backend.py
+++ b/nncf/quantization/algorithms/weight_compression/backend.py
@@ -35,6 +35,13 @@ class WeightCompressionAlgoBackend(ABC):
 
     @property
     @abstractmethod
+    def convolution_metatypes(self) -> List[OperatorMetatype]:
+        """
+        Property for the backend-specific metatypes for convolution layers.
+        """
+
+    @property
+    @abstractmethod
     def embedding_metatypes(self) -> List[OperatorMetatype]:
         """
         Property for the backend-specific metatypes for embedding layers.

--- a/nncf/quantization/algorithms/weight_compression/config.py
+++ b/nncf/quantization/algorithms/weight_compression/config.py
@@ -47,7 +47,7 @@ class WeightCompressionParameters:
     :param node_with_weight: Node with weight in the NNCF graph.
     :param weight_port_id: Number of elements in the weight array.
     :param num_weights: Number of elements in the weight array.
-    :param reduction_axes: Axess, along which to reduce (collect) different statistics (e.g. min, max).
+    :param reduction_axes: Axes, along which to reduce (collect) different statistics (e.g. min, max).
     :param compression_config: Configuration of weight compression for the weight node.
     """
 

--- a/nncf/quantization/algorithms/weight_compression/config.py
+++ b/nncf/quantization/algorithms/weight_compression/config.py
@@ -47,7 +47,7 @@ class WeightCompressionParameters:
     :param node_with_weight: Node with weight in the NNCF graph.
     :param weight_port_id: Number of elements in the weight array.
     :param num_weights: Number of elements in the weight array.
-    :param reduction_axis: Axes, along which to reduce (collect) different statistics (e.g. min, max).
+    :param reduction_axes: Axess, along which to reduce (collect) different statistics (e.g. min, max).
     :param compression_config: Configuration of weight compression for the weight node.
     """
 
@@ -55,5 +55,5 @@ class WeightCompressionParameters:
     node_with_weight: NNCFNode
     weight_port_id: int
     num_weights: int
-    reduction_axis: Tuple[int]
+    reduction_axes: Tuple[int, ...]
     compression_config = WeightCompressionConfig()

--- a/nncf/quantization/algorithms/weight_compression/mixed_precision.py
+++ b/nncf/quantization/algorithms/weight_compression/mixed_precision.py
@@ -102,8 +102,8 @@ class DataFreeCriterion(MixedPrecisionCriterion):
             weight_param.node_with_weight, weight_param.weight_port_id, self._model, self._graph
         )
         backup_config = weight_param.compression_config
-        reduction_axis = weight_param.reduction_axis
-        int_error = get_integer_quantization_error(weight, reduction_axis, backup_config)
+        reduction_axes = weight_param.reduction_axes
+        int_error = get_integer_quantization_error(weight, reduction_axes, backup_config)
         eps = fns.finfo(weight).eps
         return 1 / (int_error + eps)
 
@@ -168,14 +168,14 @@ class HAWQCriterion(DataBasedCriterion):
             weight_param.node_with_weight, weight_param.weight_port_id, self._model, self._graph
         )
         backup_config = weight_param.compression_config
-        reduction_axis = weight_param.reduction_axis
+        reduction_axes = weight_param.reduction_axes
 
         orig_shape = weight.shape
 
         if weight.dtype != TensorDataType.float32:
             weight = weight.astype(TensorDataType.float32)
 
-        compressed_weights, scale, zero_point = do_integer_quantization(weight, reduction_axis, backup_config)
+        compressed_weights, scale, zero_point = do_integer_quantization(weight, reduction_axes, backup_config)
         decompressed_weight = (compressed_weights - zero_point).astype(weight.dtype) * scale
         decompressed_weight = decompressed_weight.reshape(orig_shape)
         return fns.linalg.norm(decompressed_weight - weight, ord="fro").item()

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -19,9 +19,7 @@ from nncf.common.graph.operator_metatypes import OperatorMetatype
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
 from nncf.experimental.tensor.tensor import Tensor
-from nncf.openvino.graph.metatypes.openvino_metatypes import OVEmbeddingMetatype
-from nncf.openvino.graph.metatypes.openvino_metatypes import OVMatMulMetatype
-from nncf.openvino.graph.metatypes.openvino_metatypes import OVMultiplyMetatype
+from nncf.openvino.graph.metatypes import openvino_metatypes as om
 from nncf.openvino.graph.model_transformer import OVModelTransformer
 from nncf.openvino.graph.node_utils import get_channel_agnostic_reduction_axes
 from nncf.openvino.graph.node_utils import get_const_value
@@ -42,11 +40,21 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
     @property
     def matmul_metatypes(self) -> List[OperatorMetatype]:
-        return [OVMatMulMetatype]
+        return [om.OVMatMulMetatype]
+
+    @property
+    def convolution_metatypes(self) -> List[OperatorMetatype]:
+        return [
+            om.OVConvolutionMetatype,
+            om.OVDepthwiseConvolutionMetatype,
+            om.OVConvolutionBackpropDataMetatype,
+            om.OVGroupConvolutionMetatype,
+            om.OVGroupConvolutionBackpropDataMetatype,
+        ]
 
     @property
     def embedding_metatypes(self) -> List[OperatorMetatype]:
-        return [OVEmbeddingMetatype]
+        return [om.OVEmbeddingMetatype]
 
     @staticmethod
     def is_node_with_weights(node: NNCFNode, graph: NNCFGraph) -> bool:

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -192,4 +192,4 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 class OVAWQAlgoAlgoBackend(OVWeightCompressionAlgoBackend):
     @staticmethod
     def get_awq_patterns():
-        return get_awq_patterns(OVMatMulMetatype, OVMultiplyMetatype)
+        return get_awq_patterns(om.OVMatMulMetatype, om.OVMultiplyMetatype)

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -148,7 +148,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
             weight = Tensor(get_const_value(const_node))
             original_shape = weight.shape
-            compressed_weight = compress_weight(weight, wc_params.reduction_axis, compression_config)
+            compressed_weight = compress_weight(weight, wc_params.reduction_axes, compression_config)
 
             compressed_const = opset.constant(
                 compressed_weight.tensor.data, dtype=compression_dtype, name=const_node_name

--- a/nncf/quantization/algorithms/weight_compression/torch_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/torch_backend.py
@@ -145,28 +145,28 @@ class PTWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
         weight_node = get_weight_node(node_with_weight, weight_port_id, graph)
 
         ndims = len(weight_node.layer_attributes.shape)
-        reduction_axis = None
+        reduction_axes = None
         if node_with_weight.metatype == om.PTEmbeddingMetatype:
-            reduction_axis = [1]
+            reduction_axes = [1]
         elif node_with_weight.metatype == om.PTLinearMetatype:
-            reduction_axis = [ndims - 1]
+            reduction_axes = [ndims - 1]
         elif node_with_weight.metatype == om.PTMatMulMetatype:
             if weight_port_id == 0:
-                reduction_axis = [ndims - 1]
+                reduction_axes = [ndims - 1]
             elif weight_port_id == 1:
-                reduction_axis = [max(0, ndims - 2)]
-            reduction_axis = [max(0, reduction_axis)]
+                reduction_axes = [max(0, ndims - 2)]
+            reduction_axes = [max(0, reduction_axes)]
         elif node_with_weight.metatype == om.PTAddmmMetatype:
             if weight_port_id == 1:
-                reduction_axis = [ndims - 1]
+                reduction_axes = [ndims - 1]
             elif weight_port_id == 2:
-                reduction_axis = [max(0, ndims - 2)]
-            reduction_axis = [max(0, reduction_axis)]
+                reduction_axes = [max(0, ndims - 2)]
+            reduction_axes = [max(0, reduction_axes)]
         elif node_with_weight.metatype in PTWeightCompressionAlgoBackend.CONVOLUTION_METATYPES:
             layer_attributes = node_with_weight.layer_attributes
             channel_idx = layer_attributes.get_target_dim_for_compression()
-            reduction_axis = [i for i in range(ndims) if i != channel_idx]
-        return tuple(reduction_axis)
+            reduction_axes = [i for i in range(ndims) if i != channel_idx]
+        return tuple(reduction_axes)
 
     @staticmethod
     def target_point(target_type: TargetType, target_node_name: str, port_id: int) -> PTTargetPoint:
@@ -232,7 +232,7 @@ class PTWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                 raise nncf.InternalError(f"Could not find a torch.nn.Parameter in the model by name {weight_name}.")
 
             # calculates compressed weights and decompression parameters
-            compressed_weight = compress_weight(Tensor(weight), wc_params.reduction_axis, compression_config)
+            compressed_weight = compress_weight(Tensor(weight), wc_params.reduction_axes, compression_config)
 
             # pack compressed tensor
             packed_tensor = compressed_weight.tensor.astype(TensorDataType.uint8)

--- a/nncf/quantization/algorithms/weight_compression/weight_lowering.py
+++ b/nncf/quantization/algorithms/weight_compression/weight_lowering.py
@@ -161,7 +161,9 @@ def do_integer_quantization(
     return compressed_weights, scale, zero_point
 
 
-def get_integer_quantization_error(weight: Tensor, reduction_axes: ReductionAxes, config: WeightCompressionConfig) -> float:
+def get_integer_quantization_error(
+    weight: Tensor, reduction_axes: ReductionAxes, config: WeightCompressionConfig
+) -> float:
     """
     Calculates a quantity characterizing the difference between floating point weights and fake quantized
     (compressed and decompressed) to integer ones.

--- a/nncf/quantization/algorithms/weight_compression/weight_lowering.py
+++ b/nncf/quantization/algorithms/weight_compression/weight_lowering.py
@@ -87,6 +87,12 @@ def calculate_normalized_weight_and_nf4_scale(
 
     if group_size != -1:
         # weights are reshaped: [a1, r, a2] -> [a1, r//gs, gs, a2]
+        if isinstance(reduction_axis, tuple) and len(reduction_axis) == 1:
+            reduction_axis = reduction_axis[0]
+        if not isinstance(reduction_axis, int):
+            raise NotImplementedError(
+                f"Group-wise quantization expects a single reduction axes, but given: {reduction_axis}."
+            )
         weight, reduction_axis = reshape_weight_for_grouped_quantization(weight, reduction_axis, group_size)
         scale = fns.max(fns.abs(weight), axis=reduction_axis, keepdims=True)  # [a1, r//gs, 1, a2]
     else:
@@ -136,6 +142,12 @@ def do_integer_quantization(
 
     if group_size != -1:
         # weights are reshaped from [a1, r, a2] to [a1, r//gs, gs, a2]
+        if isinstance(reduction_axis, tuple) and len(reduction_axis) == 1:
+            reduction_axis = reduction_axis[0]
+        if not isinstance(reduction_axis, int):
+            raise NotImplementedError(
+                f"Group-wise quantization expects a single reduction axes, but given: {reduction_axis}."
+            )
         weight, reduction_axis = reshape_weight_for_grouped_quantization(weight, reduction_axis, group_size)
 
     if mode in [CompressWeightsMode.INT8_ASYM, CompressWeightsMode.INT4_ASYM]:

--- a/nncf/quantization/algorithms/weight_compression/weight_lowering.py
+++ b/nncf/quantization/algorithms/weight_compression/weight_lowering.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple
 
 import nncf
 from nncf.experimental.tensor import Tensor
@@ -19,6 +19,8 @@ from nncf.experimental.tensor.functions import numeric as fns
 from nncf.parameters import CompressWeightsMode
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionConfig
 from nncf.quantization.fake_quantize import calculate_scale_zero_point
+
+ReductionAxes = Tuple[int, ...]
 
 
 @dataclass
@@ -38,7 +40,7 @@ class CompressedWeight:
 
 
 def reshape_weight_for_grouped_quantization(
-    weight: Tensor, reduction_axis: Union[int, Tuple[int]], group_size: int
+    weight: Tensor, reduction_axes: ReductionAxes, group_size: int
 ) -> Tuple[Tensor, int]:
     """
     Reshapes weight for group-wise quantization and return a new reduction axis for collecting statistics per group
@@ -46,38 +48,38 @@ def reshape_weight_for_grouped_quantization(
     [c_out, c_in // 128, 128].
 
     :param weight: Weight array to compress.
-    :param reduction_axis: Axes, along which to reduce (collect) different statistics (e.g. min, max).
+    :param reduction_axes: Axes, along which to reduce (collect) different statistics (e.g. min, max).
     :param group_size: Number of weights (e.g. 128) in the channel dimension that share quantization parameters (scale).
     :return: reshaped weight and new reduction axis.
     """
     assert group_size != -1
-    if isinstance(reduction_axis, tuple) and len(reduction_axis) == 1:
-        reduction_axis = reduction_axis[0]
-    if not isinstance(reduction_axis, int):
+    if isinstance(reduction_axes, tuple) and len(reduction_axes) == 1:
+        reduction_axes = reduction_axes[0]
+    if not isinstance(reduction_axes, int):
         raise NotImplementedError(
-            f"Group-wise quantization expects a single reduction axis, but given: {reduction_axis}."
+            f"Group-wise quantization expects a single reduction axis, but given: {reduction_axes}."
         )
-    channel_size = weight.shape[reduction_axis]
+    channel_size = weight.shape[reduction_axes]
     if channel_size % group_size != 0:
         raise nncf.ValidationError(f"Channel size {channel_size} should be divisible by size of group {group_size}")
 
     num_groups_per_channel = channel_size // group_size
     shape = list(weight.shape)  # [a1, r, a2] - "r" refers to number of channels along reduction axis
-    shape[reduction_axis : reduction_axis + 1] = (num_groups_per_channel, group_size)
+    shape[reduction_axes : reduction_axes + 1] = (num_groups_per_channel, group_size)
     reshaped_weight = weight.reshape(shape)
-    reduction_axis += 1
-    return reshaped_weight, reduction_axis
+    reduction_axes += 1
+    return reshaped_weight, reduction_axes
 
 
 def calculate_normalized_weight_and_nf4_scale(
-    weight: Tensor, reduction_axis: Union[int, Tuple[int]], group_size: int = -1
+    weight: Tensor, reduction_axes: ReductionAxes, group_size: int = -1
 ) -> Tuple[Tensor, Tensor]:
     """
     Calculates scale for nf4 quantization and normalizes weights by the scale.
     Weights are reshaped in case of positive value of group size.
 
     :param weight: Weight array to compress.
-    :param reduction_axis: Axes, along which to reduce (collect) different statistics (e.g. min, max).
+    :param reduction_axes: Axes, along which to reduce (collect) different statistics (e.g. min, max).
     :param group_size: Number of weights (e.g. 128) in the channel dimension that share quantization parameters (scale).
         The value -1 means no grouping. Defaults to -1.
     :return: Normalized weight tensor of float32 type and nf4 scale tensor of float32 type.
@@ -87,16 +89,10 @@ def calculate_normalized_weight_and_nf4_scale(
 
     if group_size != -1:
         # weights are reshaped: [a1, r, a2] -> [a1, r//gs, gs, a2]
-        if isinstance(reduction_axis, tuple) and len(reduction_axis) == 1:
-            reduction_axis = reduction_axis[0]
-        if not isinstance(reduction_axis, int):
-            raise NotImplementedError(
-                f"Group-wise quantization expects a single reduction axes, but given: {reduction_axis}."
-            )
-        weight, reduction_axis = reshape_weight_for_grouped_quantization(weight, reduction_axis, group_size)
-        scale = fns.max(fns.abs(weight), axis=reduction_axis, keepdims=True)  # [a1, r//gs, 1, a2]
+        weight, reduction_axes = reshape_weight_for_grouped_quantization(weight, reduction_axes, group_size)
+        scale = fns.max(fns.abs(weight), axis=reduction_axes, keepdims=True)  # [a1, r//gs, 1, a2]
     else:
-        scale = fns.max(fns.abs(weight), axis=reduction_axis, keepdims=True)  # [a1, 1, a2]
+        scale = fns.max(fns.abs(weight), axis=reduction_axes, keepdims=True)  # [a1, 1, a2]
     eps = fns.finfo(weight).eps
     # NOTE: adding machine epsilon to avoid division by zero
     scale = fns.where(fns.abs(scale) < eps, eps, scale)
@@ -105,7 +101,7 @@ def calculate_normalized_weight_and_nf4_scale(
 
 
 def do_integer_quantization(
-    weight: Tensor, reduction_axis: Union[int, Tuple[int]], config: WeightCompressionConfig
+    weight: Tensor, reduction_axes: ReductionAxes, config: WeightCompressionConfig
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """
     The method quantizes the given weights to integer data type in accordance with the compression config.
@@ -124,7 +120,7 @@ def do_integer_quantization(
     (scales).
 
     :param weight: Weight array to compress.
-    :param reduction_axis: Axes, along which to reduce (collect) different statistics (e.g. min, max).
+    :param reduction_axes: Axes, along which to reduce (collect) different statistics (e.g. min, max).
     :param config: Information on how to compress (quantize) a specific weight.
     :return: The compressed weights tensor of uint8 type, scale tensor of float32 type and
         zero point tensor of int32 type that was used for its quantization.
@@ -142,22 +138,16 @@ def do_integer_quantization(
 
     if group_size != -1:
         # weights are reshaped from [a1, r, a2] to [a1, r//gs, gs, a2]
-        if isinstance(reduction_axis, tuple) and len(reduction_axis) == 1:
-            reduction_axis = reduction_axis[0]
-        if not isinstance(reduction_axis, int):
-            raise NotImplementedError(
-                f"Group-wise quantization expects a single reduction axes, but given: {reduction_axis}."
-            )
-        weight, reduction_axis = reshape_weight_for_grouped_quantization(weight, reduction_axis, group_size)
+        weight, reduction_axes = reshape_weight_for_grouped_quantization(weight, reduction_axes, group_size)
 
     if mode in [CompressWeightsMode.INT8_ASYM, CompressWeightsMode.INT4_ASYM]:
-        min_values = fns.min(weight, axis=reduction_axis, keepdims=True)  # [a1, r, a2] -> [a1, 1, a2]
-        max_values = fns.max(weight, axis=reduction_axis, keepdims=True)  # [a1, r, a2] -> [a1, 1, a2]
+        min_values = fns.min(weight, axis=reduction_axes, keepdims=True)  # [a1, r, a2] -> [a1, 1, a2]
+        max_values = fns.max(weight, axis=reduction_axes, keepdims=True)  # [a1, r, a2] -> [a1, 1, a2]
         scale, zero_point = calculate_scale_zero_point(
             min_values, max_values, level_low, level_high, narrow_range=False
         )
     else:
-        scale = fns.max(fns.abs(weight), axis=reduction_axis, keepdims=True)  # [a1, r//gs, 1, a2]
+        scale = fns.max(fns.abs(weight), axis=reduction_axes, keepdims=True)  # [a1, r//gs, 1, a2]
         level_low_sym = -(2 ** (num_bits - 1))
         level_high_sym = 2 ** (num_bits - 1) - 1
         scale = scale / level_high_sym
@@ -171,13 +161,13 @@ def do_integer_quantization(
     return compressed_weights, scale, zero_point
 
 
-def get_integer_quantization_error(weight: Tensor, reduction_axis: int, config: WeightCompressionConfig) -> float:
+def get_integer_quantization_error(weight: Tensor, reduction_axes: ReductionAxes, config: WeightCompressionConfig) -> float:
     """
     Calculates a quantity characterizing the difference between floating point weights and fake quantized
     (compressed and decompressed) to integer ones.
 
     :param weight: Weight array to compress.
-    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
+    :param reduction_axes: Axes, along which to reduce (collect) different statistics (e.g. min, max).
     :param config: Information on how to compress (quantize) a specific weight.
     :return: The quantity characterizing the error of integer quantization.
     """
@@ -186,31 +176,31 @@ def get_integer_quantization_error(weight: Tensor, reduction_axis: int, config: 
     if weight.dtype != TensorDataType.float32:
         weight = weight.astype(TensorDataType.float32)
 
-    compressed_weights, scale, zero_point = do_integer_quantization(weight, reduction_axis, config)
+    compressed_weights, scale, zero_point = do_integer_quantization(weight, reduction_axes, config)
 
     decompressed_weight = (compressed_weights - zero_point).astype(weight.dtype) * scale
 
     decompressed_weight = decompressed_weight.reshape(orig_shape)
     diff = (decompressed_weight - weight) ** 2
-    layer_err = fns.mean(diff, axis=reduction_axis)
+    layer_err = fns.mean(diff, axis=reduction_axes)
     val = fns.max(layer_err)
     return val.item()
 
 
-def compress_weight(weight: Tensor, reduction_axis: int, config: WeightCompressionConfig):
+def compress_weight(weight: Tensor, reduction_axes: ReductionAxes, config: WeightCompressionConfig):
     """
     Compress weight using compression configuration.
 
     :param weight: The weight to compress.
-    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
-    :param config: Compresssion configuration.
+    :param reduction_axes: Axes, along which to reduce (collect) different statistics (e.g. min, max).
+    :param config: Compression configuration.
     :return: The compressed weight and decompression parameters as instance of CompressedWeight
     """
     if config.mode == CompressWeightsMode.NF4:
-        compressed_weight, scale = calculate_normalized_weight_and_nf4_scale(weight, reduction_axis, config.group_size)
+        compressed_weight, scale = calculate_normalized_weight_and_nf4_scale(weight, reduction_axes, config.group_size)
         return CompressedWeight(compressed_weight, scale)
 
-    compressed_weight, scale, zero_point = do_integer_quantization(weight, reduction_axis, config)
+    compressed_weight, scale, zero_point = do_integer_quantization(weight, reduction_axes, config)
     return CompressedWeight(compressed_weight, scale, zero_point)
 
 

--- a/nncf/quantization/quantize_model.py
+++ b/nncf/quantization/quantize_model.py
@@ -339,7 +339,7 @@ def compress_weights(
         options = [all_layers, sensitivity_metric, dataset, awq]
         if any(option is not None for option in options):
             raise AttributeError(
-                "INT8 modes do not support `all_layers`, `sensitivity_metric`, `awq` and `dataset` options."
+                "INT8 modes do not support `all_layers`, `sensitivity_metric`, `awq` and `dataset` options. "
                 "Set them to None."
             )
 

--- a/nncf/quantization/quantize_model.py
+++ b/nncf/quantization/quantize_model.py
@@ -283,8 +283,8 @@ def compress_weights(
         The value -1 means no grouping.
     :param ignored_scope: An ignored scope that defined the list of model control
         flow graph nodes to be ignored during quantization.
-    :param all_layers: Indicates whether embeddings and last layers should be compressed to a primary
-        precision. By default, the backup precision is assigned for the embeddings and last layers.
+    :param all_layers: Indicates whether embeddings and last MatMul layers should be compressed to a primary
+        precision. By default, the backup precision is assigned for the embeddings and last MatMul layers.
     :param dataset: Dataset used for assigning different quantization precision by finding outliers in activations.
     :param sensitivity_metric: The sensitivity metric for assigning quantization precision to layers. In order to
         preserve the accuracy of the model, the more sensitive layers receives a higher precision.

--- a/tests/openvino/native/models.py
+++ b/tests/openvino/native/models.py
@@ -200,12 +200,14 @@ class QuantizedModel(OVReferenceModel):
 class WeightsModel(OVReferenceModel):
     def _create_ov_model(self):
         input_1 = opset.parameter([1, 3, 5, 5], name="Input_1")
-        kernel = self._rng.random((3, 3, 1, 1)).astype(np.float32)
+        kernel_data = self._rng.random((3, 3, 1, 1)).astype(np.float32)
+        kernel = opset.constant(kernel_data, dtype=np.float32, name="conv_weights_0")
         strides = [1, 1]
         pads = [0, 0]
         dilations = [1, 1]
         conv = opset.convolution(input_1, kernel, strides, pads, pads, dilations, name="Conv")
-        kernel_2 = self._rng.random((3, 3, 1, 1)).astype(np.float32)
+        kernel_data_2 = self._rng.random((3, 3, 1, 1)).astype(np.float32)
+        kernel_2 = opset.constant(kernel_data_2, dtype=np.float32, name="conv_weights_1")
         output_shape = [1, 1]
         conv_tr = opset.convolution_backprop_data(
             conv, kernel_2, output_shape, strides, pads, pads, dilations, name="Conv_backprop"

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -595,7 +595,7 @@ def test_weight_compress_with_ignored_scope(ignored_scope, num_compressed):
 @pytest.mark.parametrize("desc", CALCULATE_SCALE_DESCS)
 def test_calculate_scale_per_group(desc: CalculateScaleDesc):
     reshaped_weight, reduction_axis = reshape_weight_for_grouped_quantization(
-        desc.weight, reduction_axis=desc.axis, group_size=desc.group_size
+        desc.weight, reduction_axes=desc.axis, group_size=desc.group_size
     )
     act_scale = np.max(np.abs(reshaped_weight), axis=reduction_axis, keepdims=True)  # [a1, r//gs, 1, a2]
     assert np.allclose(act_scale, desc.ref_scale)
@@ -603,12 +603,12 @@ def test_calculate_scale_per_group(desc: CalculateScaleDesc):
 
 def test_raise_error_for_many_axes():
     with pytest.raises(RuntimeError):
-        reshape_weight_for_grouped_quantization(WEIGHTS_2x4, reduction_axis=(0, 1), group_size=1)
+        reshape_weight_for_grouped_quantization(WEIGHTS_2x4, reduction_axes=(0, 1), group_size=1)
 
 
 def test_raise_error_channel_size_is_not_divisible_by_group_size():
     with pytest.raises(ValidationError):
-        reshape_weight_for_grouped_quantization(WEIGHTS_2x4, reduction_axis=(0,), group_size=3)
+        reshape_weight_for_grouped_quantization(WEIGHTS_2x4, reduction_axes=(0,), group_size=3)
 
 
 @pytest.mark.parametrize("mode", INT8_MODES)

--- a/tests/torch/ptq/test_weights_compression.py
+++ b/tests/torch/ptq/test_weights_compression.py
@@ -11,6 +11,7 @@
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 from nncf import CompressWeightsMode
 from nncf import SensitivityMetric
@@ -51,6 +52,33 @@ class ShortTransformer(torch.nn.Module):
         return res
 
 
+class ConvolutionModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv_regular = torch.nn.Conv2d(in_channels=3, out_channels=16, kernel_size=3)
+        self.max_pool2d = torch.nn.MaxPool2d(kernel_size=2)
+        self.conv_transpose = torch.nn.ConvTranspose2d(in_channels=16, out_channels=8, kernel_size=3)
+        self.conv_depthwise = torch.nn.Conv2d(in_channels=8, out_channels=8, kernel_size=5, groups=8)
+        self.adaptive_avg_pool = torch.nn.AdaptiveAvgPool2d(output_size=1)
+        self.linear = torch.nn.Linear(in_features=8, out_features=8)
+
+    def forward(self, input_):
+        input_ = input_.to(torch.float32)
+        x = self.conv_regular(input_)
+        x = F.relu(x)
+        x.transpose_(2, 3)
+        x = self.max_pool2d(x)
+        y = self.conv_transpose(x)
+        z = F.conv_transpose2d(x, self.conv_transpose.weight)
+        x = y + z
+        x = self.conv_depthwise(x)
+        x = F.conv2d(x, self.conv_depthwise.weight, groups=self.conv_depthwise.groups)
+        x += torch.ones_like(x)
+        x = self.adaptive_avg_pool(x)
+        x = self.linear(x.flatten())
+        return x
+
+
 def test_compress_weights():
     model = ShortTransformer(5, 10)
 
@@ -63,6 +91,25 @@ def test_compress_weights():
 
     for _, module in compressed_model.named_children():
         if isinstance(module, (torch.nn.Linear, torch.nn.Embedding)):
+            n_target_modules += 1
+            if module.weight.dtype in [torch.uint8, torch.int8]:
+                n_compressed_weights += 1
+
+    assert n_compressed_weights == n_target_modules
+
+
+def test_compress_weights_conv():
+    model = ConvolutionModel()
+
+    input_ids = torch.randint(0, 10, [1, 3, 300, 300])
+    wrapped_model = wrap_model(model, example_input=input_ids, trace_parameters=True)
+    compressed_model = compress_weights(wrapped_model)
+
+    n_compressed_weights = 0
+    n_target_modules = 0
+
+    for _, module in compressed_model.named_children():
+        if isinstance(module, (torch.nn.Linear, torch.nn.Conv2d, torch.nn.ConvTranspose2d)):
             n_target_modules += 1
             if module.weight.dtype in [torch.uint8, torch.int8]:
                 n_compressed_weights += 1


### PR DESCRIPTION
### Changes

To further reduce the model footprint and handle situations when Linear layers are expressed by Convolution operation, we should add Conv layers to the scope of weight compression.

### Reason for changes

<!--- Why should the change be applied -->

### Related tickets

124822

### Tests

Added tests to tests/openvino/native/quantization/test_weights_compression.py
