### PR TITLE
Support the scale estimation inside GPTQ

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/activation_stats.py
+++ b/nncf/quantization/algorithms/weight_compression/activation_stats.py
@@ -9,14 +9,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Tuple, TypeVar
+from typing import List, Tuple
 
+from nncf.tensor import Tensor
 from nncf.tensor import functions as fns
 
-TTensor = TypeVar("TTensor")
 
-
-def process_stats(stats: List[TTensor], subset_size: int) -> Tuple[TTensor, TTensor]:
+def process_stats(stats: List[Tensor], subset_size: int) -> Tuple[Tensor, Tensor]:
     """
     It's a processing of activations shared between AWQ, Scale Estimation and LoRA Correction algorithms.
 

--- a/nncf/quantization/algorithms/weight_compression/gptq.py
+++ b/nncf/quantization/algorithms/weight_compression/gptq.py
@@ -273,7 +273,7 @@ class GPTQ:
                                 wc_params.compression_config,
                             )
                             scales.append(scale.squeeze(axis=1))
-                            zero_points.append(zero_point)
+                            zero_points.append(zero_point if zero_point is None else zero_point.squeeze(axis=1))
                         else:
                             scale, zero_point = calculate_integer_quantization_params(
                                 weight_tensor[:, (i1 + i) : (i1 + i + group_size)],

--- a/nncf/quantization/algorithms/weight_compression/gptq.py
+++ b/nncf/quantization/algorithms/weight_compression/gptq.py
@@ -25,6 +25,7 @@ from nncf.quantization.algorithms.layerwise.engine import LayerwiseEngine
 from nncf.quantization.algorithms.weight_compression.backend import WeightCompressionAlgoBackend
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionConfig
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionParameters
+from nncf.quantization.algorithms.weight_compression.scale_estimation import ScaleEstimation
 from nncf.quantization.algorithms.weight_compression.weight_lowering import calculate_integer_quantization_params
 from nncf.quantization.algorithms.weight_compression.weight_lowering import calculate_nf4_scale
 from nncf.quantization.algorithms.weight_compression.weight_lowering import calculate_quantized_weight
@@ -44,10 +45,7 @@ class GPTQ:
     """
 
     def __init__(
-        self,
-        damp_percent: float = 0.1,
-        block_size: int = 128,
-        subset_size: int = 128,
+        self, damp_percent: float = 0.1, block_size: int = 128, subset_size: int = 128, scale_estimation: bool = False
     ):
         """
         :param damp_percent: The percent of the average Hessian diagonal to use for dampening,
@@ -58,6 +56,7 @@ class GPTQ:
         self._damp_percent = damp_percent
         self._block_size = block_size
         self._subset_size = subset_size
+        self._scale_estimation = scale_estimation
         self._backend = None
         self._backend_entity = None
 
@@ -124,10 +123,9 @@ class GPTQ:
                 CompressWeightsMode.INT8_SYM,
             ]:
                 continue
-            assert len(inputs) == 1
             _, input_tensors = next(iter(inputs.items()))
             hessian = self._calculate_hessian(node, input_tensors)
-            scale, zero_point = self._quantize_weights(model, graph, wc_params, hessian)
+            scale, zero_point = self._quantize_weights(model, graph, wc_params, hessian, input_tensors)
             scales[wc_params.weight_name] = scale
             zero_points[wc_params.weight_name] = zero_point
 
@@ -193,7 +191,12 @@ class GPTQ:
         return hessian
 
     def _quantize_weights(
-        self, model: TModel, graph: NNCFGraph, wc_params: WeightCompressionParameters, hessian: Tensor
+        self,
+        model: TModel,
+        graph: NNCFGraph,
+        wc_params: WeightCompressionParameters,
+        hessian: Tensor,
+        inputs: List[Tensor],
     ):
         """
         Quantizes the weights of the model based on the calculated Hessian matrix.
@@ -260,11 +263,25 @@ class GPTQ:
                         scale = calculate_nf4_scale(weight_tensor[:, (i1 + i) : (i1 + i + group_size)], reduction_axes)
                         scales.append(scale)
                     else:
