### PR TITLE
Update accuracy drop reference value for SSD example

### DIFF
--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -155,7 +155,7 @@
         "accuracy_metrics": {
             "fp32_mAP": 0.5228869318962097,
             "int8_mAP": 0.5148677825927734,
-            "accuracy_drop": 0.009263157844543457
+            "accuracy_drop": 0.0080191493
         },
         "performance_metrics": {
             "fp32_fps": 33.7,


### PR DESCRIPTION
### Changes

Update accuracy drop reference value. 

### Reason for changes

In #2246 reference accuracy values for original and quantized models were updated, but the corresponding accuracy drop reference value was not updated.

### Related tickets

136123