### PR TITLE
nncf.quantize_with_accuracy_control fails with tune_hyperparams=True

### DIFF
--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -234,7 +234,7 @@ def native_quantize_with_accuracy_control_impl(
             fast_bias_correction,
             model_type,
             ignored_scope,
-            advanced_quantization_parameters,
+            copied_parameters,
         )
         tuned_quantized_metric_results = evaluator.collect_metric_results(
             tuned_quantized_model, validation_dataset, model_name="tuned"

--- a/nncf/quantization/quantize_model.py
+++ b/nncf/quantization/quantize_model.py
@@ -433,7 +433,8 @@ def quantize_with_tune_hyperparams(
         "advanced_parameters": advanced_quantization_parameters,
     }
 
-    param_grids = get_quantization_param_grids(create_ptq_pipeline(**init_quantization_params))
+    backend = get_backend(model)
+    param_grids = get_quantization_param_grids(create_ptq_pipeline(**init_quantization_params), backend)
 
     hyperparameter_tuner = HyperparameterTuner(
         create_ptq_pipeline,


### PR DESCRIPTION
### Changes

Minor fixes

### Reason for changes

nncf.quantize_with_accuracy_control fails with tune_hyperparams=True

### Related tickets

Ref: 131814

### Tests

Current tests
