### PR TITLE
Use latest optimum to not call deprecated shared_memory API

### DIFF
--- a/tests/post_training/pipelines/causal_language_model.py
+++ b/tests/post_training/pipelines/causal_language_model.py
@@ -25,7 +25,9 @@ class CausalLMHF(PTQTestPipeline):
 
     def prepare_model(self) -> None:
         if self.backend in OV_BACKENDS + [BackendType.FP32]:
-            self.model_hf = OVModelForCausalLM.from_pretrained(self.model_id, export=True, compile=False)
+            self.model_hf = OVModelForCausalLM.from_pretrained(
+                self.model_id, export=True, compile=False, stateful=False
+            )
             self.model = self.model_hf.model
             ov.serialize(self.model, self.fp32_model_dir / "model_fp32.xml")
 

--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -8,8 +8,8 @@ onnxruntime==1.14.1
 pytest==8.0.2
 pytest-cov
 openvino-dev==2024.0.0
-optimum[onnxruntime,openvino]==1.16.0
-optimum-intel @ git+https://github.com/huggingface/optimum-intel@622f585962e5e0ff5f927fd1a96fbc02b60a2e65
+optimum[onnxruntime,openvino]==1.17.1
+optimum-intel==1.15.2
 whowhatbench @ git+https://github.com/andreyanufr/who_what_benchmark@456d3584ce628f6c8605f37cd9a3ab2db1ebf933
 soundfile==0.12.1
 librosa==0.10.0


### PR DESCRIPTION
### Changes

use the latest release of optimum-intel==1.15.2

### Reason for changes

The previously used version of optimum had a call of deprecated API that was removed in 2024 release of OpenVINO.
https://github.com/openvinotoolkit/openvino/issues/21979

```
outputs = self.request(inputs, shared_memory=True)
```
Latest optimum migrated to the actual API.

### Related tickets

n/a

### Tests

- [x] weight compression conformance (local run) 
- [x] weight compression conformance (CI build 32)
- [x] ptq conformance build (CI build 331)
- [x] single test job for failing GPTCausal model 6314
