### PR TITLE
Fix for llm examples with openvino-nightly

### DIFF
--- a/examples/llm_compression/openvino/tiny_llama/main.py
+++ b/examples/llm_compression/openvino/tiny_llama/main.py
@@ -67,7 +67,7 @@ def main():
     )
     model.save_pretrained(OUTPUT_DIR)
 
-    model = OVModelForCausalLM.from_pretrained(OUTPUT_DIR)
+    model = OVModelForCausalLM.from_pretrained(OUTPUT_DIR, ov_config={"DYNAMIC_QUANTIZATION_GROUP_SIZE": "0"})
     input_ids = tokenizer("What is PyTorch?", return_tensors="pt").to(device=model.device)
 
     start_t = time.time()

--- a/examples/llm_compression/openvino/tiny_llama_find_hyperparams/main.py
+++ b/examples/llm_compression/openvino/tiny_llama_find_hyperparams/main.py
@@ -241,7 +241,12 @@ def tiny_llama_transform_func(item, tokenizer, ov_model):  # <YOUR_TRANSFORMATIO
 
 def main():
     model_id = "TinyLlama/TinyLlama-1.1B-step-50K-105b"  # <YOUR_MODEL_ID>
-    ov_config = {"PERFORMANCE_HINT": "LATENCY", "NUM_STREAMS": "1", "CACHE_DIR": ""}
+    ov_config = {
+        "PERFORMANCE_HINT": "LATENCY",
+        "NUM_STREAMS": "1",
+        "CACHE_DIR": "",
+        "DYNAMIC_QUANTIZATION_GROUP_SIZE": "0",
+    }
     model = OVModelForCausalLM.from_pretrained(
         model_id,
         export=True,


### PR DESCRIPTION
### Changes

Explicit enabling of dynamic quantization of activations and updating metrics in the weight compression examples. 

It's possible to adapt compression examples for new openvino-nightly by explicitly turning off the dynamic quantization of activations via 

```
OVModelForCausalLM.from_pretrained(OUTPUT_DIR, ov_config={"DYNAMIC_QUANTIZATION_GROUP_SIZE": "0"})
```
The successful 45th run of `test examples` is proving that. 
But examples with dynamic quantization should make validation faster, that's why this PR enables it and updates the metrics. 

### Reason for changes

OpenVINO 2023.2 has a dynamic quantization of activation enabled by default. (https://github.com/openvinotoolkit/openvino/pull/25054) and that's affects accuracy/metrics in the weight compression examples/tests, since before it was disabled by default.

### Related tickets

[CVS-134931](https://jira.devtools.intel.com/browse/CVS-134931)
[CVS-145701](https://jira.devtools.intel.com/browse/CVS-145701)

### Tests
`tests/cross_fw/examples/test_examples.py -k llm`

run of test examples:
- [x]  45 - with openvino-nightly

