### PR TITLE
Excluded comprasion operations from quantizable operations

### DIFF
--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -233,6 +233,10 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
                 om.ONNXSqrtMetatype,
                 om.ONNXReciprocalMetatype,
                 om.ONNXBatchNormMetatype,
+                # Сomparison operations
+                om.ONNXGreaterMetatype,
+                om.ONNXLessMetatype,
+                om.ONNXEqualMetatype,
             ]
             if device != TargetDevice.CPU_SPR:
                 types.append(om.ONNXMulLayerMetatype)

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -217,6 +217,13 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
                 om.OVDivideMetatype,
                 om.OVSqrtMetatype,
                 om.OVMaximumMetatype,
+                # Сomparison operations
+                om.OVGreaterEqualMetatype,
+                om.OVGreaterMetatype,
+                om.OVLessEqualMetatype,
+                om.OVLessMetatype,
+                om.OVNotEqualMetatype,
+                om.OVEqualMetatype,
             ]
             if device != TargetDevice.CPU_SPR:
                 types.append(om.OVMultiplyMetatype)

--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -328,6 +328,13 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
                 # Batchnorm
                 om.PTBatchNormMetatype,
                 om.PTModuleBatchNormMetatype,
+                # Сomparison operations
+                om.PTGreaterEqualMetatype,
+                om.PTGreaterMetatype,
+                om.PTLessEqualMetatype,
+                om.PTLessMetatype,
+                om.PTNotEqualMetatype,
+                om.PTEqualsMetatype,
             ]
             if device != TargetDevice.CPU_SPR:
                 types.append(om.PTMulMetatype)


### PR DESCRIPTION
### Changes

Excluded comparison operations from quantizable operations for transformer models

### Reason for changes

Quantization of comparison operations is lead to the runtime error:
```
RuntimeError: Exception from src/inference/src/cpp/infer_request.cpp:223:
Exception from src/plugins/intel_cpu/src/node.cpp:559:
Multiply node with name 'self_attn/aten::mul/Multiply' Exception from src/plugins/intel_cpu/src/shape_inference/custom/eltwise.cpp:45:
Eltwise shape infer input shapes dim index: 1 mismatch
```

### Related tickets

ref 143448

### Tests

N/A
