### PR TITLE
Compile model only for CPU

### DIFF
--- a/examples/post_training_quantization/onnx/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/onnx/mobilenet_v2/main.py
@@ -48,7 +48,7 @@ def validate(path_to_model: Path, validation_loader: torch.utils.data.DataLoader
     predictions = []
     references = []
 
-    compiled_model = ov.compile_model(path_to_model)
+    compiled_model = ov.compile_model(path_to_model, "CPU")
     output = compiled_model.outputs[0]
 
     for images, target in tqdm(validation_loader):

--- a/examples/post_training_quantization/onnx/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/onnx/mobilenet_v2/main.py
@@ -48,7 +48,7 @@ def validate(path_to_model: Path, validation_loader: torch.utils.data.DataLoader
     predictions = []
     references = []
 
-    compiled_model = ov.compile_model(path_to_model, "CPU")
+    compiled_model = ov.compile_model(path_to_model, device_name="CPU")
     output = compiled_model.outputs[0]
 
     for images, target in tqdm(validation_loader):

--- a/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/deploy.py
+++ b/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/deploy.py
@@ -45,7 +45,7 @@ def validate_ov_model(
     validator.stats = []
     validator.batch_i = 1
     validator.confusion_matrix = ConfusionMatrix(nc=validator.nc)
-    compiled_model = ov.compile_model(ov_model, "CPU")
+    compiled_model = ov.compile_model(ov_model, device_name="CPU")
     num_outputs = len(compiled_model.outputs)
     for batch_i, batch in enumerate(data_loader):
         if num_samples is not None and batch_i == num_samples:

--- a/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/deploy.py
+++ b/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/deploy.py
@@ -45,7 +45,7 @@ def validate_ov_model(
     validator.stats = []
     validator.batch_i = 1
     validator.confusion_matrix = ConfusionMatrix(nc=validator.nc)
-    compiled_model = ov.compile_model(ov_model)
+    compiled_model = ov.compile_model(ov_model, "CPU")
     num_outputs = len(compiled_model.outputs)
     for batch_i, batch in enumerate(data_loader):
         if num_samples is not None and batch_i == num_samples:

--- a/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/main.py
+++ b/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/main.py
@@ -187,12 +187,12 @@ def run_example():
     int8_fps = run_benchmark(int8_ir_path, shape=[1, 3, 256, 256], verbose=True)
 
     print("[5/7] Validate OpenVINO FP32 model:")
-    compiled_model = ov.compile_model(ov_model)
+    compiled_model = ov.compile_model(ov_model, "CPU")
     fp32_top1, _ = validate(compiled_model, test_loader, validation_params)
     print(f"Accuracy @ top1: {fp32_top1:.3f}")
 
     print("[6/7] Validate OpenVINO INT8 model:")
-    quantized_compiled_model = ov.compile_model(ov_quantized_model)
+    quantized_compiled_model = ov.compile_model(ov_quantized_model, "CPU")
     int8_top1, _ = validate(quantized_compiled_model, test_loader, validation_params)
     print(f"Accuracy @ top1: {int8_top1:.3f}")
 

--- a/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/main.py
+++ b/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/main.py
@@ -187,12 +187,12 @@ def run_example():
     int8_fps = run_benchmark(int8_ir_path, shape=[1, 3, 256, 256], verbose=True)
 
     print("[5/7] Validate OpenVINO FP32 model:")
-    compiled_model = ov.compile_model(ov_model, "CPU")
+    compiled_model = ov.compile_model(ov_model, device_name="CPU")
     fp32_top1, _ = validate(compiled_model, test_loader, validation_params)
     print(f"Accuracy @ top1: {fp32_top1:.3f}")
 
     print("[6/7] Validate OpenVINO INT8 model:")
-    quantized_compiled_model = ov.compile_model(ov_quantized_model, "CPU")
+    quantized_compiled_model = ov.compile_model(ov_quantized_model, device_name="CPU")
     int8_top1, _ = validate(quantized_compiled_model, test_loader, validation_params)
     print(f"Accuracy @ top1: {int8_top1:.3f}")
 

--- a/examples/post_training_quantization/openvino/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/openvino/mobilenet_v2/main.py
@@ -43,7 +43,7 @@ def validate(model: ov.Model, val_loader: torch.utils.data.DataLoader) -> float:
     predictions = []
     references = []
 
-    compiled_model = ov.compile_model(model)
+    compiled_model = ov.compile_model(model, "CPU")
     output = compiled_model.outputs[0]
 
     for images, target in tqdm(val_loader):

--- a/examples/post_training_quantization/openvino/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/openvino/mobilenet_v2/main.py
@@ -43,7 +43,7 @@ def validate(model: ov.Model, val_loader: torch.utils.data.DataLoader) -> float:
     predictions = []
     references = []
 
-    compiled_model = ov.compile_model(model, "CPU")
+    compiled_model = ov.compile_model(model, device_name="CPU")
     output = compiled_model.outputs[0]
 
     for images, target in tqdm(val_loader):

--- a/examples/post_training_quantization/openvino/yolov8/main.py
+++ b/examples/post_training_quantization/openvino/yolov8/main.py
@@ -39,7 +39,7 @@ def validate(
     validator.stats = []
     validator.confusion_matrix = ConfusionMatrix(nc=validator.nc)
     model.reshape({0: [1, 3, -1, -1]})
-    compiled_model = ov.compile_model(model)
+    compiled_model = ov.compile_model(model, "CPU")
     output_layer = compiled_model.output(0)
     for batch_i, batch in enumerate(data_loader):
         if num_samples is not None and batch_i == num_samples:

--- a/examples/post_training_quantization/openvino/yolov8/main.py
+++ b/examples/post_training_quantization/openvino/yolov8/main.py
@@ -39,7 +39,7 @@ def validate(
     validator.stats = []
     validator.confusion_matrix = ConfusionMatrix(nc=validator.nc)
     model.reshape({0: [1, 3, -1, -1]})
-    compiled_model = ov.compile_model(model, "CPU")
+    compiled_model = ov.compile_model(model, device_name="CPU")
     output_layer = compiled_model.output(0)
     for batch_i, batch in enumerate(data_loader):
         if num_samples is not None and batch_i == num_samples:

--- a/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/main.py
+++ b/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/main.py
@@ -42,7 +42,7 @@ def validate(
     validator.batch_i = 1
     validator.confusion_matrix = ConfusionMatrix(nc=validator.nc)
     model.reshape({0: [1, 3, -1, -1]})
-    compiled_model = ov.compile_model(model)
+    compiled_model = ov.compile_model(model, "CPU")
     num_outputs = len(model.outputs)
     for batch_i, batch in enumerate(data_loader):
         if num_samples is not None and batch_i == num_samples:

--- a/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/main.py
+++ b/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/main.py
@@ -42,7 +42,7 @@ def validate(
     validator.batch_i = 1
     validator.confusion_matrix = ConfusionMatrix(nc=validator.nc)
     model.reshape({0: [1, 3, -1, -1]})
-    compiled_model = ov.compile_model(model, "CPU")
+    compiled_model = ov.compile_model(model, device_name="CPU")
     num_outputs = len(model.outputs)
     for batch_i, batch in enumerate(data_loader):
         if num_samples is not None and batch_i == num_samples:

--- a/examples/post_training_quantization/tensorflow/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/tensorflow/mobilenet_v2/main.py
@@ -28,7 +28,7 @@ DATASET_CLASSES = 10
 
 
 def validate(model: ov.Model, val_loader: tf.data.Dataset) -> tf.Tensor:
-    compiled_model = ov.compile_model(model)
+    compiled_model = ov.compile_model(model, "CPU")
     output = compiled_model.outputs[0]
 
     metric = tf.keras.metrics.CategoricalAccuracy(name="acc@1")

--- a/examples/post_training_quantization/tensorflow/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/tensorflow/mobilenet_v2/main.py
@@ -28,7 +28,7 @@ DATASET_CLASSES = 10
 
 
 def validate(model: ov.Model, val_loader: tf.data.Dataset) -> tf.Tensor:
-    compiled_model = ov.compile_model(model, "CPU")
+    compiled_model = ov.compile_model(model, device_name="CPU")
     output = compiled_model.outputs[0]
 
     metric = tf.keras.metrics.CategoricalAccuracy(name="acc@1")

--- a/examples/post_training_quantization/torch/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/torch/mobilenet_v2/main.py
@@ -50,7 +50,7 @@ def validate(model: ov.Model, val_loader: torch.utils.data.DataLoader) -> float:
     predictions = []
     references = []
 
-    compiled_model = ov.compile_model(model, "CPU")
+    compiled_model = ov.compile_model(model, device_name="CPU")
     output = compiled_model.outputs[0]
 
     for images, target in track(val_loader, description="Validating"):

--- a/examples/post_training_quantization/torch/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/torch/mobilenet_v2/main.py
@@ -50,7 +50,7 @@ def validate(model: ov.Model, val_loader: torch.utils.data.DataLoader) -> float:
     predictions = []
     references = []
 
-    compiled_model = ov.compile_model(model)
+    compiled_model = ov.compile_model(model, "CPU")
     output = compiled_model.outputs[0]
 
     for images, target in track(val_loader, description="Validating"):

--- a/nncf/openvino/engine.py
+++ b/nncf/openvino/engine.py
@@ -69,7 +69,7 @@ class OVNativeEngine(Engine):
 
         ie = ov.Core()
         stateful = model_has_state(model)
-        compiled_model = ie.compile_model(model, target_device.value)
+        compiled_model = ie.compile_model(model, target_device.value, "CPU")
         self.engine = OVCompiledModelEngine(compiled_model, stateful)
 
     def infer(

--- a/nncf/openvino/engine.py
+++ b/nncf/openvino/engine.py
@@ -69,7 +69,7 @@ class OVNativeEngine(Engine):
 
         ie = ov.Core()
         stateful = model_has_state(model)
-        compiled_model = ie.compile_model(model, target_device.value, "CPU")
+        compiled_model = ie.compile_model(model, device_name="CPU")
         self.engine = OVCompiledModelEngine(compiled_model, stateful)
 
     def infer(

--- a/nncf/openvino/engine.py
+++ b/nncf/openvino/engine.py
@@ -16,7 +16,6 @@ import openvino.runtime as ov
 
 from nncf.common.engine import Engine
 from nncf.openvino.graph.model_utils import model_has_state
-from nncf.parameters import TargetDevice
 
 
 class OVCompiledModelEngine(Engine):
@@ -63,10 +62,7 @@ class OVNativeEngine(Engine):
     to infer the model.
     """
 
-    def __init__(self, model: ov.Model, target_device: TargetDevice = TargetDevice.CPU):
-        if target_device == TargetDevice.ANY:
-            target_device = TargetDevice.CPU
-
+    def __init__(self, model: ov.Model):
         ie = ov.Core()
         stateful = model_has_state(model)
         compiled_model = ie.compile_model(model, device_name="CPU")

--- a/nncf/quantization/algorithms/accuracy_control/openvino_backend.py
+++ b/nncf/quantization/algorithms/accuracy_control/openvino_backend.py
@@ -42,7 +42,7 @@ class OVPreparedModel(PreparedModel):
 
     def __init__(self, model: ov.Model):
         self._stateful = model_has_state(model)
-        self._compiled_model = ov.compile_model(model)
+        self._compiled_model = ov.compile_model(model, "CPU")
         self._engine = None
 
     @property

--- a/nncf/quantization/algorithms/accuracy_control/openvino_backend.py
+++ b/nncf/quantization/algorithms/accuracy_control/openvino_backend.py
@@ -42,7 +42,7 @@ class OVPreparedModel(PreparedModel):
 
     def __init__(self, model: ov.Model):
         self._stateful = model_has_state(model)
-        self._compiled_model = ov.compile_model(model, "CPU")
+        self._compiled_model = ov.compile_model(model, device_name="CPU")
         self._engine = None
 
     @property

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -243,7 +243,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
         model = ov.Model([result], parameters)
 
-        compiled_model = ov.compile_model(model, "CPU")
+        compiled_model = ov.compile_model(model, device_name="CPU")
 
         return lambda parameters: compiled_model(parameters)[0]
 
@@ -275,7 +275,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
         model = ov.Model([result], parameters)
 
-        compiled_model = ov.compile_model(model, "CPU")
+        compiled_model = ov.compile_model(model, device_name="CPU")
 
         return lambda parameters: compiled_model(parameters)[0]
 

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -243,7 +243,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
         model = ov.Model([result], parameters)
 
-        compiled_model = ov.compile_model(model)
+        compiled_model = ov.compile_model(model, "CPU")
 
         return lambda parameters: compiled_model(parameters)[0]
 
@@ -275,7 +275,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
         model = ov.Model([result], parameters)
 
-        compiled_model = ov.compile_model(model)
+        compiled_model = ov.compile_model(model, "CPU")
 
         return lambda parameters: compiled_model(parameters)[0]
 

--- a/tests/onnx/quantization/test_ptq_regression.py
+++ b/tests/onnx/quantization/test_ptq_regression.py
@@ -86,7 +86,7 @@ def validate(quantized_model_path: Path, data_loader: torch.utils.data.DataLoade
         701: 9,  # parachute
     }
     core = Core()
-    compiled_model = core.compile_model(quantized_model_path, "CPU")
+    compiled_model = core.compile_model(quantized_model_path, device_name="CPU")
     infer_queue = ov.AsyncInferQueue(compiled_model)
 
     predictions = [0] * len(data_loader)

--- a/tests/openvino/native/quantization/test_sanity.py
+++ b/tests/openvino/native/quantization/test_sanity.py
@@ -83,7 +83,7 @@ def validate(quantized_model_path: Path, data_loader: torch.utils.data.DataLoade
         701: 9,  # parachute
     }
     core = ov.Core()
-    compiled_model = core.compile_model(quantized_model_path, "CPU")
+    compiled_model = core.compile_model(quantized_model_path, device_name="CPU")
     infer_queue = ov.AsyncInferQueue(compiled_model)
 
     predictions = [0] * len(data_loader)

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -605,7 +605,7 @@ def test_bias_correction(model_with_parameters):
 def test_no_transformations():
     def infer_model_with_ones(model, shape):
         ie = ov.Core()
-        compiled_model = ie.compile_model(model)
+        compiled_model = ie.compile_model(model, "CPU")
         _input = np.ones(shape)
         model_outputs = compiled_model(_input)
         return {out.get_node().get_friendly_name(): data for out, data in model_outputs.items()}

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -605,7 +605,7 @@ def test_bias_correction(model_with_parameters):
 def test_no_transformations():
     def infer_model_with_ones(model, shape):
         ie = ov.Core()
-        compiled_model = ie.compile_model(model, "CPU")
+        compiled_model = ie.compile_model(model, device_name="CPU")
         _input = np.ones(shape)
         model_outputs = compiled_model(_input)
         return {out.get_node().get_friendly_name(): data for out, data in model_outputs.items()}

--- a/tests/openvino/test_transform_fn.py
+++ b/tests/openvino/test_transform_fn.py
@@ -55,7 +55,7 @@ def multiple_inputs_as_dict_transform_fn(data_item):
 )
 def test_transform_fn(model, transform_fn):
     # Check the transformation function
-    compiled_model = ov.compile_model(model.ov_model)
+    compiled_model = ov.compile_model(model.ov_model, "CPU")
     _ = compiled_model(transform_fn(next(iter(dataset))))
 
     # Start quantization

--- a/tests/openvino/test_transform_fn.py
+++ b/tests/openvino/test_transform_fn.py
@@ -55,7 +55,7 @@ def multiple_inputs_as_dict_transform_fn(data_item):
 )
 def test_transform_fn(model, transform_fn):
     # Check the transformation function
-    compiled_model = ov.compile_model(model.ov_model, "CPU")
+    compiled_model = ov.compile_model(model.ov_model, device_name="CPU")
     _ = compiled_model(transform_fn(next(iter(dataset))))
 
     # Start quantization

--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -838,7 +838,7 @@ def maybe_reshape_model(model, dataset, subset_size, input_to_tensor_name):
 
 def get_transform_fn(model_evaluator: ModelEvaluator, ov_model):
     if isinstance(model_evaluator, ModelEvaluator) and model_evaluator.launcher._lstm_inputs:
-        compiled_original_model = ov.Core().compile_model(ov_model)
+        compiled_original_model = ov.Core().compile_model(ov_model, "CPU")
         model_outputs = None
 
         def transform_fn(data_item: ACDattasetWrapper.DataItem):

--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -838,7 +838,7 @@ def maybe_reshape_model(model, dataset, subset_size, input_to_tensor_name):
 
 def get_transform_fn(model_evaluator: ModelEvaluator, ov_model):
     if isinstance(model_evaluator, ModelEvaluator) and model_evaluator.launcher._lstm_inputs:
-        compiled_original_model = ov.Core().compile_model(ov_model, "CPU")
+        compiled_original_model = ov.Core().compile_model(ov_model, device_name="CPU")
         model_outputs = None
 
         def transform_fn(data_item: ACDattasetWrapper.DataItem):

--- a/tests/post_training/pipelines/image_classification_timm.py
+++ b/tests/post_training/pipelines/image_classification_timm.py
@@ -138,7 +138,7 @@ class ImageClassificationTimm(PTQTestPipeline):
             core.set_property("CPU", properties={"INFERENCE_NUM_THREADS": str(inference_num_threads)})
 
         ov_model = core.read_model(self.path_compressed_ir)
-        compiled_model = core.compile_model(ov_model, "CPU")
+        compiled_model = core.compile_model(ov_model, device_name="CPU")
 
         jobs = int(os.environ.get("NUM_VAL_THREADS", DEFAULT_VAL_THREADS))
         infer_queue = ov.AsyncInferQueue(compiled_model, jobs)

--- a/tests/post_training/pipelines/image_classification_timm.py
+++ b/tests/post_training/pipelines/image_classification_timm.py
@@ -138,7 +138,7 @@ class ImageClassificationTimm(PTQTestPipeline):
             core.set_property("CPU", properties={"INFERENCE_NUM_THREADS": str(inference_num_threads)})
 
         ov_model = core.read_model(self.path_compressed_ir)
-        compiled_model = core.compile_model(ov_model)
+        compiled_model = core.compile_model(ov_model, "CPU")
 
         jobs = int(os.environ.get("NUM_VAL_THREADS", DEFAULT_VAL_THREADS))
         infer_queue = ov.AsyncInferQueue(compiled_model, jobs)


### PR DESCRIPTION
### Changes

- Set the `CPU` device for `compile_model`.

### Reason for changes

- Unstable results with the `AUTO` device.

### Related tickets

- 144747

### Tests

- nightly/test_examples/441/ - **passed**
- nightly/windows/test-examples/100/ - **passed**
- openvino-nightly/test_examples/50/ - **failed** (as expected due to 145701)
- manual/post_training_weight_compression/86/ - **passed**
- manual/post_training_quantization/420/ - **passed**