### PR TITLE
Avoiding overflow on summing 32-bit int on Windows

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/config.py
+++ b/nncf/quantization/algorithms/weight_compression/config.py
@@ -11,6 +11,8 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple, TypeVar
 
+import numpy as np
+
 from nncf.common.graph.graph import NNCFNode
 from nncf.parameters import CompressWeightsMode
 
@@ -54,6 +56,11 @@ class WeightCompressionParameters:
     weight_name: str
     node_with_weight: NNCFNode
     weight_port_id: int
-    num_weights: int
+    num_weights: np.uint64
     reduction_axes: Tuple[int, ...]
     compression_config = WeightCompressionConfig()
+
+    def __post_init__(self):
+        # Explicitly cast num_weights to avoid overflow on finding total number of weights.
+        # The issue happens on Windows, because np.ndarray.size() returns np.int32 and sum of weights is more than 2^32.
+        self.num_weights = np.uint64(self.num_weights)

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -25,6 +25,7 @@ from nncf.experimental.tensor import Tensor
 from nncf.openvino.graph.node_utils import get_const_value
 from nncf.quantization import compress_weights
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionConfig
+from nncf.quantization.algorithms.weight_compression.config import WeightCompressionParameters
 from nncf.quantization.algorithms.weight_compression.mixed_precision import MIXED_PRECISION_CRITERIA
 from nncf.quantization.algorithms.weight_compression.weight_lowering import get_integer_quantization_error
 from nncf.quantization.algorithms.weight_compression.weight_lowering import reshape_weight_for_grouped_quantization
@@ -654,3 +655,9 @@ def test_call_max_var_criterion_with_dataset_by_default_awq(mode):
     dataset = Dataset([np.ones([8, 8])])
 
     compress_weights(model, mode=mode, ratio=1.0, group_size=2, dataset=dataset, awq=True)
+
+
+def test_data_type_for_num_weights(mocker):
+    stub = mocker.stub()
+    params = WeightCompressionParameters(stub, stub, stub, np.int32(1), stub)
+    assert isinstance(params.num_weights, np.uint64)


### PR DESCRIPTION
### Changes

Explicitly use unsigned 64-bit integer for number of weight in weight compression.

### Reason for changes

The overflow is happening on Windows, when 32-bit integers are summed up: 
![image](https://github.com/openvinotoolkit/nncf/assets/4014476/292464da-e0bc-4300-a91e-7b61a0888e8e)
it leads to incorrect mixed precision selection.

### Related tickets

bug with chatglm3 on Windows - 130819

### Tests

- [x] manual check
