### PR TITLE
Fix TypeError: revert_operations_to_floating_point_precision() missing 2 required positional arguments

### DIFF
--- a/nncf/quantization/algorithms/accuracy_control/ranker.py
+++ b/nncf/quantization/algorithms/accuracy_control/ranker.py
@@ -232,6 +232,8 @@ class Ranker:
                 quantized_model_graph,
                 self._restore_mode,
                 self._algo_backend.get_op_with_weights_metatypes(),
+                self._algo_backend.is_node_with_weight,
+                self._algo_backend.get_weight_tensor_port_ids,
             )
 
             prepared_model_queue.append(executor.submit(self._evaluator.prepare_model, modified_model))


### PR DESCRIPTION
### Changes

Fix typo

### Reason for changes

TypeError: revert_operations_to_floating_point_precision() missing 2 required positional arguments: 'is_node_with_weight_fn' and 'get_weight_tensor_port_ids_fn'

### Related tickets

N/A

### Tests

Current scope
