### PR TITLE
Extending functions by diag, cholesky, cholesky_inverse, inv

### DIFF
--- a/nncf/experimental/tensor/functions/__init__.py
+++ b/nncf/experimental/tensor/functions/__init__.py
@@ -20,6 +20,7 @@ from nncf.experimental.tensor.functions.numeric import astype as astype
 from nncf.experimental.tensor.functions.numeric import clip as clip
 from nncf.experimental.tensor.functions.numeric import count_nonzero as count_nonzero
 from nncf.experimental.tensor.functions.numeric import device as device
+from nncf.experimental.tensor.functions.numeric import diag as diag
 from nncf.experimental.tensor.functions.numeric import dtype as dtype
 from nncf.experimental.tensor.functions.numeric import finfo as finfo
 from nncf.experimental.tensor.functions.numeric import flatten as flatten

--- a/nncf/experimental/tensor/functions/linalg.py
+++ b/nncf/experimental/tensor/functions/linalg.py
@@ -62,3 +62,52 @@ def norm(
     :return: Norm of the matrix or vector.
     """
     return Tensor(norm(a.data, ord, axis, keepdims))
+
+
+@functools.singledispatch
+@tensor_guard
+def cholesky(a: Tensor, upper: bool = False) -> Tensor:
+    """
+    Computes the Cholesky decomposition of a complex Hermitian or real symmetric
+    positive-definite matrix `a`.
+
+    If `upper` is False, then the Cholesky decomposition, `L * L.H` of the matrix `a`
+    is returned, where `L` is lower-triangular and .H is the conjugate transpose operator
+    If `upper` is True, then the conjugate transpose tensor of the tensor with upper=False
+    is returned.
+
+    :param a: The input tensor of size (n,n).
+    :param upper: Whether to compute the upper- or lower-triangular Cholesky factorization.
+        Default is lower-triangular.
+    :return: Upper- or lower-triangular Cholesky factor of `a`.
+    """
+    return Tensor(cholesky(a.data, upper))
+
+
+@functools.singledispatch
+@tensor_guard
+def cholesky_inverse(a: Tensor, upper: bool = False) -> Tensor:
+    """
+    Computes the inverse of a complex Hermitian or real symmetric positive-definite matrix given
+    its Cholesky decomposition.
+
+    :param a: The input tensor of size (n,n) consisting of lower or upper triangular Cholesky
+        decompositions of symmetric or Hermitian positive-definite matrices.
+    :param upper: The flag that indicates whether the input tensor is lower triangular or
+        upper triangular. Default: False.
+    :return: The inverse of matrix given its Cholesky decomposition.
+    """
+    return Tensor(cholesky_inverse(a.data, upper))
+
+
+@functools.singledispatch
+@tensor_guard
+def inv(a: Tensor) -> Tensor:
+    """
+    Computes the inverse of a matrix.
+
+    :param a: The input tensor of shape (*, n, n) where * is zero or more batch dimensions
+        consisting of invertible matrices.
+    :return: The inverse of the input tensor.
+    """
+    return Tensor(inv(a.data))

--- a/nncf/experimental/tensor/functions/numeric.py
+++ b/nncf/experimental/tensor/functions/numeric.py
@@ -599,8 +599,8 @@ def transpose(a: Tensor, axes: Optional[Tuple[int, ...]] = None) -> Tensor:
     Returns an array with axes transposed.
 
     :param a: The input tensor.
-    :param axes: list of permutations or None.
-    :return: array with permuted axes.
+    :param axes: List of permutations or None.
+    :return: A tensor with permuted axes.
     """
     return Tensor(transpose(a.data, axes=axes))
 
@@ -616,6 +616,20 @@ def argsort(a: Tensor, axis: int = -1, descending: bool = False, stable: bool = 
     :param descending: Controls the sorting order (ascending or descending).
     :param stable: If True then the sorting routine becomes stable, preserving the order of equivalent elements.
         If False, the relative order of values which compare equal is not guaranteed. True is slower.
-    :return: Array of indices that sort a along the specified axis.
+    :return: A tensor of indices that sort a along the specified axis.
     """
     return Tensor(argsort(a.data, axis=axis))
+
+
+@functools.singledispatch
+@tensor_guard
+def diag(a: Tensor, k: int = 0) -> Tensor:
+    """
+    Returns the indices that would sort an array.
+
+    :param a: The input tensor.
+    :param k: Diagonal in question. The default is 0. Use k > 0 for diagonals above the main diagonal, and k < 0
+        for diagonals below the main diagonal.
+    :return: A tensor with the extracted diagonal.
+    """
+    return Tensor(diag(a.data, k=k))

--- a/nncf/experimental/tensor/functions/numpy_linalg.py
+++ b/nncf/experimental/tensor/functions/numpy_linalg.py
@@ -12,6 +12,7 @@
 from typing import Optional, Tuple, Union
 
 import numpy as np
+import scipy
 
 from nncf.experimental.tensor.functions import linalg
 from nncf.experimental.tensor.functions.dispatcher import register_numpy_types
@@ -25,3 +26,25 @@ def _(
     keepdims: bool = False,
 ) -> np.ndarray:
     return np.array(np.linalg.norm(a, ord=ord, axis=axis, keepdims=keepdims))
+
+
+@register_numpy_types(linalg.cholesky)
+def _(a: Union[np.ndarray, np.generic], upper: bool = False) -> np.ndarray:
+    if a.ndim != 2:
+        raise ValueError(f"Input tensor needs to be 2D but received a {a.ndim}d-tensor.")
+    return scipy.linalg.cholesky(a, lower=not upper)
+
+
+@register_numpy_types(linalg.cholesky_inverse)
+def _(a: Union[np.ndarray, np.generic], upper: bool = False) -> np.ndarray:
+    if a.ndim != 2:
+        raise ValueError(f"Input tensor needs to be 2D but received a {a.ndim}d-tensor.")
+    c = np.linalg.inv(a)
+    if upper:
+        return np.dot(c, c.T)
+    return np.dot(c.T, c)
+
+
+@register_numpy_types(linalg.inv)
+def _(a: Union[np.ndarray, np.generic]) -> np.ndarray:
+    return np.linalg.inv(a)

--- a/nncf/experimental/tensor/functions/numpy_linalg.py
+++ b/nncf/experimental/tensor/functions/numpy_linalg.py
@@ -30,19 +30,19 @@ def _(
 
 @register_numpy_types(linalg.cholesky)
 def _(a: Union[np.ndarray, np.generic], upper: bool = False) -> np.ndarray:
-    if a.ndim != 2:
-        raise ValueError(f"Input tensor needs to be 2D but received a {a.ndim}d-tensor.")
-    return scipy.linalg.cholesky(a, lower=not upper)
+    l = np.linalg.cholesky(a)
+    if upper:
+        l = np.conjugate(np.swapaxes(l, -2, -1))
+    return l
 
 
 @register_numpy_types(linalg.cholesky_inverse)
 def _(a: Union[np.ndarray, np.generic], upper: bool = False) -> np.ndarray:
-    if a.ndim != 2:
-        raise ValueError(f"Input tensor needs to be 2D but received a {a.ndim}d-tensor.")
     c = np.linalg.inv(a)
+    ct = np.conjugate(np.swapaxes(c, -2, -1))
     if upper:
-        return np.dot(c, c.T)
-    return np.dot(c.T, c)
+        return np.matmul(c, ct)
+    return np.matmul(ct, c)
 
 
 @register_numpy_types(linalg.inv)

--- a/nncf/experimental/tensor/functions/numpy_linalg.py
+++ b/nncf/experimental/tensor/functions/numpy_linalg.py
@@ -12,7 +12,6 @@
 from typing import Optional, Tuple, Union
 
 import numpy as np
-import scipy
 
 from nncf.experimental.tensor.functions import linalg
 from nncf.experimental.tensor.functions.dispatcher import register_numpy_types
@@ -30,10 +29,10 @@ def _(
 
 @register_numpy_types(linalg.cholesky)
 def _(a: Union[np.ndarray, np.generic], upper: bool = False) -> np.ndarray:
-    l = np.linalg.cholesky(a)
+    lt = np.linalg.cholesky(a)
     if upper:
-        l = np.conjugate(np.swapaxes(l, -2, -1))
-    return l
+        return np.conjugate(np.swapaxes(lt, -2, -1))
+    return lt
 
 
 @register_numpy_types(linalg.cholesky_inverse)

--- a/nncf/experimental/tensor/functions/numpy_numeric.py
+++ b/nncf/experimental/tensor/functions/numpy_numeric.py
@@ -292,3 +292,8 @@ def _(
     a: Union[np.ndarray, np.generic], axis: Optional[int] = None, descending=False, stable=False
 ) -> Union[np.ndarray, np.generic]:
     return np.argsort(a, axis=axis)
+
+
+@register_numpy_types(numeric.diag)
+def _(a: Union[np.ndarray, np.generic], k: int = 0) -> np.ndarray:
+    return np.diag(a, k=k)

--- a/nncf/experimental/tensor/functions/torch_linalg.py
+++ b/nncf/experimental/tensor/functions/torch_linalg.py
@@ -23,3 +23,22 @@ def _(
     keepdims: bool = False,
 ) -> torch.Tensor:
     return torch.linalg.norm(a, ord=ord, dim=axis, keepdims=keepdims)
+
+
+@linalg.cholesky.register(torch.Tensor)
+def _(a: torch.Tensor, upper: bool = False) -> torch.Tensor:
+    if a.ndim != 2:
+        raise ValueError(f"Input tensor needs to be 2D but received a {a.ndim}d-tensor.")
+    return torch.linalg.cholesky(a, upper=upper)
+
+
+@linalg.cholesky_inverse.register(torch.Tensor)
+def _(a: torch.Tensor, upper: bool = False) -> torch.Tensor:
+    if a.ndim != 2:
+        raise ValueError(f"Input tensor needs to be 2D but received a {a.ndim}d-tensor.")
+    return torch.cholesky_inverse(a, upper=upper)
+
+
+@linalg.inv.register(torch.Tensor)
+def _(a: torch.Tensor) -> torch.Tensor:
+    return torch.linalg.inv(a)

--- a/nncf/experimental/tensor/functions/torch_linalg.py
+++ b/nncf/experimental/tensor/functions/torch_linalg.py
@@ -27,15 +27,11 @@ def _(
 
 @linalg.cholesky.register(torch.Tensor)
 def _(a: torch.Tensor, upper: bool = False) -> torch.Tensor:
-    if a.ndim != 2:
-        raise ValueError(f"Input tensor needs to be 2D but received a {a.ndim}d-tensor.")
     return torch.linalg.cholesky(a, upper=upper)
 
 
 @linalg.cholesky_inverse.register(torch.Tensor)
 def _(a: torch.Tensor, upper: bool = False) -> torch.Tensor:
-    if a.ndim != 2:
-        raise ValueError(f"Input tensor needs to be 2D but received a {a.ndim}d-tensor.")
     return torch.cholesky_inverse(a, upper=upper)
 
 

--- a/nncf/experimental/tensor/functions/torch_numeric.py
+++ b/nncf/experimental/tensor/functions/torch_numeric.py
@@ -294,3 +294,8 @@ def _(a: torch.Tensor, axes: Optional[Tuple[int, ...]] = None) -> torch.Tensor:
 @numeric.argsort.register(torch.Tensor)
 def _(a: torch.Tensor, axis: Optional[int] = None, descending=False, stable=False) -> torch.Tensor:
     return torch.argsort(a, dim=axis, descending=descending, stable=stable)
+
+
+@numeric.diag.register(torch.Tensor)
+def _(a: torch.Tensor, k: int = 0) -> torch.Tensor:
+    return torch.diag(a, diagonal=k)

--- a/tests/shared/test_templates/template_test_nncf_tensor.py
+++ b/tests/shared/test_templates/template_test_nncf_tensor.py
@@ -1107,3 +1107,93 @@ class TemplateTestNNCFTensorOperators:
         assert fns.allclose(res.data, ref_tensor)
         assert res.device == tensor.device
         assert res.shape == tuple(ref_tensor.shape)
+
+    @pytest.mark.parametrize(
+        "a, upper, ref",
+        (
+            ([[1.0, 2.0], [2.0, 5.0]], False, [[1.0, 0.0], [2.0, 1.0]]),
+            ([[1.0, 2.0], [2.0, 5.0]], True, [[1.0, 2.0], [0.0, 1.0]]),
+        ),
+    )
+    def test_fn_linalg_cholesky(self, a, upper, ref):
+        tensor_a = Tensor(self.to_tensor(a))
+        ref_tensor = self.to_tensor(ref)
+
+        res = fns.linalg.cholesky(tensor_a, upper=upper)
+
+        assert isinstance(res, Tensor)
+        assert fns.allclose(res.data, ref_tensor)
+        assert res.device == tensor_a.device
+
+    def test_fn_linalg_cholesky_3d(self):
+        tensor_a = Tensor(self.to_tensor([[[0.5, 0.2], [0.5, 0.7]], [[0.2, 0.9], [0.1, 0.9]]]))
+
+        with pytest.raises(ValueError) as excinfo:
+            fns.linalg.cholesky(tensor_a)
+        assert str(excinfo.value) == "Input tensor needs to be 2D but received a 3d-tensor."
+
+    @pytest.mark.parametrize(
+        "a, upper, ref",
+        (
+            ([[1.0, 0.0], [2.0, 1.0]], False, [[5.0, -2.0], [-2.0, 1.0]]),
+            ([[1.0, 2.0], [0.0, 1.0]], True, [[5.0, -2.0], [-2.0, 1.0]]),
+        ),
+    )
+    def test_fn_linalg_cholesky_inverse(self, a, upper, ref):
+        tensor_a = Tensor(self.to_tensor(a))
+        ref_tensor = self.to_tensor(ref)
+
+        res = fns.linalg.cholesky_inverse(tensor_a, upper=upper)
+
+        assert isinstance(res, Tensor)
+        assert fns.allclose(res.data, ref_tensor)
+        assert res.device == tensor_a.device
+
+    def test_fn_linalg_cholesky_inverse_3d(self):
+        tensor_a = Tensor(self.to_tensor([[[0.5, 0.2], [0.5, 0.7]], [[0.2, 0.9], [0.1, 0.9]]]))
+
+        with pytest.raises(ValueError) as excinfo:
+            fns.linalg.cholesky(tensor_a)
+
+        assert str(excinfo.value) == "Input tensor needs to be 2D but received a 3d-tensor."
+
+    @pytest.mark.parametrize(
+        "a, ref",
+        (
+            ([[1.0, 2.0], [2.0, 5.0]], [[5.0, -2.0], [-2.0, 1.0]]),
+            (
+                [[[0.5, 0.2], [0.5, 0.7]], [[0.2, 0.8], [0.1, 0.8]]],
+                [[[2.8, -0.8], [-2.0, 2.0]], [[10.0, -10.0], [-1.25, 2.5]]],
+            ),
+        ),
+    )
+    def test_fn_linalg_inv(self, a, ref):
+        tensor_a = Tensor(self.to_tensor(a))
+        ref_tensor = self.to_tensor(ref)
+
+        res = fns.linalg.inv(tensor_a)
+
+        assert isinstance(res, Tensor)
+        assert fns.allclose(res.data, ref_tensor)
+        assert res.device == tensor_a.device
+
+    @pytest.mark.parametrize(
+        "a, k, ref",
+        (
+            ([[1.0, 3.0], [2.0, 5.0]], 0, [1.0, 5.0]),
+            ([[1.0, 3.0], [2.0, 5.0]], 1, [3.0]),
+            ([[1.0, 3.0], [2.0, 5.0]], -1, [2.0]),
+            ([1.0, 5.0], 0, [[1.0, 0.0], [0.0, 5.0]]),
+            ([3.0], 1, [[0.0, 3.0], [0.0, 0.0]]),
+            ([2.0], -1, [[0.0, 0.0], [2.0, 0.0]]),
+        ),
+    )
+    def test_fn_diag(self, a, k, ref):
+        tensor_a = Tensor(self.to_tensor(a))
+        ref_tensor = self.to_tensor(ref)
+
+        res = fns.diag(tensor_a, k=k)
+
+        assert isinstance(res, Tensor)
+        assert fns.allclose(res.data, ref_tensor)
+        assert res.device == tensor_a.device

--- a/tests/shared/test_templates/template_test_nncf_tensor.py
+++ b/tests/shared/test_templates/template_test_nncf_tensor.py
@@ -1113,6 +1113,16 @@ class TemplateTestNNCFTensorOperators:
         (
             ([[1.0, 2.0], [2.0, 5.0]], False, [[1.0, 0.0], [2.0, 1.0]]),
             ([[1.0, 2.0], [2.0, 5.0]], True, [[1.0, 2.0], [0.0, 1.0]]),
+            (
+                [[[1.0, 2.0], [2.0, 5.0]], [[9.0, -3.0], [-3.0, 5.0]]],
+                False,
+                [[[1.0, 0.0], [2.0, 1.0]], [[3.0, 0.0], [-1.0, 2.0]]],
+            ),
+            (
+                [[[1.0, 2.0], [2.0, 5.0]], [[9.0, -3.0], [-3.0, 5.0]]],
+                True,
+                [[[1.0, 2.0], [0.0, 1.0]], [[3.0, -1.0], [0.0, 2.0]]],
+            ),
         ),
     )
     def test_fn_linalg_cholesky(self, a, upper, ref):
@@ -1125,18 +1135,21 @@ class TemplateTestNNCFTensorOperators:
         assert fns.allclose(res.data, ref_tensor)
         assert res.device == tensor_a.device
 
-    def test_fn_linalg_cholesky_3d(self):
-        tensor_a = Tensor(self.to_tensor([[[0.5, 0.2], [0.5, 0.7]], [[0.2, 0.9], [0.1, 0.9]]]))
-
-        with pytest.raises(ValueError) as excinfo:
-            fns.linalg.cholesky(tensor_a)
-        assert str(excinfo.value) == "Input tensor needs to be 2D but received a 3d-tensor."
-
     @pytest.mark.parametrize(
         "a, upper, ref",
         (
             ([[1.0, 0.0], [2.0, 1.0]], False, [[5.0, -2.0], [-2.0, 1.0]]),
             ([[1.0, 2.0], [0.0, 1.0]], True, [[5.0, -2.0], [-2.0, 1.0]]),
+            (
+                [[[1.0, 0.0], [2.0, 1.0]], [[3.0, 0.0], [-1.0, 2.0]]],
+                False,
+                [[[5.0, -2.0], [-2.0, 1.0]], [[0.1388888888888889, 0.08333333333333333], [0.08333333333333333, 0.25]]],
+            ),
+            (
+                [[[1.0, 2.0], [0.0, 1.0]], [[3.0, -1.0], [0.0, 2.0]]],
+                True,
+                [[[5.0, -2.0], [-2.0, 1.0]], [[0.1388888888888889, 0.08333333333333333], [0.08333333333333333, 0.25]]],
+            ),
         ),
     )
     def test_fn_linalg_cholesky_inverse(self, a, upper, ref):
@@ -1148,14 +1161,6 @@ class TemplateTestNNCFTensorOperators:
         assert isinstance(res, Tensor)
         assert fns.allclose(res.data, ref_tensor)
         assert res.device == tensor_a.device
-
-    def test_fn_linalg_cholesky_inverse_3d(self):
-        tensor_a = Tensor(self.to_tensor([[[0.5, 0.2], [0.5, 0.7]], [[0.2, 0.9], [0.1, 0.9]]]))
-
-        with pytest.raises(ValueError) as excinfo:
-            fns.linalg.cholesky(tensor_a)
-
-        assert str(excinfo.value) == "Input tensor needs to be 2D but received a 3d-tensor."
 
     @pytest.mark.parametrize(
         "a, ref",


### PR DESCRIPTION
### Changes
The following functions were added:

- numeric.py: diag
- linalg.py: cholesky, cholesky_inverse, inv


### Reason for changes
Part of GPTQ implementation.

### Related tickets
126887

### Tests
tests/shared/test_templates/template_test_nncf_tensor.py

