### PR TITLE
[v2.9.0] Disable broken test in examples

### DIFF
--- a/tests/cross_fw/examples/run_example.py
+++ b/tests/cross_fw/examples/run_example.py
@@ -14,6 +14,8 @@ import sys
 from argparse import ArgumentParser
 from typing import Dict, Tuple
 
+import pytest
+
 from tests.shared.paths import PROJECT_ROOT
 
 
@@ -167,6 +169,7 @@ def llm_compression() -> Dict[str, float]:
 
 
 def llm_tune_params() -> Dict[str, float]:
+    pytest.xfail("ticket 133681")
     from examples.llm_compression.openvino.tiny_llama_find_hyperparams.main import main as llm_tune_params_main
 
     awq, ratio, group_size = llm_tune_params_main()

--- a/tests/cross_fw/examples/run_example.py
+++ b/tests/cross_fw/examples/run_example.py
@@ -14,8 +14,6 @@ import sys
 from argparse import ArgumentParser
 from typing import Dict, Tuple
 
-import pytest
-
 from tests.shared.paths import PROJECT_ROOT
 
 
@@ -169,7 +167,6 @@ def llm_compression() -> Dict[str, float]:
 
 
 def llm_tune_params() -> Dict[str, float]:
-    pytest.xfail("ticket 133681")
     from examples.llm_compression.openvino.tiny_llama_find_hyperparams.main import main as llm_tune_params_main
 
     awq, ratio, group_size = llm_tune_params_main()

--- a/tests/cross_fw/examples/test_examples.py
+++ b/tests/cross_fw/examples/test_examples.py
@@ -52,6 +52,9 @@ def test_examples(
     is_check_performance: bool,
     ov_version_override: str,
 ):
+    if example_name == "llm_tune_params":
+        pytest.xfail("ticket 133681")
+
     backend = example_params["backend"]
     skip_if_backend_not_selected(backend, backends_list)
     venv_path = create_venv_with_nncf(tmp_path, "pip_e_local", "venv", set([backend]))


### PR DESCRIPTION
### Changes

- Cherry-picked change from https://github.com/openvinotoolkit/nncf/pull/2513
- Cherry-picked change from https://github.com/openvinotoolkit/nncf/pull/2520

### Reason for changes

- Failed test_examples run 271 with 
`FAILED tests/cross_fw/examples/test_examples.py::test_examples[llm_tune_params] - assert 1.0 == 0.9 ± 2.0e-03`

### Related tickets

- 132634

### Tests

- N/A
