### PR TITLE
[Experimental tensor] numeric.quantile is introduced

### DIFF
--- a/nncf/experimental/tensor/functions/__init__.py
+++ b/nncf/experimental/tensor/functions/__init__.py
@@ -33,6 +33,7 @@ from nncf.experimental.tensor.functions.numeric import minimum as minimum
 from nncf.experimental.tensor.functions.numeric import moveaxis as moveaxis
 from nncf.experimental.tensor.functions.numeric import multiply as multiply
 from nncf.experimental.tensor.functions.numeric import ones_like as ones_like
+from nncf.experimental.tensor.functions.numeric import quantile as quantile
 from nncf.experimental.tensor.functions.numeric import reshape as reshape
 from nncf.experimental.tensor.functions.numeric import round as round
 from nncf.experimental.tensor.functions.numeric import squeeze as squeeze

--- a/nncf/experimental/tensor/functions/numeric.py
+++ b/nncf/experimental/tensor/functions/numeric.py
@@ -388,7 +388,7 @@ def quantile(
     q: Union[float, List[float]],
     axis: Union[int, Tuple[int]] = None,
     keepdims: Optional[bool] = None,
-) -> Union[float, Tensor]:
+) -> Tensor:
     """
     Compute the quantile(s) of the data along the specified axis.
 

--- a/nncf/experimental/tensor/functions/numeric.py
+++ b/nncf/experimental/tensor/functions/numeric.py
@@ -386,7 +386,7 @@ def round(a: Tensor, decimals=0) -> Tensor:
 def quantile(
     a: Tensor,
     q: Union[float, List[float]],
-    axis: Union[int, Tuple[int]] = None,
+    axis: Optional[Union[int, Tuple[int]]] = None,
     keepdims: Optional[bool] = None,
 ) -> Tensor:
     """

--- a/nncf/experimental/tensor/functions/numeric.py
+++ b/nncf/experimental/tensor/functions/numeric.py
@@ -383,6 +383,29 @@ def round(a: Tensor, decimals=0) -> Tensor:
 
 @functools.singledispatch
 @tensor_guard