-                        scale, zero_point = calculate_integer_quantization_params(
-                            weight_tensor[:, (i1 + i) : (i1 + i + group_size)], reduction_axes, block_compression_config
-                        )
-                        scales.append(scale)
-                        zero_points.append(zero_point)
+                        if self._scale_estimation and block_compression_config.num_bits == 4:
+                            activations = [inp.squeeze()[:, (i1 + i) : (i1 + i + group_size)] for inp in inputs]
+                            scale, zero_point = ScaleEstimation.calculate_quantization_params(
+                                self._backend_entity,
+                                activations,
+                                weight_tensor[:, (i1 + i) : (i1 + i + group_size)],
+                                reduction_axes,
+                                wc_params.compression_config,
+                            )
+                            scales.append(scale.squeeze(axis=1))
+                            zero_points.append(zero_point)
+                        else:
+                            scale, zero_point = calculate_integer_quantization_params(
+                                weight_tensor[:, (i1 + i) : (i1 + i + group_size)],
+                                reduction_axes,
+                                block_compression_config,
+                            )
+                            scales.append(scale)
+                            zero_points.append(zero_point)
                 if block_compression_config.mode == CompressWeightsMode.NF4:
                     compressed_weights = do_nf4_quantization(
                         fns.unsqueeze(weight_col, 1), scales[-1], is_normalized_weight=False

--- a/nncf/quantization/quantize_model.py
+++ b/nncf/quantization/quantize_model.py
@@ -482,11 +482,6 @@ def compress_weights(
         if any((gptq, lora_correction)) and (dataset is None or mode == CompressWeightsMode.E2M1):
             raise AttributeError("GPTQ or Lora Correction algorithm is defined, but dataset is None or mode is E2M1.")
 
-        if gptq and scale_estimation:
-            raise AttributeError(
-                "Simultaneous use of Scale estimation and GPTQ algorithms is not supported. Select one of them."
-            )
-
         if gptq and lora_correction:
             raise AttributeError(
                 "Simultaneous use of Lora correction and GPTQ algorithms is not supported. Select one of them."

--- a/tests/openvino/native/quantization/test_gptq.py
+++ b/tests/openvino/native/quantization/test_gptq.py
@@ -341,7 +341,8 @@ def test_calculate_scale_linear():
     gptq._set_backend_entity(ov_model)
 
     nodes = graph.get_all_nodes()
-    H = gptq._calculate_hessian(nodes[1], [Tensor(inp) for inp in inputs])
+    wrapped_inputs = [Tensor(inp) for inp in inputs]
+    H = gptq._calculate_hessian(nodes[1], wrapped_inputs)
 
     ref_H = ref_gptq.H.numpy()
     assert np.all(np.isclose(ref_H, H.data))
@@ -351,7 +352,7 @@ def test_calculate_scale_linear():
     )
     wc_params.compression_config = WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=16)
 
-    scale, _ = gptq._quantize_weights(ov_model, graph, wc_params, H)
+    scale, _ = gptq._quantize_weights(ov_model, graph, wc_params, H, wrapped_inputs)
     ref_scale = ref_scale.numpy()
     scale = scale.reshape(ref_scale.shape)
     assert np.all(np.isclose(ref_scale, scale.data))

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -713,10 +713,7 @@ def test_raise_error_with_unsupported_params_for_int8(mode, params):
 @pytest.mark.parametrize("mode", INT4_MODES)
 @pytest.mark.parametrize(
     "params",
-    (
-        {"dataset": "anything", "scale_estimation": True, "gptq": True},
-        {"dataset": "anything", "lora_correction": True, "gptq": True},
-    ),
+    ({"dataset": "anything", "lora_correction": True, "gptq": True},),
 )
 def test_raise_error_with_unsupported_params_for_int4(mode, params):
     with pytest.raises(AttributeError):


### PR DESCRIPTION
### Changes
- The scale estimation algorithm is used to calculate quantization parameters inside GPTQ.
- Combination GPTQ and AWQ algorithm is supported.
- The layer-wise scheduler is deterministic.

### Reason for changes

Improve model compression accuracy for low bits.
![image](https://github.com/user-attachments/assets/a573554a-3285-4de6-a1ac-f623d7d39e0b)


### Related tickets

ref: 143637

### Tests

job/manual/job/post_training_weight_compression/152/
