### PR TITLE
Inherit OverfloFix and QuantizationPreset from StrEnum

### DIFF
--- a/nncf/__init__.py
+++ b/nncf/__init__.py
@@ -46,6 +46,7 @@ from nncf.quantization.advanced_parameters import (
     AdvancedAccuracyRestorerParameters as AdvancedAccuracyRestorerParameters,
 )
 from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters as AdvancedQuantizationParameters
+from nncf.quantization.advanced_parameters import OverflowFix as OverflowFix
 from nncf.scopes import IgnoredScope as IgnoredScope
 from nncf.scopes import Subgraph as Subgraph
 from nncf.version import __version__ as __version__

--- a/nncf/common/quantization/structs.py
+++ b/nncf/common/quantization/structs.py
@@ -19,6 +19,7 @@ from nncf.common.graph import NNCFNodeName
 from nncf.common.utils.api_marker import api
 from nncf.config.schemata.defaults import QUANTIZATION_BITS
 from nncf.config.schemata.defaults import QUANTIZATION_PER_CHANNEL
+from nncf.parameters import StrEnum
 from nncf.parameters import TargetDevice
 
 
@@ -327,7 +328,7 @@ class UnifiedScaleType(Enum):
 
 
 @api(canonical_alias="nncf.QuantizationPreset")
-class QuantizationPreset(Enum):
+class QuantizationPreset(StrEnum):
     """
     An enum with values corresponding to the available quantization presets.
     """

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -17,12 +17,12 @@ from dataclasses import field
 from dataclasses import fields
 from dataclasses import is_dataclass
 from enum import Enum
-from enum import StrEnum
 from typing import Any, Dict, Optional, Union
 
 import nncf
 from nncf.common.quantization.structs import QuantizationScheme as QuantizationMode
 from nncf.common.utils.api_marker import api
+from nncf.parameters import StrEnum
 from nncf.quantization.range_estimator import AggregatorType
 from nncf.quantization.range_estimator import RangeEstimatorParameters
 from nncf.quantization.range_estimator import StatisticsType

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -27,7 +27,7 @@ from nncf.quantization.range_estimator import RangeEstimatorParameters
 from nncf.quantization.range_estimator import StatisticsType
 
 
-@api()
+@api(canonical_alias="nncf.OverflowFix")
 class OverflowFix(Enum):
     """
     This option controls whether to apply the overflow issue fix for the 8-bit

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -17,6 +17,7 @@ from dataclasses import field
 from dataclasses import fields
 from dataclasses import is_dataclass
 from enum import Enum
+from enum import StrEnum
 from typing import Any, Dict, Optional, Union
 
 import nncf
@@ -28,7 +29,7 @@ from nncf.quantization.range_estimator import StatisticsType
 
 
 @api(canonical_alias="nncf.OverflowFix")
-class OverflowFix(Enum):
+class OverflowFix(StrEnum):
     """
     This option controls whether to apply the overflow issue fix for the 8-bit
     quantization.


### PR DESCRIPTION
### Changes

- Inherit `OverflowFix` and `QuantizationPreset` from `StrEnum` instead of `Enum` to make them serializable.
- Expose `OverflowFix` as `nncf.OverflowFix`

### Reason for changes

Came up during optimum-intel integration.