### PR TITLE
Add quantize_with_accuracy_control example for ONNX backend

### DIFF
--- a/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/README.md
+++ b/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/README.md
@@ -1,0 +1,47 @@
+# Post-Training Quantization of YOLOv8 ONNX Model
+
+This example demonstrates how to use Post-Training Quantization API from Neural Network Compression Framework (NNCF) to quantize YOLOv8n ONNX model
+with accuracy control.
+
+The example includes the following steps:
+
+- Download and prepare COCO-128-seg dataset.
+- Quantize the model with accuracy control.
+- Measure accuracy and performance of the floating-point and quantized models.
+- Convert the resulted INT8 model to the OpenVINO format.
+
+## Install requirements
+
+To run the example you should install the corresponding Python dependencies:
+
+- Install NNCF from source:
+
+    ```bash
+    git clone https://github.com/openvinotoolkit/nncf.git
+    cd nncf
+    pip install .
+    ```
+
+- Install 3rd party dependencies of this example:
+
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+## Run Example
+
+The example is fully automated. Just run the following command in the prepared Python environment:
+
+```bash
+python main.py
+```
+
+Run the following command to convert resulted INT8 model to the OpenVINO format:
+
+```bash
+python deploy.py
+```
+
+## See also
+
+- [YOLOv8 Jupyter notebook](https://github.com/openvinotoolkit/openvino_notebooks/tree/main/notebooks/230-yolov8-optimization)

--- a/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/deploy.py
+++ b/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/deploy.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2024 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+import openvino as ov
+import torch
+from tqdm import tqdm
+from ultralytics.cfg import get_cfg
+from ultralytics.engine.validator import BaseValidator as Validator
+from ultralytics.models.yolo import YOLO
+from ultralytics.utils import DEFAULT_CFG
+from ultralytics.utils.metrics import ConfusionMatrix
+
+from examples.post_training_quantization.onnx.yolov8_quantize_with_accuracy_control.main import prepare_validation
+from examples.post_training_quantization.onnx.yolov8_quantize_with_accuracy_control.main import print_statistics
+
+ROOT = Path(__file__).parent.resolve()
+MODEL_NAME = "yolov8n-seg"
+FP32_ONNX_MODEL_PATH = ROOT / f"{MODEL_NAME}.onnx"
+INT8_ONNX_MODEL_PATH = ROOT / f"{MODEL_NAME}_int8.onnx"
+FP32_OV_MODEL_PATH = ROOT / f"{MODEL_NAME}.xml"
+INT8_OV_MODEL_PATH = ROOT / f"{MODEL_NAME}_int8.xml"
+
+
+def validate_ov_model(
+    ov_model: ov.Model,
+    data_loader: torch.utils.data.DataLoader,
+    validator: Validator,
+    num_samples: Optional[int] = None,
+) -> Tuple[Dict, int, int]:
+    validator.seen = 0
+    validator.jdict = []
+    validator.stats = []
+    validator.batch_i = 1
+    validator.confusion_matrix = ConfusionMatrix(nc=validator.nc)
+    compiled_model = ov.compile_model(ov_model)
+    num_outputs = len(compiled_model.outputs)
+    for batch_i, batch in enumerate(data_loader):
+        if num_samples is not None and batch_i == num_samples:
+            break
+        batch = validator.preprocess(batch)
+        results = compiled_model(batch["img"])
+        if num_outputs == 1:
+            preds = torch.from_numpy(results[compiled_model.output(0)])
+        else:
+            preds = [
+                torch.from_numpy(results[compiled_model.output(0)]),
+                torch.from_numpy(results[compiled_model.output(1)]),
+            ]
+        preds = validator.postprocess(preds)
+        validator.update_metrics(preds, batch)
+    stats = validator.get_stats()
+    return stats, validator.seen, validator.nt_per_class.sum()
+
+
+def run_benchmark(model_path: str, config) -> float:
+    command = f"benchmark_app -m {model_path} -d CPU -api async -t 30"
+    command += f' -shape "[1,3,{config.imgsz},{config.imgsz}]"'
+    cmd_output = subprocess.check_output(command, shell=True)  # nosec
+
+    match = re.search(r"Throughput\: (.+?) FPS", str(cmd_output))
+    return float(match.group(1))
+
+
+args = get_cfg(cfg=DEFAULT_CFG)
+args.data = "coco128-seg.yaml"
+
+print(f"[1/7] Save FP32 OpenVINO model: {FP32_OV_MODEL_PATH}")
+fp32_ov_model = ov.convert_model(FP32_ONNX_MODEL_PATH)
+ov.save_model(fp32_ov_model, FP32_OV_MODEL_PATH, compress_to_fp16=False)
+
+print(f"[2/7] Save INT8 OpenVINO model: {INT8_OV_MODEL_PATH}")
+int8_ov_model = ov.convert_model(INT8_ONNX_MODEL_PATH)
+ov.save_model(int8_ov_model, INT8_OV_MODEL_PATH, compress_to_fp16=False)
+
+print("[3/7] Benchmark FP32 OpenVINO model:", end=" ")
+fp32_fps = run_benchmark(FP32_OV_MODEL_PATH, args)
+print(f"{fp32_fps} FPS")
+
+print("[4/7] Benchmark INT8 OpenVINO model:", end=" ")
+int8_fps = run_benchmark(INT8_OV_MODEL_PATH, args)
+print(f"{int8_fps} FPS")
+
+validator, data_loader = prepare_validation(YOLO(ROOT / f"{MODEL_NAME}.pt"), args)
+
+print("[5/7] Validate OpenVINO FP32 model:")
+fp32_stats, total_images, total_objects = validate_ov_model(fp32_ov_model, tqdm(data_loader), validator)
+print_statistics(fp32_stats, total_images, total_objects)
+
+print("[6/7] Validate OpenVINO INT8 model:")
+int8_stats, total_images, total_objects = validate_ov_model(int8_ov_model, tqdm(data_loader), validator)
+print_statistics(int8_stats, total_images, total_objects)
+
+print("[7/7] Report:")
+box_metric_drop = fp32_stats["metrics/mAP50-95(B)"] - int8_stats["metrics/mAP50-95(B)"]
+mask_metric_drop = fp32_stats["metrics/mAP50-95(M)"] - int8_stats["metrics/mAP50-95(M)"]
+print(f"\tMetric drop mAP50-95(B): {box_metric_drop:.6f}")
+print(f"\tMetric drop mAP50-95(M): {mask_metric_drop:.6f}")
+print(f"\tPerformance speed up (throughput mode): {int8_fps / fp32_fps:.3f}")

--- a/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/requirements.txt
+++ b/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/requirements.txt
@@ -1,0 +1,3 @@
+ultralytics==8.0.170
+onnx>=1.12.0
+openvino-dev==2023.3

--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -75,13 +75,37 @@
         "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
         "accuracy_metrics": {
             "fp32_mAP": 0.44964819083938,
-            "int8_mAP": 0.4428344895334926,
-            "accuracy_drop": 0.006813701305887432
+            "int8_mAP": 0.4507030984145927,
+            "accuracy_drop": -0.0010549075752127046
         },
         "performance_metrics": {
             "fp32_fps": 134.48,
             "int8_fps": 274.58,
             "performance_speed_up": 2.0417906008328375
+        }
+    },
+    "post_training_quantization_onnx_yolo8_quantize_with_accuracy_control": {
+        "backend": "onnx",
+        "requirements": "examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/requirements.txt",
+        "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
+        "accuracy_metrics": {
+            "onnx_fp32_box_mAP": 0.44964819166629366,
+            "onnx_fp32_mask_mAP": 0.36509415038708726,
+            "onnx_int8_box_mAP": 0.45071569411799683,
+            "onnx_int8_mask_mAP": 0.36805097120147484,
+            "onnx_drop_box_mAP": -0.0010675024517031728,
+            "onnx_drop_mask_mAP": -0.002956820814387584,
+            "ov_fp32_box_mAP": 0.44964819083938,
+            "ov_fp32_mask_mAP": 0.36509979887281135,
+            "ov_int8_box_mAP": 0.4462460126164857,
+            "ov_int8_mask_mAP": 0.3631361727753598,
+            "ov_drop_box_mAP": 0.003402178222894292,
+            "ov_drop_mask_mAP": 0.001963626097451543
+        },
+        "performance_metrics": {
+            "ov_fp32_fps": 139.32,
+            "ov_int8_fps": 269.16,
+            "performance_speed_up": 1.9319552110249787
         }
     },
     "post_training_quantization_tensorflow_mobilenet_v2": {

--- a/tests/cross_fw/examples/run_example.py
+++ b/tests/cross_fw/examples/run_example.py
@@ -87,6 +87,34 @@ def post_training_quantization_openvino_yolo8_quantize_with_accuracy_control() -
     return format_results(results)
 
 
+def post_training_quantization_onnx_yolo8_quantize_with_accuracy_control() -> Dict[str, float]:
+    from examples.post_training_quantization.onnx.yolov8_quantize_with_accuracy_control.main import (
+        run_example as yolo8_main,
+    )
+
+    onnx_fp32_box_mAP, onnx_fp32_mask_mAP, onnx_int8_box_mAP, onnx_int8_mask_mAP = yolo8_main()
+
+    import examples.post_training_quantization.onnx.yolov8_quantize_with_accuracy_control.deploy as yolov8_deploy
+
+    return {
+        "onnx_fp32_box_mAP": onnx_fp32_box_mAP,
+        "onnx_fp32_mask_mAP": onnx_fp32_mask_mAP,
+        "onnx_int8_box_mAP": onnx_int8_box_mAP,
+        "onnx_int8_mask_mAP": onnx_int8_mask_mAP,
+        "onnx_drop_box_mAP": onnx_fp32_box_mAP - onnx_int8_box_mAP,
+        "onnx_drop_mask_mAP": onnx_fp32_mask_mAP - onnx_int8_mask_mAP,
+        "ov_fp32_box_mAP": yolov8_deploy.fp32_stats["metrics/mAP50-95(B)"],
+        "ov_fp32_mask_mAP": yolov8_deploy.fp32_stats["metrics/mAP50-95(M)"],
+        "ov_int8_box_mAP": yolov8_deploy.int8_stats["metrics/mAP50-95(B)"],
+        "ov_int8_mask_mAP": yolov8_deploy.int8_stats["metrics/mAP50-95(M)"],
+        "ov_drop_box_mAP": yolov8_deploy.box_metric_drop,
+        "ov_drop_mask_mAP": yolov8_deploy.mask_metric_drop,
+        "ov_fp32_fps": yolov8_deploy.fp32_fps,
+        "ov_int8_fps": yolov8_deploy.int8_fps,
+        "performance_speed_up": yolov8_deploy.int8_fps / yolov8_deploy.fp32_fps,
+    }
+
+
 def post_training_quantization_openvino_anomaly_stfpm_quantize_with_accuracy_control() -> Dict[str, float]:
     sys.path.append(
         str(


### PR DESCRIPTION
### Changes

- Add quantize_with_accuracy_control example for ONNX backend

### Changes

Add example for ONNX backend.

### Reason for changes

An example is needed to demonstrate how to use quantize_with_accuracy_control for the ONNX backend.

### Related tickets

Ref: 127606

### Tests

test_examples build
