### PR TITLE
Fix torch operator unpatching

### DIFF
--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -24,6 +24,7 @@ from torch.nn.parallel import DistributedDataParallel
 import nncf
 from nncf import nncf_logger
 from nncf.common.utils.api_marker import api
+from nncf.torch.dynamic_graph.patch_pytorch_state import PATCHING_STATE
 from nncf.torch.dynamic_graph.structs import NamespaceTarget
 from nncf.torch.dynamic_graph.structs import PatchedOperatorInfo
 from nncf.torch.dynamic_graph.trace_tensor import TracedParameter
@@ -270,11 +271,8 @@ class OriginalOpInfo:
 
 ORIGINAL_OPERATORS: List[OriginalOpInfo] = []
 ORIGINAL_CALL = torch.nn.Module.__call__
-_JIT_ALREADY_WRAPPED = False
-_OPERATORS_ALREADY_WRAPPED = False
 _ORIG_JIT_SCRIPT = None
 _ORIG_JIT_TRACE_MAKE_MODULE = None
-_COMPILE_ALREADY_WRAPPED = False
 _ORIG_TORCH_COMPILE: Union[Callable, None] = None
 
 
@@ -352,24 +350,21 @@ def get_all_functions_from_namespace(namespace: NamespaceTarget, do_filter: bool
 
 def patch_torch_operators():
     # Only patch torch.jit.script during first patch_torch_operators call
-    global _JIT_ALREADY_WRAPPED
-    if not _JIT_ALREADY_WRAPPED:
+    if not PATCHING_STATE.jit_is_wrapped:
         patch_torch_jit()
-        _JIT_ALREADY_WRAPPED = True
+        PATCHING_STATE.jit_is_wrapped = True
 
     # Unpatch torch operators during model compilation.
-    global _COMPILE_ALREADY_WRAPPED
-    if not _COMPILE_ALREADY_WRAPPED:
+    if not PATCHING_STATE.compile_is_wrapped:
         global _ORIG_TORCH_COMPILE
         _ORIG_TORCH_COMPILE = torch.compile
         setattr(torch, "compile", get_torch_compile_wrapper())
-        _COMPILE_ALREADY_WRAPPED = True
+        PATCHING_STATE.compile_is_wrapped = True
 
     # Do not patch operators twice as well
-    global _OPERATORS_ALREADY_WRAPPED
-    if _OPERATORS_ALREADY_WRAPPED:
+    if PATCHING_STATE.operators_are_wrapped:
         return
-    _OPERATORS_ALREADY_WRAPPED = True
+    PATCHING_STATE.operators_are_wrapped = True
 
     global ORIGINAL_OPERATORS
     ORIGINAL_OPERATORS = []
@@ -437,10 +432,9 @@ def patch_torch_operators():
 
 
 def unpatch_torch_operators():
-    global _OPERATORS_ALREADY_WRAPPED
-    if not _OPERATORS_ALREADY_WRAPPED:
+    if not PATCHING_STATE.operators_are_wrapped:
         return
-    _OPERATORS_ALREADY_WRAPPED = False
+    PATCHING_STATE.operators_are_wrapped = False
 
     for orig_op_info in ORIGINAL_OPERATORS:
         setattr(orig_op_info.namespace, orig_op_info.name, orig_op_info.op)
@@ -448,7 +442,7 @@ def unpatch_torch_operators():
 
 @contextmanager
 def disable_patching():
-    was_patched = _OPERATORS_ALREADY_WRAPPED
+    was_patched = PATCHING_STATE.operators_are_wrapped
     if was_patched:
         unpatch_torch_operators()
     try:
@@ -458,7 +452,3 @@ def disable_patching():
         # Need to restore the previous state of patching in this case before continuing to the exception handling.
         if was_patched:
             patch_torch_operators()
-
-
-def operators_are_wrapped() -> bool:
-    return _OPERATORS_ALREADY_WRAPPED

--- a/nncf/torch/dynamic_graph/patch_pytorch.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch.py
@@ -458,3 +458,7 @@ def disable_patching():
         # Need to restore the previous state of patching in this case before continuing to the exception handling.
         if was_patched:
             patch_torch_operators()
+
+
+def operators_are_wrapped() -> bool:
+    return _OPERATORS_ALREADY_WRAPPED

--- a/nncf/torch/dynamic_graph/patch_pytorch_state.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch_state.py
@@ -1,3 +1,14 @@
+# Copyright (c) 2024 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass
 
 

--- a/nncf/torch/dynamic_graph/patch_pytorch_state.py
+++ b/nncf/torch/dynamic_graph/patch_pytorch_state.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class PatchingState:
+    """
+    A class to track which pytorch components were patched by NNCF.
+    """
+
+    jit_is_wrapped: bool = False
+    operators_are_wrapped: bool = False
+    compile_is_wrapped: bool = False
+
+
+PATCHING_STATE = PatchingState()

--- a/nncf/torch/dynamic_graph/wrappers.py
+++ b/nncf/torch/dynamic_graph/wrappers.py
@@ -26,6 +26,7 @@ from nncf.torch.dynamic_graph.context import get_current_context
 from nncf.torch.dynamic_graph.layer_attributes_handlers import get_layer_attributes_from_args_and_kwargs
 from nncf.torch.dynamic_graph.op_input_processing import OperatorInput
 from nncf.torch.dynamic_graph.operation_address import OperationAddress
+from nncf.torch.dynamic_graph.patch_pytorch_state import PATCHING_STATE
 from nncf.torch.dynamic_graph.structs import NamespaceTarget
 from nncf.torch.dynamic_graph.structs import PatchedOperatorInfo
 from nncf.torch.dynamic_graph.trace_functions import forward_trace_only
@@ -76,9 +77,7 @@ def wrap_operator(operator, operator_info: PatchedOperatorInfo):
 
     @functools.wraps(operator)
     def wrapped(*args, **kwargs):
-        from nncf.torch.dynamic_graph.patch_pytorch import operators_are_wrapped
-
-        if not operators_are_wrapped():
+        if not PATCHING_STATE.operators_are_wrapped:
             # If operators are not supposed to be wrapped, skip the wrapper logic
             return operator(*args, **kwargs)
 

--- a/nncf/torch/dynamic_graph/wrappers.py
+++ b/nncf/torch/dynamic_graph/wrappers.py
@@ -76,6 +76,12 @@ def wrap_operator(operator, operator_info: PatchedOperatorInfo):
 
     @functools.wraps(operator)
     def wrapped(*args, **kwargs):
+        from nncf.torch.dynamic_graph.patch_pytorch import operators_are_wrapped
+
+        if not operators_are_wrapped():
+            # If operators are not supposed to be wrapped, skip the wrapper logic
+            return operator(*args, **kwargs)
+
         ctx = get_current_context()
         if not ctx or getattr(ctx, "in_operator", False) or not ctx.is_tracing:
             op1 = operator(*args, **kwargs)

--- a/tests/torch/test_pytorch_patch.py
+++ b/tests/torch/test_pytorch_patch.py
@@ -23,7 +23,7 @@ from nncf.torch.dynamic_graph.context import get_current_context
 from nncf.torch.dynamic_graph.patch_pytorch import _ORIG_JIT_SCRIPT
 from nncf.torch.dynamic_graph.patch_pytorch import MagicFunctionsToPatch
 from nncf.torch.dynamic_graph.patch_pytorch import disable_patching
-from nncf.torch.dynamic_graph.patch_pytorch import operators_are_wrapped
+from nncf.torch.dynamic_graph.patch_pytorch_state import PATCHING_STATE
 from nncf.torch.dynamic_graph.structs import NamespaceTarget
 from nncf.torch.dynamic_graph.trace_tensor import TensorMeta
 from nncf.torch.dynamic_graph.trace_tensor import TracedTensor
@@ -216,7 +216,7 @@ def test_operator_unpatching():
     example_input = torch.ones((1,))
     wrapped_operator = wrap_model(test_model, example_input)
     with disable_patching():
-        assert not operators_are_wrapped()
+        assert not PATCHING_STATE.operators_are_wrapped
         # Despite patching is disabled, test_model holds a reference to a patched operator
         assert "_original_op" in test_model.op.__dict__
         unwrapped_operator_expected = True

--- a/tests/torch/test_pytorch_patch.py
+++ b/tests/torch/test_pytorch_patch.py
@@ -17,9 +17,13 @@ import torch
 
 import nncf
 from nncf.config import NNCFConfig
+from nncf.torch import wrap_model
 from nncf.torch.dynamic_graph.context import TracingContext
+from nncf.torch.dynamic_graph.context import get_current_context
 from nncf.torch.dynamic_graph.patch_pytorch import _ORIG_JIT_SCRIPT
 from nncf.torch.dynamic_graph.patch_pytorch import MagicFunctionsToPatch
+from nncf.torch.dynamic_graph.patch_pytorch import disable_patching
+from nncf.torch.dynamic_graph.patch_pytorch import operators_are_wrapped
 from nncf.torch.dynamic_graph.structs import NamespaceTarget
 from nncf.torch.dynamic_graph.trace_tensor import TensorMeta
 from nncf.torch.dynamic_graph.trace_tensor import TracedTensor
@@ -188,3 +192,32 @@ def get_test_quantization_config(model):
     )
     register_bn_adaptation_init_args(config)
     return config
