### PR TITLE
New metrics for weight compression with dynamic quantization

### DIFF
--- a/examples/llm_compression/openvino/tiny_llama/main.py
+++ b/examples/llm_compression/openvino/tiny_llama/main.py
@@ -67,7 +67,7 @@ def main():
     )
     model.save_pretrained(OUTPUT_DIR)
 
-    model = OVModelForCausalLM.from_pretrained(OUTPUT_DIR, ov_config={"DYNAMIC_QUANTIZATION_GROUP_SIZE": "0"})
+    model = OVModelForCausalLM.from_pretrained(OUTPUT_DIR, ov_config={"KV_CACHE_PRECISION": "u8"})
     input_ids = tokenizer("What is PyTorch?", return_tensors="pt").to(device=model.device)
 
     start_t = time.time()

--- a/examples/llm_compression/openvino/tiny_llama_find_hyperparams/main.py
+++ b/examples/llm_compression/openvino/tiny_llama_find_hyperparams/main.py
@@ -246,8 +246,8 @@ def main():
     ov_config = {
         "PERFORMANCE_HINT": "LATENCY",
         "NUM_STREAMS": "1",
+        "KV_CACHE_PRECISION": "u8",
         "CACHE_DIR": "",
-        "DYNAMIC_QUANTIZATION_GROUP_SIZE": "0",
     }
     model = OVModelForCausalLM.from_pretrained(
         model_id,

--- a/tests/post_training/data/wc_reference_data.yaml
+++ b/tests/post_training/data/wc_reference_data.yaml
@@ -1,46 +1,46 @@
-tinyllama_data_free_backend_OV:
-  metric_value: 0.73873
-  num_int4: 114
-  num_int8: 84
-tinyllama_data_aware_backend_OV:
-  metric_value: 0.85767
-  num_int4: 94
-  num_int8: 124
-tinyllama_data_aware_awq_stateful_backend_OV:
-  metric_value: 0.85571
-  num_int4: 94
-  num_int8: 124
-tinyllama_data_aware_awq_scale_estimation_backend_OV:
-  metric_value: 0.86355
-  num_int4: 94
-  num_int8: 124
-tinyllama_data_aware_awq_scale_estimation_stateful_backend_OV:
-  metric_value: 0.86355
-  num_int4: 94
-  num_int8: 124
-tinyllama_int8_data_free_backend_TORCH:
-  metric_value: 0.95624
-  num_int4: 0
-  num_int8: 312
-tinyllama_data_aware_gptq_scale_estimation_stateful_backend_OV:
-  metric_value: 0.86697
-  num_int4: 94
-  num_int8: 124
-  metrics_xfail_reason: "Issue-148819"
-tinyllama_scale_estimation_per_channel_backend_OV:
-  metric_value: 0.80798
-  num_int4: 188
-  num_int8: 124
-tinyllama_data_aware_lora_stateful_backend_OV:
-  metric_value: 0.83446
-  num_int4: 94
-  num_int8: 500
 tinyllama_NF4_scale_estimation_stateful_per_channel_backend_OV:
-  metric_value: 0.87132
+  metric_value: 0.88264
   num_int4: 11
   num_int8: 290
   metrics_xfail_reason: "Issue-148819"
 tinyllama_awq_backup_mode_none_backend_OV:
-  metric_value: 0.85679
+  metric_value: 0.84781
   num_int4: 208
   num_int8: 0
+tinyllama_data_aware_backend_OV:
+  metric_value: 0.86141
+  num_int4: 94
+  num_int8: 124
+tinyllama_data_aware_awq_scale_estimation_backend_OV:
+  metric_value: 0.87054
+  num_int4: 94
+  num_int8: 124
+tinyllama_data_aware_awq_scale_estimation_stateful_backend_OV:
+  metric_value: 0.85467
+  num_int4: 94
+  num_int8: 124
+tinyllama_data_aware_awq_stateful_backend_OV:
+  metric_value: 0.84118
+  num_int4: 94
+  num_int8: 124
+tinyllama_data_aware_gptq_scale_estimation_stateful_backend_OV:
+  metric_value: 0.85716
+  num_int4: 94
+  num_int8: 124
+  metrics_xfail_reason: "Issue-148819"
+tinyllama_data_aware_lora_stateful_backend_OV:
+  metric_value: 0.82979
+  num_int4: 94
+  num_int8: 500
+tinyllama_data_free_backend_OV:
+  metric_value: 0.73795
+  num_int4: 114
+  num_int8: 84
+tinyllama_int8_data_free_backend_TORCH:
+  metric_value: 0.94014
+  num_int4: 0
+  num_int8: 312
+tinyllama_scale_estimation_per_channel_backend_OV:
+  metric_value: 0.82413
+  num_int4: 188
+  num_int8: 124

--- a/tests/post_training/data/wc_reference_data_2024.5.yaml
+++ b/tests/post_training/data/wc_reference_data_2024.5.yaml
@@ -1,34 +1,46 @@
 tinyllama_NF4_scale_estimation_stateful_per_channel_backend_OV:
-  metric_value: 0.88663
+  metric_value: 0.86466
   num_int4: 11
   num_int8: 290
   metrics_xfail_reason: "Issue-148819"
-tinyllama_int4_data_free_backend_TORCH:
-  metric_value: 0.73873
-  num_int4: 114
-  num_int8: 84
 tinyllama_awq_backup_mode_none_backend_OV:
-  metric_value: 0.84783
+  metric_value: 0.84809
   num_int4: 208
   num_int8: 0
+tinyllama_data_aware_backend_OV:
+  metric_value: 0.85273
+  num_int4: 94
+  num_int8: 124
 tinyllama_data_aware_awq_scale_estimation_backend_OV:
-  metric_value: 0.85502
+  metric_value: 0.85473
   num_int4: 94
   num_int8: 124
 tinyllama_data_aware_awq_scale_estimation_stateful_backend_OV:
-  metric_value: 0.85502
+  metric_value: 0.85882
   num_int4: 94
   num_int8: 124
 tinyllama_data_aware_awq_stateful_backend_OV:
-  metric_value: 0.85616
+  metric_value: 0.8433
   num_int4: 94
   num_int8: 124
 tinyllama_data_aware_gptq_scale_estimation_stateful_backend_OV:
-  metric_value: 0.86503
+  metric_value: 0.83747
   num_int4: 94
   num_int8: 124
   metrics_xfail_reason: "Issue-148819"
+tinyllama_data_aware_lora_stateful_backend_OV:
+  metric_value: 0.83219
+  num_int4: 94
+  num_int8: 500
+tinyllama_data_free_backend_OV:
+  metric_value: 0.70809
+  num_int4: 114
+  num_int8: 84
+tinyllama_int8_data_free_backend_TORCH:
+  metric_value: 0.94589
+  num_int4: 0
+  num_int8: 312
 tinyllama_scale_estimation_per_channel_backend_OV:
-  metric_value: 0.81389
+  metric_value: 0.81748
   num_int4: 188
   num_int8: 124

--- a/tests/post_training/pipelines/lm_weight_compression.py
+++ b/tests/post_training/pipelines/lm_weight_compression.py
@@ -290,7 +290,7 @@ class LMWeightCompression(BaseTestPipeline):
                 load_in_8bit=False,
                 compile=False,
                 stateful=is_stateful,
-                ov_config={"DYNAMIC_QUANTIZATION_GROUP_SIZE": "0"},
+                ov_config={"KV_CACHE_PRECISION": "u8"},
             )
         print("Evaluation of the target model")
         _, all_metrics = evaluator.score(compressed_model_hf)


### PR DESCRIPTION
### Changes

Use default runtime options for weight compression in conformance tests.
Dynamic Quantization of Activations is enabled by default at least since 2024.4: https://github.com/openvinotoolkit/openvino/pull/25054
KV Cache compression to u8 since 2025: https://github.com/openvinotoolkit/openvino/pull/27454

### Reason for changes

Dynamic Quantization Activations and KV Cache compression in U8 should be default options for users since OpenVINO 2025.
Changed tests to validate weight compression with the option.

### Related tickets
144846, 146143, 145701

### Tests

51 build with openvino-nightly (2025.0.0-17353-acccb227fba)
![image](https://github.com/user-attachments/assets/7e4dfb2d-ce5d-4ba3-a251-381d478b6f43)

252 build with current openvino (2024.4.0-16579-c3152d32c9c-releases/2024/4)
![image](https://github.com/user-attachments/assets/e4b29801-dd61-40c1-9ca7-83d10a6189d7)

