### PR TITLE
[CI] Add paths-ignore like in pre-commit

### DIFF
--- a/.github/workflows/post_pr_merge.yml
+++ b/.github/workflows/post_pr_merge.yml
@@ -16,6 +16,9 @@ on:
       - develop
     types:
       - closed
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**/*'
 
 jobs:
   upload-coverage-common:


### PR DESCRIPTION
### Changes

Add `paths-ignore` to post post_pr_merge.yml, like in pre-commit

### Reason for changes

Failed job for pull request that not run pre-commit and not generate coverage reports.


