### PR TITLE
[Tests] Remove raising error when graph is not existed

### DIFF
--- a/tests/openvino/native/common.py
+++ b/tests/openvino/native/common.py
@@ -103,7 +103,7 @@ def get_actual_reference_for_current_openvino(rel_path: Path) -> Path:
     :return: Path to a reference file.
     """
     root_dir = OPENVINO_NATIVE_TEST_ROOT / "data"
-    current_ov_version = version.parse(get_openvino_version())
+    current_ov_version = get_openvino_version()
 
     def is_valid_version(dir_path: Path) -> bool:
         try:
@@ -114,10 +114,10 @@ def get_actual_reference_for_current_openvino(rel_path: Path) -> Path:
 
     ref_versions = filter(is_valid_version, root_dir.iterdir())
     ref_versions = sorted(ref_versions, key=lambda x: version.parse(x.name), reverse=True)
-    ref_versions = filter(lambda x: version.parse(x.name) <= current_ov_version, ref_versions)
+    ref_versions = filter(lambda x: version.parse(x.name) <= version.parse(current_ov_version), ref_versions)
 
     for root_version in ref_versions:
         file_name = root_version / rel_path
         if file_name.is_file():
             return file_name
-    return current_ov_version / rel_path
+    return root_dir / current_ov_version / rel_path

--- a/tests/openvino/native/common.py
+++ b/tests/openvino/native/common.py
@@ -18,7 +18,6 @@ import openvino as ov
 import torch
 from packaging import version
 
-import nncf
 from nncf import Dataset
 from nncf.openvino.graph.nncf_graph_builder import GraphConverter
 from tests.openvino.conftest import OPENVINO_NATIVE_TEST_ROOT
@@ -99,7 +98,7 @@ def get_actual_reference_for_current_openvino(rel_path: Path) -> Path:
 
     :param rel_path: Relative path to reference file.
 
-    :return: Path to reference file or raise RuntimeError.
+    :return: Path to a reference file.
     """
     root_dir = OPENVINO_NATIVE_TEST_ROOT / "data"
     current_ov_version = version.parse(get_openvino_version())
@@ -119,5 +118,4 @@ def get_actual_reference_for_current_openvino(rel_path: Path) -> Path:
         file_name = root_version / rel_path
         if file_name.is_file():
             return file_name
-
-    raise nncf.InternalError(f"Not found file {root_dir}/{current_ov_version}/{rel_path}")
+    return file_name

--- a/tests/openvino/native/common.py
+++ b/tests/openvino/native/common.py
@@ -95,6 +95,8 @@ def get_openvino_version() -> str:
 def get_actual_reference_for_current_openvino(rel_path: Path) -> Path:
     """
     Get path to actual reference file.
+    If from all of the OpenVINO versions such rel_path is not existed,
+    than the path for current OpenVINO version is returned.
 
     :param rel_path: Relative path to reference file.
 
@@ -118,4 +120,4 @@ def get_actual_reference_for_current_openvino(rel_path: Path) -> Path:
         file_name = root_version / rel_path
         if file_name.is_file():
             return file_name
-    return file_name
+    return current_ov_version / rel_path


### PR DESCRIPTION
### Changes

Remove raising an error in the test when a graph does not exist.

### Reason for changes

To return the feature with re/generating reference graphs using `NNCF_TEST_REGEN_DOT`

### Related tickets

N/A

### Tests

N/A
