### PR TITLE
[Torch][Tests] Build cuda qantizer extentions before the DataParallel

### DIFF
--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -948,9 +948,9 @@ def test_works_when_wrapped_with_dataparallel():
     if not torch.cuda.is_available() and torch.cuda.device_count() > 1:
         pytest.xfail("The executing host must have > 1 CUDA GPU in order for this test to be relevant.")
 
-    model = SharedLayersModel()
+    model = SharedLayersModel().cuda()
     config = get_quantization_config_without_range_init(model_size=1)
     register_bn_adaptation_init_args(config)
     model, _ = create_compressed_model_and_algo_for_test(model, config)
-    model = torch.nn.DataParallel(model.cuda())
+    model = torch.nn.DataParallel(model)
     model(torch.ones([10, 1, 1, 1], device="cuda"))


### PR DESCRIPTION
### Changes

Model moved to cuda before the quantization in `test_works_when_wrapped_with_dataparallel`

### Reason for changes

To build CUDA extensions in main process as pytorch could not build extensions in dataparallell mode

### Related tickets

https://github.com/pytorch/pytorch/issues/125403

### Tests

torch_nightly/204/ - Passed

Test started to fail because the order of the tests were changed:

torch_nightly/197:
```
tests/torch/nas/test_sanity_sample.py ........                           [  0%]
[2024-04-25T00:01:42.305Z] tests/torch/quantization/test_functions.py ............sss...sss........ [  2%]
...
```
torch_nightly/198
```
[2024-04-26T00:03:47.228Z] tests/torch/nas/test_sanity_sample.py ........                           [  0%]
[2024-04-26T00:03:47.804Z] tests/torch/nncf_network/test_nncf_network.py .                          [  0%]
[2024-04-26T00:04:26.574Z] tests/torch/quantization/test_algo_quantization.py F                     [  0%]
```

