### PR TITLE
Fix torch compile applied to model forward

### DIFF
--- a/nncf/torch/dynamic_graph/wrappers.py
+++ b/nncf/torch/dynamic_graph/wrappers.py
@@ -13,7 +13,6 @@ from copy import deepcopy
 from typing import Callable, List, Tuple
 
 import torch
-from torch._dynamo import OptimizedModule
 from torch.nn import DataParallel
 
 from nncf.common.graph.definitions import MODEL_CONST_OP_NAME
@@ -136,7 +135,7 @@ def wrap_module_call(module_call):
         from nncf.torch.dynamic_graph.patch_pytorch import unpatching_module_call
 
         # If called on a model compiled by torch dynamo, we unpatch torch operators and invoke original module call
-        if isinstance(self, OptimizedModule):
+        if "_torchdynamo_orig_callable" in self.forward.__dict__:
             return unpatching_module_call(self, *args, **kwargs)
 
         ctx = get_current_context()

--- a/tests/torch/test_pytorch_patch.py
+++ b/tests/torch/test_pytorch_patch.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import inspect
+import os
 from typing import List
 
 import pytest
@@ -114,8 +115,10 @@ def test_jit_script_exception_preserves_patching():
 
 
 @pytest.mark.xfail(is_windows(), reason="https://github.com/pytorch/pytorch/issues/122094")
-def test_torch_compile():
+@pytest.mark.parametrize("compile_forward", [False, True])
+def test_torch_compile(compile_forward):
     # Run test case in a separate process to track patching of torch by NNCF
+    os.environ["COMPILE_FORWARD"] = f"{int(compile_forward)}"
     run_pytest_case_function_in_separate_process(test_compile)
 
 


### PR DESCRIPTION
### Changes

Check whether model is compiled based on `"_torchdynamo_orig_callable"` property of the model forward.

### Reason for changes

`torch.compile` can be applied not only to the model itself, but to `forward()` method only. For example:
```
model.forward = torch.compile(model.forward)
```
In this case the model itself doesn't change and it won't be an instance of `torch._dynamo.OptimizedModule`.

### Related tickets

143796

### Tests

Added test when `torch.compile` is applied this way. It does not fail without the fix though, because the issue is sporadic.


### Relates to
#2665, #2719
