### PR TITLE
[OV] Compress bf16 weights

### DIFF
--- a/nncf/experimental/tensor/definitions.py
+++ b/nncf/experimental/tensor/definitions.py
@@ -29,6 +29,7 @@ class TensorDataType(Enum):
     """
 
     float16 = auto()
+    bfloat16 = auto()
     float32 = auto()
     float64 = auto()
     int8 = auto()

--- a/nncf/experimental/tensor/functions/torch_numeric.py
+++ b/nncf/experimental/tensor/functions/torch_numeric.py
@@ -21,6 +21,7 @@ from nncf.experimental.tensor.functions import numeric as numeric
 
 DTYPE_MAP = {
     TensorDataType.float16: torch.float16,
+    TensorDataType.bfloat16: torch.bfloat16,
     TensorDataType.float32: torch.float32,
     TensorDataType.float64: torch.float64,
     TensorDataType.int8: torch.int8,

--- a/nncf/openvino/graph/nncf_graph_builder.py
+++ b/nncf/openvino/graph/nncf_graph_builder.py
@@ -45,6 +45,7 @@ class GraphConverter:
         type_name = ov_type.get_type_name()
         conversion_map = {
             "f16": "float",
+            "bf16": "float",
             "f32": "float",
             "f64": "float",
             "i4": "int",

--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -109,6 +109,8 @@ def get_const_value(const_node: ov.Node, dtype: Optional[np.dtype] = None) -> np
     :param dtype: Destination type.
     :return: The constant value.
     """
+    if dtype == None:
+        return const_node.data
     return const_node.get_data(dtype=dtype)
 
 

--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -101,14 +101,15 @@ def get_number_if_op(model: ov.Model) -> int:
     return cnt_if_op(model, 0)
 
 
-def get_const_value(const_node: ov.Node) -> np.ndarray:
+def get_const_value(const_node: ov.Node, dtype: Optional[np.dtype] = None) -> np.ndarray:
     """
     Returns the constant tensor for the node.
 
     :param const_node: OpenVINO node.
+    :param dtype: Destination type.
     :return: The constant value.
     """
-    return const_node.data
+    return const_node.get_data(dtype=dtype)
 
 
 def get_bias_value(node_with_bias: NNCFNode, nncf_graph: NNCFGraph, model: ov.Model) -> np.ndarray:

