### PR TITLE
[PT] Propagate is_shared attribute from constant node

### DIFF
--- a/nncf/torch/dynamic_graph/context.py
+++ b/nncf/torch/dynamic_graph/context.py
@@ -192,7 +192,7 @@ class TracingContext:
 
     def get_processed_parameter(self, param_name: str) -> Union[torch.Tensor, None]:
         """
-        Rerturn the processed parameter by name.
+        Return the processed parameter by name.
 
         :param param_name: The parameter name.
         :return: The processed parameter by name if found, otherwise None.

--- a/nncf/torch/dynamic_graph/trace_tensor.py
+++ b/nncf/torch/dynamic_graph/trace_tensor.py
@@ -160,7 +160,7 @@ class TracedParameter(torch.nn.Parameter, TracedTensorMixin):
 
         :param tensor: The input torch.nn.Parameter.
         :param name: The parameter name.
-        :param is_shared: True if parameter is used as an input in several operations of the model otherwise False.
+        :param is_reused: True if parameter is used as an input in several operations of the model otherwise False.
         :return: The resulting TracedParameter.
         """
         TracedParameter.patch(tensor)

--- a/nncf/torch/graph/graph_builder.py
+++ b/nncf/torch/graph/graph_builder.py
@@ -23,8 +23,8 @@ from nncf.torch.dynamic_graph.graph_tracer import GraphTracer
 from nncf.torch.dynamic_graph.layer_attributes_handlers import set_nodes_attributes_in_nncf_graph
 from nncf.torch.dynamic_graph.scope import Scope
 from nncf.torch.graph.graph import PTNNCFGraph
-from nncf.torch.graph.operator_metatypes import OP_NAMES_QUANTIZE_NODE
 from nncf.torch.graph.operator_metatypes import PT_OPERATOR_METATYPES
+from nncf.torch.graph.operator_metatypes import QUANTIZE_NODE_TYPES
 
 
 class GraphBuilder:
@@ -152,7 +152,7 @@ def _propagate_true_for_is_shared_attribute(node: NNCFNode, graph: NNCFGraph):
     :param graph: The NNCFGraph instance.
     """
     node.attributes[NNCFNode.IS_SHARED_ATTR] = True
-    if node.metatype in CONST_NOOP_METATYPES or node.node_type in OP_NAMES_QUANTIZE_NODE:
+    if node.metatype in CONST_NOOP_METATYPES or node.node_type in QUANTIZE_NODE_TYPES:
         for next_node in graph.get_next_nodes(node):
             _propagate_true_for_is_shared_attribute(next_node, graph)
 

--- a/nncf/torch/graph/graph_builder.py
+++ b/nncf/torch/graph/graph_builder.py
@@ -9,10 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import defaultdict
-from typing import Any, Callable, Dict, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set
 
 import torch
 
+from nncf.common.graph import NNCFGraph
+from nncf.common.graph import NNCFNode
 from nncf.common.graph.operator_metatypes import CONST_NOOP_METATYPES
 from nncf.common.graph.operator_metatypes import INPUT_NOOP_METATYPES
 from nncf.torch.dynamic_graph.context import TracingContext
@@ -21,6 +23,7 @@ from nncf.torch.dynamic_graph.graph_tracer import GraphTracer
 from nncf.torch.dynamic_graph.layer_attributes_handlers import set_nodes_attributes_in_nncf_graph
 from nncf.torch.dynamic_graph.scope import Scope
 from nncf.torch.graph.graph import PTNNCFGraph
+from nncf.torch.graph.operator_metatypes import OP_NAMES_QUANTIZE_NODE
 from nncf.torch.graph.operator_metatypes import PT_OPERATOR_METATYPES
 
 
@@ -68,12 +71,12 @@ class GraphBuilder:
         :return: PTNNCFGraph constructed from given model.
         """
         dynamic_graph = self.build_dynamic_graph(model, context_to_use, as_eval, trace_parameters)
