### PR TITLE
[Release] Deprecate install extra packages (#2616)

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,10 @@ pip install nncf[torch]
 
 Other viable options besides `[torch]` are `[tf]`, `[onnx]` and `[openvino]`.
 
+> [!WARNING]
+> The way to install the module package with the extra dependency like `pip install nncf[torch]` is deprecated and will be removed in a future release.
+> Instead, it is recommended to install additional dependencies separately using the pip install command (e.g., `pip install torch`) or by explicitly specifying the dependency in your requirements file.
+
 NNCF is also available via [conda](https://anaconda.org/conda-forge/nncf):
 
 ```bash
@@ -383,7 +387,7 @@ conda install -c conda-forge nncf
 ### System requirements
 
 - Ubuntu\* 18.04 or later (64-bit)
-- Python\* 3.7 or later
+- Python\* 3.8 or later
 - Supported frameworks:
   - PyTorch\* >=2.1, <2.3
   - TensorFlow\* >=2.8.4, <=2.12.1

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -12,34 +12,12 @@ NNCF can be installed as a regular PyPI package via pip:
 pip install nncf
 ```
 
-If you want to install both NNCF and the supported PyTorch version in one line, you can do this by simply running:
-
-```bash
-pip install nncf[torch]
-```
-
-Other viable options besides `[torch]` are `[tf]`, `[onnx]` and `[openvino]`.
-
 ## As a package built from a checked-out repository
 
 Install the package and its dependencies by running the following command in the repository root directory:
 
 ```bash
 pip install .
-```
-
-Use the same `pip install` syntax as above to install NNCF along with the backend package version in one go:
-
-```bash
-pip install .[<BACKEND>]
-```
-
-List of supported backends: `torch`, `tf`, `onnx` and `openvino`.
-
-For development purposes install extra packages by
-
-```bash
-pip install .[dev,tests]
 ```
 
 _NB_: For launching example scripts in this repository, we recommend setting the `PYTHONPATH` variable to the root of the checked-out repository once the installation is completed.
@@ -65,7 +43,7 @@ as well as the supported versions of Python:
 
 | NNCF      | OpenVINO   | PyTorch  | ONNX     | TensorFlow | Python |
 |-----------|------------|----------|----------|------------|--------|
-| `develop` | `2024.4.0` | `2.2.1`  | `1.13.1` | `2.12.0`   | `3.8`  |
+| `develop` | `2024.4.0` | `2.2.1`  | `1.16.0` | `2.12.0`   | `3.8`  |
 | `2.9.0`   | `2024.4.0` | `2.1.2`  | `1.13.1` | `2.12.0`   | `3.8`  |
 | `2.8.1`   | `2023.3.0` | `2.1.2`  | `1.13.1` | `2.12.0`   | `3.8`  |
 | `2.8.0`   | `2023.3.0` | `2.1.2`  | `1.13.1` | `2.12.0`   | `3.8`  |


### PR DESCRIPTION
### Changes

- Depreciated message about installation extra requirements by `pip install nncf[torch]`
- Fix system requirements of python version (actual python>=3.8)
- Update corresponding onnx version

### Related tickets

134503
