### PR TITLE
[ONNX] NNCFGraph building: align edges output_port_id with OpenVINO

### DIFF
--- a/nncf/onnx/graph/nncf_graph_builder.py
+++ b/nncf/onnx/graph/nncf_graph_builder.py
@@ -38,7 +38,6 @@ from nncf.onnx.graph.onnx_helper import get_input_port_id_for_node_after_input
 from nncf.onnx.graph.onnx_helper import get_model_inputs
 from nncf.onnx.graph.onnx_helper import get_output_port_id_for_node_before_output
 from nncf.onnx.graph.onnx_helper import get_parents_node_mapping
-from nncf.onnx.graph.onnx_helper import get_port_ids_between_nodes
 from nncf.onnx.graph.onnx_helper import is_node_has_shared_weight
 
 
@@ -279,7 +278,6 @@ class GraphConverter:
                     output_port_id=output_port_id,
                     dtype=nncf_dtype,
                 )
-                output_port_id += 1
 
     @staticmethod
     def _add_nncf_output_nodes(
@@ -324,7 +322,6 @@ class GraphConverter:
                 output_port_id=output_port_id,
                 dtype=nncf_dtype,
             )
-            input_port_id += 1
 
     @staticmethod
     def convert_onnx_dtype_to_nncf_dtype(onnx_dtype: int) -> Dtype:
@@ -381,32 +378,30 @@ class GraphConverter:
                 is_shared=is_shared,
             )
 
-        for output_node in onnx_model.graph.node:
-            output_edges = output_node.output
-            for output_edge in output_edges:
-                edge = edge_info_mapping.get(output_edge)
-                if edge is None:
-                    # If the edge is None it means that the edge was not added during shape inference of ONNX model.
-                    # BatchNorm exported in Training mode has unused outputs edges: mean, var, saved_mean, saved_var.
-                    # NNCFGraph should not contain such edges.
-                    continue
-                tensor_shape = get_edge_shape(edge)
-                onnx_dtype = get_edge_dtype(edge)
-                nncf_dtype = GraphConverter.convert_onnx_dtype_to_nncf_dtype(onnx_dtype)
-                output_node_id = nncf_graph.get_node_by_name(output_node.name).node_id
-                input_nodes = children_node_mapping[output_edge]
-                for input_node in input_nodes:
-                    port_ids = get_port_ids_between_nodes(output_node, input_node)
-                    input_port_id = port_ids["input_port_id"]
-                    output_port_id = port_ids["output_port_id"]
-                    in_node_id = nncf_graph.get_node_by_name(input_node.name).node_id
+        for node in onnx_model.graph.node:
+            for output_port_id, output_edge_name in enumerate(node.output):
+                for consumed_node in children_node_mapping[output_edge_name]:
+                    edge = edge_info_mapping.get(output_edge_name)
+                    if edge is None:
+                        # If the edge is None it means that the edge was not added during shape inference of ONNX model.
+                        # BatchNorm exported in Training mode has unused outputs edges:
+                        # mean, var, saved_mean, saved_var. NNCFGraph should not contain such edges.
+                        continue
+                    input_port_id = get_input_port_id_for_node_after_input(output_edge_name, consumed_node)
+
+                    in_node_id = nncf_graph.get_node_by_name(node.name).node_id
+                    output_node_id = nncf_graph.get_node_by_name(consumed_node.name).node_id
+                    tensor_shape = get_edge_shape(edge)
+                    onnx_dtype = get_edge_dtype(edge)
+                    nncf_dtype = GraphConverter.convert_onnx_dtype_to_nncf_dtype(onnx_dtype)
+
                     nncf_graph.add_edge_between_nncf_nodes(
-                        from_node_id=output_node_id,
-                        to_node_id=in_node_id,
+                        from_node_id=in_node_id,
+                        to_node_id=output_node_id,
                         tensor_shape=tensor_shape,
                         input_port_id=input_port_id,
                         output_port_id=output_port_id,
-                        dtype=Dtype(nncf_dtype),
+                        dtype=nncf_dtype,
                     )
 
         GraphConverter._add_nncf_input_nodes(onnx_model, nncf_graph, edge_info_mapping, children_node_mapping)

--- a/nncf/onnx/graph/onnx_helper.py
+++ b/nncf/onnx/graph/onnx_helper.py
@@ -114,26 +114,6 @@ def get_output_port_id_for_node_before_output(output_name: str, from_node: onnx.
     raise nncf.ValidationError(f"The node {from_node} does not have output edge with the name {output_name}")
 
 
-def get_port_ids_between_nodes(from_node: onnx.NodeProto, to_node: onnx.NodeProto) -> Dict[str, int]:
-    """
-    Returns input_port_id and output_port_id between 'from_node' and 'to_node'.
-
-    :param from_node: Node, whose output is connected to 'to_node' node.
-    :param to_node: Node, whose input is connected to 'from_node' node.
-    :return: Dict{'input_port_id': input port id, 'output_port_id': output port id}
-    """
-    output = {"input_port_id": None, "output_port_id": None}
-    for port_id, port in enumerate(to_node.input):
-        if port in from_node.output:
-            output["input_port_id"] = port_id
-    for port_id, port in enumerate(from_node.output):
-        if port in to_node.input:
-            output["output_port_id"] = port_id
-    if output["output_port_id"] is None or output["input_port_id"] is None:
-        raise nncf.InternalError(f"The nodes {from_node.name} and {to_node.name} do not have edges between.")
-    return output
-
-
 def get_node_index(model: onnx.ModelProto, node_name: str) -> Optional[int]:
     """
     Returns the node index in the model.

--- a/tests/onnx/quantization/test_bias_correction.py
+++ b/tests/onnx/quantization/test_bias_correction.py
@@ -212,7 +212,7 @@ class TestONNXBCAlgorithm(TemplateTestBCAlgorithm):
                 MultipleConvTestModel,
                 {
                     ("/conv_1/Conv", 0): ("nncf_model_input_0", 0),
-                    ("/conv_3/Conv", 0): ("nncf_model_input_0", 1),
+                    ("/conv_3/Conv", 0): ("nncf_model_input_0", 0),
                 },
             ),
             (ConvTestModel, {("/conv/Conv", 0): ("nncf_model_input_0", 0)}),


### PR DESCRIPTION
### Changes

Align edges output_port_id values at NNCFGraph with OpenVINO

### Reason for changes

Due to the difference between values at ONNX and OpenVINO - BiasCorrection algorithm works different. 

### Related tickets

N/A

### Tests

BC test was udpated.