-        return GraphConverter.convert(dynamic_graph)
+        return GraphConverter.convert(dynamic_graph, trace_parameters)
 
 
 class GraphConverter:
     @staticmethod
-    def convert(dynamic_graph: DynamicGraph) -> PTNNCFGraph:
+    def convert(dynamic_graph: DynamicGraph, traced_parameters) -> PTNNCFGraph:
         module_id_vs_known_op_addrs_map: Dict[int, Set[Scope]] = defaultdict(set)
         for dynamic_graph_node in dynamic_graph.get_all_nodes():
             module_id_vs_known_op_addrs_map[dynamic_graph_node.calling_module_id].add(
@@ -102,7 +105,9 @@ class GraphConverter:
             if metatype in INPUT_NOOP_METATYPES:
                 is_integer_input = dynamic_graph.is_integer_input_node(dynamic_graph_node)
 
-            is_shared = len(module_id_vs_sorted_scopes_map[dynamic_graph_node.calling_module_id]) > 1
+            is_shared = False
+            if not traced_parameters:
+                is_shared = len(module_id_vs_sorted_scopes_map[dynamic_graph_node.calling_module_id]) > 1
             canonical_scope = module_id_vs_sorted_scopes_map[dynamic_graph_node.calling_module_id][0]
 
             node_name = str(op_address)
@@ -134,4 +139,34 @@ class GraphConverter:
             )
 
         set_nodes_attributes_in_nncf_graph(nncf_graph)
+        if traced_parameters:
+            propagate_is_shared_attribute_from_constant_nodes(nncf_graph)
         return nncf_graph
+
+
+def _propagate_true_for_is_shared_attribute(node: NNCFNode, graph: NNCFGraph):
+    """
+    Propagates the is_shared attribute through specific nodes in an NNCFGraph.
+
+    :param node: The start NNCFNode to process.
+    :param graph: The NNCFGraph instance.
+    """
+    node.attributes[NNCFNode.IS_SHARED_ATTR] = True
+    if node.metatype in CONST_NOOP_METATYPES or node.node_type in OP_NAMES_QUANTIZE_NODE:
+        for next_node in graph.get_next_nodes(node):
+            _propagate_true_for_is_shared_attribute(next_node, graph)
+
+
+def propagate_is_shared_attribute_from_constant_nodes(graph: NNCFGraph):
+    """
+    Detect shared constant nodes that used in several operations and propagate is_shared node attributes nodes.
+    For constant nodes the is_shared attribute set to True if constant used in multiple operations.
+    For other types of node with the is_shared attribute set to True if operation which associated
+    with node used shared constant.
+
+    :param graph: NNCGraph instance.
+    """
+    for const_node in graph.get_nodes_by_metatypes(CONST_NOOP_METATYPES):
+        next_nodes = graph.get_next_nodes(const_node)
+        if len(next_nodes) > 1:
+            _propagate_true_for_is_shared_attribute(const_node, graph)

--- a/nncf/torch/graph/graph_builder.py
+++ b/nncf/torch/graph/graph_builder.py
@@ -144,7 +144,7 @@ class GraphConverter:
         return nncf_graph
 
 
-def _propagate_true_for_is_shared_attribute(node: NNCFNode, graph: NNCFGraph, val: bool):
+def _propagate_true_for_is_shared_attribute(node: NNCFNode, graph: NNCFGraph, val: bool) -> None:
     """
     Propagates the is_shared attribute through specific nodes in an NNCFGraph.
 
@@ -158,7 +158,7 @@ def _propagate_true_for_is_shared_attribute(node: NNCFNode, graph: NNCFGraph, va
             _propagate_true_for_is_shared_attribute(next_node, graph, val)
 
 
-def propagate_is_shared_attribute_from_constant_nodes(graph: NNCFGraph):
+def propagate_is_shared_attribute_from_constant_nodes(graph: NNCFGraph) -> None:
     """
     Detect shared constant nodes that used in several operations and propagate is_shared node attributes nodes.
     For constant nodes the is_shared attribute set to True if constant used in multiple operations.

