### PR TITLE
Bump transformers version

### DIFF
--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -2,7 +2,7 @@
 torch==2.2.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torchvision==0.17.1
-transformers==4.36.0
+transformers==4.38.0
 onnx==1.16.0
 onnxruntime==1.17.1
 pytest==8.0.2

--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -2,7 +2,7 @@
 torch==2.2.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torchvision==0.17.1
-transformers==4.39.3
+transformers==4.38.2
 onnx==1.16.0
 onnxruntime==1.17.1
 pytest==8.0.2

--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -2,7 +2,7 @@
 torch==2.2.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torchvision==0.17.1
-transformers==4.38.0
+transformers==4.39.3
 onnx==1.16.0
 onnxruntime==1.17.1
 pytest==8.0.2

--- a/tests/torch/models_hub_test/requirements.txt
+++ b/tests/torch/models_hub_test/requirements.txt
@@ -2,7 +2,7 @@
 torch==2.2.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torchvision==0.17.1
-transformers==4.38.0
+transformers==4.39.3
 pytest==8.0.2
 timm==0.9.2
 scikit-learn==1.2.2

--- a/tests/torch/models_hub_test/requirements.txt
+++ b/tests/torch/models_hub_test/requirements.txt
@@ -2,7 +2,7 @@
 torch==2.2.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torchvision==0.17.1
-transformers==4.36.0
+transformers==4.38.0
 pytest==8.0.2
 timm==0.9.2
 scikit-learn==1.2.2

--- a/tests/torch/models_hub_test/requirements.txt
+++ b/tests/torch/models_hub_test/requirements.txt
@@ -2,7 +2,7 @@
 torch==2.2.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torchvision==0.17.1
-transformers==4.39.3
+transformers==4.38.2
 pytest==8.0.2
 timm==0.9.2
 scikit-learn==1.2.2

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -9,7 +9,7 @@ virtualenv
 
 # Required for search_building_blocks tests
 transformers[torch]~=4.38.2
-accelerate==0.24.1
+accelerate==0.28.0
 
 # Required for movement_sparsity tests
 datasets~=2.14.0

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -8,7 +8,7 @@ pytest-dependency>=0.5.1
 virtualenv
 
 # Required for search_building_blocks tests
-transformers[torch]~=4.39.3
+transformers[torch]~=4.38.2
 accelerate==0.24.1
 
 # Required for movement_sparsity tests

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -8,7 +8,7 @@ pytest-dependency>=0.5.1
 virtualenv
 
 # Required for search_building_blocks tests
-transformers[torch]~=4.38.0
+transformers[torch]~=4.39.3
 accelerate==0.24.1
 
 # Required for movement_sparsity tests

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -8,7 +8,7 @@ pytest-dependency>=0.5.1
 virtualenv
 
 # Required for search_building_blocks tests
-transformers[torch]~=4.36.0
+transformers[torch]~=4.38.0
 accelerate==0.24.1
 
 # Required for movement_sparsity tests


### PR DESCRIPTION
### Changes

- Bumped **transformers** package version to 4.38.2;
- Updating to 4.39.3 is not possible due to **optimum** incompatibility;
- Bumped **accelerate** package due to issue in **transformers** package;

### Reason for changes

- Package security issues;

### Related tickets

- N/A

### Tests

- post_training_quantization/355/ - passed
- additional post_training_quantization/358/ - passed
