### PR TITLE
[OpenVINO] Update reference for YOLOV8 after PR#2610

### DIFF
--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -40,8 +40,8 @@
         "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
         "accuracy_metrics": {
             "fp32_mAP": 0.45252755065175254,
-            "int8_mAP": 0.4425154975267813,
-            "accuracy_drop": 0.01001205312497122
+            "int8_mAP": 0.4561537594798616,
+            "accuracy_drop": -0.00362620882
         },
         "performance_metrics": {
             "fp32_fps": 170.69,


### PR DESCRIPTION
### Changes

Increase INT8 metrics after [2610](https://github.com/openvinotoolkit/nncf/pull/2610)

### Reason for changes

Two extra quantizers were removed -> int8 metrics improved

### Related tickets

N/A

### Tests

test job is run
