### PR TITLE
Compress Embeddings with multiple axes to 8 bit

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -298,17 +298,25 @@ class WeightCompression(Algorithm):
                 if weight.dtype not in [TensorDataType.float32, TensorDataType.float16, TensorDataType.float64]:
                     continue
                 reduction_axes = self._backend_entity.get_channel_agnostic_reduction_axes(node, weight_port_id, graph)
-                if isinstance(reduction_axes, tuple) and len(reduction_axes) != 1:
+                if (
+                    self._group_size != -1
+                    and self._all_layers
+                    and node.metatype in self._backend_entity.embedding_metatypes
+                    and isinstance(reduction_axes, tuple)
+                    and len(reduction_axes) != 1
+                ):
+                    # NNCF supports multiple reduction axes only for ops with group_size != -1.
+                    # Embedding layers are quantized to 4-bits only if all_layers=True.
+                    # MatMul ops can't have multiple reduction axes.
                     nncf_logger.warning(
                         f"Weight compression expects a single reduction axis, but {len(reduction_axes)} given. "
                         f"Weight shape: {weight.shape}, reduction axes: {reduction_axes}, "
                         f"node name: {node.node_name}. The node won't be quantized."
                     )
                     continue
-                reduction_axis = reduction_axes[0] if isinstance(reduction_axes, tuple) else reduction_axes
 
                 weight_params = WeightCompressionParameters(
-                    weight_name, node, weight_port_id, weight.size, reduction_axis
+                    weight_name, node, weight_port_id, weight.size, reduction_axes
                 )
                 all_weight_params.append(weight_params)
                 weight_names.add(weight_name)

--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -163,8 +163,11 @@ class WeightCompression(Algorithm):
             should be quantized or not.
         :return: Information about each weight node that is considered for mixed precision.
         """
-        if self._mode in [CompressWeightsMode.INT8_SYM, CompressWeightsMode.INT8_ASYM] or self._all_layers:
+        if self._mode in [CompressWeightsMode.INT8_SYM, CompressWeightsMode.INT8_ASYM]:
             return all_weight_params
+
+        if self._all_layers:
+            return list(filter(lambda wp: len(wp.reduction_axis) == 1, all_weight_params))
 
         ratio_defining_params = list(
             filter(
@@ -311,9 +314,8 @@ class WeightCompression(Algorithm):
                     nncf_logger.warning(
                         f"Weight compression expects a single reduction axis, but {len(reduction_axes)} given. "
                         f"Weight shape: {weight.shape}, reduction axes: {reduction_axes}, "
-                        f"node name: {node.node_name}. The node won't be quantized."
+                        f"node name: {node.node_name}. The node will be asymmetrically quantized to 8 bits."
                     )
-                    continue
 
                 weight_params = WeightCompressionParameters(
                     weight_name, node, weight_port_id, weight.size, reduction_axes

--- a/nncf/quantization/algorithms/weight_compression/config.py
+++ b/nncf/quantization/algorithms/weight_compression/config.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass
-from typing import Optional, TypeVar
+from typing import Optional, Tuple, TypeVar
 
 from nncf.common.graph.graph import NNCFNode
 from nncf.parameters import CompressWeightsMode
@@ -47,7 +47,7 @@ class WeightCompressionParameters:
     :param node_with_weight: Node with weight in the NNCF graph.
     :param weight_port_id: Number of elements in the weight array.
     :param num_weights: Number of elements in the weight array.
-    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
+    :param reduction_axis: Axes, along which to reduce (collect) different statistics (e.g. min, max).
     :param compression_config: Configuration of weight compression for the weight node.
     """
 
@@ -55,5 +55,5 @@ class WeightCompressionParameters:
     node_with_weight: NNCFNode
     weight_port_id: int
     num_weights: int
-    reduction_axis: int
+    reduction_axis: Tuple[int]
     compression_config = WeightCompressionConfig()

--- a/nncf/quantization/algorithms/weight_compression/torch_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/torch_backend.py
@@ -146,7 +146,7 @@ class PTWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
             elif weight_port_id == 2:
                 reduction_axis = [max(0, ndims - 2)]
             reduction_axis = [max(0, reduction_axis)]
