### PR TITLE
[OV] Clean test environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ install-openvino-test:
 	pip install -U pip
 	pip install -e .
 	pip install "git+https://github.com/openvinotoolkit/open_model_zoo.git@37f60eb#egg=accuracy_checker&subdirectory=tools/accuracy_checker"
-	pip install tensorflow==2.12.0 # Install tensorflow before to avoid conflict on install for typing-extensions
 	pip install -r tests/openvino/requirements.txt
 	pip install -r tests/cross_fw/install/requirements.txt
 	pip install -r tests/cross_fw/examples/requirements.txt


### PR DESCRIPTION
### Changes

Removed `tensorflow` from test environment.

### Reason for changes

After https://github.com/openvinotoolkit/nncf/pull/2663 module is not required in tests. It was need for yolov4.

