### PR TITLE
Preserve the constant subgraph

### DIFF
--- a/nncf/quantization/algorithms/accuracy_control/ranker.py
+++ b/nncf/quantization/algorithms/accuracy_control/ranker.py
@@ -30,7 +30,7 @@ from nncf.quantization.algorithms.accuracy_control.backend import AccuracyContro
 from nncf.quantization.algorithms.accuracy_control.evaluator import Evaluator
 from nncf.quantization.algorithms.accuracy_control.rank_functions import create_normalized_mse_func
 from nncf.quantization.algorithms.accuracy_control.subset_selection import select_subset
-from nncf.quantization.passes import remove_shapeof_subgraphs
+from nncf.quantization.passes import find_shapeof_subgraphs
 
 TModel = TypeVar("TModel")
 TPModel = TypeVar("TPModel")
@@ -109,11 +109,13 @@ class Ranker:
             *self._algo_backend.get_start_nodes_for_activation_path_tracing(quantized_model_graph),
         ]
 
-        quantized_model_graph_without_shapeof = remove_shapeof_subgraphs(
-            deepcopy(quantized_model_graph),
+        shapeof_subgraphs = find_shapeof_subgraphs(
+            quantized_model_graph,
             self._algo_backend.get_shapeof_metatypes(),
             input_nodes,
         )
+        quantized_model_graph_without_shapeof = deepcopy(quantized_model_graph)
+        quantized_model_graph_without_shapeof.remove_nodes_from(shapeof_subgraphs)
 
         for quantizer_node in reversed(quantizers):
             if processed.get(quantizer_node.node_name, False):

--- a/nncf/quantization/algorithms/layerwise/scheduler.py
+++ b/nncf/quantization/algorithms/layerwise/scheduler.py
@@ -101,7 +101,7 @@ class LayerwiseScheduler:
         """
         # Initialize input nodes and create a copy of the graph for inference
         input_nodes = graph.get_input_nodes()
-        inference_graph = transform_to_inference_graph(deepcopy(graph), input_nodes, [], [])
+        inference_graph = transform_to_inference_graph(deepcopy(graph), input_nodes, [], [], [])
 
         steps = []
         visited_map = {node: False for node in inference_graph.get_all_nodes()}

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -742,6 +742,7 @@ class MinMaxQuantization(Algorithm):
             self._backend_entity.get_start_nodes_for_activation_path_tracing(nncf_graph),
             self._backend_entity.shapeof_metatypes,
             self._backend_entity.dropout_metatypes,
+            self._backend_entity.preserved_metatypes,
         )
 
         quantizer_setup = self._get_quantizer_setup(nncf_graph, inference_nncf_graph, hw_patterns, ignored_patterns)

--- a/nncf/quantization/algorithms/min_max/backend.py
+++ b/nncf/quantization/algorithms/min_max/backend.py
@@ -34,6 +34,13 @@ TModel = TypeVar("TModel")
 class MinMaxAlgoBackend(ABC):
     @property
     @abstractmethod
+    def preserved_metatypes(self) -> List[OperatorMetatype]:
+        """
+        TODO
+        """
+
+    @property
+    @abstractmethod
     def mat_mul_metatypes(self) -> List[OperatorMetatype]:
         """
         Property for the backend-specific MatMul metatypes.

--- a/nncf/quantization/algorithms/min_max/backend.py
+++ b/nncf/quantization/algorithms/min_max/backend.py
@@ -36,7 +36,8 @@ class MinMaxAlgoBackend(ABC):
     @abstractmethod
     def preserved_metatypes(self) -> List[OperatorMetatype]:
         """
-        TODO
+        Property for backend-specific metatypes that require preserving float subgraphs
+        when removing the ShapeOf subgraph.
         """
 
     @property

--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -47,6 +47,10 @@ from nncf.quantization.range_estimator import RangeEstimatorParameters
 
 class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
     @property
+    def preserved_metatypes(self) -> List[OperatorMetatype]:
+        return []
+
+    @property
     def mat_mul_metatypes(self) -> List[OperatorMetatype]:
         return MATMUL_METATYPES
 

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -44,6 +44,10 @@ from nncf.quantization.range_estimator import AggregatorType
 
 class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
     @property
+    def preserved_metatypes(self) -> List[OperatorMetatype]:
+        return [om.OVConvolutionMetatype, om.OVLSTMSequenceMetatype]
+
+    @property
     def mat_mul_metatypes(self) -> List[OperatorMetatype]:
         return [om.OVMatMulMetatype]
 

--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -56,6 +56,10 @@ from nncf.torch.tensor_statistics.collectors import PT_REDUCERS_MAP
 
 
 class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
+    @property
+    def preserved_metatypes(self) -> List[OperatorMetatype]:
+        return []
+
     TARGET_TYPE_TO_PT_INS_TYPE_MAP = {
         TargetType.PRE_LAYER_OPERATION: TargetType.OPERATOR_PRE_HOOK,
         TargetType.POST_LAYER_OPERATION: TargetType.OPERATOR_POST_HOOK,

--- a/nncf/quantization/algorithms/min_max/torch_fx_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_fx_backend.py
@@ -60,6 +60,10 @@ class FXMinMaxAlgoBackend(MinMaxAlgoBackend):
     }
 
     @property
+    def preserved_metatypes(self) -> List[OperatorMetatype]:
+        return []
+
+    @property
     def mat_mul_metatypes(self) -> List[OperatorMetatype]:
         return [om.PTLinearMetatype, om.PTMatMulMetatype]
 

--- a/nncf/quantization/algorithms/weight_compression/awq.py
+++ b/nncf/quantization/algorithms/weight_compression/awq.py
@@ -133,7 +133,7 @@ class AWQ(Algorithm):
         """
         matches = []
 
-        inference_nncf_graph = transform_to_inference_graph(deepcopy(graph), [], [], [])
+        inference_nncf_graph = transform_to_inference_graph(deepcopy(graph), [], [], [], [])
         nx_graph = inference_nncf_graph.get_nx_graph_copy()
         for _, pattern_graph in self._patterns.items():
             matches.extend(find_subgraphs_matching_pattern(nx_graph, pattern_graph(), strict=False))

--- a/nncf/quantization/passes.py
+++ b/nncf/quantization/passes.py
@@ -152,7 +152,7 @@ def find_constant_subgraphs(
     :return: A list of nodes belonging to constant subgraphs.
     """
     if not input_nodes:
-        return nncf_graph
+        return []
 
     visited_nodes = set()
     nodes_queue = collections.deque(input_nodes)

--- a/nncf/quantization/passes.py
+++ b/nncf/quantization/passes.py
@@ -100,10 +100,11 @@ def find_preserved_nodes(
     preserved_metatypes: List[OperatorMetatype],
 ) -> List[NNCFNode]:
     """
-    :param graph:
-    :param shapeof_subgraphs:
-    :param preserved_metatypes:
-    :return:
+    :param graph: The input graph to be analyzed.
+    :param shapeof_subgraphs: A list of nodes belonging to ShapeOf subgraphs.
+    :param preserved_metatypes: Backend-specific metatypes that require preserving
+        float subgraphs when removing the ShapeOf subgraph.
+    :return: A list of nodes in float subgraphs of ShapeOf subgraphs.
     """
     preserved_nodes = set()
     for node in graph.get_nodes_by_metatypes(preserved_metatypes):

--- a/nncf/quantization/passes.py
+++ b/nncf/quantization/passes.py
@@ -34,27 +34,29 @@ def transform_to_inference_graph(
     :param dropout_metatypes: List of backend-specific Dropout metatypes.
     :return: NNCFGraph in the inference style.
     """
-    remove_shapeof_subgraphs(nncf_graph, shapeof_metatypes, input_nodes)
+    shapeof_subgraphs = find_shapeof_subgraphs(nncf_graph, shapeof_metatypes, input_nodes)
+    nncf_graph.remove_nodes_from(shapeof_subgraphs)
     filter_constant_nodes(nncf_graph, input_nodes)
     remove_nodes_and_reconnect_graph(nncf_graph, dropout_metatypes)
     return nncf_graph
 
 
-def remove_shapeof_subgraphs(
+def find_shapeof_subgraphs(
     nncf_graph: NNCFGraph,
     shapeof_metatypes: List[OperatorMetatype],
     input_nodes: List[NNCFNode],
-) -> NNCFGraph:
+) -> List[NNCFNode]:
     """
-    Removes the ShapeOf subgraphs from the provided NNCFGraph instance inplace.
-    Constant subgraph should be already removed from the given NNCFGraph.
+    Returns a list of nodes belonging to ShapeOf subgraphs.
 
-    :param nncf_graph: NNCFGraph instance for the transformation.
-    :param shapeof_metatypes: List of backend-specific ShapeOf metatypes.
-    :param input_nodes: List of input nodes for the given NNCFGraph.
-    :return: NNCFGraph without ShapeOf subgraphs.
+    :param nncf_graph: The input graph to be analyzed.
+    :param shapeof_metatypes: A list of metatypes representing backend-specific
+        ShapeOf operations.
+    :param input_nodes: A list of nodes designated as graph inputs. These nodes are
+        used to identify which nodes depend on input data.
+    :return: A list of nodes belonging to ShapeOf subgraphs.
     """
-    nodes_to_drop = set()
+    shapeof_subgraphs = set()
     shape_of_nodes = []
     infer_nodes = []
 
@@ -70,21 +72,20 @@ def remove_shapeof_subgraphs(
         nodes_queue.extend(nncf_graph.get_next_nodes(node))
 
     for shape_of_node in shape_of_nodes:
-        nodes_to_drop.add(shape_of_node.node_name)
+        shapeof_subgraphs.add(shape_of_node)
 
         shape_of_queue = collections.deque()
         shape_of_queue.extend(nncf_graph.get_next_nodes(shape_of_node))
         while shape_of_queue:
             node = shape_of_queue.pop()
-            if node.node_name in nodes_to_drop or node.node_name in infer_nodes:
+            if node in shapeof_subgraphs or node.node_name in infer_nodes:
                 continue
-            nodes_to_drop.add(node.node_name)
+            shapeof_subgraphs.add(node)
             # traverse forward and backward to exclude full shape of subgraph
             # recursion excluded due to infer_nodes list around subgraph shape
             shape_of_queue.extend(nncf_graph.get_next_nodes(node) + nncf_graph.get_previous_nodes(node))
 
-    nncf_graph.remove_nodes_from([nncf_graph.get_node_by_name(name) for name in nodes_to_drop])
-    return nncf_graph
+    return list(shapeof_subgraphs)
 
 
 def remove_nodes_and_reconnect_graph(

--- a/tests/common/quantization/test_passes.py
+++ b/tests/common/quantization/test_passes.py
@@ -16,7 +16,7 @@ import pytest
 
 from nncf.common.graph.layer_attributes import MultipleInputLayerAttributes
 from nncf.common.graph.operator_metatypes import OperatorMetatype
-from nncf.quantization.passes import filter_constant_nodes
+from nncf.quantization.passes import find_constant_subgraphs
 from nncf.quantization.passes import remove_nodes_and_reconnect_graph
 from tests.cross_fw.test_templates.models import NNCFGraphDropoutRemovingCase
 from tests.cross_fw.test_templates.models import NNCFGraphToTestConstantFiltering
@@ -63,7 +63,7 @@ def test_remove_nodes_and_reconnect_graph(mode: ParameterTestModes):
 
 
 @pytest.mark.parametrize("node_between_const_and_op", [False, True])
-def test_filter_constant_nodes(node_between_const_and_op):
+def test_find_constant_subgraphs(node_between_const_and_op):
     dot_reference_path_before = (
         Path("passes") / f"test_constant_filtering_model_before{int(node_between_const_and_op)}.dot"
     )
@@ -88,5 +88,6 @@ def test_filter_constant_nodes(node_between_const_and_op):
     additional_input_names = ["/Conv2_0", "/Concat_with_missed_input_0"]
     input_nodes = nncf_graph.get_input_nodes() + [nncf_graph.get_node_by_name(name) for name in additional_input_names]
     _check_graphs(dot_reference_path_before, nncf_graph)
-    filter_constant_nodes(nncf_graph, input_nodes)
+    constant_subgraphs = find_constant_subgraphs(nncf_graph, input_nodes)
+    nncf_graph.remove_nodes_from(constant_subgraphs)
     _check_graphs(dot_reference_path_after, nncf_graph)

--- a/tests/common/quantization/test_quantizer_removal.py
+++ b/tests/common/quantization/test_quantizer_removal.py
@@ -18,7 +18,7 @@ import pytest
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph.layer_attributes import Dtype
 from nncf.common.quantization.quantizer_removal import find_quantizer_nodes_to_cut
-from nncf.quantization.passes import remove_shapeof_subgraphs
+from nncf.quantization.passes import find_shapeof_subgraphs
 from tests.common.quantization.metatypes import CONSTANT_METATYPES
 from tests.common.quantization.metatypes import METATYPES_FOR_TEST
 from tests.common.quantization.metatypes import QUANTIZABLE_METATYPES
@@ -304,7 +304,11 @@ def test_find_quantizer_nodes_to_cut(nncf_graph: NNCFGraph, test_case: Parameter
     # As test graphs are fully connected and does not have readvariable metatype,
     # this should work
     input_nodes = nncf_graph.get_input_nodes()
-    nncf_graph_without_shapeof = remove_shapeof_subgraphs(deepcopy(nncf_graph), SHAPEOF_METATYPES, input_nodes)
+
+    shapeof_subgraphs = find_shapeof_subgraphs(nncf_graph, SHAPEOF_METATYPES, input_nodes)
+    nncf_graph_without_shapeof = deepcopy(nncf_graph)
+    nncf_graph_without_shapeof.remove_nodes_from(shapeof_subgraphs)
+
     nodes, ops = find_quantizer_nodes_to_cut(
         nncf_graph_without_shapeof,
         quantizer_node,

--- a/tests/cross_fw/test_templates/test_ptq_params.py
+++ b/tests/cross_fw/test_templates/test_ptq_params.py
@@ -236,6 +236,7 @@ class TemplateTestPTQParams:
             min_max_algo._backend_entity.get_start_nodes_for_activation_path_tracing(nncf_graph),
             min_max_algo._backend_entity.shapeof_metatypes,
             min_max_algo._backend_entity.dropout_metatypes,
+            min_max_algo._backend_entity.preserved_metatypes,
         )
         q_setup = min_max_algo._get_quantizer_setup(nncf_graph, inference_nncf_graph, hw_patterns, ignored_patterns)
         act_num_q, weight_num_q = 0, 0
@@ -261,6 +262,7 @@ class TemplateTestPTQParams:
             min_max_algo._backend_entity.get_start_nodes_for_activation_path_tracing(nncf_graph),
             min_max_algo._backend_entity.shapeof_metatypes,
             min_max_algo._backend_entity.dropout_metatypes,
+            min_max_algo._backend_entity.preserved_metatypes,
         )
         q_setup = min_max_algo._get_quantizer_setup(nncf_graph, inference_nncf_graph, hw_patterns, ignored_patterns)
         act_num_q, weight_num_q = 0, 0
@@ -286,6 +288,7 @@ class TemplateTestPTQParams:
             min_max_algo._backend_entity.get_start_nodes_for_activation_path_tracing(nncf_graph),
             min_max_algo._backend_entity.shapeof_metatypes,
             min_max_algo._backend_entity.dropout_metatypes,
+            min_max_algo._backend_entity.preserved_metatypes,
         )
         q_setup = min_max_algo._get_quantizer_setup(nncf_graph, inference_nncf_graph, hw_patterns, ignored_patterns)
         for quantization_point in q_setup.quantization_points.values():
@@ -382,6 +385,7 @@ class TemplateTestPTQParams:
         inference_nncf_graph = transform_to_inference_graph(
             deepcopy(nncf_graph),
             self.get_algo_backend().get_start_nodes_for_activation_path_tracing(nncf_graph),
+            [],
             [],
             [],
         )

--- a/tests/cross_fw/test_templates/test_quantizer_config.py
+++ b/tests/cross_fw/test_templates/test_quantizer_config.py
@@ -134,6 +134,7 @@ class TemplateTestQuantizerConfig:
             min_max_algo._backend_entity.get_start_nodes_for_activation_path_tracing(nncf_graph),
             min_max_algo._backend_entity.shapeof_metatypes,
             min_max_algo._backend_entity.dropout_metatypes,
+            min_max_algo._backend_entity.preserved_metatypes,
         )
         q_setup = min_max_algo._get_quantizer_setup(
             nncf_graph, inference_nncf_graph, hw_patterns=GraphPattern(), ignored_patterns=GraphPattern()
@@ -188,6 +189,7 @@ class TemplateTestQuantizerConfig:
             min_max_algo._backend_entity.get_start_nodes_for_activation_path_tracing(nncf_graph),
             min_max_algo._backend_entity.shapeof_metatypes,
             min_max_algo._backend_entity.dropout_metatypes,
+            min_max_algo._backend_entity.preserved_metatypes,
         )
         if signed_weights is False or signed_activations in [True, False]:  # Incompatible with HW CPU config
             with pytest.raises(
@@ -230,6 +232,7 @@ class TemplateTestQuantizerConfig:
             min_max_algo._backend_entity.get_start_nodes_for_activation_path_tracing(nncf_graph),
             min_max_algo._backend_entity.shapeof_metatypes,
             min_max_algo._backend_entity.dropout_metatypes,
+            min_max_algo._backend_entity.preserved_metatypes,
         )
         q_setup = min_max_algo._get_quantizer_setup(
             nncf_graph, inference_nncf_graph, hw_patterns=GraphPattern(), ignored_patterns=GraphPattern()


### PR DESCRIPTION
### Reason for changes

Removing the ShapeOf subgraph may lead to the removal of some input edges of operations, and QPS doesn't place FQ on these edges. In this case, the operations are quantized incorrectly because not all required inputs are quantized. These operations don't change their runtime precision in the execution graph, which means we do not have a fully quantized model.

### Changes

To resolve the described problem, this PR introduces the following algorithm:

- **Step 1:** Find all nodes belonging to the ShapeOf subgraphs in the graph. Let's denote the found nodes as $S$. At this step, we don't remove the found subgraphs; we only store the nodes they consist of. See `find_shapeof_subgraphs()` method.

- **Step 2:** Check the producers for the specified nodes (currently, we are considering only nodes of the LSTMSequence and Convolution types). If any of these producers are in set $S$, it means that we will lose this input edge when the ShapeOf subgraph is removed. Therefore, we try to exclude float subgraphs from this ShapeOf subgraph. Let's denote the nodes that are part of such float subgraphs as $P$. We can see that $P \subset S$. See `find_preserved_nodes()` method.

- **Step 3:** Find all nodes belonging to the Constant subgraphs in the graph. Let's denote the found nodes as $C$. At this step, we don't remove the found subgraphs; we only store the nodes they consist of. See `find_constant_subgraphs()` method.

- **Step 4:** Remove $S \cup C - P$ nodes from the graph.

### Related tickets

- 146088