### PR TITLE
Fix missed openvino-dev version package

### DIFF
--- a/tests/openvino/requirements.txt
+++ b/tests/openvino/requirements.txt
@@ -2,6 +2,6 @@ pytest==8.0.2
 virtualenv
 pytest-cov
 pytest-mock>=3.3.1
-openvino-dev[onnx,pytorch,tensorflow2]==2023.3
+openvino-dev[onnx,pytorch,tensorflow2]==2024.0
 torch==2.2.1
 fastdownload


### PR DESCRIPTION
### Changes

- Bumped missed **openvino-dev** package version;

### Reason for changes

- Missed package version;

### Related tickets

- N/A

### Tests

- post_training_quantization/359/ - passed