### PR TITLE
[Torch] tabulate is removed from torch examples requirements

### DIFF
--- a/examples/torch/requirements.txt
+++ b/examples/torch/requirements.txt
@@ -3,7 +3,6 @@ pillow>=8.0.1
 tensorboard>=2.1
 matplotlib>=3.3.3
 defusedxml>=0.7.0rc1
-tabulate~=0.9.0
 opencv-python>=4.4.0.46
 torch==2.2.1
 torchvision==0.17.1


### PR DESCRIPTION
### Changes

tabulate is removed from torch examples requirements

### Reason for changes

Redundant requirements is removed



