### PR TITLE
Use tabulate instead of texttable

### DIFF
--- a/examples/quantization_aware_training/torch/resnet18/main.py
+++ b/examples/quantization_aware_training/torch/resnet18/main.py
@@ -27,11 +27,11 @@ import torchvision.datasets as datasets
 import torchvision.models as models
 import torchvision.transforms as transforms
 from fastdownload import FastDownload
-from tabulate import tabulate
 from torch.jit import TracerWarning
 
 import nncf
 from nncf.common.logging.track_progress import track
+from nncf.common.utils.helpers import create_table
 
 warnings.filterwarnings("ignore", category=TracerWarning)
 warnings.filterwarnings("ignore", category=UserWarning)
@@ -303,32 +303,23 @@ def main():
     ###############################################################################
     # Step 6: Summary
     print(os.linesep + "[Step 6] Summary")
-    print(
-        tabulate(
-            headers=["", "FP32", "INT8", "Summary"],
-            tabular_data=[
-                [
-                    "Accuracy@1",
-                    f"{acc1_fp32:.3f}",
-                    f"{acc1_int8:.3f}",
-                    f"{acc1_int8_init:.3f} (init) + {acc1_int8 - acc1_int8_init:.3f} (tuned)",
-                ],
-                [
-                    "Model Size, Mb",
-                    f"{fp32_model_size:.3f}",
-                    f"{int8_model_size:.3f}",
-                    f"Compression rate is {fp32_model_size / int8_model_size:.3f}",
-                ],
-                [
-                    "Performance, FPS",
-                    f"{fp32_fps:.1f} FPS",
-                    f"{int8_fps:.1f} FPS",
-                    f"Speedup x{int8_fps / fp32_fps:.3f}",
-                ],
-            ],
-            tablefmt="rounded_outline",
-        )
-    )
+    tabular_data = [
+        [
+            "Accuracy@1",
+            acc1_fp32,
+            acc1_int8,
+            f"{acc1_int8_init:.3f} (init) + {acc1_int8 - acc1_int8_init:.3f} (tuned)",
+        ],
+        [
+            "Model Size, Mb",
+            fp32_model_size,
+            int8_model_size,
+            f"Compression rate is {fp32_model_size / int8_model_size:.3f}",
+        ],
+        ["Performance, FPS", fp32_fps, int8_fps, f"Speedup x{int8_fps / fp32_fps:.3f}"],
+    ]
+    print(create_table(["", "FP32", "INT8", "Summary"], tabular_data))
+
     return acc1_fp32, acc1_int8_init, acc1_int8, fp32_fps, int8_fps, fp32_model_size, int8_model_size
 
 

--- a/examples/quantization_aware_training/torch/resnet18/main.py
+++ b/examples/quantization_aware_training/torch/resnet18/main.py
@@ -27,7 +27,7 @@ import torchvision.datasets as datasets
 import torchvision.models as models
 import torchvision.transforms as transforms
 from fastdownload import FastDownload
-from texttable import Texttable
+from tabulate import tabulate
 from torch.jit import TracerWarning
 
 import nncf
@@ -303,28 +303,32 @@ def main():
     ###############################################################################
     # Step 6: Summary
     print(os.linesep + "[Step 6] Summary")
