### PR TITLE
[TF] Increase thresholds for e2e

### DIFF
--- a/tests/tensorflow/sota_checkpoints_eval.json
+++ b/tests/tensorflow/sota_checkpoints_eval.json
@@ -119,7 +119,8 @@
                     "metric_type": "Acc@1",
                     "model_description": "MobileNet V3 (Small)",
                     "compression_description": "INT8 (per-channel symmetric for weights, per-tensor asymmetric half-range for activations)",
-                    "diff_target_min": -0.15,
+                    "diff_target_tf_min": -0.15,
+                    "diff_target_tf_max": 0.15,
                     "target_tf": 67.66,
                     "target_ov": 67.74
                 },
@@ -131,6 +132,8 @@
                     "metric_type": "Acc@1",
                     "model_description": "MobileNet V3 (Small)",
                     "compression_description": "INT8 (per-channel symmetric for weights, per-tensor asymmetric half-range for activations) + Sparsity 42% (Magnitude)",
+                    "diff_target_tf_min": -0.15,
+                    "diff_target_tf_max": 0.15,
                     "target_tf": 67.69,
                     "target_ov": 67.68
                 },
@@ -149,7 +152,8 @@
                     "metric_type": "Acc@1",
                     "model_description": "MobileNet V3 (Large)",
                     "compression_description": "INT8 (per-channel symmetric for weights, per-tensor asymmetric half-range for activations)",
-                    "diff_target_min": -0.15,
+                    "diff_target_tf_min": -0.15,
+                    "diff_target_tf_max": 0.15,
                     "target_tf": 74.91,
                     "target_ov": 74.96
                 },
@@ -161,6 +165,8 @@
                     "metric_type": "Acc@1",
                     "model_description": "MobileNet V3 (Large)",
                     "compression_description": "INT8 (per-channel symmetric for weights, per-tensor asymmetric half-range for activations) + Sparsity 42% (RB)",
+                    "diff_target_tf_min": -0.15,
+                    "diff_target_tf_max": 0.15,
                     "target_tf": 75.23,
                     "target_ov": 75.02
                 },
@@ -179,7 +185,8 @@
                     "metric_type": "Acc@1",
                     "model_description": "ResNet-50",
                     "compression_description": "INT8",
-                    "diff_target_max": 0.15,
+                    "diff_target_tf_min": -0.15,
+                    "diff_target_tf_max": 0.15,
                     "target_tf": 74.99,
                     "target_ov": 74.99
                 },
@@ -224,6 +231,8 @@
                     "metric_type": "Acc@1",
                     "model_description": "ResNet-50",
                     "compression_description": "INT8 (per-tensor symmetric for weights, per-tensor asymmetric half-range for activations) + Filter pruning, 40%, geometric median criterion",
+                    "diff_target_tf_min": -0.15,
+                    "diff_target_tf_max": 0.15,
                     "target_tf": 75.06,
                     "target_ov": 75.00
                 }
@@ -255,7 +264,8 @@
                     "model_description": "RetinaNet",
                     "compression_description": "INT8 (per-tensor symmetric for weights, per-tensor asymmetric half-range for activations)",
                     "batch_per_gpu": 15,
-                    "diff_target_max": 0.15,
+                    "diff_target_tf_min": -0.15,
+                    "diff_target_tf_max": 0.15,
                     "target_tf": 33.19,
                     "target_ov": 33.23
                 },
@@ -314,8 +324,9 @@
                     "model_description": "YOLO v4",
                     "compression_description": "INT8 (per-channel symmetric for weights, per-tensor asymmetric half-range for activations)",
                     "batch_per_gpu": 15,
-                    "diff_target_max": 0.15,
-                    "diff_target_min": -0.15,
+                    "diff_target_tf_min": -0.15,
+                    "diff_target_tf_max": 0.15,
+                    "diff_target_ov_max": 0.07,
                     "target_tf": 46.2,
                     "target_ov": 47.78
                 },
@@ -328,8 +339,8 @@
                     "model_description": "YOLO v4",
                     "compression_description": "Magnitude sparsity, 50%",
                     "batch_per_gpu": 15,
