### PR TITLE
[Torch] Do not change state of the compression parameter

### DIFF
--- a/nncf/torch/layer_utils.py
+++ b/nncf/torch/layer_utils.py
@@ -149,12 +149,7 @@ class CompressionParameter(nn.Parameter):
         """
         super().__init__()
 
-        self._compression_lr_multiplier = compression_lr_multiplier
         if compression_lr_multiplier is not None and self.dtype.is_floating_point:
             self.requires_grad = True
             self.register_hook(lambda grad: compression_lr_multiplier * grad)
             self.requires_grad = requires_grad
-
-    @property
-    def compression_lr_multiplier(self):
-        return self._compression_lr_multiplier

--- a/nncf/torch/sparsity/rb/layers.py
+++ b/nncf/torch/sparsity/rb/layers.py
@@ -37,6 +37,7 @@ class RBSparsifyingWeight(BinaryMask, StatefullModuleInterface):
             requires_grad=not self.frozen,
             compression_lr_multiplier=compression_lr_multiplier,
         )
+        self._compression_lr_multiplier = compression_lr_multiplier
         self.binary_mask = binary_mask(self._mask)
         self.register_buffer("uniform", torch.zeros(weight_shape))
         self.mask_calculation_hook = MaskCalculationHook(self)
@@ -61,7 +62,7 @@ class RBSparsifyingWeight(BinaryMask, StatefullModuleInterface):
         return {
             self.WEIGHTS_SHAPE_KEY: list(self.mask.shape),
             self.FROZEN_KEY: self.frozen,
-            self.COMPRESSION_LR_MULTIPLIER_KEY: self.mask.compression_lr_multiplier,
+            self.COMPRESSION_LR_MULTIPLIER_KEY: self._compression_lr_multiplier,
             self.EPS_KEY: self.eps,
         }
 

--- a/tests/torch/test_serialization.py
+++ b/tests/torch/test_serialization.py
@@ -306,7 +306,7 @@ def test_rb_sparsity_mask_serialization():
 
     assert list(recovered_mask.mask.shape) == ref_weights_shape
     assert recovered_mask.frozen == ref_frozen
-    assert recovered_mask.mask.compression_lr_multiplier == ref_compression_lr_multiplier
+    assert recovered_mask._compression_lr_multiplier == ref_compression_lr_multiplier
     assert recovered_mask.eps == ref_eps
 
     assert torch.all(mask.mask == recovered_mask.mask)


### PR DESCRIPTION
### Changes

`_compression_lr_multiplier`  attribute introduced in  #2531 is removed from the `CompressionParameter`

### Reason for changes

`_compression_lr_multiplier` makes the `CompressionParameter` a stateful parameter which for some reason does not work properly in distributed/dataparallel mode


### Tests

torch_nightly/213/ - finished successfully