+
+
+def test_operator_unpatching():
+    unwrapped_operator_expected = False
+
+    class TestModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.op = torch.nn.functional.gelu
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            ctx = get_current_context()
+            original_in_operator_value = ctx.in_operator
+            ctx.in_operator = "unexpected_value"
+            result = self.op(x)
+            # If ctx.in_operator value was not changed, then operator wrapper exited early
+            assert not unwrapped_operator_expected or ctx.in_operator == "unexpected_value"
+            ctx.in_operator = original_in_operator_value
+            return result
+
+    test_model = TestModel()
+    example_input = torch.ones((1,))
+    wrapped_operator = wrap_model(test_model, example_input)
+    with disable_patching():
+        assert not operators_are_wrapped()
+        # Despite patching is disabled, test_model holds a reference to a patched operator
+        assert "_original_op" in test_model.op.__dict__
+        unwrapped_operator_expected = True
+        wrapped_operator(example_input)


### PR DESCRIPTION
### Changes

- Add condition to skip operator wrapping if torch is in unpatched state
- Fix test from a previous PR #2665 (remove dependency of the test on `nncf.torch`)

### Reason for changes

Fix inference of compiled torch models when `nncf.torch` is imported

### Related tickets

140265

### Tests

Added `test_operator_unpatching`
