### PR TITLE
Revert round bahaviour as in u4 for i4.

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/weight_lowering.py
+++ b/nncf/quantization/algorithms/weight_compression/weight_lowering.py
@@ -305,9 +305,14 @@ def calculate_quantized_weight(
         compressed_weights = weight * scale
     else:
         compressed_weights = weight / scale
+
     if zero_point is not None:
         compressed_weights += zero_point.astype(weight.dtype)
-    compressed_weights = fns.round(compressed_weights)
+        compressed_weights = fns.round(compressed_weights)
+    else:
+        level_low_sym = 2 ** (num_bits - 1)
+        compressed_weights = fns.round(compressed_weights + level_low_sym) - level_low_sym
+
     compressed_weights = fns.clip(compressed_weights, level_low, level_high).astype(dtype)
     return compressed_weights
 


### PR DESCRIPTION
### Changes

Revert zero point adding to round to align rounding error between u4 and i4 compression.

### Reason for changes

Different results for round(+-3.4555559) + 8 and round(+-3.4555559 + 8) which lead to different results in int4_sym compression for some models.

### Related tickets

### Tests

