### PR TITLE
Update references for 2024.1

### DIFF
--- a/tests/openvino/native/data/2024.1/reference_scales/yolo-v3-tiny-onnx_mixed.json
+++ b/tests/openvino/native/data/2024.1/reference_scales/yolo-v3-tiny-onnx_mixed.json
@@ -7155,7 +7155,7 @@
         "output_low": -0.3303394019603729,
         "output_high": 3.881488084793091
     },
-    "Multiply_6981/fq_weights_1": {
+    "Multiply_6911/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -14339,7 +14339,7 @@
         "output_low": -1.0861154794692993,
         "output_high": 7.848060131072998
     },
-    "Multiply_6939/fq_weights_1": {
+    "Multiply_6869/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -21523,7 +21523,7 @@
         "output_low": -1.0673936605453491,
         "output_high": 13.258152961730957
     },
-    "Multiply_6932/fq_weights_1": {
+    "Multiply_6862/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -25123,7 +25123,7 @@
         "output_low": -0.6687189340591431,
         "output_high": 11.511518478393555
     },
-    "Multiply_6925/fq_weights_1": {
+    "Multiply_6855/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -26931,7 +26931,7 @@
         "output_low": -0.5482831001281738,
         "output_high": 6.109440326690674
     },
-    "Multiply_6918/fq_weights_1": {
+    "Multiply_6848/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -27843,7 +27843,7 @@
         "output_low": -1.5592432022094727,
         "output_high": 3.473757028579712
     },
-    "Multiply_6911/fq_weights_1": {
+    "Multiply_6841/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -28319,7 +28319,7 @@
         "output_low": -0.2852116525173187,
         "output_high": 3.020650625228882
     },
-    "Multiply_6974/fq_weights_1": {
+    "Multiply_6904/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -31919,7 +31919,7 @@
         "output_low": -0.21894927322864532,
         "output_high": 1.706294298171997
     },
-    "Multiply_6960/fq_weights_1": {
+    "Multiply_6890/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -39103,7 +39103,7 @@
         "output_low": -1.4062703847885132,
         "output_high": 7.131800174713135
     },
-    "Multiply_6953/fq_weights_1": {
+    "Multiply_6883/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -67791,7 +67791,7 @@
         "output_low": -0.7759751081466675,
         "output_high": 3.3463926315307617
     },
-    "Multiply_6946/fq_weights_1": {
+    "Multiply_6876/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -89293,7 +89293,7 @@
         "output_low": -0.3361658453941345,
         "output_high": 3.5603017807006836
     },
-    "Multiply_6967/fq_weights_1": {
+    "Multiply_6897/fq_weights_1": {
         "input_low": [
             [
                 [

--- a/tests/openvino/native/data/2024.1/reference_scales/yolo-v3-tiny-onnx_performance.json
+++ b/tests/openvino/native/data/2024.1/reference_scales/yolo-v3-tiny-onnx_performance.json
@@ -7155,7 +7155,7 @@
         "output_low": -3.859119176864624,
         "output_high": 3.828969717025757
     },
-    "Multiply_6981/fq_weights_1": {
+    "Multiply_6911/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -14339,7 +14339,7 @@
         "output_low": -7.785910606384277,
         "output_high": 7.725083351135254
     },
-    "Multiply_6939/fq_weights_1": {
+    "Multiply_6869/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -21523,7 +21523,7 @@
         "output_low": -13.285137176513672,
         "output_high": 13.181346893310547
     },
-    "Multiply_6932/fq_weights_1": {
+    "Multiply_6862/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -25123,7 +25123,7 @@
         "output_low": -11.602160453796387,
         "output_high": 11.511518478393555
     },
-    "Multiply_6925/fq_weights_1": {
+    "Multiply_6855/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -26931,7 +26931,7 @@
         "output_low": -6.0120320320129395,
         "output_high": 5.965063095092773
     },
-    "Multiply_6918/fq_weights_1": {
+    "Multiply_6848/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -27843,7 +27843,7 @@
         "output_low": -3.5011093616485596,
         "output_high": 3.473757028579712
     },
-    "Multiply_6911/fq_weights_1": {
+    "Multiply_6841/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -28319,7 +28319,7 @@
         "output_low": -3.0029969215393066,
         "output_high": 2.9795360565185547
     },
-    "Multiply_6974/fq_weights_1": {
+    "Multiply_6904/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -31919,7 +31919,7 @@
         "output_low": -1.6986862421035767,
         "output_high": 1.685415267944336
     },
-    "Multiply_6960/fq_weights_1": {
+    "Multiply_6890/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -39103,7 +39103,7 @@
         "output_low": -7.094355583190918,
         "output_high": 7.038930892944336
     },
-    "Multiply_6953/fq_weights_1": {
+    "Multiply_6883/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -67791,7 +67791,7 @@
         "output_low": -3.372742176055908,
         "output_high": 3.3463926315307617
     },
-    "Multiply_6946/fq_weights_1": {
+    "Multiply_6876/fq_weights_1": {
         "input_low": [
             [
                 [
@@ -89293,7 +89293,7 @@
         "output_low": -3.5883357524871826,
         "output_high": 3.5603017807006836
     },
-    "Multiply_6967/fq_weights_1": {
+    "Multiply_6897/fq_weights_1": {
         "input_low": [
             [
                 [


### PR DESCRIPTION
### Changes

- Update references for OV 2024.1;

### Reason for changes

- Bugfix for `openvino-nightly`;

### Related tickets

- N/A

### Tests

- openvino-nightly/windows_precommit_openvino/23 - failed (with the issue from CVS-135890, expected to fix on the OpenVINO side)
- openvino-nightly/ubuntu20_precommit_openvino/57 - failed (with the issue from CVS-135890, expected to fix on the OpenVINO side)