-                    "diff_target_max": 0.15,
-                    "diff_target_min": -0.15,
+                    "diff_target_tf_min": -0.15,
+                    "diff_target_tf_max": 0.15,
                     "target_tf": 46.49,
                     "target_ov": 48.08
                 }

--- a/tests/tensorflow/sota_checkpoints_eval.json
+++ b/tests/tensorflow/sota_checkpoints_eval.json
@@ -121,6 +121,7 @@
                     "compression_description": "INT8 (per-channel symmetric for weights, per-tensor asymmetric half-range for activations)",
                     "diff_target_tf_min": -0.15,
                     "diff_target_tf_max": 0.15,
+                    "diff_target_ov_min": -0.06,
                     "target_tf": 67.66,
                     "target_ov": 67.74
                 },
@@ -154,6 +155,7 @@
                     "compression_description": "INT8 (per-channel symmetric for weights, per-tensor asymmetric half-range for activations)",
                     "diff_target_tf_min": -0.15,
                     "diff_target_tf_max": 0.15,
+                    "diff_target_ov_min": -0.09,
                     "target_tf": 74.91,
                     "target_ov": 74.96
                 },
@@ -167,6 +169,7 @@
                     "compression_description": "INT8 (per-channel symmetric for weights, per-tensor asymmetric half-range for activations) + Sparsity 42% (RB)",
                     "diff_target_tf_min": -0.15,
                     "diff_target_tf_max": 0.15,
+                    "diff_target_ov_max": 0.04,
                     "target_tf": 75.23,
                     "target_ov": 75.02
                 },

--- a/tests/tensorflow/test_sota_checkpoints.py
+++ b/tests/tensorflow/test_sota_checkpoints.py
@@ -80,8 +80,8 @@ class EvalRunParamsStruct:
     batch: Optional[int]
     diff_fp32_min: float
     diff_fp32_max: float
-    diff_target_pt_min: float
-    diff_target_pt_max: float
+    diff_target_tf_min: float
+    diff_target_tf_max: float
     diff_target_ov_min: float
     diff_target_ov_max: float
     skip_ov: Optional[str]
@@ -160,8 +160,8 @@ def read_reference_file(ref_path: Path) -> List[EvalRunParamsStruct]:
                         diff_fp32_max=sample_dict.get("diff_fp32_max", DIFF_FP32_MAX_GLOBAL),
                         diff_target_ov_min=sample_dict.get("diff_target_ov_min", DIFF_TARGET_OV_MIN),
                         diff_target_ov_max=sample_dict.get("diff_target_ov_max", DIFF_TARGET_OV_MAX),
-                        diff_target_pt_min=sample_dict.get("diff_target_pt_min", DIFF_TARGET_TF_MIN),
-                        diff_target_pt_max=sample_dict.get("diff_target_pt_max", DIFF_TARGET_TF_MAX),
+                        diff_target_tf_min=sample_dict.get("diff_target_tf_min", DIFF_TARGET_TF_MIN),
+                        diff_target_tf_max=sample_dict.get("diff_target_tf_max", DIFF_TARGET_TF_MAX),
                         skip_ov=sample_dict.get("skip_ov"),
                         xfail_ov=sample_dict.get("xfail_ov"),
                     )
@@ -429,8 +429,8 @@ class TestSotaCheckpoints:
 
         threshold_errors = self.threshold_check(
             diff_target=diff_target,
-            diff_target_min=eval_test_struct.diff_target_pt_min,
-            diff_target_max=eval_test_struct.diff_target_pt_max,
+            diff_target_min=eval_test_struct.diff_target_tf_min,
+            diff_target_max=eval_test_struct.diff_target_tf_max,
             diff_fp32=diff_fp32,
             diff_fp32_min=eval_test_struct.diff_fp32_min,
             diff_fp32_max=eval_test_struct.diff_fp32_max,


### PR DESCRIPTION
### Changes

- Increase threshold for test int8 model on GPU
- Increase max threshold for metric on OV for yolo_v4_coco_int8 (that depends from TF version)


### Related tickets

132089