--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -109,7 +109,7 @@ def get_const_value(const_node: ov.Node, dtype: Optional[np.dtype] = None) -> np
     :param dtype: Destination type.
     :return: The constant value.
     """
-    if dtype == None:
+    if dtype is None:
         return const_node.data
     return const_node.get_data(dtype=dtype)
 

--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -318,7 +318,12 @@ class WeightCompression(Algorithm):
                     continue
 
                 weight = self._backend_entity.get_weight(node, weight_port_id, model, graph)
-                if weight.dtype not in [TensorDataType.float32, TensorDataType.float16, TensorDataType.float64]:
+                if weight.dtype not in [
+                    TensorDataType.float16,
+                    TensorDataType.bfloat16,
+                    TensorDataType.float32,
+                    TensorDataType.float64,
+                ]:
                     continue
                 reduction_axes = self._backend_entity.get_reduction_axes(node, weight_port_id, graph)
                 if (

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -160,7 +160,10 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                         should_add_convert_node = True
                         break
 
-            weight = Tensor(get_const_value(const_node, np.float32))
+            dtype = None
+            if const_dtype == ov.Type.bf16:
+                dtype = np.float32
+            weight = Tensor(get_const_value(const_node, dtype))
             original_shape = weight.shape
             compressed_weight = compress_weight(
                 weight,

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -150,7 +150,15 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
             const_attributes = wc_params.node_with_weight.layer_attributes.constant_attributes[wc_params.weight_port_id]
             const_node_name = const_attributes["name"]
             const_node = self.name_to_node_mapping[const_node_name]
-            const_dtype = const_node.output(0).get_element_type()
+            const_node_output = const_node.output(0)
+            const_dtype = const_node_output.get_element_type()
+
+            should_add_convert_node = False
+            if const_dtype != ov.Type.f16:
+                for inp in const_node_output.get_target_inputs():
+                    if inp.get_node().get_type_name() != "Convert":
+                        should_add_convert_node = True
+                        break
 
             weight = Tensor(get_const_value(const_node, np.float32))
             original_shape = weight.shape
@@ -188,7 +196,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
             if compression_config.group_size != -1:
                 mul = opset.reshape(mul, output_shape=original_shape, special_zero=False)
 
-            if const_dtype != ov.Type.f16:
+            if should_add_convert_node:
                 mul = opset.convert(
                     mul, const_dtype, name=f"{const_node_name}/fq_weights_{wc_params.weight_port_id}/convert"
                 )

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -160,10 +160,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                         should_add_convert_node = True
                         break
 
-            dtype = None
-            if const_dtype == ov.Type.bf16:
-                dtype = np.float32
-            weight = Tensor(get_const_value(const_node, dtype))
+            weight = Tensor(get_const_value(const_node, np.float32 if const_dtype == ov.Type.bf16 else None))
             original_shape = weight.shape
             compressed_weight = compress_weight(
                 weight,

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 from typing import Dict, Iterable, List, Optional, Tuple
 
+import numpy as np
 import openvino as ov
 from openvino.runtime import opset13 as opset
 
@@ -151,7 +152,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
             const_node = self.name_to_node_mapping[const_node_name]
             const_dtype = const_node.output(0).get_element_type()
 
-            weight = Tensor(get_const_value(const_node))
+            weight = Tensor(get_const_value(const_node, np.float32))
             original_shape = weight.shape
             compressed_weight = compress_weight(
                 weight,

--- a/tests/openvino/native/models.py
+++ b/tests/openvino/native/models.py
@@ -12,7 +12,7 @@
 from abc import ABC
 from abc import abstractmethod
 from functools import partial
-from typing import Callable, Tuple
+from typing import Callable, Optional, Tuple
 
 import numpy as np
 import openvino.runtime as ov
@@ -812,13 +812,13 @@ class SequentialMatmulModel(OVReferenceModel):
 
 
 class IdentityMatmul(OVReferenceModel):
-    def _create_ov_model(self, weights_dtype=None, activation_dtype=None):
+    def _create_ov_model(self, weights_dtype: Optional[ov.Type] = None, activation_dtype: Optional[ov.Type] = None):
         """