-        return reduction_axis
+        return tuple(reduction_axis)
 
     @staticmethod
     def target_point(target_type: TargetType, target_node_name: str, port_id: int) -> PTTargetPoint:

--- a/nncf/quantization/algorithms/weight_compression/weight_lowering.py
+++ b/nncf/quantization/algorithms/weight_compression/weight_lowering.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import nncf
 from nncf.experimental.tensor import Tensor
@@ -63,14 +63,14 @@ def reshape_weight_for_grouped_quantization(weight: Tensor, reduction_axis: int,
 
 
 def calculate_normalized_weight_and_nf4_scale(
-    weight: Tensor, reduction_axis: int, group_size: int = -1
+    weight: Tensor, reduction_axis: Union[int, Tuple[int]], group_size: int = -1
 ) -> Tuple[Tensor, Tensor]:
     """
     Calculates scale for nf4 quantization and normalizes weights by the scale.
     Weights are reshaped in case of positive value of group size.
 
     :param weight: Weight array to compress.
-    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
+    :param reduction_axis: Axes, along which to reduce (collect) different statistics (e.g. min, max).
     :param group_size: Number of weights (e.g. 128) in the channel dimension that share quantization parameters (scale).
         The value -1 means no grouping. Defaults to -1.
     :return: Normalized weight tensor of float32 type and nf4 scale tensor of float32 type.
@@ -80,6 +80,12 @@ def calculate_normalized_weight_and_nf4_scale(
 
     if group_size != -1:
         # weights are reshaped: [a1, r, a2] -> [a1, r//gs, gs, a2]
+        if isinstance(reduction_axis, tuple) and len(reduction_axis) == 1:
+            reduction_axis = reduction_axis[0]
+        if not isinstance(reduction_axis, int):
+            raise NotImplementedError(
+                f"Group-wise quantization expects a single reduction axis, but given: {reduction_axis}."
+            )
         weight, reduction_axis = reshape_weight_for_grouped_quantization(weight, reduction_axis, group_size)
         scale = fns.max(fns.abs(weight), axis=reduction_axis, keepdims=True)  # [a1, r//gs, 1, a2]
     else:
@@ -92,7 +98,7 @@ def calculate_normalized_weight_and_nf4_scale(
 
 
 def do_integer_quantization(
-    weight: Tensor, reduction_axis: int, config: WeightCompressionConfig
+    weight: Tensor, reduction_axis: Union[int, Tuple[int]], config: WeightCompressionConfig
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """
     The method quantizes the given weights to integer data type in accordance with the compression config.
@@ -111,7 +117,7 @@ def do_integer_quantization(
     (scales).
 
     :param weight: Weight array to compress.
-    :param reduction_axis: Axis, along which to reduce (collect) different statistics (e.g. min, max).
+    :param reduction_axis: Axes, along which to reduce (collect) different statistics (e.g. min, max).
     :param config: Information on how to compress (quantize) a specific weight.
     :return: The compressed weights tensor of uint8 type, scale tensor of float32 type and
         zero point tensor of int32 type that was used for its quantization.
@@ -129,6 +135,12 @@ def do_integer_quantization(
 
     if group_size != -1:
         # weights are reshaped from [a1, r, a2] to [a1, r//gs, gs, a2]
+        if isinstance(reduction_axis, tuple) and len(reduction_axis) == 1:
+            reduction_axis = reduction_axis[0]
+        if not isinstance(reduction_axis, int):
+            raise NotImplementedError(
+                f"Group-wise quantization expects a single reduction axis, but given: {reduction_axis}."
+            )
         weight, reduction_axis = reshape_weight_for_grouped_quantization(weight, reduction_axis, group_size)
 
     if mode in [CompressWeightsMode.INT8_ASYM, CompressWeightsMode.INT4_ASYM]:

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -365,12 +365,13 @@ def test_quantize_Gather_with_multiple_reduction_axes_in_8bit(mode):
 
 
 @pytest.mark.parametrize("mode", (CompressWeightsMode.INT4_SYM, CompressWeightsMode.INT4_ASYM))
-def test_not_quantize_Gather_with_multiple_reduction_axes_if_all_layers(mode):
+@pytest.mark.parametrize("all_layers", (True, False))
+def test_quantize_Gather_with_multiple_reduction_axes_if_mode_4bit(mode, all_layers):
     model = GatherWithTwoReductionAxes().ov_model
-    compressed_model = compress_weights(model, mode=mode, all_layers=True)
+    compressed_model = compress_weights(model, mode=mode, all_layers=all_layers)
     for op in compressed_model.get_ordered_ops():
         if op.get_type_name() == "Constant" and op.get_friendly_name() == "gather_1_data":
-            assert op.get_element_type() == ov.Type.f32
+            assert op.get_element_type() == ov.Type.u8
 
 
 @pytest.mark.parametrize("mode", (CompressWeightsMode.INT4_SYM, CompressWeightsMode.INT4_ASYM))

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -20,6 +20,7 @@ from attr import dataclass
 from nncf import CompressWeightsMode
 from nncf import SensitivityMetric
 from nncf.data.dataset import Dataset
+from nncf.errors import ValidationError
 from nncf.experimental.tensor import Tensor
 from nncf.openvino.graph.node_utils import get_const_value
 from nncf.quantization import compress_weights
@@ -576,7 +577,7 @@ def test_raise_error_for_many_axes():
 
 
 def test_raise_error_channel_size_is_not_divisible_by_group_size():
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValidationError):
         reshape_weight_for_grouped_quantization(WEIGHTS_2x4, reduction_axis=(0,), group_size=3)
 
 

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -356,12 +356,21 @@ def test_data_based_criterion(mode, ref_scores, ref_act_scores, mocker):
 
 
 @pytest.mark.parametrize("mode", (CompressWeightsMode.INT8_SYM, CompressWeightsMode.INT8_ASYM))
-def test_not_quantize_with_multiple_reduction_axes(mode):
+def test_quantize_Gather_with_multiple_reduction_axes_in_8bit(mode):
     model = GatherWithTwoReductionAxes().ov_model
     compressed_model = compress_weights(model, mode=mode)
     for op in compressed_model.get_ordered_ops():
         if op.get_type_name() == "Constant" and op.get_friendly_name() == "gather_1_data":
-            assert op.get_element_type() == ov.Type(np.float32)
+            assert op.get_element_type() == ov.Type.u8
+
+
+@pytest.mark.parametrize("mode", (CompressWeightsMode.INT4_SYM, CompressWeightsMode.INT4_ASYM))
+def test_not_quantize_Gather_with_multiple_reduction_axes_if_all_layers(mode):
+    model = GatherWithTwoReductionAxes().ov_model
+    compressed_model = compress_weights(model, mode=mode, all_layers=True)
+    for op in compressed_model.get_ordered_ops():
+        if op.get_type_name() == "Constant" and op.get_friendly_name() == "gather_1_data":
+            assert op.get_element_type() == ov.Type.f32
 
 
 @pytest.mark.parametrize("mode", (CompressWeightsMode.INT4_SYM, CompressWeightsMode.INT4_ASYM))

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -571,12 +571,12 @@ def test_calculate_scale_per_group(desc: CalculateScaleDesc):
 
 
 def test_raise_error_for_many_axes():
-    with pytest.raises(AssertionError):
+    with pytest.raises(RuntimeError):
         reshape_weight_for_grouped_quantization(WEIGHTS_2x4, reduction_axis=(0, 1), group_size=1)
 
 
-def test_raise_error_with_tuple():
-    with pytest.raises(AssertionError):
+def test_raise_error_channel_size_is_not_divisible_by_group_size():
+    with pytest.raises(RuntimeError):
         reshape_weight_for_grouped_quantization(WEIGHTS_2x4, reduction_axis=(0,), group_size=3)
 
 


### PR DESCRIPTION
### Changes

<!--- What was changed (briefly), how to reproduce (if applicable), what the reviewers should focus on -->

### Reason for changes

To further reduce the model footprint

### Related tickets

124822

### Tests

test_quantize_Gather_with_multiple_reduction_axes_in_8bit
test_not_quantize_Gather_with_multiple_reduction_axes_if_all_layers
