### PR TITLE
[Torch] Drop `PTQuantizerInsertionCommand` 

### DIFF
--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 import torch
 
@@ -36,7 +36,9 @@ from nncf.quantization.fake_quantize import FakeQuantizeParameters
 from nncf.quantization.range_estimator import RangeEstimatorParameters
 from nncf.torch.graph.graph import PTNNCFGraph
 from nncf.torch.graph.graph import PTTargetPoint
-from nncf.torch.graph.transformations.commands import PTQuantizerInsertionCommand
+from nncf.torch.graph.transformations.command_creation import create_quantizer_insertion_command
+from nncf.torch.graph.transformations.commands import PTInsertionCommand
+from nncf.torch.graph.transformations.commands import PTSharedFnInsertionCommand
 from nncf.torch.hardware.config import PTHWConfig
 from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.quantization.default_quantization import DEFAULT_PT_QUANT_TRAIT_TO_OP_DICT
@@ -127,17 +129,6 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
         if target_type in PTMinMaxAlgoBackend.TARGET_TYPE_TO_PT_INS_TYPE_MAP:
             target_type = PTMinMaxAlgoBackend.TARGET_TYPE_TO_PT_INS_TYPE_MAP[target_type]
         return PTTargetPoint(target_type, target_node_name, input_port_id=port_id)
