### PR TITLE
Increase approx abs 

### DIFF
--- a/tests/torch/sparsity/movement/test_model_saving.py
+++ b/tests/torch/sparsity/movement/test_model_saving.py
@@ -268,9 +268,8 @@ class TestONNXExport:
         pruned_file_bytes = pruned_file.stat().st_size
         not_pruned_file_bytes = not_pruned_file.stat().st_size
         file_size_ratio = 1 - pruned_file_bytes / not_pruned_file_bytes
-        assert pytest.approx(compression_rate, abs=1e-2) == desc.nncf_weight_ratio
         assert (
-            pytest.approx(file_size_ratio, abs=1e-2) == desc.ov_weight_ratio
+            pytest.approx(file_size_ratio, abs=3e-2) == desc.ov_weight_ratio
         ), f"IR's size ratio: 1 - {pruned_file_bytes}/{not_pruned_file_bytes}"
         if abs(desc.ov_weight_ratio - desc.nncf_weight_ratio) >= 0.15:
             pytest.skip("Known issue in the ngraph transformation")

--- a/tests/torch/sparsity/movement/test_model_saving.py
+++ b/tests/torch/sparsity/movement/test_model_saving.py
@@ -268,6 +268,7 @@ class TestONNXExport:
         pruned_file_bytes = pruned_file.stat().st_size
         not_pruned_file_bytes = not_pruned_file.stat().st_size
         file_size_ratio = 1 - pruned_file_bytes / not_pruned_file_bytes
+        assert pytest.approx(compression_rate, abs=1e-2) == desc.nncf_weight_ratio
         assert (
             pytest.approx(file_size_ratio, abs=3e-2) == desc.ov_weight_ratio
         ), f"IR's size ratio: 1 - {pruned_file_bytes}/{not_pruned_file_bytes}"


### PR DESCRIPTION
### Changes

Increase abs from 1e-2 to 3e-2

### Reason for changes

Size of pruned and not prunned IR models can changes by openvino version.
it's not first time when reference size required to be change, so increase threshold to be more tolerance.

```
2024.2
desc0 pruned_file_bytes=596  not_pruned_file_bytes=932
desc1 pruned_file_bytes=1004  not_pruned_file_bytes=1340
desc2 pruned_file_bytes=2552  not_pruned_file_bytes=2756
desc3 pruned_file_bytes=584  not_pruned_file_bytes=872
desc4 pruned_file_bytes=748  not_pruned_file_bytes=940
desc5 pruned_file_bytes=1156  not_pruned_file_bytes=1900
desc6 pruned_file_bytes=1240  not_pruned_file_bytes=1900
desc7 pruned_file_bytes=620  not_pruned_file_bytes=956

2024.3
desc0 pruned_file_bytes=604  not_pruned_file_bytes=940
desc1 pruned_file_bytes=1004  not_pruned_file_bytes=1340
desc2 pruned_file_bytes=2552  not_pruned_file_bytes=2756
desc3 pruned_file_bytes=584  not_pruned_file_bytes=872
desc4 pruned_file_bytes=748  not_pruned_file_bytes=940
desc5 pruned_file_bytes=1228  not_pruned_file_bytes=1972
desc6 pruned_file_bytes=1312  not_pruned_file_bytes=1972
desc7 pruned_file_bytes=620  not_pruned_file_bytes=956
```

### Tests

sparsity.movement.test_model_saving.TestONNXExport.test_ngraph_pruning
sparsity.movement.test_model_saving.TestONNXExport.test_ngraph_pruning


