### PR TITLE
[OpenVINO] Remove unnecessary extra input

### DIFF
--- a/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/main.py
+++ b/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/main.py
@@ -193,7 +193,6 @@ def quantize_ac(model: ov.Model, data_loader: torch.utils.data.DataLoader, valid
                     inputs=[
                         "/model.22/Concat_3",
                         "/model.22/Concat_6",
-                        "/model.22/Concat_24",
                         "/model.22/Concat_5",
                         "/model.22/Concat_4",
                     ],


### PR DESCRIPTION
### Changes

One of the subgraph inputs can be safely removed from ignored_scope as does not affect the resulted quantized model.

### Reason for changes

Fix the incorrect name on a new OV release version.

### Related tickets

142369

### Tests

N/A
