### PR TITLE
[PTQ] Metatypes with bias list alignment

### DIFF
--- a/nncf/onnx/graph/metatypes/groups.py
+++ b/nncf/onnx/graph/metatypes/groups.py
@@ -119,8 +119,6 @@ BATCH_NORMALIZATION_OPERATIONS = [
 # Contains the operation metatypes for which bias can be applied.
 OPERATIONS_WITH_BIAS = [
     onnx_metatypes.ONNXConvolutionMetatype,
-    onnx_metatypes.ONNXDepthwiseConvolutionMetatype,
-    onnx_metatypes.ONNXConvolutionTransposeMetatype,
     onnx_metatypes.ONNXGemmMetatype,
     onnx_metatypes.ONNXMatMulMetatype,
 ]

--- a/nncf/onnx/graph/metatypes/groups.py
+++ b/nncf/onnx/graph/metatypes/groups.py
@@ -120,6 +120,7 @@ BATCH_NORMALIZATION_OPERATIONS = [
 OPERATIONS_WITH_BIAS = [
     onnx_metatypes.ONNXConvolutionMetatype,
     onnx_metatypes.ONNXDepthwiseConvolutionMetatype,
+    onnx_metatypes.ONNXConvolutionTransposeMetatype,
 ]
 
 

--- a/nncf/onnx/graph/metatypes/groups.py
+++ b/nncf/onnx/graph/metatypes/groups.py
@@ -120,7 +120,7 @@ BATCH_NORMALIZATION_OPERATIONS = [
 OPERATIONS_WITH_BIAS = [
     onnx_metatypes.ONNXConvolutionMetatype,
     onnx_metatypes.ONNXGemmMetatype,
-    onnx_metatypes.ONNXMatMulMetatype,
+    # TODO: Need to add MatMul with the separate bias support (CVS-135433)
 ]
 
 

--- a/nncf/onnx/graph/metatypes/groups.py
+++ b/nncf/onnx/graph/metatypes/groups.py
@@ -121,6 +121,8 @@ OPERATIONS_WITH_BIAS = [
     onnx_metatypes.ONNXConvolutionMetatype,
     onnx_metatypes.ONNXDepthwiseConvolutionMetatype,
     onnx_metatypes.ONNXConvolutionTransposeMetatype,
+    onnx_metatypes.ONNXGemmMetatype,
+    onnx_metatypes.ONNXMatMulMetatype,
 ]
 
 

--- a/nncf/onnx/graph/metatypes/onnx_metatypes.py
+++ b/nncf/onnx/graph/metatypes/onnx_metatypes.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import deque
 from typing import Dict, List, Optional, Type
 
 import onnx
@@ -44,14 +45,15 @@ class ONNXOpMetatype(OperatorMetatype):
     @classmethod
     def determine_subtype(cls, model: onnx.ModelProto, node: onnx.NodeProto) -> Optional[Type[OperatorMetatype]]:
         matches = []
-        for subtype in cls.get_subtypes():
+        subtypes_list = deque(cls.get_subtypes())
+        while subtypes_list:
+            subtype = subtypes_list.popleft()
             if subtype.matches(model, node):
+                subtypes_list.extend(subtype.get_subtypes())
                 matches.append(subtype)
-        if len(matches) > 1:
-            raise nncf.InternalError("Multiple subtypes match operator call - cannot determine single subtype.")
         if not matches:
             return None
-        return matches[0]
+        return matches[-1]
 
 
 class ONNXOpWithWeightsMetatype(ONNXOpMetatype):
@@ -86,6 +88,22 @@ class ONNXDepthwiseConvolutionMetatype(ONNXOpWithWeightsMetatype):
 
 
 @ONNX_OPERATION_METATYPES.register()
+class ONNXGroupConvolutionMetatype(ONNXOpWithWeightsMetatype):
+    name = "GroupConvOp"
+    op_names = ["Conv"]
+    hw_config_names = [HWConfigOpName.CONVOLUTION]
+    weight_channel_axis = 0
+    weight_port_ids = [1]
+    bias_port_id = 2
+    output_channel_axis = 1
+    subtypes = [ONNXDepthwiseConvolutionMetatype]
+
+    @classmethod
+    def matches(cls, model: onnx.ModelProto, node: onnx.NodeProto) -> bool:
+        return _is_group_conv(node)
+
+
+@ONNX_OPERATION_METATYPES.register()
 class ONNXConvolutionMetatype(ONNXOpWithWeightsMetatype):
     name = "ConvOp"
     op_names = ["Conv"]
@@ -94,7 +112,7 @@ class ONNXConvolutionMetatype(ONNXOpWithWeightsMetatype):
     weight_port_ids = [1]
     bias_port_id = 2
     output_channel_axis = 1
-    subtypes = [ONNXDepthwiseConvolutionMetatype]
+    subtypes = [ONNXGroupConvolutionMetatype]
 
 
 @ONNX_OPERATION_METATYPES.register()
@@ -699,6 +717,23 @@ def get_tensor_edge_name(
     return None
 
 
+def _is_group_conv(node: onnx.NodeProto) -> bool:
+    """
+    Returns True if the convolution is group, False - otherwise.
+    Group convolution is a convolution with the group attribute.
+
+    :param node: Convolution node to check whether it is depthwise.
+    :return: True if the convolution is group, False - otherwise.
+    """
+    conv_group = None
+    for attribute in node.attribute:
+        if attribute.name == "group":
+            conv_group = onnx.helper.get_attribute_value(attribute)
+    if conv_group is None or conv_group == 1:
+        return False
+    return True
+
+
 def _is_depthwise_conv(model: onnx.ModelProto, node: onnx.NodeProto) -> bool:
     """
     Returns True if the convolution is depthwise, False - otherwise.
@@ -711,12 +746,9 @@ def _is_depthwise_conv(model: onnx.ModelProto, node: onnx.NodeProto) -> bool:
     :param node: Convolution node to check whether it is depthwise.
     :return: True if the convolution is depthwise, False - otherwise.
     """
-    conv_group = None
     for attribute in node.attribute:
         if attribute.name == "group":
             conv_group = onnx.helper.get_attribute_value(attribute)
-    if conv_group is None:
-        return False
     weight_tensor_value = None
     initializer_name = node.input[1]
     for init in model.graph.initializer:

--- a/nncf/onnx/graph/metatypes/onnx_metatypes.py
+++ b/nncf/onnx/graph/metatypes/onnx_metatypes.py
@@ -14,7 +14,6 @@ from typing import Dict, List, Optional, Type
 
 import onnx
 
-import nncf
 from nncf.common.graph.operator_metatypes import OperatorMetatype
 from nncf.common.graph.operator_metatypes import OperatorMetatypeRegistry
 from nncf.common.hardware.opset import HWConfigOpName

--- a/nncf/openvino/graph/metatypes/groups.py
+++ b/nncf/openvino/graph/metatypes/groups.py
@@ -186,6 +186,7 @@ OPERATIONS_WITH_CONST_PORT_ID = [
 OPERATIONS_WITH_BIAS = [
     ov_metatypes.OVConvolutionMetatype,
     ov_metatypes.OVMatMulMetatype,
+    ov_metatypes.OVDepthwiseConvolutionMetatype,
 ]
 
 

--- a/nncf/openvino/graph/metatypes/groups.py
+++ b/nncf/openvino/graph/metatypes/groups.py
@@ -182,17 +182,17 @@ OPERATIONS_WITH_CONST_PORT_ID = [
 ]
 
 
+# Contains the operation metatypes for which bias can be applied.
+OPERATIONS_WITH_BIAS = [
+    ov_metatypes.OVConvolutionMetatype,
+    ov_metatypes.OVMatMulMetatype,
+]
+
+
 CONV_OPERATIONS = [
     ov_metatypes.OVConvolutionMetatype,
     ov_metatypes.OVDepthwiseConvolutionMetatype,
     ov_metatypes.OVGroupConvolutionMetatype,
     ov_metatypes.OVConvolutionBackpropDataMetatype,
     ov_metatypes.OVGroupConvolutionBackpropDataMetatype,
-]
-
-
-# Contains the operation metatypes for which bias can be applied.
-OPERATIONS_WITH_BIAS = [
-    *CONV_OPERATIONS,
-    ov_metatypes.OVMatMulMetatype,
 ]

--- a/nncf/openvino/graph/metatypes/groups.py
+++ b/nncf/openvino/graph/metatypes/groups.py
@@ -182,18 +182,17 @@ OPERATIONS_WITH_CONST_PORT_ID = [
 ]
 
 
-# Contains the operation metatypes for which bias can be applied.
-OPERATIONS_WITH_BIAS = [
-    ov_metatypes.OVConvolutionMetatype,
-    # TODO: add all metatypes with bias
-    ov_metatypes.OVMatMulMetatype,
-]
-
-
 CONV_OPERATIONS = [
     ov_metatypes.OVConvolutionMetatype,
     ov_metatypes.OVDepthwiseConvolutionMetatype,
     ov_metatypes.OVGroupConvolutionMetatype,
     ov_metatypes.OVConvolutionBackpropDataMetatype,
     ov_metatypes.OVGroupConvolutionBackpropDataMetatype,
+]
+
+
+# Contains the operation metatypes for which bias can be applied.
+OPERATIONS_WITH_BIAS = [
+    *CONV_OPERATIONS,
+    ov_metatypes.OVMatMulMetatype,
 ]

--- a/nncf/openvino/graph/metatypes/groups.py
+++ b/nncf/openvino/graph/metatypes/groups.py
@@ -186,7 +186,6 @@ OPERATIONS_WITH_CONST_PORT_ID = [
 OPERATIONS_WITH_BIAS = [
     ov_metatypes.OVConvolutionMetatype,
     ov_metatypes.OVMatMulMetatype,
-    ov_metatypes.OVDepthwiseConvolutionMetatype,
 ]
 
 

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -1038,8 +1038,7 @@ OPERATORS_WITH_BIAS_METATYPES = [
     PTModuleConv1dMetatype,
     PTModuleConv2dMetatype,
     PTModuleConv3dMetatype,
-    # Need to verify that Linear handles correctly
-    PTModuleLinearMetatype,
+    # TODO: Need to add Linear support (CVS-111111)
 ]
 
 OPERATORS_FUSED_METATYPES = [

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -1044,7 +1044,6 @@ OPERATORS_WITH_BIAS_METATYPES = [
     PTModuleConvTranspose1dMetatype,
     PTModuleConvTranspose2dMetatype,
     PTModuleConvTranspose3dMetatype,
-    PTModuleLinearMetatype,
 ]
 
 OPERATORS_FUSED_METATYPES = [

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -1038,12 +1038,8 @@ OPERATORS_WITH_BIAS_METATYPES = [
     PTModuleConv1dMetatype,
     PTModuleConv2dMetatype,
     PTModuleConv3dMetatype,
-    PTDepthwiseConv1dSubtype,
-    PTDepthwiseConv2dSubtype,
-    PTDepthwiseConv3dSubtype,
-    PTModuleConvTranspose1dMetatype,
-    PTModuleConvTranspose2dMetatype,
-    PTModuleConvTranspose3dMetatype,
+    # Need to verify that Linear handles correctly
+    PTModuleLinearMetatype,
 ]
 
 OPERATORS_FUSED_METATYPES = [

--- a/nncf/torch/graph/operator_metatypes.py
+++ b/nncf/torch/graph/operator_metatypes.py
@@ -1044,6 +1044,7 @@ OPERATORS_WITH_BIAS_METATYPES = [
     PTModuleConvTranspose1dMetatype,
     PTModuleConvTranspose2dMetatype,
     PTModuleConvTranspose3dMetatype,
+    PTModuleLinearMetatype,
 ]
 
 OPERATORS_FUSED_METATYPES = [

--- a/tests/openvino/native/quantization/test_sanity.py
+++ b/tests/openvino/native/quantization/test_sanity.py
@@ -35,7 +35,7 @@ OMZ_MODELS = [
     (
         "mobilenet-v3-small-1.0-224-tf",
         "imagenette2-320",
-        {"accuracy@top1": 0.735, "accuracy@top5": 0.919},
+        {"accuracy@top1": 0.735, "accuracy@top5": 0.925},
         AdvancedQuantizationParameters(disable_channel_alignment=False),
     ),
     ("googlenet-v3-pytorch", "imagenette2-320", {"accuracy@top1": 0.911, "accuracy@top5": 0.994}, None),

--- a/tests/openvino/native/quantization/test_sanity.py
+++ b/tests/openvino/native/quantization/test_sanity.py
@@ -35,7 +35,7 @@ OMZ_MODELS = [
     (
         "mobilenet-v3-small-1.0-224-tf",
         "imagenette2-320",
-        {"accuracy@top1": 0.735, "accuracy@top5": 0.925},
+        {"accuracy@top1": 0.735, "accuracy@top5": 0.919},
         AdvancedQuantizationParameters(disable_channel_alignment=False),
     ),
     ("googlenet-v3-pytorch", "imagenette2-320", {"accuracy@top1": 0.911, "accuracy@top5": 0.994}, None),

--- a/tests/post_training/data/ptq_reference_data.yaml
+++ b/tests/post_training/data/ptq_reference_data.yaml
@@ -39,7 +39,7 @@ timm/deit3_small_patch16_224_backend_CUDA_TORCH:
 timm/deit3_small_patch16_224_backend_FP32:
   metric_value: 0.81358
 timm/deit3_small_patch16_224_backend_ONNX:
-  metric_value: 0.81268
+  metric_value: 0.81154
 timm/deit3_small_patch16_224_backend_OV:
   metric_value: 0.81276
 timm/deit3_small_patch16_224_backend_TORCH:
@@ -131,7 +131,7 @@ timm/mobilenetv2_050_backend_CUDA_TORCH:
 timm/mobilenetv2_050_backend_FP32:
   metric_value: 0.6594
 timm/mobilenetv2_050_backend_ONNX:
-  metric_value: 0.65462
+  metric_value: 0.65332
 timm/mobilenetv2_050_backend_OV:
   metric_value: 0.65282
 timm/mobilenetv2_050_backend_TORCH:
@@ -141,7 +141,7 @@ timm/mobilenetv3_small_050_backend_CUDA_TORCH:
 timm/mobilenetv3_small_050_backend_FP32:
   metric_value: 0.57906
 timm/mobilenetv3_small_050_backend_ONNX:
-  metric_value: 0.5617
+  metric_value: 0.42104
 timm/mobilenetv3_small_050_backend_OV:
   metric_value: 0.42184
 timm/mobilenetv3_small_050_backend_TORCH:


### PR DESCRIPTION
### Changes

- Reduced metatypes in `OPERATIONS_WITH_BIAS` list for ONNX;
- Reduced metatypes in `OPERATIONS_WITH_BIAS` list for PyTorch;
- Separated GroupConvolution from the Convolutions on ONNX;

### Reason for changes

- Alignment for algorithms between backends;

### Related tickets

- 133198
- 104166
- 106469

### Tests

- post_training_quantization/323 - failed with regressions for ONNX (as expected)
- post_training_quantization/324 - passed (updated references)
