### PR TITLE
Port `.take` functionality for Good First Issues from OpenVINO repository

### DIFF
--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -1,0 +1,23 @@
+name: Take Issue
+
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+
+jobs:
+  take-issue:
+    name: Take issue
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    timeout-minutes: 10
+    steps:
+      - name: take an issue
+        uses: bdougie/take-action@v1.6.1
+        with:
+          message: Thank you for looking into this issue! Please let us know if you have any questions or require any help.
+          issueCurrentlyAssignedMessage: Thanks for being interested in this issue. It looks like this ticket is already assigned to a contributor. Please communicate with the assigned contributor to confirm the status of the issue.
+          trigger: .take
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changes / Reason for changes

Merging this workflow allows open source contributors to comment .take under a Good First Issue and automatically pick it up. The community is already accustomed to that and currently it does not work in NNCF GFIs.

### Related tickets

N/A

### Tests

`.take` has been proven to be a convenient feature for both project maintainers and open source contributors. Here it is in OpenVINO repo: https://github.com/openvinotoolkit/openvino/blob/master/.github/workflows/assign_issue.yml.
