### PR TITLE
[GA] Remove unreached step

### DIFF
--- a/.github/workflows/api_changes_check.yml
+++ b/.github/workflows/api_changes_check.yml
@@ -63,15 +63,3 @@ jobs:
               repo: context.repo.repo,
               labels: ["API"]
             })
-      - name: Add release label
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        if: ${{ contains(github.event.pull_request.base.ref, 'release_v') }}
-        with:
-          github-token: ${{ secrets.ADD_LABELS_WITH_REST_API }}
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ["release_target"]
-            })


### PR DESCRIPTION
### Changes

Remove "Add release label" step

### Reason for changes

The condition `${{ contains(github.event.pull_request.base.ref, 'release_v') }}` will never be `True`, because this action triggered only for a pull request to develop branch.

```
on:
  pull_request:
    branches:
      - develop
```

Label `release target` should be added by https://github.com/openvinotoolkit/nncf/pull/2836