### PR TITLE
Add a linalg.pinv wrapper to common tensor

### DIFF
--- a/nncf/tensor/functions/linalg.py
+++ b/nncf/tensor/functions/linalg.py
@@ -115,6 +115,18 @@ def inv(a: Tensor) -> Tensor:
 
 @functools.singledispatch
 @tensor_guard
+def pinv(a: Tensor) -> Tensor:
+    """
+    Compute the (Moore-Penrose) pseudo-inverse of a matrix.
+
+    :param a: The input tensor of shape (*, M, N) where * is zero or more batch dimensions.
+    :return: The pseudo-inverse of input tensor.
+    """
+    return Tensor(pinv(a.data))
+
+
+@functools.singledispatch
+@tensor_guard
 def lstsq(a: Tensor, b: Tensor, driver: Optional[str] = None) -> Tensor:
     """
     Compute least-squares solution to equation Ax = b.

--- a/nncf/tensor/functions/numpy_linalg.py
+++ b/nncf/tensor/functions/numpy_linalg.py
@@ -50,6 +50,11 @@ def _(a: Union[np.ndarray, np.generic]) -> np.ndarray:
     return np.linalg.inv(a)
 
 
+@register_numpy_types(linalg.pinv)
+def _(a: Union[np.ndarray, np.generic]) -> np.ndarray:
+    return np.linalg.pinv(a)
+
+
 @register_numpy_types(linalg.lstsq)
 def _(a: Union[np.ndarray, np.generic], b: Union[np.ndarray, np.generic], driver: Optional[str] = None) -> np.ndarray:
     return lstsq(a, b, lapack_driver=driver)[0]

--- a/nncf/tensor/functions/torch_linalg.py
+++ b/nncf/tensor/functions/torch_linalg.py
@@ -42,14 +42,10 @@ def _(a: torch.Tensor) -> torch.Tensor:
 
 @linalg.pinv.register(torch.Tensor)
 def _(a: torch.Tensor) -> torch.Tensor:
-    """
-    Consider using torch.linalg.lstsq() if possible for multiplying a matrix on the left by the pseudo-inverse, as:
-
-    torch.linalg.lstsq(A, B).solution == A.pinv() @ B
-
-    It is always preferred to use lstsq() when possible, as it is faster and more numerically stable than computing
-    the pseudo-inverse explicitly.
-    """
+    # Consider using torch.linalg.lstsq() if possible for multiplying a matrix on the left by the pseudo-inverse, as:
+    # torch.linalg.lstsq(A, B).solution == A.pinv() @ B
+    # It is always preferred to use lstsq() when possible, as it is faster and more numerically stable than computing
+    # the pseudo-inverse explicitly.
     return torch.linalg.pinv(a)
 
 

--- a/nncf/tensor/functions/torch_linalg.py
+++ b/nncf/tensor/functions/torch_linalg.py
@@ -40,6 +40,19 @@ def _(a: torch.Tensor) -> torch.Tensor:
     return torch.linalg.inv(a)
 
 
+@linalg.pinv.register(torch.Tensor)
+def _(a: torch.Tensor) -> torch.Tensor:
+    """
+    Consider using torch.linalg.lstsq() if possible for multiplying a matrix on the left by the pseudo-inverse, as:
+
+    torch.linalg.lstsq(A, B).solution == A.pinv() @ B
+
+    It is always preferred to use lstsq() when possible, as it is faster and more numerically stable than computing
+    the pseudo-inverse explicitly.
+    """
+    return torch.linalg.pinv(a)
+
+
 @linalg.lstsq.register(torch.Tensor)
 def _(a: torch.Tensor, b: torch.Tensor, driver: Optional[str] = None) -> torch.Tensor:
     return torch.linalg.lstsq(a, b, driver=driver).solution

--- a/tests/shared/test_templates/template_test_nncf_tensor.py
+++ b/tests/shared/test_templates/template_test_nncf_tensor.py
@@ -1353,7 +1353,6 @@ class TemplateTestNNCFTensorOperators:
         a = [[1.0], [2.0]]
         A = Tensor(self.to_tensor(a))
         B = fns.linalg.pinv(A)
-        print(B)
         assert isinstance(B, Tensor)
         assert B.device == A.device
         assert fns.allclose(A, A @ B @ A)

--- a/tests/shared/test_templates/template_test_nncf_tensor.py
+++ b/tests/shared/test_templates/template_test_nncf_tensor.py
@@ -1349,6 +1349,16 @@ class TemplateTestNNCFTensorOperators:
         assert fns.allclose(res.data, ref_tensor)
         assert res.device == tensor_a.device
 
+    def test_fn_linalg_pinv(self):
+        a = [[1.0], [2.0]]
+        A = Tensor(self.to_tensor(a))
+        B = fns.linalg.pinv(A)
+        print(B)
+        assert isinstance(B, Tensor)
+        assert B.device == A.device
+        assert fns.allclose(A, A @ B @ A)
+        assert fns.allclose(B, B @ A @ B)
+
     @pytest.mark.parametrize(
         "a, k, ref",
         (


### PR DESCRIPTION
### Changes
The following functions were added:

- linalg.py: pinv

### Reason for changes
Part of int4 with LoRA adaptation implementation.

### Related tickets
CVS-135863

### Tests
tests/shared/test_templates/template_test_nncf_tensor.py

