### PR TITLE
Remove friendly names duplicates after model weight compression

### DIFF
--- a/nncf/openvino/graph/model_utils.py
+++ b/nncf/openvino/graph/model_utils.py
@@ -64,7 +64,7 @@ def get_start_nodes_for_activation_path_tracing(nncf_graph: NNCFGraph) -> List[N
 
 def remove_friendly_name_duplicates(model: ov.Model) -> ov.Model:
     """
-    Removes diplicates of node names (friendly_name attribute) in the model.
+    Removes duplicates of node names (friendly_name attribute) in the model.
 
     :param model: ov.Model instance to update.
     :return: Updated ov.Model without duplicated names.

--- a/nncf/openvino/graph/model_utils.py
+++ b/nncf/openvino/graph/model_utils.py
@@ -69,11 +69,6 @@ def remove_friendly_name_duplicates(model: ov.Model) -> ov.Model:
     :param model: ov.Model instance to update.
     :return: Updated ov.Model without duplicated names.
     """
-    rt_info_path = ["nncf", "friendly_names_were_updated"]
-    friendly_names_flag = "True"
-    if model.has_rt_info(rt_info_path) and model.get_rt_info(rt_info_path).value == friendly_names_flag:
-        return model
-
     existing_names = set()
     for op in model.get_ops():
         friendly_name = op.get_friendly_name()
@@ -81,7 +76,6 @@ def remove_friendly_name_duplicates(model: ov.Model) -> ov.Model:
             friendly_name = friendly_name + "0"
             op.set_friendly_name(friendly_name)
         existing_names.add(friendly_name)
-    model.set_rt_info(friendly_names_flag, rt_info_path)
     return model
 
 

--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -415,5 +415,5 @@ def compress_weights_impl(
     )
     graph = NNCFGraphFactory.create(model)
     compressed_model = compression_algorithm.apply(model, graph, dataset=dataset)
-    model = remove_friendly_name_duplicates(compressed_model)
+    compressed_model = remove_friendly_name_duplicates(compressed_model)
     return compressed_model

--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -414,4 +414,6 @@ def compress_weights_impl(
         mode, ratio, group_size, ignored_scope, all_layers, sensitivity_metric, awq, subset_size
     )
     graph = NNCFGraphFactory.create(model)
-    return compression_algorithm.apply(model, graph, dataset=dataset)
+    compressed_model = compression_algorithm.apply(model, graph, dataset=dataset)
+    model = remove_friendly_name_duplicates(compressed_model)
+    return compressed_model


### PR DESCRIPTION
### Changes

It was found that model weight compression may sometimes (randomly) result in a model with duplicate friendly names. 

With hybrid quantization pipeline we quantize a model that was compressed beforehand. In such case the compressed model may contain duplicate friendly names, but they will not be removed at quantization start because `nncf.friendly_names_were_updated` flag was set at the start of compression. 

Changes:
- Remove duplicates after model weight compression
- Don't skip duplicates removal if it was applied before (the model may have changed since the last removal)


### Related tickets
132595
