### PR TITLE
Fix pass to remove ShapeOf subgraph

### DIFF
--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -61,7 +61,7 @@ from nncf.quantization.algorithms.algorithm import Algorithm
 from nncf.quantization.fake_quantize import calculate_convert_parameters
 from nncf.quantization.fake_quantize import calculate_quantizer_parameters
 from nncf.quantization.fake_quantize import get_quantizer_narrow_range
-from nncf.quantization.passes import transform_to_inference_graph
+from nncf.quantization.passes import transform_graph
 from nncf.quantization.range_estimator import RangeEstimatorParameters
 from nncf.quantization.range_estimator import RangeEstimatorParametersSet
 from nncf.scopes import IgnoredScope
@@ -741,11 +741,12 @@ class MinMaxQuantization(Algorithm):
         )
         hw_patterns = PatternsManager.get_full_hw_pattern_graph(backend=backend, device=device, model_type=model_type)
 
-        inference_nncf_graph = transform_to_inference_graph(
+        inference_nncf_graph = transform_graph(
             deepcopy(nncf_graph),
             self._backend_entity.get_start_nodes_for_activation_path_tracing(nncf_graph),
             self._backend_entity.shapeof_metatypes,
             self._backend_entity.dropout_metatypes,
+            self._backend_entity.constant_metatypes,
         )
 
         quantizer_setup = self._get_quantizer_setup(nncf_graph, inference_nncf_graph, hw_patterns, ignored_patterns)

--- a/nncf/quantization/algorithms/min_max/backend.py
+++ b/nncf/quantization/algorithms/min_max/backend.py
@@ -34,6 +34,13 @@ TModel = TypeVar("TModel")
 class MinMaxAlgoBackend(ABC):
     @property
     @abstractmethod
+    def constant_metatypes(self) -> List[OperatorMetatype]:
+        """
+        Property for the backend-specific constant metatypes.
+        """
+
+    @property
+    @abstractmethod
     def mat_mul_metatypes(self) -> List[OperatorMetatype]:
         """
         Property for the backend-specific MatMul metatypes.

--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -83,10 +83,6 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
         return []
 
     @property
-    def read_variable_metatypes(self) -> List[OperatorMetatype]:
-        return []
-
-    @property
     def scaled_dot_product_attention_metatypes(self) -> List[OperatorMetatype]:
         return []
 

--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -47,6 +47,10 @@ from nncf.quantization.range_estimator import RangeEstimatorParameters
 
 class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
     @property
+    def constant_metatypes(self) -> List[OperatorMetatype]:
+        return [om.ONNXConstantMetatype]
+
+    @property
     def mat_mul_metatypes(self) -> List[OperatorMetatype]:
         return MATMUL_METATYPES
 

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -82,10 +82,6 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
         return []
 
     @property
-    def read_variable_metatypes(self) -> List[OperatorMetatype]:
-        return [om.OVReadValueMetatype]
-
-    @property
     def scaled_dot_product_attention_metatypes(self) -> List[OperatorMetatype]:
         return [om.OVScaledDotProductAttentionMetatype]
 

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -44,6 +44,10 @@ from nncf.quantization.range_estimator import AggregatorType
 
 class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
     @property
+    def constant_metatypes(self) -> List[OperatorMetatype]:
+        return [om.OVConstantMetatype]
+
+    @property
     def mat_mul_metatypes(self) -> List[OperatorMetatype]:
         return [om.OVMatMulMetatype]
 

--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -62,6 +62,10 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
     }
 
     @property
+    def constant_metatypes(self) -> List[OperatorMetatype]:
+        return [om.PTConstNoopMetatype]
+
+    @property
     def mat_mul_metatypes(self) -> List[OperatorMetatype]:
         return [om.PTLinearMetatype, om.PTMatMulMetatype, om.PTAddmmMetatype]
 

--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -78,10 +78,6 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
         return [om.PTDropoutMetatype]
 
     @property
-    def read_variable_metatypes(self) -> List[OperatorMetatype]:
-        return []
-
-    @property
     def conv_metatypes(self) -> List[OperatorMetatype]:
         return [om.PTConv1dMetatype, om.PTConv2dMetatype, om.PTConv3dMetatype]
 

--- a/nncf/quantization/passes.py
+++ b/nncf/quantization/passes.py
@@ -12,9 +12,9 @@
 import collections
 from typing import List, TypeVar
 
-from nncf.common.graph.layer_attributes import Dtype
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
+from nncf.common.graph.layer_attributes import Dtype
 from nncf.common.graph.operator_metatypes import OperatorMetatype
 
 TModel = TypeVar("TModel")

--- a/nncf/quantization/passes.py
+++ b/nncf/quantization/passes.py
@@ -10,7 +10,8 @@
 # limitations under the License.
 
 import collections
-from typing import List, TypeVar
+from enum import Enum
+from typing import Dict, List, TypeVar
 
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
@@ -18,6 +19,151 @@ from nncf.common.graph.layer_attributes import Dtype
 from nncf.common.graph.operator_metatypes import OperatorMetatype
 
 TModel = TypeVar("TModel")
+
+
+class NodeMarker(Enum):
+    """
+    Markers are used to classify graph nodes.
+
+    - Node marker `DEPENDS_ON_INPUTS` means that the node depends on input data (nodes that are
+      designated as graph inputs).
+    - Node marker `CONSTANT_SUBGRAPH` means that the node is part of a constant subgraph, i.e.,
+      its output tensor does not depend on any input data.
+    """
+
+    DEPENDS_ON_INPUT = "DEPENDS_ON_INPUT"
+    CONSTANT_SUBGRAPH = "CONSTANT_SUBGRAPH"
+
+
+def classify_nodes(
+    graph: NNCFGraph,
+    start_nodes: List[NNCFNode],
+    constant_metatypes: List[OperatorMetatype],
+) -> Dict[NNCFNode, NodeMarker]:
+    """
+    Assigns a marker to each node in the input graph.
+
+    :param graph: The input graph to be analyzed.
+    :param start_nodes: A list of nodes designated as graph inputs. These nodes are used to identify
+        which nodes depend on input data.
+    :param constant_metatypes: A list of metatypes representing backend-specific constant operations.
+    :return: A dictionary mapping each node to its assigned marker.
+    """
+    # NOTE: All nodes in the graph that have no input edges should either be
+    # in `start_nodes` or have a constant metatype.
+
+    # TODO(andrey-churkin): It seems possible to identify a ShapeOf subgraph using
+    # this approach. Suppose we have a marker `SHAPEOF_SUBGRAPH`. If a node has this marker,
+    # it means that the node is part of a ShapeOf subgraph. Naturally, all nodes with the
+    # ShapeOf metatype have this marker. Next, for each node, if all input edges have integer type
+    # and all producers are marked using `SHAPEOF_SUBGRAPH` marker, then we assign the `SHAPEOF_SUBGRAPH`
+    # marker to the node.
+
+    sorted_nodes = graph.topological_sort()
+
+    node_markers: Dict[NNCFNode, NodeMarker] = {}
+    for node in sorted_nodes:
+        producer_nodes = graph.get_previous_nodes(node)
+        if producer_nodes:
+            # NOTE: If there are producer nodes, the `node` marker is determined using the markers
+            # of the producer nodes according to the following rule: If all producer nodes
+            # have the `CONSTANT_SUBGRAPH` marker, then the marker for `node` is also `CONSTANT_SUBGRAPH`.
+            # Otherwise, the marker for node is `DEPENDS_ON_INPUT`.
+
+            # NOTE: It is guaranteed that all producers already have their markers because the nodes
+            # are considered in topological order.
+            node_markers[node] = (
+                NodeMarker.CONSTANT_SUBGRAPH
+                if all(node_markers[v] == NodeMarker.CONSTANT_SUBGRAPH for v in producer_nodes)
+                else NodeMarker.DEPENDS_ON_INPUT
+            )
+        elif node in start_nodes:
+            node_markers[node] = NodeMarker.DEPENDS_ON_INPUT
+        elif node.metatype in constant_metatypes:
+            node_markers[node] = NodeMarker.CONSTANT_SUBGRAPH
+        else:
+            raise ValueError(
+                "The input graph contains a node {node} that does not have input edges but is not classified "
+                " as a constant node or a start node."
+            )
+
+    return node_markers
+
+
+def remove_constant_subgraphs(
+    graph: NNCFGraph,
+    initial_node_markers: Dict[NNCFNode, NodeMarker],
+    current_node_markers: Dict[NNCFNode, NodeMarker],
+) -> NNCFGraph:
+    """
+    :param graph:
+    :param initial_node_markers:
+    :param current_node_markers:
+    :return:
+    """
+    constant_subgraph_nodes = set()
+
+    node_to_input_port_ids: Dict[NNCFNode, List[int]] = {}
+    for node in graph.get_all_nodes():
+        # Collect all nodes with `CONSTANT_SUBGRAPH` marker
+        if current_node_markers[node] == NodeMarker.CONSTANT_SUBGRAPH:
+            constant_subgraph_nodes.add(node)
+
+        for e in graph.get_input_edges(node):
+            initial_marker = initial_node_markers[e.from_node]
+            current_marker = current_node_markers[e.from_node]
+            if initial_marker == NodeMarker.DEPENDS_ON_INPUT and current_marker == NodeMarker.CONSTANT_SUBGRAPH:
+                node_to_input_port_ids.setdefault(node, []).append(e.input_port_id)
+
+    preserved_nodes = set(node_to_input_port_ids)
+    queue = collections.deque(node_to_input_port_ids)
+    while queue:
+        node = queue.pop()
+        port_ids = node_to_input_port_ids.get(node)
+        if port_ids:
+            producers = [graph.get_input_edge_by_port_id(node, port_id).from_node for port_id in port_ids]
+        else:
+            producers = graph.get_previous_nodes(node)
+
+        for v in producers:
+            if v not in preserved_nodes:
+                queue.append(v)
+                preserved_nodes.add(v)
+
+    constant_subgraph_nodes = constant_subgraph_nodes.difference(preserved_nodes)
+    graph.remove_nodes_from(constant_subgraph_nodes)
+
+    return graph
+
+
+def transform_graph(
+    graph: NNCFGraph,
+    start_nodes: List[NNCFNode],
+    shapeof_metatypes: List[OperatorMetatype],
+    dropout_metatypes: List[OperatorMetatype],
+    constant_metatypes: List[OperatorMetatype],
+) -> NNCFGraph:
+    """
+    Applies the following ordered list of transformations to the provided graph:
+        1. Removes all shapeof subgraphs.
+        2. Removes constant subgraphs while preserving some of them.
+        3. Removes all dropout operations and connects their producers with consumers.
+           It assumes that each dropout node has only one producer and one consumer.
+
+    :param graph: The input graph to be transformed.
+    :param start_nodes: A list of nodes designated as graph inputs. These nodes are used to identify
+        which nodes depend on input data.
+    :param shapeof_metatypes: A list of metatypes representing backend-specific shapeof operations.
+    :param dropout_metatypes: A list of metatypes representing backend-specific dropout operations.
+    :param constant_metatypes: A list of metatypes representing backend-specific constant operations.
+    :return: A transformed graph.
+    """
+    initial_node_markers = classify_nodes(graph, start_nodes, constant_metatypes)
+    remove_shapeof_subgraphs(graph, shapeof_metatypes, start_nodes)
+    current_node_markers = classify_nodes(graph, start_nodes, constant_metatypes)
+    remove_constant_subgraphs(graph, initial_node_markers, current_node_markers)
+    remove_nodes_and_reconnect_graph(graph, dropout_metatypes)
+    return graph
 
 
 def transform_to_inference_graph(

--- a/nncf/quantization/passes.py
+++ b/nncf/quantization/passes.py
@@ -83,7 +83,7 @@ def classify_nodes(
             node_markers[node] = NodeMarker.CONSTANT_SUBGRAPH
         else:
             raise ValueError(
-                "The input graph contains a node {node} that does not have input edges but is not classified "
+                f"The input graph contains a node {node} that does not have input edges but is not classified "
                 " as a constant node or a start node."
             )
 

--- a/nncf/quantization/passes.py
+++ b/nncf/quantization/passes.py
@@ -12,6 +12,7 @@
 import collections
 from typing import List, TypeVar
 
+from nncf.common.graph.layer_attributes import Dtype
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.operator_metatypes import OperatorMetatype
@@ -72,11 +73,11 @@ def remove_shapeof_subgraphs(
     for shape_of_node in shape_of_nodes:
         nodes_to_drop.add(shape_of_node.node_name)
 
-        shape_of_queue = collections.deque()
-        shape_of_queue.extend(nncf_graph.get_next_nodes(shape_of_node))
+        shape_of_queue = collections.deque(nncf_graph.get_next_nodes(shape_of_node))
         while shape_of_queue:
             node = shape_of_queue.pop()
-            if node.node_name in nodes_to_drop or node.node_name in infer_nodes:
+            all_output_edges_integer = all(e.dtype == Dtype.INTEGER for e in nncf_graph.get_output_edges(node))
+            if node.node_name in nodes_to_drop or node.node_name in infer_nodes or not all_output_edges_integer:
                 continue
             nodes_to_drop.add(node.node_name)
             # traverse forward and backward to exclude full shape of subgraph


### PR DESCRIPTION
### Changes

It is possible to remove a node in the Shape Of subgraph only if all output edges have an integer dtype. An additional condition has been added to check for this.

### Reason for changes

In the picture below, integer edges are colored blue, and float edges are colored black. Nodes with a red border are removed during the ShapeOf removal pass, but they shouldn't be.

![shapeof_pass](https://github.com/user-attachments/assets/ebc700c7-3038-4330-bd4b-f38e614db090)

### Related tickets

Ref: 146088

### Tests

TODO
