### PR TITLE
[TF] Fix dependency conflict

### DIFF
--- a/examples/tensorflow/requirements.txt
+++ b/examples/tensorflow/requirements.txt
@@ -4,6 +4,7 @@ absl-py==1.0.0
 tensorflow
 tensorflow_datasets==4.2.0
 tensorflow_hub
-tensorflow_addons~=0.20.0
+tensorflow_addons==0.20.0
+tensorflow-metadata==1.13.0
 opencv-python
 pycocotools==2.0.6

--- a/tests/tensorflow/requirements.txt
+++ b/tests/tensorflow/requirements.txt
@@ -1,6 +1,8 @@
+-c ../../constraints.txt
 PyYAML
-tensorflow_addons~=0.20.0
-pytest==8.0.2
+tensorflow_addons==0.20.0
+tensorflow-metadata==1.13.0
+pytest
 pytest-cov
 pytest-mock
 pytest-dependency
@@ -12,4 +14,4 @@ virtualenv
 # filelock 3.12.3 requires typing-extensions>=4.7.1, but tensorflow 2.12.1 requires typing-extensions<4.6.0,>=3.6.6
 # TODO: remove after upgrade to TF 2.13
 filelock<3.12.3
-openvino-dev==2024.1
+openvino-dev


### PR DESCRIPTION
### Changes

tensorflow-metadata 1.13.0

### Reason for changes

```
tensorflow-metadata 1.14.0 requires protobuf<4.21,>=3.20.3, but you have protobuf 3.19.6 which is incompatible.
```

### Related tickets

140478

