### PR TITLE
[PTQ] Extend layers list for BiasCorrection

### DIFF
--- a/nncf/openvino/graph/metatypes/groups.py
+++ b/nncf/openvino/graph/metatypes/groups.py
@@ -183,12 +183,13 @@ OPERATIONS_WITH_CONST_PORT_ID = [
 
 
 # Contains the operation metatypes for which bias can be applied.
-OPERATIONS_WITH_BIAS = [
+# Limited operations scope
+OPERATIONS_WITH_BIAS_REDUCED = [
     ov_metatypes.OVConvolutionMetatype,
-    # TODO: add all metatypes with bias
     ov_metatypes.OVMatMulMetatype,
 ]
 
+OPERATIONS_WITH_BIAS = [*OPERATIONS_WITH_BIAS_REDUCED, ov_metatypes.OVDepthwiseConvolutionMetatype]
 
 CONV_OPERATIONS = [
     ov_metatypes.OVConvolutionMetatype,

--- a/nncf/openvino/graph/metatypes/groups.py
+++ b/nncf/openvino/graph/metatypes/groups.py
@@ -189,7 +189,7 @@ OPERATIONS_WITH_BIAS_REDUCED = [
     ov_metatypes.OVMatMulMetatype,
 ]
 
-OPERATIONS_WITH_BIAS = [*OPERATIONS_WITH_BIAS_REDUCED, ov_metatypes.OVDepthwiseConvolutionMetatype]
+OPERATIONS_WITH_BIAS = [*OPERATIONS_WITH_BIAS_REDUCED]
 
 CONV_OPERATIONS = [
     ov_metatypes.OVConvolutionMetatype,

--- a/nncf/openvino/graph/metatypes/groups.py
+++ b/nncf/openvino/graph/metatypes/groups.py
@@ -189,7 +189,7 @@ OPERATIONS_WITH_BIAS_REDUCED = [
     ov_metatypes.OVMatMulMetatype,
 ]
 
-OPERATIONS_WITH_BIAS = [*OPERATIONS_WITH_BIAS_REDUCED]
+OPERATIONS_WITH_BIAS = [*OPERATIONS_WITH_BIAS_REDUCED, ov_metatypes.OVDepthwiseConvolutionMetatype]
 
 CONV_OPERATIONS = [
     ov_metatypes.OVConvolutionMetatype,

--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -44,17 +44,20 @@ from nncf.openvino.graph.metatypes.openvino_metatypes import get_node_metatype
 InplaceInsertionFnType = Callable[[ov.Node, int], ov.Node]
 
 
-def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+def is_node_with_bias(
+    node: NNCFNode, nncf_graph: NNCFGraph, metatypes_with_bias: List[OVOpMetatype] = OPERATIONS_WITH_BIAS
+) -> bool:
     """
     Checks if the node has a bias or not.
 
     :param node: The node to check.
     :param nncf_graph: NNCFGraph instance.
+    :param metatypes_with_bias: List of the metatypes that contains biases.
     :return: Return `True` if `node` corresponds to the operation
         with bias (bias is added to the output tensor of that operation),
         `False` otherwise.
     """
-    if node.metatype not in OPERATIONS_WITH_BIAS:
+    if node.metatype not in metatypes_with_bias:
         return False
 
     add_node = nncf_graph.get_next_nodes(node)[0]

--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -44,7 +44,9 @@ from nncf.openvino.graph.metatypes.openvino_metatypes import get_node_metatype
 InplaceInsertionFnType = Callable[[ov.Node, int], ov.Node]
 
 
-def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph, metatypes_with_bias: Optional[List[OVOpMetatype]]) -> bool:
+def is_node_with_bias(
+    node: NNCFNode, nncf_graph: NNCFGraph, metatypes_with_bias: Optional[List[OVOpMetatype]] = None
+) -> bool:
     """
     Checks if the node has a bias or not.
 

--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -44,9 +44,7 @@ from nncf.openvino.graph.metatypes.openvino_metatypes import get_node_metatype
 InplaceInsertionFnType = Callable[[ov.Node, int], ov.Node]
 
 
-def is_node_with_bias(
-    node: NNCFNode, nncf_graph: NNCFGraph, metatypes_with_bias: List[OVOpMetatype] = OPERATIONS_WITH_BIAS
-) -> bool:
+def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph, metatypes_with_bias: Optional[List[OVOpMetatype]]) -> bool:
     """
     Checks if the node has a bias or not.
 
@@ -57,6 +55,9 @@ def is_node_with_bias(
         with bias (bias is added to the output tensor of that operation),
         `False` otherwise.
     """
+    if metatypes_with_bias is None:
+        metatypes_with_bias = OPERATIONS_WITH_BIAS
+
     if node.metatype not in metatypes_with_bias:
         return False
 

--- a/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
@@ -20,6 +20,7 @@ from nncf.common.graph.transformations.commands import TargetType
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
 from nncf.experimental.tensor import Tensor
 from nncf.openvino.graph.metatypes.groups import FAKE_QUANTIZE_OPERATIONS
+from nncf.openvino.graph.metatypes.groups import OPERATIONS_WITH_BIAS_REDUCED
 from nncf.openvino.graph.node_utils import get_bias_value
 from nncf.openvino.graph.node_utils import is_node_with_bias
 from nncf.openvino.graph.transformations.command_creation import OVCommandCreator
@@ -95,7 +96,7 @@ class OVFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
 
     @staticmethod
     def is_node_with_bias(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
-        return is_node_with_bias(node, nncf_graph)
+        return is_node_with_bias(node, nncf_graph, OPERATIONS_WITH_BIAS_REDUCED)
 
     @staticmethod
     def get_node_names_for_input_output_statistics(node: NNCFNode, nncf_graph: NNCFGraph) -> Tuple[str, str]:

--- a/nncf/quantization/quantize_model.py
+++ b/nncf/quantization/quantize_model.py
@@ -44,7 +44,7 @@ def quantize(
     preset: Optional[QuantizationPreset] = None,
     target_device: TargetDevice = TargetDevice.ANY,
     subset_size: int = 300,
-    fast_bias_correction: bool = False,
+    fast_bias_correction: bool = True,
     model_type: Optional[ModelType] = None,
     ignored_scope: Optional[IgnoredScope] = None,
     advanced_parameters: Optional[AdvancedQuantizationParameters] = None,

--- a/nncf/quantization/quantize_model.py
+++ b/nncf/quantization/quantize_model.py
@@ -44,7 +44,7 @@ def quantize(
     preset: Optional[QuantizationPreset] = None,
     target_device: TargetDevice = TargetDevice.ANY,
     subset_size: int = 300,
-    fast_bias_correction: bool = True,
+    fast_bias_correction: bool = False,
     model_type: Optional[ModelType] = None,
     ignored_scope: Optional[IgnoredScope] = None,
     advanced_parameters: Optional[AdvancedQuantizationParameters] = None,

--- a/tests/post_training/data/ptq_reference_data.yaml
+++ b/tests/post_training/data/ptq_reference_data.yaml
@@ -151,7 +151,7 @@ timm/mobilenetv3_small_050_BC_backend_FP32:
 timm/mobilenetv3_small_050_BC_backend_ONNX:
   metric_value: 0.56496
 timm/mobilenetv3_small_050_BC_backend_OV:
-  metric_value: 0.52608
+  metric_value: 0.56476
 timm/regnetx_002_backend_CUDA_TORCH:
   metric_value: 0.67452
 timm/regnetx_002_backend_FP32:

--- a/tests/post_training/data/ptq_reference_data.yaml
+++ b/tests/post_training/data/ptq_reference_data.yaml
@@ -146,6 +146,10 @@ timm/mobilenetv3_small_050_backend_OV:
   metric_value: 0.42184
 timm/mobilenetv3_small_050_backend_TORCH:
   metric_value: 0.4291
+timm/mobilenetv3_small_050_BC_backend_ONNX:
+  metric_value: 0.56496
+timm/mobilenetv3_small_050_BC_backend_OV:
+  metric_value: 0.52608
 timm/regnetx_002_backend_CUDA_TORCH:
   metric_value: 0.67452
 timm/regnetx_002_backend_FP32:

--- a/tests/post_training/data/ptq_reference_data.yaml
+++ b/tests/post_training/data/ptq_reference_data.yaml
@@ -146,6 +146,8 @@ timm/mobilenetv3_small_050_backend_OV:
   metric_value: 0.42184
 timm/mobilenetv3_small_050_backend_TORCH:
   metric_value: 0.4291
+timm/mobilenetv3_small_050_BC_backend_FP32:
+  metric_value: 0.57906
 timm/mobilenetv3_small_050_BC_backend_ONNX:
   metric_value: 0.56496
 timm/mobilenetv3_small_050_BC_backend_OV:

--- a/tests/post_training/model_scope.py
+++ b/tests/post_training/model_scope.py
@@ -189,6 +189,16 @@ QUANTIZATION_MODELS = [
         "backends": ALL_PTQ_BACKENDS,
     },
     {
+        "reported_name": "timm/mobilenetv3_small_050_BC",
+        "model_id": "mobilenetv3_small_050",
+        "pipeline_cls": ImageClassificationTimm,
+        "compression_params": {
+            "preset": QuantizationPreset.MIXED,
+            "fast_bias_correction": False,
+        },
+        "backends": [BackendType.ONNX, BackendType.OV],
+    },
+    {
         "reported_name": "timm/regnetx_002",
         "model_id": "regnetx_002",
         "pipeline_cls": ImageClassificationTimm,


### PR DESCRIPTION
### Changes

- Extended OPERATIONS_WITH_BIAS for BiasCorrection algorithm;
- Extended conformance test scope with the `mobilenetv3` + BiasCorrection;

### Reason for changes

- List extension would allow us to restore accuracy for the specific models;
- To observe differences between BiasCorrection algorithms;

### Related tickets

- 133198

### Tests

- manual/post_training_quantization/326/ - passed
