### PR TITLE
Fixed netron visualization

### DIFF
--- a/nncf/experimental/common/graph/netron.py
+++ b/nncf/experimental/common/graph/netron.py
@@ -34,14 +34,13 @@ class Tags:
 class PortDesc:
     """
     Represents a port description in the computational graph.
-
     """
 
     def __init__(self, port_id: str, precision: str, shape: Optional[List[int]] = None):
         """
         :param port_id: The identifier of the port.
-        :param shape: The shape of the port. Defaults to an empty list if not provided.
-        :param precision: precision of the port expressed as ov dtype.
+        :param precision: Precision of the tensor corresponding to the port, either "fp32" or "i32".
+        :param shape: The shape of the tensor. Defaults to an empty list if not provided.
         """
         self.port_id = port_id
         if shape is None:
@@ -53,7 +52,7 @@ class PortDesc:
         """
         Converts the PortDesc object into an XML element.
 
-        :return: the Element representing the port in XML 
+        :return: The Element representing the port in XML
         """
         port = ET.Element(Tags.PORT, id=self.port_id, precision=self.precision)
 
@@ -67,7 +66,6 @@ class PortDesc:
 class NodeDesc:
     """
     Represents a node description in the computational graph.
-    
     """
 
     def __init__(
@@ -100,7 +98,7 @@ class NodeDesc:
         """
         Converts the NodeDesc object into an XML element.
 
-        :return: the Element representing the node in XML 
+        :return: The Element representing the node in XML
         """
         node = ET.Element(Tags.NODE, id=self.node_id, name=self.name, type=self.type)
         ET.SubElement(node, Tags.DATA, self.attrs)
@@ -121,16 +119,9 @@ class NodeDesc:
 class EdgeDesc:
     """
     Represents an edge description in the computational graph.
-
     """
 
-    def __init__(
-        self, 
-        from_node: str,
-        from_port: str,
-        to_node: str,
-        to_port: str
-    ):
+    def __init__(self, from_node: str, from_port: str, to_node: str, to_port: str):
         """
         :param from_node: The identifier of the source node.
         :param from_port: The identifier of the output port of the source node.
@@ -146,7 +137,7 @@ class EdgeDesc:
         """
         Converts the EdgeDesc object into an XML element.
 
-        :return: the Element representing the edge in XML 
+        :return: The Element representing the edge in XML
         """
         attrs = {
             "from-layer": self.from_node,
@@ -165,22 +156,17 @@ def convert_nncf_dtype_to_ov_dtype(dtype: Dtype) -> str:
     """
     Converts a nncf dtype to an openvino dtype string.
 
-    :param dtype: The data type to be converted. Should be one of the nncf Dtype.
+    :param dtype: The data type to be converted.
     :return: The openvino dtype string corresponding to the given data type.
     """
 
-    dummy_precision_map: Dict[Dtype, str] = {
-        Dtype.INTEGER: "i32",
-        Dtype.FLOAT: "f32"
-    }
+    dummy_precision_map: Dict[Dtype, str] = {Dtype.INTEGER: "i32", Dtype.FLOAT: "f32"}
 
     return dummy_precision_map[dtype]
 
 
 def get_graph_desc(
-    graph: NNCFGraph,
-    include_fq_params: bool = False,
-    get_attributes_fn: Optional[GET_ATTRIBUTES_FN_TYPE] = None
+    graph: NNCFGraph, include_fq_params: bool = False, get_attributes_fn: Optional[GET_ATTRIBUTES_FN_TYPE] = None
 ) -> Tuple[List[NodeDesc], List[EdgeDesc]]:
     """
     Retrieves descriptions of nodes and edges from an NNCFGraph.
@@ -191,9 +177,8 @@ def get_graph_desc(
         Defaults to a function returning {"metatype": str(x.metatype.name)}.
     :return: A tuple containing lists of NodeDesc and EdgeDesc objects
         representing the nodes and edges of the NNCFGraph.
-
     """
-    
+
     if get_attributes_fn is None:
         get_attributes_fn = lambda x: {
             "metatype": str(x.metatype.name),
@@ -227,7 +212,7 @@ def get_graph_desc(
                 PortDesc(
                     port_id=str(edge.input_port_id),
                     precision=convert_nncf_dtype_to_ov_dtype(edge.dtype),
-                    shape=edge.tensor_shape
+                    shape=edge.tensor_shape,
                 )
             )
 
@@ -237,7 +222,7 @@ def get_graph_desc(
                 PortDesc(
                     port_id=str(edge.output_port_id),
                     precision=convert_nncf_dtype_to_ov_dtype(edge.dtype),
-                    shape=edge.tensor_shape
+                    shape=edge.tensor_shape,
                 )
             )
 

--- a/nncf/experimental/common/graph/netron.py
+++ b/nncf/experimental/common/graph/netron.py
@@ -15,6 +15,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
+from nncf.common.graph.layer_attributes import Dtype
 
 
 class Tags:
@@ -31,7 +32,20 @@ class Tags:
 
 
 class PortDesc:
-    def __init__(self, port_id: str, shape: Optional[List[int]] = None, precision: str = None):
+    """
+    Represents a port description for a node in the computational graph.
+
+    Attributes:
+        port_id (str): The identifier of the port.
+        shape (Optional[List[int]]): The shape of the port. Defaults to an empty list if not provided.
+        precision (str): precision of the port expressed as ov dtype.
+
+    Methods:
+        as_xml_element() -> ET.Element:
+            Converts the PortDesc object into an XML element.
+    """
+
+    def __init__(self, port_id: str, precision: str, shape: Optional[List[int]] = None):
         self.port_id = port_id
         if shape is None:
             shape = []
@@ -39,9 +53,8 @@ class PortDesc:
         self.precision = precision
 
     def as_xml_element(self) -> ET.Element:
-        port = ET.Element(Tags.PORT, id=self.port_id)
-        if self.precision:
-            port.set("precision", self.precision)
+        port = ET.Element(Tags.PORT, id=self.port_id, precision=self.precision)
+
         for i in self.shape:
             dim = ET.Element(Tags.DIM)
             dim.text = str(i)
@@ -50,6 +63,22 @@ class PortDesc:
 
 
 class NodeDesc:
+    """
+    Represents a node description in the computational graph.
+
+    Attributes:
+        node_id (str): The identifier of the node.
+        name (str): The name of the node.
+        type (str): The type of the node.
+        attrs (Optional[Dict[str, str]]): Additional attributes of the node. Defaults to an empty dictionary if not provided.
+        inputs (Optional[List[PortDesc]]): List of input ports for the node.
+        outputs (Optional[List[PortDesc]]): List of output ports for the node.
+
+    Methods:
+        as_xml_element() -> ET.Element:
+            Converts the NodeDesc object into an XML element.
+    """
+
     def __init__(
         self,
         node_id: str,
@@ -86,7 +115,26 @@ class NodeDesc:
 
 
 class EdgeDesc:
-    def __init__(self, from_node: str, from_port: str, to_node: str, to_port: str):
+    """
+    Represents an edge description in the computational graph.
+
+    Attributes:
+        from_node (str): The identifier of the source node.
+        from_port (str): The identifier of the output port of the source node.
+        to_node (str): The identifier of the target node.
+        to_port (str): The identifier of the input port of the target node.
+
+    Methods:
+        as_xml_element() -> ET.Element:
+            Converts the EdgeDesc object into an XML element.
+    """
+
+    def __init__(
+        self, from_node: str,
+        from_port: str,
+        to_node: str,
+        to_port: str
+    ):
         self.from_node = from_node
         self.from_port = from_port
         self.to_node = to_node
@@ -106,10 +154,50 @@ class EdgeDesc:
 GET_ATTRIBUTES_FN_TYPE = Callable[[NNCFNode], Dict[str, str]]
 
 
-# TODO(andrey-churkin): Add support for `PortDesc.precision` param.
+def convert_dummy_precision(dtype: Dtype) -> str:
+    """
+    Converts a nncf dtype to a dummy openvino dtype string.
+
+    Parameters:
+    - dtype (Dtype): The data type to be converted. Should be one of the nncf Dtype.
+
+    Returns:
+    - str: The dummy openvino dtype string corresponding to the given data type.
+    """
+
+    dummy_precision_map: Dict[Dtype, str] = {
+        Dtype.INTEGER: "i32",
+        Dtype.FLOAT: "f32"
+    }
+
+    return dummy_precision_map[dtype]
+
+
 def get_graph_desc(
-    graph: NNCFGraph, include_fq_params: bool = False, get_attributes_fn: Optional[GET_ATTRIBUTES_FN_TYPE] = None
+    graph: NNCFGraph,
+    include_fq_params: bool = False,
+    get_attributes_fn: Optional[GET_ATTRIBUTES_FN_TYPE] = None
 ) -> Tuple[List[NodeDesc], List[EdgeDesc]]:
+    """
+    Retrieves descriptions of nodes and edges from an NNCFGraph.
+
+    Args:
+        graph (NNCFGraph): The NNCFGraph instance to extract descriptions from.
+        include_fq_params (bool): Whether to include FakeQuantize parameters in the description.
+        get_attributes_fn (Optional[GET_ATTRIBUTES_FN_TYPE]): A function to retrieve additional attributes for nodes.
+            Defaults to a function returning {"metatype": str(x.metatype.name)}.
+
+    Returns:
+        Tuple[List[NodeDesc], List[EdgeDesc]]: A tuple containing lists of NodeDesc and EdgeDesc objects
+        representing the nodes and edges of the NNCFGraph.
+
+    Notes:
+        The NodeDesc and EdgeDesc objects contain detailed information about nodes and edges, respectively.
+
+    Example:
+        nodes, edges = get_graph_desc(graph_instance)
+    """
+    
     if get_attributes_fn is None:
         get_attributes_fn = lambda x: {
             "metatype": str(x.metatype.name),
@@ -139,15 +227,21 @@ def get_graph_desc(
         for edge in graph.get_input_edges(node):
             if not include_fq_params and node.node_type == "FakeQuantize" and edge.input_port_id != 0:
                 continue
-
-            inputs.append(PortDesc(port_id=str(edge.input_port_id), shape=edge.tensor_shape))
+            inputs.append(
+                PortDesc(
+                    port_id=str(edge.input_port_id),
+                    precision=convert_dummy_precision(edge.dtype),
+                    shape=edge.tensor_shape
+                )
+            )
 
         outputs = []
         for edge in graph.get_output_edges(node):
             outputs.append(
                 PortDesc(
                     port_id=str(edge.output_port_id),
-                    shape=edge.tensor_shape,
+                    precision=convert_dummy_precision(edge.dtype),
+                    shape=edge.tensor_shape
                 )
             )
 
@@ -172,6 +266,25 @@ def save_for_netron(
     include_fq_params: bool = False,
     get_attributes_fn: Optional[GET_ATTRIBUTES_FN_TYPE] = None,
 ):
+    """
+    Save the NNCFGraph information in an onnx file suitable for visualization with Netron.
+
+    Args:
+        graph (NNCFGraph): The NNCFGraph instance to visualize.
+        save_path (str): The path to save the Netron-compatible file.
+        graph_name (str): The name of the graph. Defaults to "Graph".
+        include_fq_params (bool): Whether to include FakeQuantize parameters in the visualization.
+        get_attributes_fn (Optional[GET_ATTRIBUTES_FN_TYPE]): A function to retrieve additional attributes for nodes.
+            Defaults to a function returning {"metatype": str(x.metatype.name)}.
+
+    Notes:
+        This function uses the provided NNCFGraph instance to generate node and edge descriptions,
+        and then creates an XML representation suitable for Netron visualization.
+
+    Example:
+        save_for_netron(graph_instance, save_path="path/to/save/file.onnx", graph_name="MyGraph", include_fq_params=True)
+    """
+
     node_descs, edge_descs = get_graph_desc(graph, include_fq_params, get_attributes_fn)
 
     net = ET.Element(Tags.NET, name=graph_name)

--- a/nncf/experimental/common/graph/netron.py
+++ b/nncf/experimental/common/graph/netron.py
@@ -33,19 +33,16 @@ class Tags:
 
 class PortDesc:
     """
-    Represents a port description for a node in the computational graph.
+    Represents a port description in the computational graph.
 
-    Attributes:
-        port_id (str): The identifier of the port.
-        shape (Optional[List[int]]): The shape of the port. Defaults to an empty list if not provided.
-        precision (str): precision of the port expressed as ov dtype.
-
-    Methods:
-        as_xml_element() -> ET.Element:
-            Converts the PortDesc object into an XML element.
     """
 
     def __init__(self, port_id: str, precision: str, shape: Optional[List[int]] = None):
+        """
+        :param port_id: The identifier of the port.
+        :param shape: The shape of the port. Defaults to an empty list if not provided.
+        :param precision: precision of the port expressed as ov dtype.
+        """
         self.port_id = port_id
         if shape is None:
             shape = []
@@ -53,6 +50,11 @@ class PortDesc:
         self.precision = precision
 
     def as_xml_element(self) -> ET.Element:
+        """
+        Converts the PortDesc object into an XML element.
+
+        :return: the Element representing the port in XML 
+        """
         port = ET.Element(Tags.PORT, id=self.port_id, precision=self.precision)
 
         for i in self.shape:
@@ -65,18 +67,7 @@ class PortDesc:
 class NodeDesc:
     """
     Represents a node description in the computational graph.
-
-    Attributes:
-        node_id (str): The identifier of the node.
-        name (str): The name of the node.
-        type (str): The type of the node.
-        attrs (Optional[Dict[str, str]]): Additional attributes of the node. Default empty dictionary.
-        inputs (Optional[List[PortDesc]]): List of input ports for the node.
-        outputs (Optional[List[PortDesc]]): List of output ports for the node.
-
-    Methods:
-        as_xml_element() -> ET.Element:
-            Converts the NodeDesc object into an XML element.
+    
     """
 
     def __init__(
@@ -88,6 +79,14 @@ class NodeDesc:
         inputs: Optional[List[PortDesc]] = None,
         outputs: Optional[List[PortDesc]] = None,
     ):
+        """
+        :param node_id: The identifier of the node.
+        :param name: The name of the node.
+        :param type: The type of the node.
+        :param attrs: Additional attributes of the node. Default empty dictionary.
+        :param inputs: List of input ports for the node.
+        :param outputs: List of output ports for the node.
+        """
         self.node_id = node_id
         self.name = name
         self.type = node_type
@@ -98,6 +97,11 @@ class NodeDesc:
         self.outputs = outputs
 
     def as_xml_element(self) -> ET.Element:
+        """
+        Converts the NodeDesc object into an XML element.
+
+        :return: the Element representing the node in XML 
+        """
         node = ET.Element(Tags.NODE, id=self.node_id, name=self.name, type=self.type)
         ET.SubElement(node, Tags.DATA, self.attrs)
 
@@ -118,29 +122,32 @@ class EdgeDesc:
     """
     Represents an edge description in the computational graph.
 
-    Attributes:
-        from_node (str): The identifier of the source node.
-        from_port (str): The identifier of the output port of the source node.
-        to_node (str): The identifier of the target node.
-        to_port (str): The identifier of the input port of the target node.
-
-    Methods:
-        as_xml_element() -> ET.Element:
-            Converts the EdgeDesc object into an XML element.
     """
 
     def __init__(
-        self, from_node: str,
+        self, 
+        from_node: str,
         from_port: str,
         to_node: str,
         to_port: str
     ):
+        """
+        :param from_node: The identifier of the source node.
+        :param from_port: The identifier of the output port of the source node.
+        :param to_node: The identifier of the target node.
+        :param to_port: The identifier of the input port of the target node.
+        """
         self.from_node = from_node
         self.from_port = from_port
         self.to_node = to_node
         self.to_port = to_port
 
     def as_xml_element(self) -> ET.Element:
+        """
+        Converts the EdgeDesc object into an XML element.
+
+        :return: the Element representing the edge in XML 
+        """
         attrs = {
             "from-layer": self.from_node,
             "from-port": self.from_port,
@@ -154,15 +161,12 @@ class EdgeDesc:
 GET_ATTRIBUTES_FN_TYPE = Callable[[NNCFNode], Dict[str, str]]
 
 
-def convert_dummy_precision(dtype: Dtype) -> str:
+def convert_nncf_dtype_to_ov_dtype(dtype: Dtype) -> str:
     """
-    Converts a nncf dtype to a dummy openvino dtype string.
+    Converts a nncf dtype to an openvino dtype string.
 
-    Parameters:
-    - dtype (Dtype): The data type to be converted. Should be one of the nncf Dtype.
-
-    Returns:
-    - str: The dummy openvino dtype string corresponding to the given data type.
+    :param dtype: The data type to be converted. Should be one of the nncf Dtype.
+    :return: The openvino dtype string corresponding to the given data type.
     """
 
     dummy_precision_map: Dict[Dtype, str] = {
@@ -181,21 +185,13 @@ def get_graph_desc(
     """
     Retrieves descriptions of nodes and edges from an NNCFGraph.
 
-    Args:
-        graph (NNCFGraph): The NNCFGraph instance to extract descriptions from.
-        include_fq_params (bool): Whether to include FakeQuantize parameters in the description.
-        get_attributes_fn (Optional[GET_ATTRIBUTES_FN_TYPE]): A function to retrieve additional attributes for nodes.
-            Defaults to a function returning {"metatype": str(x.metatype.name)}.
-
-    Returns:
-        Tuple[List[NodeDesc], List[EdgeDesc]]: A tuple containing lists of NodeDesc and EdgeDesc objects
+    :param graph: The NNCFGraph instance to extract descriptions from.
+    :param include_fq_params: Whether to include FakeQuantize parameters in the description.
+    :param get_attributes_fn: A function to retrieve additional attributes for nodes.
+        Defaults to a function returning {"metatype": str(x.metatype.name)}.
+    :return: A tuple containing lists of NodeDesc and EdgeDesc objects
         representing the nodes and edges of the NNCFGraph.
 
-    Notes:
-        The NodeDesc and EdgeDesc objects contain detailed information about nodes and edges, respectively.
-
-    Example:
-        nodes, edges = get_graph_desc(graph_instance)
     """
     
     if get_attributes_fn is None:
@@ -230,7 +226,7 @@ def get_graph_desc(
             inputs.append(
                 PortDesc(
                     port_id=str(edge.input_port_id),
-                    precision=convert_dummy_precision(edge.dtype),
+                    precision=convert_nncf_dtype_to_ov_dtype(edge.dtype),
                     shape=edge.tensor_shape
                 )
             )
@@ -240,7 +236,7 @@ def get_graph_desc(
             outputs.append(
                 PortDesc(
                     port_id=str(edge.output_port_id),
-                    precision=convert_dummy_precision(edge.dtype),
+                    precision=convert_nncf_dtype_to_ov_dtype(edge.dtype),
                     shape=edge.tensor_shape
                 )
             )
@@ -267,22 +263,14 @@ def save_for_netron(
     get_attributes_fn: Optional[GET_ATTRIBUTES_FN_TYPE] = None,
 ):
     """
-    Save the NNCFGraph information in an onnx file suitable for visualization with Netron.
+    Save the NNCFGraph information in an XML file suitable for visualization with Netron.
 
-    Args:
-        graph (NNCFGraph): The NNCFGraph instance to visualize.
-        save_path (str): The path to save the Netron-compatible file.
-        graph_name (str): The name of the graph. Defaults to "Graph".
-        include_fq_params (bool): Whether to include FakeQuantize parameters in the visualization.
-        get_attributes_fn (Optional[GET_ATTRIBUTES_FN_TYPE]): A function to retrieve additional attributes for nodes.
-            Defaults to a function returning {"metatype": str(x.metatype.name)}.
-
-    Notes:
-        This function uses the provided NNCFGraph instance to generate node and edge descriptions,
-        and then creates an XML representation suitable for Netron visualization.
-
-    Example:
-        save_for_netron(graph_instance, save_path="path/to/save/file.onnx", graph_name="MyGraph", include_fq_params=True)
+    :param graph: The NNCFGraph instance to visualize.
+    :param save_path: The path to save the Netron-compatible file.
+    :param graph_name: The name of the graph. Defaults to "Graph".
+    :param include_fq_params: Whether to include FakeQuantize parameters in the visualization.
+    :param get_attributes_fn: A function to retrieve additional attributes for nodes.
+        Defaults to a function returning {"metatype": str(x.metatype.name)}.
     """
 
     node_descs, edge_descs = get_graph_desc(graph, include_fq_params, get_attributes_fn)

--- a/nncf/experimental/common/graph/netron.py
+++ b/nncf/experimental/common/graph/netron.py
@@ -70,7 +70,7 @@ class NodeDesc:
         node_id (str): The identifier of the node.
         name (str): The name of the node.
         type (str): The type of the node.
-        attrs (Optional[Dict[str, str]]): Additional attributes of the node. Defaults to an empty dictionary if not provided.
+        attrs (Optional[Dict[str, str]]): Additional attributes of the node. Default empty dictionary.
         inputs (Optional[List[PortDesc]]): List of input ports for the node.
         outputs (Optional[List[PortDesc]]): List of output ports for the node.
 

--- a/tests/common/experimental/test_netron.py
+++ b/tests/common/experimental/test_netron.py
@@ -1,0 +1,119 @@
+import xml.etree.ElementTree as ET  # nosec
+from dataclasses import dataclass
+from typing import Optional
+
+from nncf.experimental.common.graph.netron import get_graph_desc, convert_dummy_precision, EdgeDesc, NodeDesc, PortDesc, Tags, GET_ATTRIBUTES_FN_TYPE
+from tests.common.quantization.mock_graphs import get_two_branch_mock_model_graph
+
+import pytest
+
+@dataclass
+class GraphDescTestCase:
+    include_fq_params: Optional[bool]
+    get_attributes_fn: GET_ATTRIBUTES_FN_TYPE
+
+GRAPH_DESC_TEST_CASES = [
+    GraphDescTestCase(
+        include_fq_params = False,
+        get_attributes_fn = None
+    ),
+
+    GraphDescTestCase(
+        include_fq_params = True,
+        get_attributes_fn = None
+    ),
+
+    GraphDescTestCase(
+        include_fq_params = True,
+        get_attributes_fn = lambda x: {
+            "name": x.node_name,
+            "type": x.node_type
+        } 
+    )
+]
+
+@pytest.mark.parametrize(
+    "graph_desc_test_case",
+    GRAPH_DESC_TEST_CASES,
+)
+def test_get_graph_desc(graph_desc_test_case: GraphDescTestCase):
+    include_fq_params = graph_desc_test_case.include_fq_params
+    get_attributes_fn = graph_desc_test_case.get_attributes_fn
+    
+    nncf_graph = get_two_branch_mock_model_graph()
+
+    edges = list(nncf_graph.get_all_edges())
+    nodes = list(nncf_graph.get_all_nodes())
+
+    node_desc_list, edges_desc_list = get_graph_desc(nncf_graph, include_fq_params, get_attributes_fn)
+
+    assert all(isinstance(node_desc, NodeDesc) for node_desc in node_desc_list)
+    assert all(isinstance(edge_desc, EdgeDesc) for edge_desc in edges_desc_list)
+
+    assert len(node_desc_list) == len(nodes)
+    assert len(edges_desc_list) == len(edges)
+
+    if get_attributes_fn is not None:
+        assert all([node_desc.attrs == get_attributes_fn(node) for node, node_desc in zip(nodes, node_desc_list)])
+
+
+def test_edge_desc():
+    nncf_graph = get_two_branch_mock_model_graph()
+
+    for edge in nncf_graph.get_all_edges():
+
+        edgeDesc = EdgeDesc(
+            from_node=str(edge.from_node.node_id),
+            from_port=str(edge.output_port_id),
+            to_node=str(edge.to_node.node_id),
+            to_port=str(edge.input_port_id),
+        )
+
+        xmlElement = edgeDesc.as_xml_element()
+
+        assert isinstance(xmlElement, ET.Element)
+        assert xmlElement.tag == Tags.EDGE
+        assert xmlElement.attrib["from-layer"] == str(edge.from_node.node_id)
+        assert xmlElement.attrib["from-port"] == str(edge.output_port_id)
+        assert xmlElement.attrib["to-layer"] == str(edge.to_node.node_id)
+        assert xmlElement.attrib["to-port"] == str(edge.input_port_id)
+
+
+def test_node_desc():
+    nncf_graph = get_two_branch_mock_model_graph()
+
+    for node in nncf_graph.get_all_nodes():
+        nodeDesc = NodeDesc(
+            node_id=str(node.node_id),
+            name=node.node_name,
+            node_type=node.node_type.title(),
+        )
+
+        xmlElement = nodeDesc.as_xml_element()
+
+        assert isinstance(xmlElement, ET.Element)
+        assert xmlElement.tag == Tags.NODE
+        assert xmlElement.attrib["id"] == str(node.node_id)
+        assert xmlElement.attrib["name"] == node.node_name
+        assert xmlElement.attrib["type"] == node.node_type.title()
+        assert all([child.tag == Tags.DATA for child in xmlElement])
+
+
+def test_port_desc():
+    nncf_graph = get_two_branch_mock_model_graph()
+
+    for edge in nncf_graph.get_all_edges():
+        portDesc = PortDesc(
+            port_id=str(edge.input_port_id),
+            precision=convert_dummy_precision(edge.dtype),
+            shape=edge.tensor_shape
+        )
+
+        xmlElement = portDesc.as_xml_element()
+
+        assert xmlElement.tag == Tags.PORT
+        assert xmlElement.attrib["id"] == str(edge.input_port_id)
+        assert xmlElement.attrib["precision"] == convert_dummy_precision(edge.dtype)
+        assert all([child.tag == Tags.DIM for child in xmlElement])
+        assert all([str(edge_shape) == port_shape.text for edge_shape, port_shape in zip(edge.tensor_shape, xmlElement)])
+        

--- a/tests/common/experimental/test_netron.py
+++ b/tests/common/experimental/test_netron.py
@@ -1,3 +1,14 @@
+# Copyright (c) 2024 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
 import xml.etree.ElementTree as ET  # nosec
 from dataclasses import dataclass
 from typing import Optional

--- a/tests/common/experimental/test_netron.py
+++ b/tests/common/experimental/test_netron.py
@@ -13,7 +13,7 @@ import xml.etree.ElementTree as ET  # nosec
 from dataclasses import dataclass
 from typing import Optional
 
-from nncf.experimental.common.graph.netron import get_graph_desc, convert_dummy_precision, EdgeDesc, NodeDesc, PortDesc, Tags, GET_ATTRIBUTES_FN_TYPE
+from nncf.experimental.common.graph.netron import get_graph_desc, convert_nncf_dtype_to_ov_dtype, EdgeDesc, NodeDesc, PortDesc, Tags, GET_ATTRIBUTES_FN_TYPE
 from tests.common.quantization.mock_graphs import get_two_branch_mock_model_graph
 
 import pytest
@@ -116,7 +116,7 @@ def test_port_desc():
     for edge in nncf_graph.get_all_edges():
         portDesc = PortDesc(
             port_id=str(edge.input_port_id),
-            precision=convert_dummy_precision(edge.dtype),
+            precision=convert_nncf_dtype_to_ov_dtype(edge.dtype),
             shape=edge.tensor_shape
         )
 
@@ -124,7 +124,7 @@ def test_port_desc():
 
         assert xmlElement.tag == Tags.PORT
         assert xmlElement.attrib["id"] == str(edge.input_port_id)
-        assert xmlElement.attrib["precision"] == convert_dummy_precision(edge.dtype)
+        assert xmlElement.attrib["precision"] == convert_nncf_dtype_to_ov_dtype(edge.dtype)
         assert all([child.tag == Tags.DIM for child in xmlElement])
         assert all([str(edge_shape) == port_shape.text for edge_shape, port_shape in zip(edge.tensor_shape, xmlElement)])
         


### PR DESCRIPTION
### Changes

This PR solves #2552 by fixing the Netron visualization. The function `save_for_netron` now produces an XML file that can be correctly opened by Netron. To achieve this, a dummy `dtype` conversion has been introduced, as discussed in #2552. This conversion maps the nncf dtype `Dtype.FLOAT` to `f32` and `DType.INTEGER` to `i32`.

The `precision` parameter of the class `PortDesc` now is no longer optional as it's always available and it's necessary to produce a working XML file.

In addition, I added a docstring for all the functions/classes and implemented tests for the following methods:

- `get_graph_desc()`
- `PortDesc.as_xml_element()`
- `NodeDesc.as_xml_element()`
- `EdgeDesc.as_xml_element()`
 

### Reason for changes

<!--- Why should the change be applied -->
It was not possible to open XML files produced by the function `save_for_netron` due to the error: `Error loading OpenVINO model. Unsupported precision 'undefined'`

### Related tickets

N/A

### Tests

To validate the accuracy of the modifications, I created Netron XML files from multiple ONNX models. The visualization of these models in Netron was successful, confirming the effectiveness of the changes.

