### PR TITLE
[CI] Move mask_rcnn model to nightly TF tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,12 @@ install-tensorflow-dev: install-tensorflow-test install-pre-commit
 	pip install -r examples/post_training_quantization/tensorflow/mobilenet_v2/requirements.txt
 
 test-tensorflow:
-	pytest ${COVERAGE_ARGS} tests/tensorflow    \
+	pytest ${COVERAGE_ARGS} tests/tensorflow -m "not nightly"   \
+		--junitxml ${JUNITXML_PATH}         \
+		$(DATA_ARG)
+
+test-tensorflow-nightly:
+	pytest ${COVERAGE_ARGS} tests/tensorflow -m 'nightly'  \
 		--junitxml ${JUNITXML_PATH}         \
 		$(DATA_ARG)
 

--- a/tests/tensorflow/pytest.ini
+++ b/tests/tensorflow/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
   install
+  nightly

--- a/tests/tensorflow/test_compressed_graph.py
+++ b/tests/tensorflow/test_compressed_graph.py
@@ -194,13 +194,13 @@ SKIP_MAP = {
         "nasnet_mobile": pytest.mark.skip(reason="gitlab issue #18"),
         "mobilenet_v2_slim": pytest.mark.skip(reason="ticket #46349"),
         "xception": pytest.mark.skip(reason="gitlab issue #28"),
-        "mask_rcnn": pytest.mark.nightly()
+        "mask_rcnn": pytest.mark.nightly(),
     },
     "magnitude_sparsity": {
         "inception_resnet_v2": pytest.mark.skip(reason="gitlab issue #17"),
         "nasnet_mobile": pytest.mark.skip(reason="gitlab issue #18"),
         "xception": pytest.mark.skip(reason="gitlab issue #28"),
-        "mask_rcnn": pytest.mark.nightly()
+        "mask_rcnn": pytest.mark.nightly(),
     },
     "filter_pruning": {
         "densenet121": pytest.mark.skip(reason="ticket #50604"),
@@ -211,10 +211,7 @@ SKIP_MAP = {
         "resnet50v2": pytest.mark.skip(reason="Several masks on one weight"),
         "mobilenet_v2_slim": pytest.mark.skip(reason="ticket #46349"),
     },
-    "rb_sparsity": {
-        "mobilenet_v2_slim": pytest.mark.skip(reason="ticket #46349"),
-        "mask_rcnn": pytest.mark.nightly()
-    },
+    "rb_sparsity": {"mobilenet_v2_slim": pytest.mark.skip(reason="ticket #46349"), "mask_rcnn": pytest.mark.nightly()},
 }
 
 

--- a/tests/tensorflow/test_compressed_graph.py
+++ b/tests/tensorflow/test_compressed_graph.py
@@ -194,11 +194,13 @@ SKIP_MAP = {
         "nasnet_mobile": pytest.mark.skip(reason="gitlab issue #18"),
         "mobilenet_v2_slim": pytest.mark.skip(reason="ticket #46349"),
         "xception": pytest.mark.skip(reason="gitlab issue #28"),
+        "mask_rcnn": pytest.mark.nightly()
     },
     "magnitude_sparsity": {
         "inception_resnet_v2": pytest.mark.skip(reason="gitlab issue #17"),
         "nasnet_mobile": pytest.mark.skip(reason="gitlab issue #18"),
         "xception": pytest.mark.skip(reason="gitlab issue #28"),
+        "mask_rcnn": pytest.mark.nightly()
     },
     "filter_pruning": {
         "densenet121": pytest.mark.skip(reason="ticket #50604"),
@@ -209,7 +211,10 @@ SKIP_MAP = {
         "resnet50v2": pytest.mark.skip(reason="Several masks on one weight"),
         "mobilenet_v2_slim": pytest.mark.skip(reason="ticket #46349"),
     },
-    "rb_sparsity": {"mobilenet_v2_slim": pytest.mark.skip(reason="ticket #46349")},
+    "rb_sparsity": {
+        "mobilenet_v2_slim": pytest.mark.skip(reason="ticket #46349"),
+        "mask_rcnn": pytest.mark.nightly()
+    },
 }
 
 

--- a/tests/tensorflow/test_sota_checkpoints.py
+++ b/tests/tensorflow/test_sota_checkpoints.py
@@ -250,7 +250,6 @@ def metrics_dump_dir(request: FixtureRequest):
     return dump_path
 
 
-@pytest.mark.nightly
 class TestSotaCheckpoints:
     @pytest.fixture(scope="class")
     def collected_data(self, metrics_dump_dir: Path):


### PR DESCRIPTION
### Changes

- TF tests: Add nightly mark for mask_rcnn model.
- Reduced time of TF precommit from ~65min to ~30min.

### Reason for changes

Skip long-running tests in precommit 


