### PR TITLE
[OpenVINO] Add Slice metatype

### DIFF
--- a/nncf/common/hardware/configs/cpu.json
+++ b/nncf/common/hardware/configs/cpu.json
@@ -279,6 +279,7 @@
         {"type": "Transpose"},
         {"type": "Tile"},
         {"type": "StridedSlice"},
+        {"type": "Slice"},
         {"type": "ShuffleChannels"},
         {"type": "Broadcast"},
         {"type": "Pad"},

--- a/nncf/common/hardware/configs/gpu.json
+++ b/nncf/common/hardware/configs/gpu.json
@@ -247,6 +247,7 @@
         {"type": "Crop"},
         {"type": "Transpose"},
         {"type": "Tile"},
-        {"type": "StridedSlice"}
+        {"type": "StridedSlice"},
+        {"type": "Slice"}
     ]
 }

--- a/nncf/common/hardware/configs/npu.json
+++ b/nncf/common/hardware/configs/npu.json
@@ -372,6 +372,7 @@
         {"type": "Transpose"},
         {"type": "Tile"},
         {"type": "StridedSlice"},
+        {"type": "Slice"},
         {"type": "ShuffleChannels"},
         {"type": "Broadcast"},
         {"type": "Pad"},

--- a/nncf/common/hardware/opset.py
+++ b/nncf/common/hardware/opset.py
@@ -54,6 +54,7 @@ class HWConfigOpName:
     EMBEDDINGBAG = "EmbeddingBag"
     PAD = "Pad"
     STRIDEDSLICE = "StridedSlice"
+    SLICE = "Slice"
     GELU = "Gelu"
     LSTMSEQUENCE = "LSTMSequence"
     GRUSEQUENCE = "GRUSequence"

--- a/nncf/openvino/graph/metatypes/groups.py
+++ b/nncf/openvino/graph/metatypes/groups.py
@@ -22,6 +22,7 @@ QUANTIZE_AGNOSTIC_OPERATIONS = [
     ov_metatypes.OVTransposeMetatype,
     ov_metatypes.OVTileMetatype,
     ov_metatypes.OVStridedSliceMetatype,
+    ov_metatypes.OVSliceMetatype,
     ov_metatypes.OVShuffleChannelsMetatype,
     ov_metatypes.OVBroadcastMetatype,
     ov_metatypes.OVPadMetatype,

--- a/nncf/openvino/graph/metatypes/openvino_metatypes.py
+++ b/nncf/openvino/graph/metatypes/openvino_metatypes.py
@@ -569,6 +569,7 @@ class OVStridedSliceMetatype(OVOpMetatype):
 class OVSliceMetatype(OVOpMetatype):
     name = "SliceOp"
     op_names = ["Slice"]
+    hw_config_names = [HWConfigOpName.SLICE]
 
 
 @OV_OPERATOR_METATYPES.register()

--- a/nncf/openvino/graph/metatypes/openvino_metatypes.py
+++ b/nncf/openvino/graph/metatypes/openvino_metatypes.py
@@ -566,6 +566,12 @@ class OVStridedSliceMetatype(OVOpMetatype):
 
 
 @OV_OPERATOR_METATYPES.register()
+class OVSliceMetatype(OVOpMetatype):
+    name = "SliceOp"
+    op_names = ["Slice"]
+
+
+@OV_OPERATOR_METATYPES.register()
 class OVExpMetatype(OVOpMetatype):
     name = "ExpOp"
     op_names = ["Exp"]


### PR DESCRIPTION
### Changes

Adds Slice operation - https://docs.openvino.ai/2022.3/openvino_docs_ops_movement_Slice_8.html
As a result the performance for modnet_webcam_portrait_matting from DLB was improved (local measurement)
from 44 FPS till 72 FPS.
![image](https://github.com/user-attachments/assets/579dab90-38d6-49e0-9aed-d643a61af5f2)



### Reason for changes

Fix incorrect quantization scheme due to unknown metatype

### Related tickets

144218

### Tests

Manually