-
-    @staticmethod
-    def create_quantizer_insertion_command(
-        nncf_graph: NNCFGraph,
-        target_point: PTTargetPoint,
-        quantizer_config: QuantizerConfig,
-        parameters: FakeQuantizeParameters,
-    ) -> PTQuantizerInsertionCommand:
-        return PTMinMaxAlgoBackend._create_quantizer_insertion_command(
-            nncf_graph, target_point, quantizer_config, parameters
-        )
 
     @staticmethod
     def create_convert_insertion_command(
@@ -290,12 +281,12 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
             quantizer.scale = torch.nn.Parameter(parameters.input_high.data - quantizer.eps)
 
     @staticmethod
-    def _create_quantizer_insertion_command(
+    def create_quantizer_insertion_command(
         nncf_graph: NNCFGraph,
         target_point: PTTargetPoint,
         quantizer_config: QuantizerConfig,
         parameters: FakeQuantizeParameters,
-    ) -> PTQuantizerInsertionCommand:
+    ) -> Union[PTInsertionCommand, PTSharedFnInsertionCommand]:
         _, scale_shape, _ = PTMinMaxAlgoBackend._get_input_scale_shape(
             nncf_graph, target_point, quantizer_config.per_channel
         )
@@ -303,7 +294,7 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
         quantizer = PTMinMaxAlgoBackend._create_quantizer(
             quantizer_config, scale_shape, parameters, target_point.target_type
         )
-        return PTQuantizerInsertionCommand(target_point, quantizer)
+        return create_quantizer_insertion_command(target_point, quantizer)
 
     @staticmethod
     def get_ignored_metatypes(model_type: ModelType, device: TargetDevice) -> List[OperatorMetatype]:

--- a/nncf/torch/external_hook.py
+++ b/nncf/torch/external_hook.py
@@ -11,7 +11,7 @@
 
 from typing import Any
 
-from nncf.torch.dynamic_graph.context import TracingContext
+from nncf.torch.dynamic_graph.context import get_current_context
 
 EXTERNAL_OP_STORAGE_NAME = "external_op"
 
@@ -26,17 +26,15 @@ class ExternalOpCallHook:
     the base module execution.
     """
 
-    def __init__(self, storage_name: str, context: TracingContext, storage_key: str):
+    def __init__(self, storage_name: str, storage_key: str):
         """
         :param storage_name: Attribute name of a model NNCFInterface.
-        :param context: Current tracing context.
         :param storage_key: Key to retrieve callable hook
         """
         self._storage_name = storage_name
-        self._compressed_context = context
         self._storage_key = storage_key
 
     def __call__(self, *args: Any, **kwargs) -> Any:
-        replica = self._compressed_context.base_module_thread_local_replica
+        replica = get_current_context().base_module_thread_local_replica
         storage = getattr(replica.nncf, self._storage_name)
         return storage[self._storage_key](*args, **kwargs)

--- a/nncf/torch/graph/transformations/commands.py
+++ b/nncf/torch/graph/transformations/commands.py
@@ -178,25 +178,6 @@ class PTSharedFnInsertionCommand(PTTransformationCommand):
         return True
 
 
-class PTQuantizerInsertionCommand(PTTransformationCommand):
-    """
-    Insertion quantizer operation to the models.
-    """
-
-    def __init__(
-        self,
-        point: PTTargetPoint,
-        quantizer: "BaseQuantizer",  # noqa: F821
-        hooks_group_name: str = DEFAULT_HOOKS_GROUP_NAME,
-    ):
-        super().__init__(TransformationType.INSERT, point)
-        self.quantizer = quantizer
-        self.hooks_group_name = hooks_group_name
-
-    def requires_graph_rebuild(self):
-        return True
-
-
 class PTModelExtractionWithFusedBiasCommand(PTCommand):
     """
     Extracts sequence by name with node that contain fused bias.

--- a/nncf/torch/graph/transformations/commands.py
+++ b/nncf/torch/graph/transformations/commands.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from enum import Enum
 from typing import Any, Callable, Dict, List
 
 import torch
@@ -150,12 +151,18 @@ class PTInsertionCommand(PTTransformationCommand):
         return self.priority == TransformationPriority.QUANTIZATION_PRIORITY
 
 
+class ExtraCompressionModuleType(Enum):
+    EXTERNAL_QUANTIZER = 0
+    EXTERNAL_OP = 1
+
+
 class PTSharedFnInsertionCommand(PTTransformationCommand):
     def __init__(
         self,
         target_points: List[PTTargetPoint],
         fn: Callable,
         op_unique_name: str,
+        compression_module_type: ExtraCompressionModuleType,
         priority: TransformationPriority = TransformationPriority.DEFAULT_PRIORITY,
         hooks_group_name: str = DEFAULT_HOOKS_GROUP_NAME,
     ):
@@ -163,6 +170,7 @@ class PTSharedFnInsertionCommand(PTTransformationCommand):
         self.target_points = target_points
         self.fn = fn
         self.op_name = op_unique_name
+        self.compression_module_type = compression_module_type
         self.priority = priority
         self.hooks_group_name = hooks_group_name
 

--- a/nncf/torch/graph/transformations/commands.py
+++ b/nncf/torch/graph/transformations/commands.py
@@ -162,7 +162,7 @@ class PTSharedFnInsertionCommand(PTTransformationCommand):
         target_points: List[PTTargetPoint],
         fn: Callable,
         op_unique_name: str,
-        compression_module_type: ExtraCompressionModuleType,
+        compression_module_type: ExtraCompressionModuleType = ExtraCompressionModuleType.EXTERNAL_OP,
         priority: TransformationPriority = TransformationPriority.DEFAULT_PRIORITY,
         hooks_group_name: str = DEFAULT_HOOKS_GROUP_NAME,
     ):

--- a/nncf/torch/model_graph_manager.py
+++ b/nncf/torch/model_graph_manager.py
@@ -18,10 +18,11 @@ from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.operator_metatypes import CONST_NOOP_METATYPES
 from nncf.torch.dynamic_graph.context import PreHookId
+from nncf.torch.external_hook import ExternalOpCallHook
 from nncf.torch.graph import operator_metatypes as om
 from nncf.torch.nncf_network import NNCFNetwork
-from nncf.torch.quantization.external_quantizer import ExternalQuantizerCallHook
 from nncf.torch.quantization.layers import AsymmetricQuantizer
