### PR TITLE
[PT] Return bias value after fusing layer for FBC

### DIFF
--- a/nncf/torch/model_analyzer.py
+++ b/nncf/torch/model_analyzer.py
@@ -81,7 +81,7 @@ def get_fused_bias_value(node: NNCFNode, model: NNCFNetwork) -> Optional[torch.T
         return fused_module.bias
 
     # Return bias value after fusing
-    return target_module.bias * fused_node.weight + fused_node.bis
+    return target_module.bias * fused_module.weight + fused_module.bias
 
 
 def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:

--- a/nncf/torch/model_analyzer.py
+++ b/nncf/torch/model_analyzer.py
@@ -65,12 +65,23 @@ def get_fused_bias_value(node: NNCFNode, model: NNCFNetwork) -> Optional[torch.T
     :return: The bias value that is applied to the output tensor of the node's operation.
     """
     nncf_graph = model.nncf.get_graph()
+
+    target_module = model.nncf.get_containing_module(node.node_name)
     fused_node = get_potential_fused_node(node.node_name, nncf_graph)
-    target_node_name = fused_node.node_name if fused_node else node.node_name
-    node_module = model.nncf.get_containing_module(target_node_name)
-    if node_module.bias is None:
-        return None
-    return node_module.bias.data
+    bias = target_module.bias
+
+    if fused_node is None:
+        # No fused layer
+        return bias
+
+    fused_module = model.nncf.get_containing_module(fused_node.node_name)
+
+    if bias is None:
+        # No bias in target module, return bias from fused module
+        return fused_module.bias
+
+    # Return bias value after fusing
+    return target_module.bias * fused_node.weight + fused_node.bis
 
 
 def is_quantized_weights(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:

--- a/nncf/torch/model_transformer.py
+++ b/nncf/torch/model_transformer.py
@@ -250,7 +250,7 @@ def update_fused_bias(target_node_name: str, new_bias: Tensor, model: NNCFNetwor
         return
 
     new_bias = new_bias - target_module.bias * fused_module.weight
-    update_parameter(target_node_name, "bias", new_bias, model)
+    update_parameter(fused_node.node_name, "bias", new_bias, model)
 
 
 def update_parameter(target_node_name: str, parameter_name: str, new_value: Tensor, model: NNCFNetwork) -> None:

--- a/nncf/torch/model_transformer.py
+++ b/nncf/torch/model_transformer.py
@@ -251,7 +251,6 @@ def update_fused_bias(target_node_name: str, new_bias: Tensor, model: NNCFNetwor
 
     new_bias = new_bias - target_module.bias * fused_module.weight
     update_parameter(target_node_name, "bias", new_bias, model)
-    return target_module.bias * fused_node.weight + fused_node.bis
 
 
 def update_parameter(target_node_name: str, parameter_name: str, new_value: Tensor, model: NNCFNetwork) -> None:

--- a/nncf/torch/model_transformer.py
+++ b/nncf/torch/model_transformer.py
@@ -243,12 +243,11 @@ def update_fused_bias(target_node_name: str, new_bias: Tensor, model: NNCFNetwor
         update_parameter(target_node_name, "bias", new_bias, model)
         return
     target_module = model.nncf.get_containing_module(target_node_name)
-    fused_module = get_potential_fused_node(fused_node.node_name, nncf_graph)
+    fused_module = model.nncf.get_containing_module(fused_node.node_name)
 
     if target_module.bias is None:
         update_parameter(fused_node.node_name, "bias", new_bias, model)
         return
-
     new_bias = new_bias - target_module.bias * fused_module.weight
     update_parameter(fused_node.node_name, "bias", new_bias, model)
 

--- a/tests/post_training/test_templates/helpers.py
+++ b/tests/post_training/test_templates/helpers.py
@@ -92,6 +92,24 @@ class ConvBNTestModel(nn.Module):
         return x
 
 
+class BiasConvBiasBNTestModel(torch.nn.Module):
+    INPUT_SIZE = [1, 1, 4, 4]
+
+    def __init__(self):
+        super().__init__()
+        self.conv = create_conv(1, 2, 2)
+        self.conv.bias.data = torch.Tensor([0.3, 1.3])
+        self.conv.weight.data = torch.Tensor([[[[0.1, -2.0], [1.0, 0.1]]], [[[0.1, 2.0], [-1.0, 0.1]]]])
+        self.bn = create_bn(2)
+        self.bn.bias.data = torch.Tensor([0.1, 1.0])
+        self.bn.weight.data = torch.Tensor([0.2, 2.0])
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.bn(x)
+        return x
+
+
 class FCTestModel(nn.Module):
     INPUT_SIZE = [1, 1, 4, 4]
 

--- a/tests/torch/test_model_analyzer.py
+++ b/tests/torch/test_model_analyzer.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2024 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nncf.torch import wrap_model
+from nncf.torch.model_analyzer import get_fused_bias_value
+from nncf.torch.model_transformer import update_fused_bias
+from tests.post_training.test_templates.helpers import BiasConvBiasBNTestModel
+from tests.post_training.test_templates.helpers import ConvBNTestModel
+from tests.post_training.test_templates.helpers import ConvTestModel
+
+
+@pytest.mark.parametrize(
+    "model_cls, ref",
+    (
+        (ConvTestModel, [0.1000, 1.0000]),  # conv.bias
+        (ConvBNTestModel, [0.1000, 1.0000]),  # bn.bias
+        (BiasConvBiasBNTestModel, [0.1600, 3.6000]),  # conv.bias*bn.weight + bn.bias
+    ),
+)
+def test_get_fused_bias_value(model_cls, ref):
+    model = wrap_model(model_cls(), torch.ones(model_cls.INPUT_SIZE))
+
+    graph = model.nncf.get_graph()
+    target_node = graph.get_nodes_by_types("conv2d")[0]
+
+    bias = get_fused_bias_value(target_node, model)
+    assert torch.all(torch.isclose(bias, torch.tensor(ref)))
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    (
+        (ConvTestModel),  # conv.bias
+        (ConvBNTestModel),  # bn.bias
+        (BiasConvBiasBNTestModel),  # conv.bias*bn.weight + bn.bias
+    ),
+)
+def test_update_fused_bias(model_cls):
+    model = wrap_model(model_cls(), torch.ones(model_cls.INPUT_SIZE))
+    ref_new_bias = torch.tensor([-1.0, -1.0])
+    graph = model.nncf.get_graph()
+    target_node = graph.get_nodes_by_types("conv2d")[0]
+
+    update_fused_bias(target_node.node_name, ref_new_bias, model)
+    bias = get_fused_bias_value(target_node, model)
+    assert torch.all(torch.isclose(bias, ref_new_bias))
+
+    if model_cls == ConvTestModel:
+        assert torch.all(torch.isclose(model.conv.bias, ref_new_bias))
+    if model_cls == ConvBNTestModel:
+        assert model.conv.bias is None
+        assert torch.all(torch.isclose(model.bn.bias, ref_new_bias))
+    if model_cls == BiasConvBiasBNTestModel:
+        assert torch.all(torch.isclose(model.conv.bias, torch.tensor([0.3000, 1.3000])))
+        assert torch.all(torch.isclose(model.bn.bias, torch.tensor([-1.0600, -3.6000])))
+        assert torch.all(torch.isclose(model.conv.bias * model.bn.weight + model.bn.bias, ref_new_bias))


### PR DESCRIPTION
### Changes


Return bias value after fusing layer, only for conv+bn (other layers does not supported by PT FBC). 
It's temporal fix, working with bias and extracted model will be reworked in 129581.

### Reason for changes

Incorrect calculation bias shift magnitude
