### PR TITLE
[OV] Parallel tests by scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,8 @@ install-openvino-dev: install-openvino-test install-pre-commit
 	pip install -r examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/requirements.txt
 
 test-openvino:
-	ONEDNN_MAX_CPU_ISA=AVX2 pytest ${COVERAGE_ARGS} ${NUM_WORKERS_ARG} -ra tests/openvino $(DATA_ARG) --junitxml ${JUNITXML_PATH}
+	ONEDNN_MAX_CPU_ISA=AVX2 pytest ${COVERAGE_ARGS} ${NUM_WORKERS_ARG} -ra tests/openvino $(DATA_ARG) \
+		--junitxml ${JUNITXML_PATH} --dist loadscope
 
 test-install-openvino:
 	pytest tests/cross_fw/install -s        \


### PR DESCRIPTION
### Changes

Add `--dist loadscope` for OV tests.

### Reason for changes

Try to fix sporadically issue `EOFError: Compressed file ended before the end-of-stream marker was reached` for  tests/openvino/native/quantization/test_sanity.py::test_compression

Possible reason is downloading dataset in several process at the same time.

Example: https://github.com/openvinotoolkit/nncf/actions/runs/9610990503/job/26508643899