--- a/nncf/torch/graph/graph_builder.py
+++ b/nncf/torch/graph/graph_builder.py
@@ -144,17 +144,18 @@ class GraphConverter:
         return nncf_graph
 
 
-def _propagate_true_for_is_shared_attribute(node: NNCFNode, graph: NNCFGraph):
+def _propagate_true_for_is_shared_attribute(node: NNCFNode, graph: NNCFGraph, val: bool):
     """
     Propagates the is_shared attribute through specific nodes in an NNCFGraph.
 
     :param node: The start NNCFNode to process.
     :param graph: The NNCFGraph instance.
+    :param val: Propagated value for is_shared.
     """
-    node.attributes[NNCFNode.IS_SHARED_ATTR] = True
+    node.attributes[NNCFNode.IS_SHARED_ATTR] = val
     if node.metatype in CONST_NOOP_METATYPES or node.node_type in QUANTIZE_NODE_TYPES:
         for next_node in graph.get_next_nodes(node):
-            _propagate_true_for_is_shared_attribute(next_node, graph)
+            _propagate_true_for_is_shared_attribute(next_node, graph, val)
 
 
 def propagate_is_shared_attribute_from_constant_nodes(graph: NNCFGraph):
@@ -169,4 +170,4 @@ def propagate_is_shared_attribute_from_constant_nodes(graph: NNCFGraph):
     for const_node in graph.get_nodes_by_metatypes(CONST_NOOP_METATYPES):
         next_nodes = graph.get_next_nodes(const_node)
         if len(next_nodes) > 1:
-            _propagate_true_for_is_shared_attribute(const_node, graph)
+            _propagate_true_for_is_shared_attribute(const_node, graph, True)

--- a/nncf/torch/graph/graph_builder.py
+++ b/nncf/torch/graph/graph_builder.py
@@ -106,8 +106,8 @@ class GraphConverter:
                 is_integer_input = dynamic_graph.is_integer_input_node(dynamic_graph_node)
 
             is_shared = False
-            # if not traced_parameters:
-            is_shared = len(module_id_vs_sorted_scopes_map[dynamic_graph_node.calling_module_id]) > 1
+            if not traced_parameters:
+                is_shared = len(module_id_vs_sorted_scopes_map[dynamic_graph_node.calling_module_id]) > 1
             canonical_scope = module_id_vs_sorted_scopes_map[dynamic_graph_node.calling_module_id][0]
 
             node_name = str(op_address)
@@ -139,8 +139,8 @@ class GraphConverter:
             )
 
         set_nodes_attributes_in_nncf_graph(nncf_graph)
-        # if traced_parameters:
-        #     propagate_is_shared_attribute_from_constant_nodes(nncf_graph)
+        if traced_parameters:
+            propagate_is_shared_attribute_from_constant_nodes(nncf_graph)
         return nncf_graph
 
 

--- a/nncf/torch/graph/graph_builder.py
+++ b/nncf/torch/graph/graph_builder.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, Optional, Set
 
 import torch
 
@@ -106,8 +106,8 @@ class GraphConverter:
                 is_integer_input = dynamic_graph.is_integer_input_node(dynamic_graph_node)
 
             is_shared = False
-            if not traced_parameters:
-                is_shared = len(module_id_vs_sorted_scopes_map[dynamic_graph_node.calling_module_id]) > 1
+            # if not traced_parameters:
+            is_shared = len(module_id_vs_sorted_scopes_map[dynamic_graph_node.calling_module_id]) > 1
             canonical_scope = module_id_vs_sorted_scopes_map[dynamic_graph_node.calling_module_id][0]
 
             node_name = str(op_address)
@@ -139,8 +139,8 @@ class GraphConverter:
             )
 
         set_nodes_attributes_in_nncf_graph(nncf_graph)