-        :param: weights_dtype: precision of weights, should be either np.float32 or np.float16
-        :param: activation_dtype: precision of activations, should be either np.float32 or np.float16
+        :param: weights_dtype: precision of weights
+        :param: activation_dtype: precision of activations
         """
-        weights_dtype = np.float32 if weights_dtype is None else weights_dtype
-        activation_dtype = np.float32 if activation_dtype is None else activation_dtype
+        weights_dtype = ov.Type.f32 if weights_dtype is None else weights_dtype
+        activation_dtype = ov.Type.f32 if activation_dtype is None else activation_dtype
 
         input_node = opset.parameter([3, 3], dtype=activation_dtype, name="Input_1")
         weights_data = np.eye(3) * 255

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -783,8 +783,8 @@ def test_compression_for_different_dtypes(activation_dtype, weight_dtype):
         assert next_node.get_type_name() != "Convert"
     else:
         assert next_node.get_type_name() == "Convert"
-        # In case weight is in fp32, the convert node is manually inserted
-        if weight_dtype == np.float32:
+        # In case precision of weight and activation were equal, but not f16, the convert node is manually inserted
+        if activation_dtype == weight_dtype and weight_dtype != ov.Type.f16:
             assert next_node.get_friendly_name() == "weights/fq_weights_1/convert"
 
 

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -33,6 +33,7 @@ from nncf.quantization.algorithms.weight_compression.weight_lowering import get_
 from nncf.quantization.algorithms.weight_compression.weight_lowering import reshape_weight_for_grouped_quantization
 from nncf.scopes import IgnoredScope
 from tests.openvino.native.common import get_actual_reference_for_current_openvino
+from tests.openvino.native.common import get_openvino_major_minor_version
 from tests.openvino.native.models import AWQActMatmulModel
 from tests.openvino.native.models import AWQMatmulModel
 from tests.openvino.native.models import GatherAndMatmulShareData
@@ -747,35 +748,44 @@ def test_data_type_for_num_weights(mocker):
     assert isinstance(params.num_weights, np.uint64)
 
 
-def test_compression_for_different_dtypes():
-    for activation_dtype in [np.float32, np.float16]:
-        for weight_dtype in [np.float32, np.float16]:
-            if activation_dtype == np.float16 and weight_dtype == np.float32:
-                # Activations can be in f16 only if weights are in f16
-                continue
+@pytest.mark.parametrize(
+    "activation_dtype, weight_dtype",
+    [
+        (ov.Type.f32, ov.Type.f32),
+        (ov.Type.f32, ov.Type.f16),
+        (ov.Type.f32, ov.Type.bf16),
+        (ov.Type.f16, ov.Type.f16),
+        (ov.Type.bf16, ov.Type.bf16),
+    ],
+)
+def test_compression_for_different_dtypes(activation_dtype, weight_dtype):
+    if weight_dtype == ov.Type.bf16:
+        ov_major_version, ov_minor_version = get_openvino_major_minor_version()
+        if ov_major_version < 2024 or (ov_major_version == 2024 and ov_minor_version < 2):
+            pytest.xfail("const_node.get_data() is not supported until 2024.2")
 
-            model = IdentityMatmul(weights_dtype=weight_dtype, activation_dtype=activation_dtype).ov_model
-            compressed_model = compress_weights(
-                model, mode=CompressWeightsMode.INT4_SYM, ratio=1, group_size=1, all_layers=True
-            )
-            name_to_node_map = {op.get_friendly_name(): op for op in compressed_model.get_ops()}
+    model = IdentityMatmul(weights_dtype=weight_dtype, activation_dtype=activation_dtype).ov_model
+    compressed_model = compress_weights(
+        model, mode=CompressWeightsMode.INT4_SYM, ratio=1, group_size=1, all_layers=True
+    )
+    name_to_node_map = {op.get_friendly_name(): op for op in compressed_model.get_ops()}
 
-            # Weight scale should be in fp16 nevertheless the weight data type
-            scale_multiply_node = name_to_node_map["weights/fq_weights_1"]
-            assert scale_multiply_node.input_value(1).get_node().get_element_type() == ov.Type.f16
+    # Weight scale should be in fp16 nevertheless the weight data type
+    scale_multiply_node = name_to_node_map["weights/fq_weights_1"]
+    assert scale_multiply_node.input_value(1).get_node().get_element_type() == ov.Type.f16
 
-            reshape_node = get_next_node(scale_multiply_node)
-            assert reshape_node.get_type_name() == "Reshape"
+    reshape_node = get_next_node(scale_multiply_node)
+    assert reshape_node.get_type_name() == "Reshape"
 
-            next_node = get_next_node(reshape_node)
-            if activation_dtype == np.float16:
-                # There should be no convert node after multiply if both weights and activations are in f16
-                assert next_node.get_type_name() != "Convert"
-            else:
-                assert next_node.get_type_name() == "Convert"
-                # In case weight is in fp32, the convert node is manually inserted
-                if weight_dtype == np.float32:
-                    assert next_node.get_friendly_name() == "weights/fq_weights_1/convert"
+    next_node = get_next_node(reshape_node)
+    if activation_dtype == ov.Type.f16:
+        # There should be no convert node after multiply if both weights and activations are in f16
+        assert next_node.get_type_name() != "Convert"
+    else:
+        assert next_node.get_type_name() == "Convert"
+        # In case weight is in fp32, the convert node is manually inserted
+        if weight_dtype == np.float32:
+            assert next_node.get_friendly_name() == "weights/fq_weights_1/convert"
 
 
 DATASET_SIZE = 129

--- a/tests/openvino/native/test_nncf_graph_builder.py
+++ b/tests/openvino/native/test_nncf_graph_builder.py
@@ -124,12 +124,10 @@ def test_convert_to_nncf_dtype_supported_types(ov_type: ov.Type, expected_nncf_d
 @pytest.mark.parametrize(
     "ov_type",
     [
-        ov.Type.bf16,
         ov.Type.nf4,
         ov.Type.undefined,
-        # TODO(andrey-churkin): Add in OV 2024.0
-        # ov.Type.f8e4m3,
-        # ov.Type.f8e5m2,
+        ov.Type.f8e4m3,
+        ov.Type.f8e5m2,
     ],
 )
 def test_convert_to_nncf_dtype_unsupported_types(ov_type: ov.Type):


### PR DESCRIPTION
### Changes

Added support for bf16 in `nncf.compress_weights`

### Reason for changes

Support models with bf16 weights and fp32 or fp16 inference precision.

### Related tickets

ref: 141582

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->

tests/openvino/native/quantization/test_weights_compression.py:test_compression_for_different_dtypes