### PR TITLE
Link to Stable-Zephyr-3b notebook is removed

### DIFF
--- a/docs/usage/post_training_compression/weights_compression/Usage.md
+++ b/docs/usage/post_training_compression/weights_compression/Usage.md
@@ -538,5 +538,4 @@ List of notebooks demonstrating OpenVINO conversion and inference together with 
 
 - [LLM Instruction Following](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/llm-question-answering)
 - [Dolly 2.0](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/dolly-2-instruction-following)
-- [Stable-Zephyr-3b](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/stable-zephyr-3b-chatbot)
 - [LLM Chat Bots](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/llm-chatbot)


### PR DESCRIPTION
### Changes

Link to Stable-Zephyr-3b notebook is removed after the notebook was removed from the openvino notebooks repo https://github.com/openvinotoolkit/openvino_notebooks/pull/2225


### Reason for changes

Fix pre-commit job