-        if traced_parameters:
-            propagate_is_shared_attribute_from_constant_nodes(nncf_graph)
+        # if traced_parameters:
+        #     propagate_is_shared_attribute_from_constant_nodes(nncf_graph)
         return nncf_graph
 
 

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -1050,4 +1050,4 @@ OPERATORS_FUSED_METATYPES = [
     PTModuleBatchNormMetatype,
 ]
 
-OP_NAMES_QUANTIZE_NODE = ["symmetric_quantize", "asymmetric_quantize"]
+QUANTIZE_NODE_TYPES = ["symmetric_quantize", "asymmetric_quantize"]

--- a/nncf/torch/model_analyzer.py
+++ b/nncf/torch/model_analyzer.py
@@ -15,9 +15,9 @@ import torch
 
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
-from nncf.torch.graph.operator_metatypes import OP_NAMES_QUANTIZE_NODE
 from nncf.torch.graph.operator_metatypes import OPERATORS_FUSED_METATYPES
 from nncf.torch.graph.operator_metatypes import OPERATORS_WITH_BIAS_METATYPES
+from nncf.torch.graph.operator_metatypes import QUANTIZE_NODE_TYPES
 from nncf.torch.nncf_network import NNCFNetwork
 
 
@@ -82,6 +82,6 @@ def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
     :return bool: return `True` if the node is quantized.
     """
     for prev_node in nncf_graph.get_previous_nodes(node):
-        if prev_node.node_type in OP_NAMES_QUANTIZE_NODE:
+        if prev_node.node_type in QUANTIZE_NODE_TYPES:
             return True
     return False

--- a/tests/torch/helpers.py
+++ b/tests/torch/helpers.py
@@ -228,6 +228,32 @@ class LeNet(nn.Module):
         return num_features
 
 
+class SharedConv(nn.Module):
+    INPUT_SIZE = [1, 1, 4, 4]
+
+    def __init__(self):
+        super().__init__()
+        self.conv = create_conv(1, 1, 2, 2)
+
+    def forward(self, x):
+        a = self.conv(x)
+        b = self.conv(x + 1)
+        return a + b
+
+
+class SharedCustomConv(nn.Module):
+    INPUT_SIZE = [1, 1, 4, 4]
+
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones((1, 1, 2, 2)))
+
+    def forward(self, x):
+        a = F.conv2d(x, self.weight)
+        b = F.conv2d(x + 1, self.weight)
+        return a + b
+
+
 def get_empty_config(
     model_size=4, input_sample_sizes: Union[Tuple[List[int]], List[int]] = None, input_info: Dict = None
 ) -> NNCFConfig:
@@ -511,7 +537,7 @@ HookType = TypeVar("HookType")
 class HookChecker:
     """
     Class to check pre/post hooks and pre ops are placed correctly.
-    Suports check for one wrapped NNCFModule for now.
+    Supports check for one wrapped NNCFModule for now.
     """
 
     def __init__(self, target_model: torch.nn.Module, nncf_module_attr_name: str):

--- a/tests/torch/nas/helpers.py
+++ b/tests/torch/nas/helpers.py
@@ -65,7 +65,7 @@ class DebugGraphContext:
 
     def dump_graph(self, file_name):
         dyn_graph = self._model.nncf.get_dynamic_graph()
-        nncf_graph = GraphConverter.convert(dyn_graph)
+        nncf_graph = GraphConverter.convert(dyn_graph, False)
         nncf_graph.visualize_graph(f"{file_name}.dot")
 
     def __enter__(self):


### PR DESCRIPTION
### Changes

- If model traced with trace_parameters=True, detect shared constant nodes by number of output nodes and propagate this attribute to next nodes.

- Rename OP_NAMES_QUANTIZE_NODE to QUANTIZE_NODE_TYPES
### Reason for changes

Incorrect set `is_shared` attributes. 

### Tests

test_shared_nodes_in_wrapped_model_with_trace_parameters