### PR TITLE
Update readme and release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [Usage](#usage) •
 [Tutorials and Samples](#demos-tutorials-and-samples) •
 [Third-party integration](#third-party-repository-integration) •
-[NNCF Model Zoo](./docs/ModelZoo.md)
+[Model Zoo](./docs/ModelZoo.md)
 
 [![GitHub Release](https://img.shields.io/github/v/release/openvinotoolkit/nncf?color=green)](https://github.com/openvinotoolkit/nncf/releases)
 [![Website](https://img.shields.io/website?up_color=blue&up_message=docs&url=https%3A%2F%2Fdocs.openvino.ai%2Flatest%2Fopenvino_docs_model_optimization_guide.html)](https://docs.openvino.ai/nncf)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -40,7 +40,6 @@ Compression-aware training:
 Requirements:
 
 - Updated Tensorflow (2.15) version. This version requires Python 3.9-3.11.
-- Added NumPy 2.0 support.
 
 ## New in Release 2.11.0
 


### PR DESCRIPTION
### Changes

- Minor update in Readme to have links on one line
- Remove numpy2.0 from release notes to avoid any confusion 
