### PR TITLE
Revert inheritance of QuantizationScheme from StrEnum

### DIFF
--- a/nncf/common/quantization/structs.py
+++ b/nncf/common/quantization/structs.py
@@ -24,7 +24,7 @@ from nncf.parameters import TargetDevice
 
 
 @api()
-class QuantizationScheme(StrEnum):
+class QuantizationScheme:
     """
     Basic enumeration for quantization scheme specification.
 


### PR DESCRIPTION
### Changes

Do not inherit `QuantizationScheme` from `StrEnum`

### Reason for changes

Fix degradation introduced in #2624 