+from nncf.torch.quantization.layers import BaseQuantizer
 from nncf.torch.quantization.layers import SymmetricQuantizer
 
 CONV_META_TYPES = [
@@ -295,7 +296,9 @@ def get_fake_quantizer(
         hook_container = model.nncf._compressed_context._post_hooks.get(op_addr, {})
 
     for call_hook in hook_container.values():
-        if isinstance(call_hook, ExternalQuantizerCallHook):
+        if isinstance(call_hook, ExternalOpCallHook):
             storage = getattr(model.nncf, call_hook._storage_name)
-            return storage[call_hook._storage_key]
+            module = storage[call_hook._storage_key]
+            if isinstance(module, BaseQuantizer):
+                return module
     return None

--- a/nncf/torch/model_transformer.py
+++ b/nncf/torch/model_transformer.py
@@ -127,8 +127,16 @@ class PTModelTransformer(ModelTransformer):
 
         insertion_commands: List[PTInsertionCommand] = []
 
+        device = None
+        if not is_multidevice(model):
+            device = get_model_device(model)
+
         for shared_command in transformations:
-            model.nncf.add_compression_module(shared_command.op_name, shared_command.fn, compression_module_type)
+            fn = shared_command.fn
+            if device is not None:
+                fn.to(device)
+
+            model.nncf.add_compression_module(shared_command.op_name, fn, compression_module_type)
 
             for target_point in shared_command.target_points:
                 fn = ExternalOpCallHook(

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -604,18 +604,6 @@ class NNCFNetworkInterface(torch.nn.Module):
         """
         return compression_module_type in self._extra_module_types
 
-    @staticmethod
-    def compression_module_type_to_attr_name(compression_module_type: ExtraCompressionModuleType):
-        """
-        Required for backward compatibility with checkpoints that store function and activation
-        quantizers directly under corresponding attributes of NNCFNetwork.
-        """
-        if compression_module_type == ExtraCompressionModuleType.EXTERNAL_QUANTIZER:
-            return EXTERNAL_QUANTIZERS_STORAGE_NAME
-        if compression_module_type == ExtraCompressionModuleType.EXTERNAL_OP:
-            return EXTERNAL_OP_STORAGE_NAME
-        raise nncf.ValidationError("Unknown extra module type")
-
     def sort_compression_modules(self, compression_module_type: ExtraCompressionModuleType):
         attr_name = compression_module_type_to_attr_name(compression_module_type)
         if compression_module_type not in self._extra_module_types:

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -17,7 +17,6 @@ from collections import defaultdict
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
-from enum import Enum
 from enum import IntEnum
 from typing import Callable, Dict, Iterator, List, Optional, Tuple, TypeVar
 
@@ -67,6 +66,7 @@ from nncf.torch.graph.graph_builder import GraphConverter
 from nncf.torch.graph.operator_metatypes import OPERATORS_WITH_WEIGHTS_METATYPES
 from nncf.torch.graph.operator_metatypes import PTSplitMetatype
 from nncf.torch.graph.transformations.commands import DEFAULT_HOOKS_GROUP_NAME
+from nncf.torch.graph.transformations.commands import ExtraCompressionModuleType
 from nncf.torch.graph.transformations.commands import PTTargetPoint
 from nncf.torch.knowledge_distillation.knowledge_distillation_handler import KnowledgeDistillationLossHandler
 from nncf.torch.layer_utils import _NNCFModuleMixin
@@ -140,11 +140,6 @@ class PTInsertionPoint:
 
     def __hash__(self):
         return hash(str(self))
-
-
-class ExtraCompressionModuleType(Enum):
-    EXTERNAL_QUANTIZER = 0
-    EXTERNAL_OP = 1
 
 
 @dataclass
@@ -576,7 +571,7 @@ class NNCFNetworkInterface(torch.nn.Module):
         return False
 
     def register_compression_module_type(self, compression_module_type: ExtraCompressionModuleType):
-        attr_name = self._compression_module_type_to_attr_name(compression_module_type)
+        attr_name = compression_module_type_to_attr_name(compression_module_type)
         if compression_module_type in self._extra_module_types:
             raise nncf.ValidationError(f"Module type {compression_module_type} is already registered")
 
@@ -586,7 +581,7 @@ class NNCFNetworkInterface(torch.nn.Module):
     def add_compression_module(
         self, module_key: str, module: nn.Module, compression_module_type: ExtraCompressionModuleType
     ):
-        attr_name = self._compression_module_type_to_attr_name(compression_module_type)
+        attr_name = compression_module_type_to_attr_name(compression_module_type)
         if compression_module_type not in self._extra_module_types:
             raise nncf.InternalError(f"Module type {compression_module_type} was not registered")
         storage = self.__getattr__(attr_name)
@@ -595,7 +590,7 @@ class NNCFNetworkInterface(torch.nn.Module):
         storage[module_key] = module
 
     def get_compression_modules_by_type(self, compression_module_type: ExtraCompressionModuleType) -> nn.ModuleDict:
-        attr_name = self._compression_module_type_to_attr_name(compression_module_type)
+        attr_name = compression_module_type_to_attr_name(compression_module_type)
         if compression_module_type not in self._extra_module_types:
             raise nncf.InternalError(f"Module type {compression_module_type} was not registered")
         return self.__getattr__(attr_name)
@@ -610,7 +605,7 @@ class NNCFNetworkInterface(torch.nn.Module):
         return compression_module_type in self._extra_module_types
 
     @staticmethod
-    def _compression_module_type_to_attr_name(compression_module_type: ExtraCompressionModuleType):
+    def compression_module_type_to_attr_name(compression_module_type: ExtraCompressionModuleType):
         """
         Required for backward compatibility with checkpoints that store function and activation
         quantizers directly under corresponding attributes of NNCFNetwork.
@@ -622,7 +617,7 @@ class NNCFNetworkInterface(torch.nn.Module):
         raise nncf.ValidationError("Unknown extra module type")
 
     def sort_compression_modules(self, compression_module_type: ExtraCompressionModuleType):
-        attr_name = self._compression_module_type_to_attr_name(compression_module_type)
+        attr_name = compression_module_type_to_attr_name(compression_module_type)
         if compression_module_type not in self._extra_module_types:
             raise nncf.InternalError("Module type {} was not registered".format(compression_module_type))
         module_dict = self.__getattr__(attr_name)
@@ -1137,3 +1132,15 @@ class LoadStateListener:
 
     def close(self):
         self.hook.remove()
+
+
+def compression_module_type_to_attr_name(compression_module_type: ExtraCompressionModuleType):
+    """
+    Required for backward compatibility with checkpoints that store function and activation
+    quantizers directly under corresponding attributes of NNCFNetwork.
+    """
+    if compression_module_type == ExtraCompressionModuleType.EXTERNAL_QUANTIZER:
+        return EXTERNAL_QUANTIZERS_STORAGE_NAME
+    if compression_module_type == ExtraCompressionModuleType.EXTERNAL_OP:
+        return EXTERNAL_OP_STORAGE_NAME
+    raise nncf.ValidationError("Unknown extra module type")

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -83,6 +83,7 @@ from nncf.torch.graph.operator_metatypes import UNIFICATION_PRODUCING_METATYPES
 from nncf.torch.graph.operator_metatypes import PTCatMetatype
 from nncf.torch.graph.operator_metatypes import PTDepthwiseConv2dSubtype
 from nncf.torch.graph.operator_metatypes import PTModuleConv2dMetatype
+from nncf.torch.graph.transformations.commands import ExtraCompressionModuleType
 from nncf.torch.graph.transformations.commands import PTInsertionCommand
 from nncf.torch.graph.transformations.commands import PTTargetPoint
 from nncf.torch.graph.transformations.commands import TransformationPriority
@@ -90,7 +91,6 @@ from nncf.torch.graph.transformations.layout import PTTransformationLayout
 from nncf.torch.hardware.config import PTHWConfig
 from nncf.torch.initialization import SimpleDataLoaderRunner
 from nncf.torch.module_operations import UpdatePaddingValue
-from nncf.torch.nncf_network import ExtraCompressionModuleType
 from nncf.torch.nncf_network import LoadStateListener
 from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.quantization.adjust_padding import AdjustPaddingArgs
@@ -1208,15 +1208,11 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
                     # share the single module and this would be impossible for multiple weight quantizer sharing if
                     # the corresponding UpdateWeights operations contained real modules (these would simply get copied
                     # by PyTorch internals)
-                    callable_obj = ExternalQuantizerCallHook(
-                        target_model.nncf.get_tracing_context(), external_quantizer_storage_key, self._debug_interface
-                    )
+                    callable_obj = ExternalQuantizerCallHook(external_quantizer_storage_key, self._debug_interface)
             else:
                 # Hooks will be identical for each affected op_address in the linked scenario
                 # - will call one and the same quantizer
-                callable_obj = ExternalQuantizerCallHook(
-                    target_model.nncf.get_tracing_context(), external_quantizer_storage_key, self._debug_interface
-                )
+                callable_obj = ExternalQuantizerCallHook(external_quantizer_storage_key, self._debug_interface)
 
             nncf_logger.debug(
                 f"Performing "

--- a/nncf/torch/quantization/debug_interface.py
+++ b/nncf/torch/quantization/debug_interface.py
@@ -59,7 +59,7 @@ class QuantizationDebugInterface(DebugInterface):
         self._strict_forward = False
 
     def init_actual(self, owner_model: NNCFNetwork):
-        from nncf.torch.nncf_network import ExtraCompressionModuleType
+        from nncf.torch.graph.transformations.commands import ExtraCompressionModuleType
 
         quantization_types = [class_type.__name__ for class_type in QUANTIZATION_MODULES.registry_dict.values()]
         quantizers_in_nncf_modules = owner_model.nncf.get_modules_in_nncf_modules_by_type(quantization_types)

--- a/nncf/torch/quantization/external_quantizer.py
+++ b/nncf/torch/quantization/external_quantizer.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nncf.torch.dynamic_graph.context import TracingContext
 from nncf.torch.external_hook import ExternalOpCallHook
 from nncf.torch.quantization.debug_interface import QuantizationDebugInterface
 
@@ -25,11 +24,10 @@ class ExternalQuantizerCallHook(ExternalOpCallHook):
 
     def __init__(
         self,
-        context: TracingContext,
         quantizer_storage_key: str,
         debug_interface: QuantizationDebugInterface = None,
     ):
-        super().__init__(EXTERNAL_QUANTIZERS_STORAGE_NAME, context, quantizer_storage_key)
+        super().__init__(EXTERNAL_QUANTIZERS_STORAGE_NAME, quantizer_storage_key)
         self.debug_interface = debug_interface
 
     def __call__(self, *args, **kwargs):

--- a/nncf/torch/quantization/precision_init/base_init.py
+++ b/nncf/torch/quantization/precision_init/base_init.py
@@ -18,8 +18,8 @@ from nncf.common.quantization.quantizer_setup import SingleConfigQuantizerSetup
 from nncf.common.quantization.structs import QuantizerId
 from nncf.common.quantization.structs import WeightQuantizerId
 from nncf.torch.dynamic_graph.scope import Scope
+from nncf.torch.graph.transformations.commands import ExtraCompressionModuleType
 from nncf.torch.module_operations import UpdateWeight
-from nncf.torch.nncf_network import ExtraCompressionModuleType
 from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.quantization.layers import QUANTIZATION_MODULES
 from nncf.torch.quantization.layers import BaseQuantizer

--- a/nncf/torch/quantization/precision_init/hawq_debug.py
+++ b/nncf/torch/quantization/precision_init/hawq_debug.py
@@ -20,7 +20,7 @@ from torch import Tensor
 from nncf.common.logging import nncf_logger
 from nncf.common.utils.decorators import skip_if_dependency_unavailable
 from nncf.common.utils.dot_file_rw import write_dot_graph
-from nncf.torch.nncf_network import ExtraCompressionModuleType
+from nncf.torch.graph.transformations.commands import ExtraCompressionModuleType
 from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.quantization.adjust_padding import add_adjust_padding_nodes
 from nncf.torch.quantization.layers import QUANTIZATION_MODULES

--- a/nncf/torch/quantization/strip.py
+++ b/nncf/torch/quantization/strip.py
@@ -15,7 +15,7 @@ import torch
 from torch.quantization.fake_quantize import FakeQuantize
 
 import nncf
-from nncf.torch.nncf_network import ExtraCompressionModuleType
+from nncf.torch.graph.transformations.commands import ExtraCompressionModuleType
 from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.quantization.layers import AsymmetricQuantizer
 from nncf.torch.quantization.layers import BaseQuantizer

--- a/tests/torch/ptq/test_smooth_quant.py
+++ b/tests/torch/ptq/test_smooth_quant.py
@@ -21,9 +21,9 @@ from nncf.quantization.algorithms.smooth_quant.torch_backend import PTSmoothQuan
 from nncf.quantization.algorithms.smooth_quant.torch_backend import SQMultiply
 from nncf.torch.graph.operator_metatypes import PTModuleConv2dMetatype
 from nncf.torch.graph.operator_metatypes import PTModuleLinearMetatype
+from nncf.torch.graph.transformations.commands import ExtraCompressionModuleType
 from nncf.torch.graph.transformations.commands import PTSharedFnInsertionCommand
 from nncf.torch.model_creation import wrap_model
-from nncf.torch.nncf_network import ExtraCompressionModuleType
 from tests.post_training.test_templates.helpers import ConvTestModel
 from tests.post_training.test_templates.helpers import LinearMultiShapeModel
 from tests.post_training.test_templates.helpers import ShareWeghtsConvAndShareLinearModel

--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -36,11 +36,11 @@ from nncf.torch.checkpoint_loading import load_state
 from nncf.torch.compression_method_api import PTCompressionLoss
 from nncf.torch.dynamic_graph.scope import Scope
 from nncf.torch.dynamic_graph.scope import ScopeElement
+from nncf.torch.graph.transformations.commands import ExtraCompressionModuleType
 from nncf.torch.layers import NNCFConv2d
 from nncf.torch.model_creation import create_compression_algorithm_builder
 from nncf.torch.module_operations import UpdateInputs
 from nncf.torch.module_operations import UpdateWeight
-from nncf.torch.nncf_network import ExtraCompressionModuleType
 from nncf.torch.quantization.algo import QuantizationBuilder
 from nncf.torch.quantization.algo import QuantizationController
 from nncf.torch.quantization.layers import QUANTIZATION_MODULES

--- a/tests/torch/quantization/test_strip.py
+++ b/tests/torch/quantization/test_strip.py
@@ -22,7 +22,7 @@ from nncf.common.quantization.quantizers import calculate_symmetric_level_ranges
 from nncf.common.quantization.quantizers import get_num_levels
 from nncf.common.quantization.structs import QuantizationScheme as QuantizationMode
 from nncf.config import NNCFConfig
-from nncf.torch.nncf_network import ExtraCompressionModuleType
+from nncf.torch.graph.transformations.commands import ExtraCompressionModuleType
 from nncf.torch.quantization.layers import AsymmetricQuantizer
 from nncf.torch.quantization.layers import PTQuantizerSpec
 from nncf.torch.quantization.layers import SymmetricQuantizer

--- a/tests/torch/test_model_graph_manager.py
+++ b/tests/torch/test_model_graph_manager.py
@@ -21,7 +21,7 @@ from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.torch import wrap_model
-from nncf.torch.graph.transformations.commands import PTQuantizerInsertionCommand
+from nncf.torch.graph.transformations.command_creation import create_quantizer_insertion_command
 from nncf.torch.graph.transformations.commands import PTTargetPoint
 from nncf.torch.model_graph_manager import get_const_data
 from nncf.torch.model_graph_manager import get_const_data_on_port
@@ -268,7 +268,7 @@ def test_get_fake_quantizer(target_type, port_id):
     )
 
     fq = SymmetricQuantizer(qspec)
-    command = PTQuantizerInsertionCommand(PTTargetPoint(target_type, node_name, input_port_id=port_id), fq)
+    command = create_quantizer_insertion_command(PTTargetPoint(target_type, node_name, input_port_id=port_id), fq)
     layout = PTTransformationLayout()
     layout.register(command)
     q_model = transformer.transform(layout)
@@ -303,7 +303,9 @@ def test_is_quantized_weights():
     )
 
     fq = SymmetricQuantizer(qspec)
-    command = PTQuantizerInsertionCommand(PTTargetPoint(TargetType.OPERATOR_PRE_HOOK, node_name, input_port_id=1), fq)
+    command = create_quantizer_insertion_command(
+        PTTargetPoint(TargetType.OPERATOR_PRE_HOOK, node_name, input_port_id=1), fq
+    )
     layout = PTTransformationLayout()
     layout.register(command)
     q_model = transformer.transform(layout)

--- a/tests/torch/test_model_transformer.py
+++ b/tests/torch/test_model_transformer.py
@@ -757,7 +757,7 @@ def test_shared_fn_insertion_point(
     mock = PTModelTransformer._apply_insertion_transformations
     mock.assert_called_once()
 
-    _, commands = mock.call_args.args
+    _, commands, device = mock.call_args.args
     assert len(commands) == len(tps)
     for command in commands:
         assert command.target_point in tps
@@ -769,8 +769,11 @@ def test_shared_fn_insertion_point(
 
     if multidevice_model:
         assert hook_instance.to_device is None
+        assert device is None
     else:
-        assert hook_instance.to_device == get_model_device(transformed_model)
+        actual_model_device = get_model_device(transformed_model)
+        assert hook_instance.to_device == actual_model_device
+        assert device == actual_model_device
 
     # Check torch can correctly save and load model state dict with an external quantizer
     state_dict = transformed_model.state_dict()

--- a/tests/torch/test_nncf_network.py
+++ b/tests/torch/test_nncf_network.py
@@ -39,11 +39,11 @@ from nncf.torch.graph.graph import PTNNCFGraph
 from nncf.torch.graph.graph_builder import GraphBuilder
 from nncf.torch.graph.operator_metatypes import PTConv2dMetatype
 from nncf.torch.graph.operator_metatypes import PTModuleConv2dMetatype
+from nncf.torch.graph.transformations.commands import ExtraCompressionModuleType
 from nncf.torch.layer_utils import _NNCFModuleMixin
 from nncf.torch.layers import NNCFConv2d
 from nncf.torch.model_creation import wrap_model
 from nncf.torch.nncf_module_replacement import replace_modules_by_nncf_modules
-from nncf.torch.nncf_network import ExtraCompressionModuleType
 from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.nncf_network import PTInsertionPoint
 from nncf.torch.nncf_network import PTInsertionType

--- a/tests/torch/test_tracing_context.py
+++ b/tests/torch/test_tracing_context.py
@@ -17,7 +17,7 @@ from nncf.torch.dynamic_graph.context import TracingContext
 from nncf.torch.dynamic_graph.trace_tensor import TracedParameter
 from nncf.torch.dynamic_graph.trace_tensor import TracedTensor
 from nncf.torch.dynamic_graph.wrappers import wrap_parameters
-from nncf.torch.nncf_network import ExtraCompressionModuleType
+from nncf.torch.graph.transformations.commands import ExtraCompressionModuleType
 from tests.torch.helpers import BasicConvTestModel
 
 


### PR DESCRIPTION
Preparation for #2531

### Changes

1) `PTQuantizerInsertionCommand` is removed and replaced with create_quantizer_insertion_command function
2) `SharedFNInsertionCommand` updates with one new attribute: compression_module_type
3) `ExtraOpCallHook` doesn't require context in constructor anymore
4) Multidevice support is moved from `apply_quantizers_insertion_commands_transformation` to `apply_insertion_transformation`

### Reason for changes

1) To make it easier to store and restore commands: less commands - less amount of adapters are needed
2) To make it possible to express  `PTQuantizerInsertionCommand` by  `SharedFNInsertionCommand`
3) To make it possible to create `ExtraOpCallHook` outside of the `PTModelTransformer`
4) To unify multidevice support for all insertion operations

### Related tickets
2531

### Tests

1)`test_quantizer_insertion_transformation` is updated
2) -
3) `test_shared_fn_insertion_point` is updated
4) `test_pt_insertion_command` is introduced
