### PR TITLE
Update anomaly_stfpm_quantize_with_accuracy_control example

### DIFF
--- a/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/README.md
+++ b/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/README.md
@@ -29,8 +29,8 @@ pip install -r requirements.txt
 
 It's pretty simple. The example does not require additional preparation. It will do the preparation itself, such as loading the dataset and model, etc.
 
-The maximum accuracy drop you can pass as a command line argument. F1 score is calculted in range [0,1] for STFPM. Thus if you want to specify the maximum accuracy drop between the quantized and pre-trained model of 0.1% you must specify 0.001 as a command line argument:
+The maximum accuracy drop you can pass as a command line argument. F1 score is calculted in range [0,1] for STFPM. Thus if you want to specify the maximum accuracy drop between the quantized and pre-trained model of 0.5% you must specify 0.005 as a command line argument:
 
 ```bash
-python main.py 0.001
+python main.py 0.005
 ```

--- a/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/main.py
+++ b/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/main.py
@@ -44,7 +44,7 @@ DATASET_INFO = download.DownloadInfo(
 )
 DATASET_PATH = HOME_PATH / ".cache/nncf/datasets/mvtec_capsule"
 
-max_accuracy_drop = 0.001 if len(sys.argv) < 2 else float(sys.argv[1])
+max_accuracy_drop = 0.005 if len(sys.argv) < 2 else float(sys.argv[1])
 
 
 def download_and_extract(root: Path, info: download.DownloadInfo) -> None:

--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -55,18 +55,18 @@
         "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
         "accuracy_metrics": {
             "fp32_top1": 0.9680365324020386,
-            "int8_top1": 0.9683257937431335,
-            "accuracy_drop": -0.0002892613410949707
+            "int8_top1": 0.9636363983154297,
+            "accuracy_drop": 0.004400134086608887
         },
         "performance_metrics": {
-            "fp32_fps": 346.23,
-            "int8_fps": 833.56,
-            "performance_speed_up": 2.407532565057909
+            "fp32_fps": 330.17,
+            "int8_fps": 838.9,
+            "performance_speed_up": 2.5408123088106125
         },
         "model_size_metrics": {
             "fp32_model_size": 21.33917808532715,
-            "int8_model_size": 5.725968360900879,
-            "model_compression_rate": 3.726736988461077
+            "int8_model_size": 5.742419242858887,
+            "model_compression_rate": 3.7160606327836403
         }
     },
     "post_training_quantization_openvino_yolo8_quantize_with_accuracy_control": {


### PR DESCRIPTION
### Changes

Relax the default accuracy drop to 0.005

### Reason for changes

test_examples fix

### Related tickets

ref: 130462

### Tests

test_examples 216
