### PR TITLE
[PTQ][OV] Added scale constant creation

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -163,10 +163,12 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                 converted_zero_point = opset.convert(zero_point_const, const_dtype)
                 converted_const = opset.subtract(converted_const, converted_zero_point)
 
-            scale_data = compressed_weight.scale.data
+            scale_const = opset.constant(
+                compressed_weight.scale.data, dtype=const_dtype, name=f"{const_node_name}/scale"
+            )
             mul = opset.multiply(
                 converted_const,
-                scale_data.astype(const_dtype),
+                scale_const,
                 name=f"{const_node_name}/fq_weights_{wc_params.weight_port_id}",
             )
 

--- a/tests/openvino/native/models.py
+++ b/tests/openvino/native/models.py
@@ -957,6 +957,28 @@ class DuplicatedNamesModel(OVReferenceModel):
         return model
 
 
+class ModelNamedConsts(OVReferenceModel):
+    """
+    Model with named constant nodes (friendly_name field).
+    """
+
+    def _create_ov_model(self):
+        main_shape = [1, 2]
+        input_1 = opset.parameter(main_shape, name="Parameter")
+
+        add_1_data = self._rng.random(main_shape).astype(np.float32)
+        add_1_const = opset.constant(add_1_data, name="Constant_16")
+        add_1 = opset.add(input_1, add_1_const, name="Add_1")
+
+        matmul_1_data = self._rng.random(main_shape).astype(np.float32)
+        matmul_1_const = opset.constant(matmul_1_data, name="Constant_1")
+        matmul_1 = opset.matmul(add_1, matmul_1_const, transpose_a=False, transpose_b=True, name="MatMul_1")
+
+        result = opset.result(matmul_1, name="Result")
+        model = ov.Model([result], [input_1])
+        return model
+
+
 class StatefulModel(OVReferenceModel):
     """
     Stateful model for testing.


### PR DESCRIPTION
### Changes

- Changed `multiply` node `scale` creation to `opset.constant` with unique name;

### Reason for changes

-  Robustness of the `compress_weights` pipeline;

### Related tickets

- 132595

### Tests

- Updated `tests/openvino/native/quantization/test_weights_compression.py`;
