### PR TITLE
Remove dependency from typing_extensions 

### DIFF
--- a/nncf/common/accuracy_aware_training/training_loop.py
+++ b/nncf/common/accuracy_aware_training/training_loop.py
@@ -15,12 +15,10 @@ import pathlib
 from abc import ABC
 from abc import abstractmethod
 from functools import partial
-from typing import Callable, Dict, List, Optional, Tuple, TypedDict, TypeVar, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, cast
 
 import numpy as np
 from scipy.interpolate import interp1d  # type: ignore
-from typing_extensions import NotRequired
-from typing_extensions import Unpack
 
 import nncf
 from nncf.api.compression import CompressionAlgorithmController
@@ -635,19 +633,11 @@ class AccuracyAwareTrainingMode:
     ADAPTIVE_COMPRESSION_LEVEL = "adaptive_compression_level"
 
 
-class additionalRunnerArgs(TypedDict):
-    lr_updates_needed: bool
-    verbose: bool
-    minimal_compression_rate: NotRequired[float]
-    maximal_compression_rate: float
-    dump_checkpoints: bool
-
-
 def create_accuracy_aware_training_loop(
     nncf_config: NNCFConfig,
     compression_ctrl: CompressionAlgorithmController,
     uncompressed_model_accuracy: float,
-    **additional_runner_args: Unpack[additionalRunnerArgs],
+    **additional_runner_args: Any,
 ) -> BaseEarlyExitCompressionTrainingLoop:
     """
     Creates an accuracy aware training loop corresponding to NNCFConfig and CompressionAlgorithmController.
@@ -661,7 +651,7 @@ def create_accuracy_aware_training_loop(
     accuracy_aware_training_mode = accuracy_aware_training_params.get("mode")
     if accuracy_aware_training_mode == AccuracyAwareTrainingMode.EARLY_EXIT:
         return EarlyExitCompressionTrainingLoop(
-            nncf_config, compression_ctrl, uncompressed_model_accuracy, **additional_runner_args  # type: ignore
+            nncf_config, compression_ctrl, uncompressed_model_accuracy, **additional_runner_args
         )
     if accuracy_aware_training_mode == AccuracyAwareTrainingMode.ADAPTIVE_COMPRESSION_LEVEL:
         return AdaptiveCompressionTrainingLoop(

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,6 @@ INSTALL_REQUIRES = [
     "scipy>=1.3.2",
     "tabulate>=0.9.0",
     "tqdm>=4.54.1",
-    "typing_extensions>=4.1.1",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ INSTALL_REQUIRES = [
     "scipy>=1.3.2",
     "tabulate>=0.9.0",
     "tqdm>=4.54.1",
+    "typing_extensions>=4.1.1",
 ]
 
 


### PR DESCRIPTION
### Changes

Remove dependency from typing_extensions 

### Reason for changes

Fail with `ImportError` on python>=3.9.

nncf.common depends from typing_extensions packages
https://github.com/openvinotoolkit/nncf/blob/47187e5bbaef678508fdfdc980b258fc4e32d3db/nncf/common/accuracy_aware_training/training_loop.py#L22-L23

With python3.8 typing_extensions installs as depends of rich module, but it works only on `python<3.9`
```
Collecting typing-extensions<5.0,>=4.0.0 (from rich>=13.5.2->nncf==2.11.0.dev0+1406e7f)
```
https://github.com/Textualize/rich/blob/349042fd8912ab5f0714ff9a46a70ef8a4be4700/pyproject.toml#L31

### Tests
tests/cross_fw/install (python 3.10)
