### PR TITLE
[GA] Add `Set api label` action

### DIFF
--- a/.github/workflows/api_changes_check.yml
+++ b/.github/workflows/api_changes_check.yml
@@ -41,25 +41,21 @@ jobs:
           echo ${CHANGED_FILES}
           CHANGED_FILES=$(echo $CHANGED_FILES | tr '\n' ' ')
           echo "changed_files=${CHANGED_FILES}" >> $GITHUB_OUTPUT
-      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        if: ${{ !(contains(steps.diff.outputs.changed_files, 'differ'))  && contains(github.event.pull_request.labels.*.name, 'API') }}
-        with:
-          github-token: ${{ secrets.ADD_LABELS_WITH_REST_API }}
-          script: |
-            github.rest.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: "API"
-            })
-      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+
+      - name: Add label
         if: ${{ contains(steps.diff.outputs.changed_files, 'differ') }}
+        run: echo "add" > api_status.txt
+
+      - name: Remove label
+        if: ${{ !(contains(steps.diff.outputs.changed_files, 'differ')) && contains(github.event.pull_request.labels.*.name, 'API') }}
+        run: echo "remove" > api_status.txt
+
+      - name: No change label
+        if: ${{ !(contains(steps.diff.outputs.changed_files, 'differ')) && !contains(github.event.pull_request.labels.*.name, 'API') }}
+        run: echo "none" > api_status.txt
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.ADD_LABELS_WITH_REST_API }}
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ["API"]
-            })
+          name: api_status
+          path: api_status.txt

--- a/.github/workflows/api_set_label.yml
+++ b/.github/workflows/api_set_label.yml
@@ -1,0 +1,59 @@
+name: Set API label
+permissions: read-all
+
+on:
+  workflow_run:
+    workflows: ["API changes check"]
+    types:
+      - completed
+
+jobs:
+  update_labels:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Download artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        with:
+            run_id: ${{ github.event.workflow_run.id }}
+            name: api_status
+
+      - name: Get api_status
+        run: cat api_status.txt
+
+      - name: Set output value
+        id: status
+        run: echo "api_status=$(cat api_status.txt)" >> $GITHUB_OUTPUT
+
+      - name: Print api_status
+        run: echo ${{ steps.status.outputs.api_status }}
+
+      - name: Add label
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        if: ${{ steps.status.outputs.api_status == 'add' }}
+        with:
+            github-token: "${{ secrets.GITHUB_TOKEN }}"
+            script: |
+              github.rest.issues.addLabels({
+                  issue_number: ${{ github.event.workflow_run.pull_requests[0].number }},
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  labels: ["API"]
+              })
+
+      - name: Remove label
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        if: ${{ steps.status.outputs.api_status == 'remove' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: ${{ github.event.workflow_run.pull_requests[0].number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["API"]
+            })


### PR DESCRIPTION
### Changes

Add "Set api label" action
Workflow to update API label:
1) `api_changes_check.yml` runs (build docs, compare with develop) and saves artifacts with status of check 'add, remove or none` (for external contributor only after approval)
2) After finished job will be triggered `api_set_label.yml` with write permission to update label from `api_changes_check.yml`, that downloads artifact and updates API label in pull request 

### Reason for changes

To follow [Good practices for mitigating script injection attacks](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks) pull_request_target is not allow to use for api_changes_check.yml.
But pull_request provide only read permission in result not possible to add label to PR.


