### PR TITLE
Update commands.py

### DIFF
--- a/nncf/common/graph/transformations/commands.py
+++ b/nncf/common/graph/transformations/commands.py
@@ -54,7 +54,7 @@ class TargetType(IntEnum):
     `PRE_LAYER_OPERATION` - a location before the associated PT-module or TF-layer
                             execution, for which the local attributes of said
                             PT-module or TF-layer are accessible
-    `POST_LAYER_OPERATION` - a location before the associated PT-module or TF-layer
+    `POST_LAYER_OPERATION` - a location after the associated PT-module or TF-layer
                              execution, for which the local attributes of said
                              PT-module or TF-layer are accessible
     `OPERATION_WITH_WEIGHTS` - same as PRE_LAYER_OPERATION, but targets weights


### PR DESCRIPTION
### Changes

Change the docstring for TargetType in post_layer_operation

### Reason for changes

Post layer operation docstring was the same as pre layer and mentioned adding the operation before the PT module/TF layer when in reality it inserts the operation after.