+def quantile(
+    a: Tensor,
+    q: Union[float, List[float]],
+    axis: Union[int, Tuple[int]] = None,
+    keepdims: Optional[bool] = None,
+) -> Union[float, Tensor]:
+    """
+    Compute the quantile(s) of the data along the specified axis.
+
+    :param a: Given tensor.
+    :params q: Quantile or sequence of quantiles to compute, which must be between
+        0 and 1 inclusive.
+    :param axis: Axis or axes along which the quantiles are computed.
+    :param keepdims: If True, the axes which are reduced are left in the result
+        as dimensions with size one.
+    :return: An tensor with quantiles, the first axis of the result corresponds
+        to the quantiles, other axes of the result correspond to the quantiles values.
+    """
+    return Tensor(quantile(a.data, q, axis, keepdims))
+
+
+@functools.singledispatch
+@tensor_guard
 def _binary_op_nowarn(a: Tensor, b: Union[Tensor, float], operator_fn: Callable) -> Tensor:
     """
     Applies a binary operation with disable warnings.

--- a/nncf/experimental/tensor/functions/numpy_numeric.py
+++ b/nncf/experimental/tensor/functions/numpy_numeric.py
@@ -185,7 +185,7 @@ def _(
     q: Union[float, List[float]],
     axis: Union[int, Tuple[int]] = None,
     keepdims: Optional[bool] = None,
-) -> Union[float, Union[np.ndarray, np.generic]]:
+) -> Union[np.ndarray, np.generic]:
     if keepdims is None:
         keepdims = np._NoValue
     return np.array(np.quantile(a, q=q, axis=axis, keepdims=keepdims))

--- a/nncf/experimental/tensor/functions/numpy_numeric.py
+++ b/nncf/experimental/tensor/functions/numpy_numeric.py
@@ -188,10 +188,7 @@ def _(
 ) -> Union[float, Union[np.ndarray, np.generic]]:
     if keepdims is None:
         keepdims = np._NoValue
-    ret_val = np.quantile(a, q=q, axis=axis, keepdims=keepdims)
-    if isinstance(ret_val, np.ndarray):
-        return ret_val
-    return np.array(ret_val)
+    return np.array(np.quantile(a, q=q, axis=axis, keepdims=keepdims))
 
 
 @register_numpy_types(numeric._binary_op_nowarn)

--- a/nncf/experimental/tensor/functions/numpy_numeric.py
+++ b/nncf/experimental/tensor/functions/numpy_numeric.py
@@ -179,6 +179,21 @@ def _(a: Union[np.ndarray, np.generic], decimals: int = 0) -> np.ndarray:
     return np.round(a, decimals=decimals)
 
 
+@register_numpy_types(numeric.quantile)
+def _(
+    a: Union[np.ndarray, np.generic],
+    q: Union[float, List[float]],
+    axis: Union[int, Tuple[int]] = None,
+    keepdims: Optional[bool] = None,
+) -> Union[float, Union[np.ndarray, np.generic]]:
+    if keepdims is None:
+        keepdims = np._NoValue
+    ret_val = np.quantile(a, q=q, axis=axis, keepdims=keepdims)
+    if isinstance(ret_val, np.ndarray):
+        return ret_val
+    return np.array(ret_val)
+
+
 @register_numpy_types(numeric._binary_op_nowarn)
 def _(
     a: Union[np.ndarray, np.generic], b: Union[np.ndarray, np.generic, float], operator_fn: Callable

--- a/nncf/experimental/tensor/functions/numpy_numeric.py
+++ b/nncf/experimental/tensor/functions/numpy_numeric.py
@@ -183,11 +183,9 @@ def _(a: Union[np.ndarray, np.generic], decimals: int = 0) -> np.ndarray:
 def _(
     a: Union[np.ndarray, np.generic],
     q: Union[float, List[float]],
-    axis: Union[int, Tuple[int]] = None,
+    axis: Optional[Union[int, Tuple[int]]] = None,
     keepdims: Optional[bool] = None,
 ) -> Union[np.ndarray, np.generic]:
-    if keepdims is None:
-        keepdims = np._NoValue
     return np.array(np.quantile(a, q=q, axis=axis, keepdims=keepdims))
 
 

--- a/nncf/experimental/tensor/functions/torch_numeric.py
+++ b/nncf/experimental/tensor/functions/torch_numeric.py
@@ -202,16 +202,14 @@ def _(
     device = a.device
     # See https://github.com/pytorch/pytorch/issues/61582
     # https://github.com/pytorch/pytorch/issues/64947
-    if len(a) <= 16_000_000 and isinstance(axis, int):
-        result = torch.quantile(
+    if len(a) <= 16_000_000 and isinstance(axis, int) and a.dtype in [torch.float32, torch.float64]:
+        return torch.quantile(
             a,
             torch.tensor(q, dtype=a.dtype, device=a.device),
             axis,
             keepdims,
-        )
-    else:
-        result = torch.tensor(np.quantile(a.detach().cpu().numpy(), q=q, axis=axis, keepdims=keepdims))
-    return result.type(a.dtype).to(device)
+        ).type(torch.float64)
+    return torch.tensor(np.quantile(a.detach().cpu().numpy(), q=q, axis=axis, keepdims=keepdims)).to(device)
 
 
 @numeric._binary_op_nowarn.register(torch.Tensor)

--- a/nncf/experimental/tensor/functions/torch_numeric.py
+++ b/nncf/experimental/tensor/functions/torch_numeric.py
@@ -198,7 +198,7 @@ def _(
     q: Union[float, List[float]],
     axis: Union[int, Tuple[int]] = None,
     keepdims: Optional[bool] = None,
-) -> Union[float, torch.Tensor]:
+) -> torch.Tensor:
     device = a.device
     # See https://github.com/pytorch/pytorch/issues/61582
     # https://github.com/pytorch/pytorch/issues/64947

--- a/nncf/experimental/tensor/functions/torch_numeric.py
+++ b/nncf/experimental/tensor/functions/torch_numeric.py
@@ -202,7 +202,7 @@ def _(
     device = a.device
     # See https://github.com/pytorch/pytorch/issues/61582
     # https://github.com/pytorch/pytorch/issues/64947
-    if len(a) <= 16_000_000 and isinstance(axis, int) and a.dtype in [torch.float32, torch.float64]:
+    if a.numel() <= 16_000_000 and isinstance(axis, int) and a.dtype in [torch.float32, torch.float64]:
         return torch.quantile(
             a,
             torch.tensor(q, dtype=a.dtype, device=a.device),

--- a/nncf/experimental/tensor/functions/torch_numeric.py
+++ b/nncf/experimental/tensor/functions/torch_numeric.py
@@ -196,7 +196,7 @@ def _(a: torch.Tensor, decimals=0) -> torch.Tensor:
 def _(
     a: torch.Tensor,
     q: Union[float, List[float]],
-    axis: Union[int, Tuple[int]] = None,
+    axis: Optional[Union[int, Tuple[int]]] = None,
     keepdims: Optional[bool] = None,
 ) -> torch.Tensor:
     device = a.device

--- a/tests/common/test_tensor.py
+++ b/tests/common/test_tensor.py
@@ -11,6 +11,7 @@
 
 import numpy as np
 
+from nncf.experimental.tensor import TensorDataType
 from tests.shared.test_templates.template_test_nncf_tensor import TemplateTestNNCFTensorOperators
 
 
@@ -18,3 +19,11 @@ class TestNPNNCFTensorOperators(TemplateTestNNCFTensorOperators):
     @staticmethod
     def to_tensor(x):
         return np.array(x)
+
+    @staticmethod
+    def cast_to(x: np.ndarray, dtype: TensorDataType) -> np.ndarray:
+        if dtype is TensorDataType.float32:
+            return x.astype(np.float32)
+        if dtype is TensorDataType.float16:
+            return x.astype(np.float16)
+        raise NotImplementedError

--- a/tests/shared/test_templates/template_test_nncf_tensor.py
+++ b/tests/shared/test_templates/template_test_nncf_tensor.py
@@ -962,6 +962,7 @@ class TemplateTestNNCFTensorOperators:
     @pytest.mark.parametrize(
         "x,q,axis,keepdims,ref",
         (
+            (1.0, 0.1, None, True, 1.0),
             (zero_ten_range, 0.1, 0, True, [1.0]),
             (zero_ten_range, 0.1, 0, False, 1.0),
             (zero_ten_range, (0.1, 0.9), 0, False, [1.0, 9.0]),

--- a/tests/shared/test_templates/template_test_nncf_tensor.py
+++ b/tests/shared/test_templates/template_test_nncf_tensor.py
@@ -964,6 +964,7 @@ class TemplateTestNNCFTensorOperators:
             (zero_ten_range_two_axes, (0.1, 0.9), (0, 1), False, [1.0, 9.0]),
             (zero_ten_range_two_axes, (0.1, 0.9), (0, 1), True, [[[1.0]], [[9.0]]]),
             (16000 * zero_ten_range, 0.1, 0, False, 1.0),  # reason: https://github.com/pytorch/pytorch/issues/64947
+            (zero_ten_range_two_axes, (0.1, 0.9), None, False, [1.0, 9.0]),
         ),
     )
     def test_fn_quantile(self, x, q, axis, keepdims, ref):

--- a/tests/torch/test_tensor.py
+++ b/tests/torch/test_tensor.py
@@ -12,8 +12,17 @@ import pytest
 import torch
 
 from nncf.experimental.tensor import Tensor
+from nncf.experimental.tensor import TensorDataType
 from nncf.experimental.tensor.definitions import TensorDeviceType
 from tests.shared.test_templates.template_test_nncf_tensor import TemplateTestNNCFTensorOperators
+
+
+def cast_to(x: torch.Tensor, dtype: TensorDataType) -> torch.Tensor:
+    if dtype is TensorDataType.float32:
+        return x.type(torch.float32)
+    if dtype is TensorDataType.float16:
+        return x.type(torch.float16)
+    raise NotImplementedError
 
 
 class TestPTNNCFTensorOperators(TemplateTestNNCFTensorOperators):
@@ -21,12 +30,20 @@ class TestPTNNCFTensorOperators(TemplateTestNNCFTensorOperators):
     def to_tensor(x):
         return torch.tensor(x)
 
+    @staticmethod
+    def cast_to(x: torch.Tensor, dtype: TensorDataType) -> torch.Tensor:
+        return cast_to(x, dtype)
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skipping for CPU-only setups")
 class TestCudaPTNNCFTensorOperators(TemplateTestNNCFTensorOperators):
     @staticmethod
     def to_tensor(x):
         return torch.tensor(x).cuda()
+
+    @staticmethod
+    def cast_to(x: torch.Tensor, dtype: TensorDataType) -> torch.Tensor:
+        return cast_to(x, dtype)
 
     def test_device(self):
         tensor = Tensor(self.to_tensor([1]))


### PR DESCRIPTION
### Changes

Numeric.quantile is introduced

### Reason for changes

To make it possible to calculate quantile on `nncf.experimental.tensor.Tensor`

### Related tickets


### Tests

test_fn_quantile
