### PR TITLE
Enable llm_tune_params test

### DIFF
--- a/examples/llm_compression/openvino/tiny_llama_find_hyperparams/main.py
+++ b/examples/llm_compression/openvino/tiny_llama_find_hyperparams/main.py
@@ -220,8 +220,8 @@ def tiny_llama_transform_func(item, tokenizer, ov_model):  # <YOUR_TRANSFORMATIO
     position_ids = np.cumsum(attention_mask, axis=1) - 1
     position_ids[attention_mask == 0] = 1
     res = {
-        "input_ids": ov.Tensor(input_ids, input_ids.shape, input_dtypes["input_ids"]),
-        "attention_mask": ov.Tensor(attention_mask, attention_mask.shape, input_dtypes["attention_mask"]),
+        "input_ids": input_ids,
+        "attention_mask": attention_mask,
         "position_ids": position_ids.reshape(*attention_mask.shape),
     }
 

--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -182,8 +182,8 @@
         "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
         "accuracy_metrics": {
             "awq": true,
-            "ratio": 0.9,
-            "group_size": 128
+            "ratio": 1.0,
+            "group_size": 64
         }
     }
 }

--- a/tests/cross_fw/examples/test_examples.py
+++ b/tests/cross_fw/examples/test_examples.py
@@ -52,9 +52,6 @@ def test_examples(
     is_check_performance: bool,
     ov_version_override: str,
 ):
-    if example_name == "llm_tune_params":
-        pytest.xfail("ticket 133681")
-
     backend = example_params["backend"]
     skip_if_backend_not_selected(backend, backends_list)
     venv_path = create_venv_with_nncf(tmp_path, "pip_e_local", "venv", set([backend]))


### PR DESCRIPTION
### Changes

Fix problem with inputs in `tiny_llama_find_hyperparams` example and remove xfail for `llm_tune_params` test
test_examples job: 274

### Reason for changes

Enable test in nightly validation

### Related tickets

132631

### Tests

Enable `llm_tune_params` test
