### PR TITLE
[Torch] Do not wrap not tensor inputs

### DIFF
--- a/nncf/torch/dynamic_graph/io_handling.py
+++ b/nncf/torch/dynamic_graph/io_handling.py
@@ -308,6 +308,9 @@ class InputInfoWrapManager:
     def wrap_inputs(self, model_args: Tuple, model_kwargs: Dict) -> Tuple[Tuple, Dict]:
         bound_model_params = self._fwd_signature.bind(*model_args, **model_kwargs)
         for param_name, dummy_input in self._fwd_param_names_to_dummy_inputs_odict.items():
+            if not isinstance(dummy_input, torch.Tensor):
+                continue  # Did not expect a tensor at this parameter during graph building, shouldn't wrap now too
+
             param_kind = self._fwd_signature.parameters[param_name].kind
             if param_kind is Parameter.VAR_POSITIONAL or param_kind is Parameter.VAR_KEYWORD:
                 nncf_logger.warning(
@@ -327,14 +330,6 @@ class InputInfoWrapManager:
                 bound_model_params.apply_defaults()
 
             potential_tensor = bound_model_params.arguments[param_name]
-            if not isinstance(dummy_input, torch.Tensor):
-                if isinstance(potential_tensor, torch.Tensor):
-                    raise RuntimeError(
-                        f'Original model forward parameter "{param_name}" expected to not be a tensor,'
-                        " but the tensor type recieved. Please use a tensor type as an example input"
-                        f' for the "{param_name}" parameter_name'
-                    )
-                continue  # Did not expect a tensor at this parameter during graph building, shouldn't wrap now too
 
             if potential_tensor is None:
                 # Default was None - cannot wrap as-is. Will wrap a dummy tensor as specified in

--- a/tests/torch/helpers.py
+++ b/tests/torch/helpers.py
@@ -365,6 +365,24 @@ class EmptyModel(nn.Module):
         return None
 
 
+class ModelWithReloadedForward(nn.Module):
+    """
+    Model accepts tensor or a dict in format
+    {"tensor": input_tensor}
+    """
+
+    INPUT_SHAPE = [1, 1]
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(1, 1)
+
+    def forward(self, x):
+        if isinstance(x, dict):
+            self.forward(x["tensor"])
+        return self.linear(x)
+
+
 def check_correct_nncf_modules_replacement(
     model: torch.nn.Module, compressed_model: NNCFNetwork
 ) -> Tuple[Dict[Scope, Module], Dict[Scope, Module]]:


### PR DESCRIPTION
### Changes

* NNCF wrapping for Tensor input parameters is skipped when actual parameter is not a tensor


### Reason for changes

* To support models which could accept different types as an input
(example: [YolovV8](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py#L77-L89) 
```
def forward(self, x, *args, **kwargs):
    if isinstance(x, dict):  # for cases of training and validating while training.
        return self.loss(x, *args, **kwargs)
    return self.predict(x, *args, **kwargs)
```

### Related tickets

138682

### Tests

* tests/torch/test_input_management.py is extended
