### PR TITLE
Bump laber action to v5

### DIFF
--- a/.github/action_configs/labeler.yml
+++ b/.github/action_configs/labeler.yml
@@ -1,49 +1,76 @@
 # See help here: https://github.com/marketplace/actions/labeler
 
 dependencies:
-  - 'requirements.txt'
-  - '**/setup.py'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'requirements.txt'
+      - '**/setup.py'
 
 NNCF PT:
-  - 'examples/torch/**/*!(.md)'
-  - 'examples/post_training_quantization/torch/**/*!(.md)'
-  - 'nncf/torch/**/*!(.md)'
-  - 'tests/torch/**/*!(.md)'
-  - 'nncf/quantization/**/torch_backend.py'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'examples/torch/**/*!(.md)'
+      - 'examples/post_training_quantization/torch/**/*!(.md)'
+      - 'nncf/torch/**/*!(.md)'
+      - 'tests/torch/**/*!(.md)'
+      - 'nncf/quantization/**/torch_backend.py'
 
 NNCF TF:
-  - 'examples/tensorflow/**/*!(.md)'
-  - 'examples/post_training_quantization/tensorflow/**/*!(.md)'
-  - 'nncf/tensorflow/**/*!(.md)'
-  - 'tests/tensorflow/**/*!(.md)'
-  - 'nncf/quantization/**/tf_backend.py'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'examples/tensorflow/**/*!(.md)'
+      - 'examples/post_training_quantization/tensorflow/**/*!(.md)'
+      - 'nncf/tensorflow/**/*!(.md)'
+      - 'tests/tensorflow/**/*!(.md)'
+      - 'nncf/quantization/**/tf_backend.py'
 
 NNCF ONNX:
-  - 'examples/onnx/**/*!(.md)'
-  - 'examples/post_training_quantization/onnx/**/*!(.md)'
-  - 'nncf/onnx/**/*!(.md)'
-  - 'tests/onnx/**/*!(.md)'
-  - 'nncf/quantization/**/onnx_backend.py'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'examples/onnx/**/*!(.md)'
+      - 'examples/post_training_quantization/onnx/**/*!(.md)'
+      - 'nncf/onnx/**/*!(.md)'
+      - 'tests/onnx/**/*!(.md)'
+      - 'nncf/quantization/**/onnx_backend.py'
 
 NNCF OpenVINO:
-  - 'examples/openvino/**/*!(.md)'
-  - 'examples/post_training_quantization/openvino/**/*!(.md)'
-  - 'nncf/openvino/**/*!(.md)'
-  - 'tests/openvino/**/*!(.md)'
-  - 'nncf/quantization/**/openvino_backend.py'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'examples/openvino/**/*!(.md)'
+      - 'examples/post_training_quantization/openvino/**/*!(.md)'
+      - 'nncf/openvino/**/*!(.md)'
+      - 'tests/openvino/**/*!(.md)'
+      - 'nncf/quantization/**/openvino_backend.py'
 
 NNCF PTQ:
-  - 'nncf/quantization/**/*!(.md)'
-  - 'tests/post_training/**/*!(.md)'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'nncf/quantization/**/*!(.md)'
+      - 'tests/post_training/**/*!(.md)'
 
 documentation:
-  - '**/*.md'
-  - 'docs/**/*'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.md'
+      - 'docs/**/*'
 
 experimental:
-  - 'nncf/experimental/**/*!(.md)'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'nncf/experimental/**/*!(.md)'
 
 NNCF Common:
-  - 'examples/common/**/*!(.md)'
-  - 'nncf/common/**/*!(.md)'
-  - 'tests/common/**/*!(.md)'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'examples/common/**/*!(.md)'
+      - 'nncf/common/**/*!(.md)'
+      - 'tests/common/**/*!(.md)'

--- a/.github/action_configs/labeler.yml
+++ b/.github/action_configs/labeler.yml
@@ -74,3 +74,8 @@ NNCF Common:
       - 'examples/common/**/*!(.md)'
       - 'nncf/common/**/*!(.md)'
       - 'tests/common/**/*!(.md)'
+
+release target:
+- any:
+  - base-branch:
+    - '^release_v*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: '.github/action_configs/labeler.yml'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Changes

- Bump action/laber v5
- Update laber.yml to be compatible new version
- New rule to add `release target` label for pull requests to `release_v*` branch

