### PR TITLE
[API][Torch] Save/Load transformations

### DIFF
--- a/nncf/torch/__init__.py
+++ b/nncf/torch/__init__.py
@@ -48,6 +48,7 @@ from nncf.torch.knowledge_distillation import algo as knowledge_distillation_alg
 from nncf.torch.model_creation import create_compressed_model
 from nncf.torch.model_creation import is_wrapped_model
 from nncf.torch.model_creation import wrap_model
+from nncf.torch.model_creation import load_from_config
 from nncf.torch.checkpoint_loading import load_state
 from nncf.torch.initialization import register_default_init_args
 from nncf.torch.layers import register_module

--- a/nncf/torch/model_creation.py
+++ b/nncf/torch/model_creation.py
@@ -39,6 +39,8 @@ from nncf.torch.dynamic_graph.io_handling import ExampleInputInfo
 from nncf.torch.dynamic_graph.io_handling import FillerInputInfo
 from nncf.torch.dynamic_graph.io_handling import LoaderInputInfo
 from nncf.torch.dynamic_graph.io_handling import ModelInputInfo
+from nncf.torch.graph.transformations.serialization import deserialize_transformations
+from nncf.torch.model_transformer import PTModelTransformer
 from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.utils import is_dist_avail_and_initialized
 from nncf.torch.utils import is_main_process
@@ -351,3 +353,20 @@ def is_wrapped_model(model: torch.nn.Module) -> bool:
     :return: True if the model is wrapped, False otherwise.
     """
     return isinstance(model, NNCFNetwork)
+
+
+def load_from_config(model: torch.nn.Module, config: Dict[str, Any], example_input: Any) -> NNCFNetwork:
+    """
+    Wraps given model to a NNCFNetwork and recovers additional modules from given NNCFNetwork config.
+    Does not recover additional modules weights as they are located in a corresponded state_dict.
+
+    :param model: PyTorch model.
+    :param config: NNCNetwork config.
+    :param example_input: An example input that will be used for model tracing. A tuple is interpreted
+        as an example input of a set of non keyword arguments, and a dict as an example input of a set
+        of keywords arguments.
+    :return: NNCFNetwork builded from given model with additional modules recovered from given NNCFNetwork config.
+    """
+    nncf_network = wrap_model(model, example_input, trace_parameters=config.pop(NNCFNetwork.TRACE_PARAMETERS_KEY))
+    transformation_layout = deserialize_transformations(config)
+    return PTModelTransformer(nncf_network).transform(transformation_layout)


### PR DESCRIPTION
### Changes

`model.nncf.get_config` method and `nncf.torch.load_from_config` function are presented

### Reason for changes

To enable saving/loading NNCFNetwork transformations

### Related tickets

129586

### Tests

`tests/torch/test_serialization.py` is updated
