### PR TITLE
Fix default value for ignored scope in calibrate.py

### DIFF
--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -349,7 +349,7 @@ def map_ignored_scope(ignored):
             if op.get("attributes") is not None:
                 raise ValueError('"attributes" in the ignored operations ' "are not supported")
             ignored_operations.append(op["type"])
-    return {"ignored_scope": IgnoredScope(names=ignored.get("scope"), types=ignored_operations)}
+    return {"ignored_scope": IgnoredScope(names=ignored.get("scope", []), types=ignored_operations)}
 
 
 def map_preset(preset):


### PR DESCRIPTION
### Changes

Change None to []

### Reason for changes

Incorrect API usage

### Related tickets

144809

### Tests

Manually tested on failed scenario
