### PR TITLE
Extending functions by lstsq, svd, eye

### DIFF
--- a/nncf/tensor/README.md
+++ b/nncf/tensor/README.md
@@ -39,24 +39,24 @@ nncf_tensor = fns.zeros((2,2), backend=TensorBackend.torch)
 
 ### Math operations
 
-All math operations are overrided to operated with wrapped object and return `Tensor`
+All math operations are overridden to operated with wrapped object and return `Tensor`
 
 ```python
 tensor_a = Tensor(np.array([1,2]))
-tenor_b = Tensor(np.array([1,2]))
-tensor_a + tenor_b  # Tensor(array([2, 4]))
+tensor_b = Tensor(np.array([1,2]))
+tensor_a + tensor_b  # Tensor(array([2, 4]))
 ```
 
 **NOTE** Division operations for the numpy backend are performed with warnings disabled for the same for all backends.
 
 ### Comparison operators
 
-All math operations are overrided to operated with wrapped object and return `Tensor`
+All math operations are overridden to operated with wrapped object and return `Tensor`
 
 ```python
 tensor_a = Tensor(np.array([1,2]))
-tenor_b = Tensor(np.array([1,2]))
-tensor_a < tenor_b  # Tensor(array([False, False]))
+tensor_b = Tensor(np.array([1,2]))
+tensor_a < tensor_b  # Tensor(array([False, False]))
 ```
 
 ### Method of the Tensor class
@@ -148,7 +148,7 @@ tensor_a[0:2]  # Tensor(array([[1],[2]]))
         raise NotImplementedError(f"Function `foo` is not implemented for {type(x)}")
     ```
 
-3. Add backend specific implementation of method to correcponding module:
+3. Add backend specific implementation of method to corresponding module:
 
     - `functions/numpy_*.py`
 
@@ -172,7 +172,7 @@ tensor_a[0:2]  # Tensor(array([[1],[2]]))
 
 1. Add backend specific implementation for all function from functions module in `functions/<NEW_BACKEND>_*.py` file.
 
-2. Add `test_tensor.py` in backend-specific t directory for tests that inherited from class `TemplateTestNNCFTensorOperators`
+2. Add `test_tensor.py` in backend-specific directory for tests that inherited from class `TemplateTestNNCFTensorOperators`
 
     ```python
     class TestNPNNCFTensorOperators(TemplateTestNNCFTensorOperators):

--- a/nncf/tensor/functions/__init__.py
+++ b/nncf/tensor/functions/__init__.py
@@ -25,6 +25,7 @@ from nncf.tensor.functions.numeric import device as device
 from nncf.tensor.functions.numeric import diag as diag
 from nncf.tensor.functions.numeric import dtype as dtype
 from nncf.tensor.functions.numeric import expand_dims as expand_dims
+from nncf.tensor.functions.numeric import eye as eye
 from nncf.tensor.functions.numeric import finfo as finfo
 from nncf.tensor.functions.numeric import flatten as flatten
 from nncf.tensor.functions.numeric import from_numpy as from_numpy