-
-    table = Texttable()
-    table.header(["", "FP32", "INT8", "Summary"])
-    table.add_rows(
-        [
-            [
-                "Accuracy@1",
-                f"{acc1_fp32:.3f}",
-                f"{acc1_int8:.3f}",
-                f"{acc1_int8_init:.3f} (init) + {acc1_int8 - acc1_int8_init:.3f} (tuned)",
+    print(
+        tabulate(
+            headers=["", "FP32", "INT8", "Summary"],
+            tabular_data=[
+                [
+                    "Accuracy@1",
+                    f"{acc1_fp32:.3f}",
+                    f"{acc1_int8:.3f}",
+                    f"{acc1_int8_init:.3f} (init) + {acc1_int8 - acc1_int8_init:.3f} (tuned)",
+                ],
+                [
+                    "Model Size, Mb",
+                    f"{fp32_model_size:.3f}",
+                    f"{int8_model_size:.3f}",
+                    f"Compression rate is {fp32_model_size / int8_model_size:.3f}",
+                ],
+                [
+                    "Performance, FPS",
+                    f"{fp32_fps:.1f} FPS",
+                    f"{int8_fps:.1f} FPS",
+                    f"Speedup x{int8_fps / fp32_fps:.3f}",
+                ],
             ],
-            [
-                "Model Size, Mb",
-                f"{fp32_model_size:.3f}",
-                f"{int8_model_size:.3f}",
-                f"Compression rate is {fp32_model_size / int8_model_size:.3f}",
-            ],
-            ["Performance, FPS", f"{fp32_fps:.3f}", f"{int8_fps:.3f}", f"Speedup x{int8_fps / fp32_fps:.3f}"],
-        ],
-        header=False,
+            tablefmt="rounded_outline",
+        )
     )
-    print(table.draw())
     return acc1_fp32, acc1_int8_init, acc1_int8, fp32_fps, int8_fps, fp32_model_size, int8_model_size
 
 

--- a/licensing/third-party-programs.txt
+++ b/licensing/third-party-programs.txt
@@ -867,7 +867,7 @@ Apache License
 
    END OF TERMS AND CONDITIONS
 -------------------------------------------------------------
-* Other names and brands may be claimed as the property of others. 
+* Other names and brands may be claimed as the property of others.
 
 Ma-Dan keras-yolo4
 
@@ -1594,3 +1594,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 -------------------------------------------------------------
+
+astanin/python-tabulate
+
+Copyright (c) 2011-2020 Sergey Astanin and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/nncf/common/utils/helpers.py
+++ b/nncf/common/utils/helpers.py
@@ -32,7 +32,10 @@ def create_table(
     :param max_col_widths: Max widths of columns.
     :return: A string which represents a table with a header and rows.
     """
-    return tabulate(tabular_data=rows, headers=header, tablefmt=table_fmt, maxcolwidths=max_col_widths)
+    if not rows:
+        # For empty rows max_col_widths raises IndexError
+        max_col_widths = None
+    return tabulate(tabular_data=rows, headers=header, tablefmt=table_fmt, maxcolwidths=max_col_widths, floatfmt=".3f")
 
 
 def configure_accuracy_aware_paths(log_dir: str) -> str:

--- a/nncf/common/utils/helpers.py
+++ b/nncf/common/utils/helpers.py
@@ -12,20 +12,27 @@ import datetime
 import itertools
 import os
 import os.path as osp
-from typing import Any, Dict, Hashable, List
+from typing import Any, Dict, Hashable, Iterable, List, Optional, Union
 
-from texttable import Texttable
+from tabulate import tabulate
 
 
-def create_table(header: List[str], rows: List[List[Any]]) -> str:
+def create_table(
+    header: List[str],
+    rows: List[List[Any]],
+    table_fmt: str = "mixed_grid",
+    max_col_widths: Optional[Union[int, Iterable[int]]] = None,
+) -> str:
     """
     Returns a string which represents a table with a header and rows.
 
     :param header: Table's header.
     :param rows: Table's rows.
+    :param table_fmt: Type of formatting of the table.
+    :param max_col_widths: Max widths of columns.
     :return: A string which represents a table with a header and rows.
     """
-    return Texttable().header(header).add_rows(rows, header=False).draw()
+    return tabulate(tabular_data=rows, headers=header, tablefmt=table_fmt, maxcolwidths=max_col_widths)
 
 
 def configure_accuracy_aware_paths(log_dir: str) -> str:

--- a/nncf/torch/pruning/filter_pruning/algo.py
+++ b/nncf/torch/pruning/filter_pruning/algo.py
@@ -622,7 +622,7 @@ class FilterPruningController(BasePruningAlgoController):
         self._propagate_masks()
 
         pruned_layers_stats = self.get_stats_for_pruned_modules()
-        nncf_logger.info(f"Pruned layers statistics: \n{pruned_layers_stats.draw()}")
+        nncf_logger.info(f"Pruned layers statistics: \n{pruned_layers_stats}")
 
     def compression_stage(self) -> CompressionStage:
         target_pruning_level = self.scheduler.target_level

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ INSTALL_REQUIRES = [
     "rich>=13.5.2",
     "scikit-learn>=0.24.0",
     "scipy>=1.3.2",
-    "texttable>=1.6.3",
+    "tabulate>=0.9.0",
     "tqdm>=4.54.1",
 ]
 


### PR DESCRIPTION
### Changes

Using tabulate instead of texttable package to create tables.

### Reason for changes

Avoid installation two packages to same task.
Tabulate is optional dependencies of pandas package, that used in NNCF. https://github.com/openvinotoolkit/nncf/pull/2542

### Related tickets

134603

