### PR TITLE
[OV] Speedup precommit tests

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -64,7 +64,7 @@ jobs:
           name: coverage_onnx
           flags: ONNX
   openvino:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-8-cores
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ install-openvino-dev: install-openvino-test install-pre-commit
 	pip install -r examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/requirements.txt
 
 test-openvino:
-	ONEDNN_MAX_CPU_ISA=AVX2 pytest ${COVERAGE_ARGS} -n4 tests/openvino $(DATA_ARG) --junitxml ${JUNITXML_PATH}
+	ONEDNN_MAX_CPU_ISA=AVX2 pytest ${COVERAGE_ARGS} -n4 -ra tests/openvino $(DATA_ARG) --junitxml ${JUNITXML_PATH}
 
 test-install-openvino:
 	pytest tests/cross_fw/install -s        \

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ install-openvino-dev: install-openvino-test install-pre-commit
 	pip install -r examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/requirements.txt
 
 test-openvino:
-	ONEDNN_MAX_CPU_ISA=AVX2 pytest ${COVERAGE_ARGS} tests/openvino $(DATA_ARG) --junitxml ${JUNITXML_PATH}
+	ONEDNN_MAX_CPU_ISA=AVX2 pytest ${COVERAGE_ARGS} -n4 tests/openvino $(DATA_ARG) --junitxml ${JUNITXML_PATH}
 
 test-install-openvino:
 	pytest tests/cross_fw/install -s        \

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -122,7 +122,8 @@ class InplaceOpTestCase:
     dims: str = "DEFAULT"
 
     def __str__(self) -> str:
-        return str(self.__dict__.values())
+        s = f"{self.name}-{self.reduce_shape}-{self.op_builder.__name__}-{self.ref_types}-{self.ref_values}-{self.dims}"
+        return s.replace(" ", "")
 
 
 LINEAR_MODEL_SHAPES = {

--- a/tests/openvino/requirements.txt
+++ b/tests/openvino/requirements.txt
@@ -1,4 +1,5 @@
 pytest==8.0.2
+pytest-xdist==3.5.0
 virtualenv
 pytest-cov
 pytest-mock>=3.3.1


### PR DESCRIPTION
### Changes

Use `ubuntu-20.04-8-cores` runner 
Run tests in parallel by xdist (12 vs 37 mins)
Add summary `-ra` to show list of not passed tests (skip, xfail, fail)

