### PR TITLE
[PT] Do not trace parameters for modules inserted by NNCF

### DIFF
--- a/nncf/torch/dynamic_graph/wrappers.py
+++ b/nncf/torch/dynamic_graph/wrappers.py
@@ -278,15 +278,10 @@ def wrap_parameters(model: torch.nn.Module):
 
     :param model: A model.
     """
-    from nncf.torch.external_hook import EXTERNAL_OP_STORAGE_PREFIX
-    from nncf.torch.quantization.external_quantizer import EXTERNAL_QUANTIZERS_STORAGE_PREFIX
-
-    # Ignore modules that will be added by NNCF
-    ignored_prefixes = [EXTERNAL_QUANTIZERS_STORAGE_PREFIX, EXTERNAL_OP_STORAGE_PREFIX]
-
     ctx = get_current_context()
     for name, param in model.named_parameters():
-        if any(name.startswith(ignore_prefix) for ignore_prefix in ignored_prefixes):
+        if name.startswith("_nncf"):
+            # Exclude parameters in modules which added by NNCF.
             continue
         is_reused = name in ctx.reused_parameters
         tt = TracedParameter.from_torch_parameter(param, name, is_reused)

--- a/nncf/torch/dynamic_graph/wrappers.py
+++ b/nncf/torch/dynamic_graph/wrappers.py
@@ -278,8 +278,16 @@ def wrap_parameters(model: torch.nn.Module):
 
     :param model: A model.
     """
+    from nncf.torch.external_hook import EXTERNAL_OP_STORAGE_PREFIX
+    from nncf.torch.quantization.external_quantizer import EXTERNAL_QUANTIZERS_STORAGE_PREFIX
+
+    # Ignore modules that will be added by NNCF
+    ignored_prefixes = [EXTERNAL_QUANTIZERS_STORAGE_PREFIX, EXTERNAL_OP_STORAGE_PREFIX]
+
     ctx = get_current_context()
     for name, param in model.named_parameters():
+        if any(name.startswith(ignore_prefix) for ignore_prefix in ignored_prefixes):
+            continue
         is_reused = name in ctx.reused_parameters
         tt = TracedParameter.from_torch_parameter(param, name, is_reused)
         ctx.register_traced_tensor(tt)

--- a/nncf/torch/external_hook.py
+++ b/nncf/torch/external_hook.py
@@ -14,7 +14,6 @@ from typing import Any
 from nncf.torch.dynamic_graph.context import TracingContext
 
 EXTERNAL_OP_STORAGE_NAME = "external_op"
-EXTERNAL_OP_STORAGE_PREFIX = "_nncf." + EXTERNAL_OP_STORAGE_NAME
 
 
 class ExternalOpCallHook:

--- a/nncf/torch/external_hook.py
+++ b/nncf/torch/external_hook.py
@@ -14,6 +14,7 @@ from typing import Any
 from nncf.torch.dynamic_graph.context import TracingContext
 
 EXTERNAL_OP_STORAGE_NAME = "external_op"
+EXTERNAL_OP_STORAGE_PREFIX = "_nncf." + EXTERNAL_OP_STORAGE_NAME
 
 
 class ExternalOpCallHook:

--- a/tests/torch/test_nncf_graph.py
+++ b/tests/torch/test_nncf_graph.py
@@ -31,8 +31,8 @@ def test_get_nodes_with_missed_input_edges(node_between_const_and_target):
         node_between_const_and_target,
         PTNNCFGraph,
     ).nncf_graph
-    ref_diconnected_nodes = ["/Conv2_0", "/Concat_with_missed_input_0"]
+    ref_disconnected_nodes = ["/Conv2_0", "/Concat_with_missed_input_0"]
     disconnected_nodes = nncf_graph.get_nodes_with_missed_input_edges()
-    assert len(ref_diconnected_nodes) == len(disconnected_nodes)
+    assert len(ref_disconnected_nodes) == len(disconnected_nodes)
     for node in disconnected_nodes:
-        assert node.node_name in ref_diconnected_nodes
+        assert node.node_name in ref_disconnected_nodes


### PR DESCRIPTION
### Changes

Do not trace parameters for modules inserted by NNCF

### Reason for changes

Reduce number of nodes in NNCFGraph, this parameters will not used to anilazine graph or insert points. 


### Tests

test_not_trace_parameters_in_nncf_modules