### PR TITLE
Correct dtype handling for compressed torch.nn.Parameter

### DIFF
--- a/nncf/torch/__init__.py
+++ b/nncf/torch/__init__.py
@@ -48,6 +48,7 @@ from nncf.torch.knowledge_distillation import algo as knowledge_distillation_alg
 # listed below for importing convenience
 
 from nncf.torch.model_creation import create_compressed_model
+from nncf.torch.model_creation import is_wrapped_model
 from nncf.torch.model_creation import wrap_model
 from nncf.torch.checkpoint_loading import load_state
 from nncf.torch.initialization import register_default_init_args

--- a/nncf/torch/dynamic_graph/structs.py
+++ b/nncf/torch/dynamic_graph/structs.py
@@ -20,6 +20,7 @@ class NamespaceTarget(Enum):
 
     TORCH_NN_FUNCTIONAL = "torch.nn.functional"
     TORCH_TENSOR = "torch.tensor"
+    TORCH_NN_PARAMETER = "torch.nn.parameter"
     TORCH = "torch"
     EXTERNAL = "external_function"
 

--- a/nncf/torch/dynamic_graph/trace_tensor.py
+++ b/nncf/torch/dynamic_graph/trace_tensor.py
@@ -152,6 +152,15 @@ class TracedParameter(torch.nn.Parameter, TracedTensorMixin):
     def is_reused(self):
         return self.tracing_attrs[TracedParameter.IS_REUSED]
 
+    def get_dtype(self):
+        # Type of self is TracedParameter or TracedTensor
+        return super(self.__class__, self).__getattribute__("dtype")
+
+    def __getattribute__(self, name):
+        if name == "dtype":
+            return self.get_dtype()
+        return super().__getattribute__(name)
+
     @staticmethod
     def from_torch_parameter(tensor: torch.nn.Parameter, name: str, is_reused: bool) -> "TracedParameter":
         """


### PR DESCRIPTION
### Changes

Correct dtype handling for compressed torch.nn.Parameter

### Reason for changes

Weight compression for `CompVis/ldm-super-resolution-4x-openimages`

### Related tickets

PR: https://github.com/openvinotoolkit/openvino.genai/pull/232

### Tests

test_get_dtype_attribute_of_parameter
