### PR TITLE
Skip llm_tune_params test

### DIFF
--- a/tests/cross_fw/examples/run_example.py
+++ b/tests/cross_fw/examples/run_example.py
@@ -14,6 +14,8 @@ import sys
 from argparse import ArgumentParser
 from typing import Dict, Tuple
 
+import pytest
+
 from tests.shared.paths import PROJECT_ROOT
 
 
@@ -167,6 +169,7 @@ def llm_compression() -> Dict[str, float]:
 
 
 def llm_tune_params() -> Dict[str, float]:
+    pytest.xfail("ticket 133681")
     from examples.llm_compression.openvino.tiny_llama_find_hyperparams.main import main as llm_tune_params_main
 
     awq, ratio, group_size = llm_tune_params_main()


### PR DESCRIPTION
### Changes

Skip `llm_tune_params` test due to different in output for the same sentence (Runtime ticket 133681)

### Reason for changes

To fix nightly job

### Related tickets

132631

