### PR TITLE
Expose some advanced quantization parameters to be available as nncf.*

### DIFF
--- a/nncf/__init__.py
+++ b/nncf/__init__.py
@@ -45,7 +45,9 @@ from nncf.quantization import quantize_with_accuracy_control as quantize_with_ac
 from nncf.quantization.advanced_parameters import (
     AdvancedAccuracyRestorerParameters as AdvancedAccuracyRestorerParameters,
 )
+from nncf.quantization.advanced_parameters import AdvancedBiasCorrectionParameters as AdvancedBiasCorrectionParameters
 from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters as AdvancedQuantizationParameters
+from nncf.quantization.advanced_parameters import AdvancedSmoothQuantParameters as AdvancedSmoothQuantParameters
 from nncf.quantization.advanced_parameters import OverflowFix as OverflowFix
 from nncf.scopes import IgnoredScope as IgnoredScope
 from nncf.scopes import Subgraph as Subgraph

--- a/nncf/common/quantization/structs.py
+++ b/nncf/common/quantization/structs.py
@@ -24,7 +24,7 @@ from nncf.parameters import TargetDevice
 
 
 @api()
-class QuantizationScheme:
+class QuantizationScheme(StrEnum):
     """
     Basic enumeration for quantization scheme specification.
 

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -59,7 +59,7 @@ class OverflowFix(StrEnum):
 
 
 @api()
-class FP8Type(Enum):
+class FP8Type(StrEnum):
     """
     Defines FP8 special types (https://arxiv.org/pdf/2209.05433.pdf).
 


### PR DESCRIPTION
Follow-up to #2608.

### Changes

- Expose `AdvancedSmoothQuantParameters` and `AdvancedBiasCorrectionParameters` to be available as `nncf.AdvancedSmoothQuantParameters`, `nncf.AdvancedBiasCorrectionParameters`.
- Inherit `QuantizationScheme` and `FP8Type` from `StrEnum`.

### Reason for changes

Improving NNCF UX.
