### PR TITLE
[PT] Update reference for squeezenet1_1_imagenet_int8_per_tensor (#2831)

### DIFF
--- a/tests/torch/sota_checkpoints_eval.json
+++ b/tests/torch/sota_checkpoints_eval.json
@@ -222,7 +222,7 @@
             "squeezenet1_1_imagenet_int8_per_tensor": {
                 "config": "examples/torch/classification/configs/quantization/squeezenet1_1_imagenet_int8_per_tensor.json",
                 "reference": "squeezenet1_1_imagenet",
-                "target_ov": 58.07,
+                "target_ov": 58.09,
                 "target_pt": 58.14,
                 "metric_type": "Acc@1",
                 "resume": "squeezenet1_1_imagenet_int8_per_tensor.pth",


### PR DESCRIPTION
### Changes

Update reference from 58.07 to 58.09

### Reason for changes

Changed in maxpoll layer:
-  `opset8` -> `opset14`
- `rounding_type="ceil"` ->  `rounding_type="ceil_torch"`

```
# 2024.3
<layer id="18" name="__module.features.2/aten::max_pool2d/MaxPool" type="MaxPool" version="opset14">
	<data strides="2, 2" dilations="1, 1" pads_begin="0, 0" pads_end="0, 0" kernel="3, 3" rounding_type="ceil_torch" auto_pad="explicit" index_element_type="i64" axis="2" />
	
# 2024.2
<layer id="18" name="__module.features.2/aten::max_pool2d/MaxPool" type="MaxPool" version="opset8">
	<data strides="2, 2" dilations="1, 1" pads_begin="0, 0" pads_end="0, 0" kernel="3, 3" rounding_type="ceil" auto_pad="explicit" index_element_type="i64" axis="2" />

```

