### PR TITLE
Fix test examples

### DIFF
--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -109,7 +109,7 @@
         }
     },
     "post_training_quantization_tensorflow_mobilenet_v2": {
-        "backend": "tensorflow",
+        "backend": "tf",
         "requirements": "examples/post_training_quantization/tensorflow/mobilenet_v2/requirements.txt",
         "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
         "accuracy_metrics": {


### PR DESCRIPTION
### Changes

Fix name of backend

### Reason for changes

```
>   packages = [item for b in backends for item in MAP_BACKEND_PACKAGES[b]]
E   KeyError: 'tensorflow'
```


### Tests

tests.cross_fw.examples.test_examples.test_examples[post_training_quantization_tensorflow_mobilenet_v2] 
