### PR TITLE
More strict threshold for accuracy and minor corrections

### DIFF
--- a/tests/post_training/data/wc_reference_data.yaml
+++ b/tests/post_training/data/wc_reference_data.yaml
@@ -1,8 +1,6 @@
 tinyllama_data_free_backend_OV:
   metric_value: 0.72119
 tinyllama_data_aware_backend_OV:
-  metric_value: 0.82593
-  atol: 0.3
+  metric_value: 0.83084
 tinyllama_data_aware_awq_backend_OV:
-  metric_value: 0.82126
-  atol: 0.3
+  metric_value: 0.81229

--- a/tests/post_training/pipelines/lm_weight_compression.py
+++ b/tests/post_training/pipelines/lm_weight_compression.py
@@ -116,7 +116,7 @@ class LMWeightCompression(BaseTestPipeline):
         return transform_fn
 
     def prepare_calibration_dataset(self):
-        dataset = load_dataset("wikitext", "wikitext-2-v1", split="train", revision='b08601e')
+        dataset = load_dataset("wikitext", "wikitext-2-v1", split="train", revision="b08601e")
         dataset = dataset.filter(lambda example: len(example["text"]) > 80)
         self.calibration_dataset = nncf.Dataset(dataset, self.get_transform_calibration_fn())
 

--- a/tests/post_training/pipelines/lm_weight_compression.py
+++ b/tests/post_training/pipelines/lm_weight_compression.py
@@ -116,7 +116,7 @@ class LMWeightCompression(BaseTestPipeline):
         return transform_fn
 
     def prepare_calibration_dataset(self):
-        dataset = load_dataset("wikitext", "wikitext-2-v1", split="train")
+        dataset = load_dataset("wikitext", "wikitext-2-v1", split="train", revision='b08601e')
         dataset = dataset.filter(lambda example: len(example["text"]) > 80)
         self.calibration_dataset = nncf.Dataset(dataset, self.get_transform_calibration_fn())
 

--- a/tests/post_training/test_quantize_conformance.py
+++ b/tests/post_training/test_quantize_conformance.py
@@ -85,7 +85,7 @@ def fixture_wc_reference_data():
         data = yaml.safe_load(f)
         fp32_test_cases = defaultdict(dict)
         for test_case_name in data:
-            data[test_case_name]['atol'] = 1e-5
+            data[test_case_name]["atol"] = 1e-5
             model_name = test_case_name.split("_backend_")[0]
             fp32_test_cases[f"{model_name}_backend_FP32"]["metric_value"] = 1
             fp32_test_cases[f"{model_name}_backend_FP32"]["atol"] = 1e-10

--- a/tests/post_training/test_quantize_conformance.py
+++ b/tests/post_training/test_quantize_conformance.py
@@ -85,8 +85,10 @@ def fixture_wc_reference_data():
         data = yaml.safe_load(f)
         fp32_test_cases = defaultdict(dict)
         for test_case_name in data:
+            data[test_case_name]['atol'] = 1e-5
             model_name = test_case_name.split("_backend_")[0]
             fp32_test_cases[f"{model_name}_backend_FP32"]["metric_value"] = 1
+            fp32_test_cases[f"{model_name}_backend_FP32"]["atol"] = 1e-10
         data.update(fp32_test_cases)
     return data
 
@@ -273,10 +275,9 @@ def test_weight_compression(
     except Exception as e:
         err_msg = str(e)
         traceback.print_exc()
-    finally:
-        pipeline.cleanup_cache()
 
     if pipeline is not None:
+        pipeline.cleanup_cache()
         run_info = pipeline.run_info
         if err_msg:
             run_info.status = f"{run_info.status} | {err_msg}" if run_info.status else err_msg


### PR DESCRIPTION
### Changes

Introduced a more strict criterion for passing conformance tests for weight compression: similarity should match at least to the fifth decimal place.

Also use a specific dataset revision to avoid issues with different accuracy

### Reason for changes

in order to catch regressions - e.g., https://github.com/openvinotoolkit/nncf/pull/2420

### Related tickets

n/a

### Tests

- [x] weight compression conformance test build 2

![image](https://github.com/openvinotoolkit/nncf/assets/4014476/72d7a41b-4c30-4759-b4b7-74150255dcbb)