--- a/nncf/tensor/functions/numeric.py
+++ b/nncf/tensor/functions/numeric.py
@@ -818,6 +818,29 @@ def zeros(
     return Tensor(get_numeric_backend_fn("zeros", backend)(shape, dtype=dtype, device=device))
 
 
+def eye(
+    n: int,
+    m: Optional[int] = None,
+    *,
+    backend: TensorBackend,
+    dtype: Optional[TensorDataType] = None,
+    device: Optional[TensorDeviceType] = None,
+) -> Tensor:
+    """
+    Return a 2-D array with ones on the diagonal and zeros elsewhere.
+
+    :param n: Number of rows in the output.
+    :param m: Number of columns in the output. If None, defaults to n.
+    :param backend: The backend type for which the eye tensor is required.
+    :param dtype: The data type of the returned tensor, If dtype is not given,
+        then the default data type is determined by backend.
+    :param device: The device on which the tensor will be allocated, If device is not given,
+        then the default device is determined by backend.
+    :return: A tensor where all elements are equal to zero, except for the k-th diagonal, whose values are equal to one.
+    """
+    return Tensor(get_numeric_backend_fn("eye", backend)(n, m, dtype=dtype, device=device))
+
+
 def arange(
     start: float,
     end: Optional[float] = None,

--- a/nncf/tensor/functions/numpy_linalg.py
+++ b/nncf/tensor/functions/numpy_linalg.py
@@ -12,6 +12,7 @@
 from typing import Optional, Tuple, Union
 
 import numpy as np
+from scipy.linalg import lstsq
 
 from nncf.tensor.functions import linalg
 from nncf.tensor.functions.dispatcher import register_numpy_types
@@ -47,3 +48,13 @@ def _(a: Union[np.ndarray, np.generic], upper: bool = False) -> np.ndarray:
 @register_numpy_types(linalg.inv)
 def _(a: Union[np.ndarray, np.generic]) -> np.ndarray:
     return np.linalg.inv(a)
+
+
+@register_numpy_types(linalg.lstsq)
+def _(a: Union[np.ndarray, np.generic], b: Union[np.ndarray, np.generic], driver: str = "gelsy") -> np.ndarray:
+    return lstsq(a, b, lapack_driver=driver)[0]
+
+
+@register_numpy_types(linalg.svd)
+def _(a: Union[np.ndarray, np.generic], full_matrices: Optional[bool] = True) -> np.ndarray:
+    return np.linalg.svd(a, compute_uv=True, full_matrices=full_matrices)

--- a/nncf/tensor/functions/numpy_linalg.py
+++ b/nncf/tensor/functions/numpy_linalg.py
@@ -51,7 +51,7 @@ def _(a: Union[np.ndarray, np.generic]) -> np.ndarray:
 
 
 @register_numpy_types(linalg.lstsq)
-def _(a: Union[np.ndarray, np.generic], b: Union[np.ndarray, np.generic], driver: str = "gelsy") -> np.ndarray:
+def _(a: Union[np.ndarray, np.generic], b: Union[np.ndarray, np.generic], driver: Optional[str] = None) -> np.ndarray:
     return lstsq(a, b, lapack_driver=driver)[0]
 
 

--- a/nncf/tensor/functions/numpy_numeric.py
+++ b/nncf/tensor/functions/numpy_numeric.py
@@ -392,6 +392,20 @@ def zeros(
     return np.zeros(shape, dtype=dtype)
 
 
+def eye(
+    n: int,
+    m: Optional[int] = None,
+    *,
+    dtype: Optional[TensorDataType] = None,
+    device: Optional[TensorDeviceType] = None,
+) -> np.ndarray:
+    if device is not None and device != TensorDeviceType.CPU:
+        raise ValueError("numpy_numeric.eye only supports CPU device.")
+    if dtype is not None:
+        dtype = DTYPE_MAP[dtype]
+    return np.eye(n, m, dtype=dtype)
+
+
 def arange(
     start: float,
     end: float,

--- a/nncf/tensor/functions/torch_linalg.py
+++ b/nncf/tensor/functions/torch_linalg.py
@@ -38,3 +38,13 @@ def _(a: torch.Tensor, upper: bool = False) -> torch.Tensor:
 @linalg.inv.register(torch.Tensor)
 def _(a: torch.Tensor) -> torch.Tensor:
     return torch.linalg.inv(a)
+
+
+@linalg.lstsq.register(torch.Tensor)
+def _(a: torch.Tensor, b: torch.Tensor, driver: Optional[str] = None) -> torch.Tensor:
+    return torch.linalg.lstsq(a, b, driver=driver).solution
+
+
+@linalg.svd.register(torch.Tensor)
+def _(a: torch.Tensor, full_matrices: Optional[bool] = True) -> torch.Tensor:
+    return torch.linalg.svd(a, full_matrices=full_matrices)

--- a/nncf/tensor/functions/torch_numeric.py
+++ b/nncf/tensor/functions/torch_numeric.py
@@ -421,6 +421,21 @@ def zeros(
     return torch.zeros(*shape, dtype=dtype, device=device)
 
 
+def eye(
+    n: int,
+    m: Optional[int] = None,
+    *,
+    dtype: Optional[TensorDataType] = None,
+    device: Optional[TensorDeviceType] = None,
+) -> torch.Tensor:
+    if dtype is not None:
+        dtype = DTYPE_MAP[dtype]
+    if device is not None:
+        device = DEVICE_MAP[device]
+    p_args = (n,) if m is None else (n, m)
+    return torch.eye(*p_args, dtype=dtype, device=device)
+
+
 def arange(
     start: float,
     end: float,

--- a/tests/shared/test_templates/template_test_nncf_tensor.py
+++ b/tests/shared/test_templates/template_test_nncf_tensor.py
@@ -12,6 +12,7 @@
 
 import operator
 from abc import abstractmethod
+from math import sqrt
 from typing import TypeVar
 
 import numpy as np
@@ -1492,6 +1493,28 @@ class TemplateTestNNCFTensorOperators:
             assert fns.all(tensor_a == 0)
 
     @pytest.mark.parametrize(
+        "n, m, ref",
+        (
+            (2, None, [[1, 0], [0, 1]]),
+            (2, 2, [[1, 0], [0, 1]]),
+            (2, 1, [[1], [0]]),
+            (1, 2, [[1, 0]]),
+        ),
+    )
+    def test_fn_eye(self, n, m, ref):
+        for dtype in TensorDataType:
+            if dtype == TensorDataType.bfloat16 and self.backend() == TensorBackend.numpy:
+                continue
+            tensor_a = fns.eye(n, m, backend=self.backend(), dtype=dtype, device=self.device())
+            assert isinstance(tensor_a, Tensor)
+            assert tensor_a.device == self.device()
+            assert tensor_a.backend == self.backend()
+            assert tensor_a.dtype == dtype
+            ref_shape = (n, n) if m is None else (n, m)
+            assert tensor_a.shape == ref_shape
+            assert fns.allclose(tensor_a, ref)
+
+    @pytest.mark.parametrize(
         "start, end, stop, ref",
         ((3, None, None, [0, 1, 2]), (0, 3, None, [0, 1, 2]), (0, 3, 1, [0, 1, 2]), (2, -1, -1, [2, 1, 0])),
     )
@@ -1550,3 +1573,65 @@ class TemplateTestNNCFTensorOperators:
         tensor_v = Tensor(self.to_tensor([-2.0, -0.6, 0.0, 0.3, 1.5]))
         with pytest.raises(ValueError):
             fns.searchsorted(tensor_a, tensor_v)
+
+    @pytest.mark.parametrize(
+        "x, y, a_ref, b_ref",
+        (
+            ([1.0, 2.0, 4.0], [3.0, 4.0, 6.0], 1, 2),
+            ([1.0, 2.0, 3.0], [3.0, 2.5, 1.0], -1, 25 / 6),
+        ),
+    )
+    def test_lstsq(self, x, y, a_ref, b_ref):
+        t_x = Tensor(self.to_tensor(x))
+        t_y = Tensor(self.to_tensor(y))
+        M = Tensor(self.to_tensor(np.vstack([x, np.ones_like(x) ** 0]).transpose()))
+        M = M.astype(t_x.dtype)
+
+        solution = fns.linalg.lstsq(M, t_y)
+        a, b = solution
+
+        assert isinstance(solution, Tensor)
+        assert fns.allclose(a, a_ref)
+        assert fns.allclose(b, b_ref)
+
+    @pytest.mark.parametrize(
+        "a, full_matrices, abs_res_ref",
+        (
+            # example is taken from: https://www.d.umn.edu/~mhampton/m4326svd_example.pdf
+            # compare absolute values, since different backends may vary the sign.
+            (
+                [[3.0, 2.0, 2.0], [2.0, 3.0, -2.0]],
+                True,
+                (
+                    [[1 / sqrt(2), 1 / sqrt(2)], [1 / sqrt(2), 1 / sqrt(2)]],
+                    [5.0, 3.0],
+                    [
+                        [1 / sqrt(2), 1 / sqrt(2), 0.0],
+                        [1 / sqrt(18), 1 / sqrt(18), 4 / sqrt(18)],
+                        [2 / 3, 2 / 3, 1 / 3],
+                    ],
+                ),
+            ),
+            (
+                [[3.0, 2.0, 2.0], [2.0, 3.0, -2.0]],
+                False,
+                (
+                    [[1 / sqrt(2), 1 / sqrt(2)], [1 / sqrt(2), 1 / sqrt(2)]],
+                    [5.0, 3.0],
+                    [
+                        [1 / sqrt(2), 1 / sqrt(2), 0.0],
+                        [1 / sqrt(18), 1 / sqrt(18), 4 / sqrt(18)],
+                    ],
+                ),
+            ),
+        ),
+    )
+    def test_svd(self, a, full_matrices, abs_res_ref):
+        t_a = Tensor(self.to_tensor(a))
+
+        res = fns.linalg.svd(t_a, full_matrices)
+
+        assert isinstance(res, tuple)
+        for act, abs_ref in zip(res, abs_res_ref):
+            assert isinstance(act, Tensor)
+            assert fns.allclose(fns.abs(act), abs_ref, atol=1e-7)


### PR DESCRIPTION
### Changes
The following functions were added:

- numeric.py: eye
- linalg.py: lstsq, svd


### Reason for changes
Part of int4 with LoRA adaptation implementation.

### Related tickets
CVS-135863

### Tests
tests/shared/test_templates/template_test_nncf_tensor.py

