### PR TITLE
[WC] Store weight scale in FP16

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -164,11 +164,12 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                 converted_const = opset.subtract(converted_const, converted_zero_point)
 
             scale_const = opset.constant(
-                compressed_weight.scale.data, dtype=const_dtype, name=f"{const_node_name}/scale"
+                compressed_weight.scale.data, dtype="float16", name=f"{const_node_name}/scale"
             )
+            scale_const_converted = opset.convert(scale_const, const_dtype)
             mul = opset.multiply(
                 converted_const,
-                scale_const,
+                scale_const_converted,
                 name=f"{const_node_name}/fq_weights_{wc_params.weight_port_id}",
             )
 


### PR DESCRIPTION
### Changes

Store weight scale constant in FP16 data type for consistency. Add a Convert node to convert FP16 scale to the original weight data type.
