### PR TITLE
Introduced versioning of reference for conformance tests

### DIFF
--- a/tests/post_training/data/wc_reference_data_2024.3.yaml
+++ b/tests/post_training/data/wc_reference_data_2024.3.yaml
@@ -1,0 +1,6 @@
+tinyllama_data_aware_awq_scale_estimation_backend_OV:
+  metric_value: 0.84038
+tinyllama_data_aware_awq_scale_estimation_stateful_backend_OV:
+  metric_value: 0.84038
+tinyllama_data_aware_gptq_backend_OV:
+  metric_value: 0.81936


### PR DESCRIPTION
### Changes

Introduced opportunity to override metrics in the conformance test for different OpenVINO versions

### Reason for changes

There are some known differences in accuracy between OV 2024.2 and OV nightly, but tests for OV nightly are constantly failing
until migration to 2024.3. 
This PR helps to keep track of changes in accuracy during release preparation.

### Related tickets

CVS-146143

### Tests

16 build of weekly/openvino-nightly/post_training_weight_compression

Thanks to @AlexanderDokuchaev for the implementation