### PR TITLE
[PTQ] Fix mobilenetv3 in conformance

### DIFF
--- a/nncf/openvino/graph/metatypes/groups.py
+++ b/nncf/openvino/graph/metatypes/groups.py
@@ -185,6 +185,7 @@ OPERATIONS_WITH_CONST_PORT_ID = [
 # Contains the operation metatypes for which bias can be applied.
 OPERATIONS_WITH_BIAS = [
     ov_metatypes.OVConvolutionMetatype,
+    ov_metatypes.OVDepthwiseConvolutionMetatype,
     # TODO: add all metatypes with bias
     ov_metatypes.OVMatMulMetatype,
 ]

--- a/tests/post_training/model_scope.py
+++ b/tests/post_training/model_scope.py
@@ -19,6 +19,7 @@ from nncf.parameters import CompressWeightsMode
 from nncf.parameters import SensitivityMetric
 from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
 from nncf.quantization.advanced_parameters import AdvancedSmoothQuantParameters
+from nncf.quantization.advanced_parameters import AdvancedBiasCorrectionParameters
 from tests.post_training.pipelines.base import ALL_PTQ_BACKENDS
 from tests.post_training.pipelines.base import NNCF_PTQ_BACKENDS
 from tests.post_training.pipelines.base import BackendType
@@ -185,6 +186,9 @@ QUANTIZATION_MODELS = [
         "pipeline_cls": ImageClassificationTimm,
         "compression_params": {
             "preset": QuantizationPreset.MIXED,
+            "advanced_parameters": AdvancedQuantizationParameters(
+                bias_correction_params=AdvancedBiasCorrectionParameters(threshold=1000)
+            )
         },
         "backends": ALL_PTQ_BACKENDS,
     },


### PR DESCRIPTION
### Changes

- Added `DepthwiseConvolution` to the `OPERATIONS_WITH_BIAS` list for the OV backend;
- Increased `threshold` for FBC in conformance model scope;

### Reason for changes

- Metrics improvement;

### Related tickets

- 133198

### Tests

- TBD
