### PR TITLE
Tests for torch device and dtype utils

### DIFF
--- a/nncf/torch/utils.py
+++ b/nncf/torch/utils.py
@@ -461,7 +461,7 @@ def get_model_dtype(model: torch.nn.Module) -> torch.dtype:
 
     :param model: The PyTorch model.
     :return: The datatype of the first model parameter.
-        Defaults to torch.float32 if the model has no parameters.
+        Default to torch.float32 if the model has no parameters.
     """
 
     try:

--- a/nncf/torch/utils.py
+++ b/nncf/torch/utils.py
@@ -413,6 +413,14 @@ def maybe_convert_legacy_names_in_compress_state(compression_state: Dict[str, An
 
 
 def get_model_device(model: torch.nn.Module) -> torch.device:
+    """
+    Get the device on which the model's parameters reside.
+
+    :param model: The PyTorch model.
+    :return: The device where the model's parameters reside.
+        Default cpu if the model has no parameters.
+    """
+
     try:
         device = next(model.parameters()).device
     except StopIteration:
@@ -427,6 +435,14 @@ def get_all_model_devices_generator(model: torch.nn.Module) -> Generator[torch.d
 
 
 def is_multidevice(model: torch.nn.Module) -> bool:
+    """
+    Checks if the model's parameters are distributed across multiple devices.
+
+    :param model: The PyTorch model.
+    :return: True if the parameters reside on multiple devices, False otherwise.
+        Default False if the models has no parameters
+    """
+
     device_generator = get_all_model_devices_generator(model)
     try:
         curr_device = next(device_generator)
@@ -440,6 +456,14 @@ def is_multidevice(model: torch.nn.Module) -> bool:
 
 
 def get_model_dtype(model: torch.nn.Module) -> torch.dtype:
+    """
+    Get the datatype of the model's parameters.
+
+    :param model: The PyTorch model.
+    :return: The datatype of the model's parameters.
+        Defaults to torch.float32 if the model has no parameters.
+    """
+
     try:
         dtype = next(model.parameters()).dtype
     except StopIteration:

--- a/nncf/torch/utils.py
+++ b/nncf/torch/utils.py
@@ -414,10 +414,10 @@ def maybe_convert_legacy_names_in_compress_state(compression_state: Dict[str, An
 
 def get_model_device(model: torch.nn.Module) -> torch.device:
     """
-    Get the device on which the model's parameters reside.
+    Get the device on which the first model parameters reside.
 
     :param model: The PyTorch model.
-    :return: The device where the model's parameters reside.
+    :return: The device where the first model parameter reside.
         Default cpu if the model has no parameters.
     """
 
@@ -457,10 +457,10 @@ def is_multidevice(model: torch.nn.Module) -> bool:
 
 def get_model_dtype(model: torch.nn.Module) -> torch.dtype:
     """
-    Get the datatype of the model's parameters.
+    Get the datatype of the first model parameter.
 
     :param model: The PyTorch model.
-    :return: The datatype of the model's parameters.
+    :return: The datatype of the first model parameter.
         Defaults to torch.float32 if the model has no parameters.
     """
 

--- a/tests/torch/helpers.py
+++ b/tests/torch/helpers.py
@@ -357,6 +357,14 @@ class MockModel(nn.Module):
         return None
 
 
+class EmptyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, *input_, **kwargs):
+        return None
+
+
 def check_correct_nncf_modules_replacement(
     model: torch.nn.Module, compressed_model: NNCFNetwork
 ) -> Tuple[Dict[Scope, Module], Dict[Scope, Module]]:

--- a/tests/torch/test_utils.py
+++ b/tests/torch/test_utils.py
@@ -36,15 +36,12 @@ def compare_saved_model_state_and_current_model_state(model: nn.Module, model_st
         assert param.requires_grad == model_state.requires_grad_state[name]
 
 
-def change_model_state(module: nn.Module, trainable_paramaters: bool = True):
+def change_model_state(module: nn.Module):
     for i, ch in enumerate(module.modules()):
         ch.training = i % 2 == 0
 
     for i, p in enumerate(module.parameters()):
-        if trainable_paramaters:
-            p.requires_grad = i % 2 == 0
-        else:
-            p.requires_grad = False
+        p.requires_grad = i % 2 == 0
 
 
 @pytest.mark.parametrize(
@@ -72,7 +69,9 @@ def test_bn_training_state_switcher(model: nn.Module):
 
     runner = DataLoaderBNAdaptationRunner(model, "cuda")
 
-    change_model_state(model, trainable_paramaters=False)
+    for p in model.parameters():
+        p.requires_grad = False
+
     saved_state = save_module_state(model)
 
     with runner._bn_training_state_switcher():

--- a/tests/torch/test_utils.py
+++ b/tests/torch/test_utils.py
@@ -89,10 +89,8 @@ def test_bn_training_state_switcher(_seed, model: nn.Module):
     compare_saved_model_state_and_current_model_state(model, saved_state)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Cuda is not available in current environment")
 def test_model_device():
-    if not torch.cuda.is_available():
-        return
-
     model = TwoConvTestModel()
     cuda = torch.device("cuda")
 


### PR DESCRIPTION
### Changes

This PR addresses #2579.
- Add tests for torch device utils. The tests consider the case in which the model has no parameters, has all parameters on CPU, has all parameters on CUDA, and has parameters placed on different devices. In the latter, the parameters are moved on different devices randomly. 
- Add tests for torch `dtype` utils. The case in which the model has no parameters is also considered.
- Created a test torch helper class `EmptyModel` to take into account the case in which the model has no parameters at all.
- Add docstrings in utils.

### Tests

I compared all the results manually checking for their correctness. The code is also compliant with the coding style having been verified with `pre-commit run`
