### PR TITLE
[FX/PT/ONNX][MinMax] Weights nodes/ constant matmuls collection fix

### DIFF
--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -1026,7 +1026,7 @@ class MinMaxQuantization(Algorithm):
                             continue
                         if (
                             quantization_point.qconfig.mode != QuantizationScheme.SYMMETRIC
-                            and not self._backend_entity.is_constant_matmul(node, nncf_graph)
+                            and not self._backend_entity.is_matmul_with_constant(node, nncf_graph)
                         ):
                             quantization_point.qconfig.mode = QuantizationScheme.SYMMETRIC
                             nncf_logger.debug(

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -1026,7 +1026,7 @@ class MinMaxQuantization(Algorithm):
                             continue
                         if (
                             quantization_point.qconfig.mode != QuantizationScheme.SYMMETRIC
-                            and node.layer_attributes is None
+                            and not self._backend_entity.is_constant_matmul(node, nncf_graph)
                         ):
                             quantization_point.qconfig.mode = QuantizationScheme.SYMMETRIC
                             nncf_logger.debug(

--- a/nncf/quantization/algorithms/min_max/backend.py
+++ b/nncf/quantization/algorithms/min_max/backend.py
@@ -312,3 +312,15 @@ class MinMaxAlgoBackend(ABC):
         :param nncf_graph: Instance of NNCFGraph.
         :return: All nodes with weights.
         """
+
+    @staticmethod
+    @abstractmethod
+    def is_constant_matmul(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        """
+        Returns true if given nncf matmul node is a matmul with a constant,
+            False otherwise.
+        :param Node: Instance of NNCFNode.
+        :param nncf_graph: Instance of NNCFGraph.
+        :return: True if given nncf matmul node is a matmul with a constant,
+            False otherwise.
+        """

--- a/nncf/quantization/algorithms/min_max/backend.py
+++ b/nncf/quantization/algorithms/min_max/backend.py
@@ -303,9 +303,8 @@ class MinMaxAlgoBackend(ABC):
         :return: List of ignored names.
         """
 
-    @staticmethod
     @abstractmethod
-    def get_weight_nodes(nncf_graph: NNCFGraph) -> List[NNCFNode]:
+    def get_weight_nodes(self, nncf_graph: NNCFGraph) -> List[NNCFNode]:
         """
         Returns nodes that have weights.
 
@@ -313,9 +312,8 @@ class MinMaxAlgoBackend(ABC):
         :return: All nodes with weights.
         """
 
-    @staticmethod
     @abstractmethod
-    def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+    def is_matmul_with_constant(self, node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         """
         Returns true if given nncf matmul node is a matmul with a constant, False otherwise.
 

--- a/nncf/quantization/algorithms/min_max/backend.py
+++ b/nncf/quantization/algorithms/min_max/backend.py
@@ -315,12 +315,11 @@ class MinMaxAlgoBackend(ABC):
 
     @staticmethod
     @abstractmethod
-    def is_constant_matmul(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+    def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         """
-        Returns true if given nncf matmul node is a matmul with a constant,
-            False otherwise.
+        Returns true if given nncf matmul node is a matmul with a constant, False otherwise.
+
         :param Node: Instance of NNCFNode.
         :param nncf_graph: Instance of NNCFGraph.
-        :return: True if given nncf matmul node is a matmul with a constant,
-            False otherwise.
+        :return: True if given nncf matmul node is a matmul with a constant, False otherwise.
         """

--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -268,3 +268,7 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
     def should_quantize_weight(weight_name: str, quantized_weight_names: Set[str]) -> bool:
         # If the nodes share one weight tensor, we should have only one quantizer on that
         return weight_name not in quantized_weight_names
+
+    @staticmethod
+    def is_constant_matmul(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        return node.layer_attributes.has_weight()

--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -271,4 +271,5 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
 
     @staticmethod
     def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        assert node.metatype in ONNXMinMaxAlgoBackend().mat_mul_metatypes
         return node.layer_attributes.has_weight()

--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -269,5 +269,4 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
         return weight_name not in quantized_weight_names
 
     def is_matmul_with_constant(self, node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
-        assert node.metatype in self.mat_mul_metatypes
-        return node.layer_attributes.has_weight()
+        return node.metatype in self.mat_mul_metatypes and node.layer_attributes.has_weight()

--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -270,5 +270,5 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
         return weight_name not in quantized_weight_names
 
     @staticmethod
-    def is_constant_matmul(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+    def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         return node.layer_attributes.has_weight()

--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -255,8 +255,7 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
     def get_ignored_names_by_layer_attributes(nncf_graph: NNCFGraph) -> Set[str]:
         return set()
 
-    @staticmethod
-    def get_weight_nodes(nncf_graph: NNCFGraph) -> List[NNCFNode]:
+    def get_weight_nodes(self, nncf_graph: NNCFGraph) -> List[NNCFNode]:
         return [node for node in nncf_graph.get_all_nodes() if node.layer_attributes.has_weight()]
 
     @staticmethod
@@ -269,7 +268,6 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
         # If the nodes share one weight tensor, we should have only one quantizer on that
         return weight_name not in quantized_weight_names
 
-    @staticmethod
-    def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
-        assert node.metatype in ONNXMinMaxAlgoBackend().mat_mul_metatypes
+    def is_matmul_with_constant(self, node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        assert node.metatype in self.mat_mul_metatypes
         return node.layer_attributes.has_weight()

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -265,6 +265,10 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
         ]
 
     @staticmethod
+    def is_constant_matmul(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        return node.layer_attributes is not None
+
+    @staticmethod
     def get_weight_name(nncf_graph: NNCFGraph, target_point: OVTargetPoint) -> str:
         node = nncf_graph.get_node_by_name(target_point.target_node_name)
         return node.layer_attributes.constant_attributes[target_point.port_id]["name"]

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -265,7 +265,7 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
         ]
 
     @staticmethod
-    def is_constant_matmul(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+    def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         return node.layer_attributes is not None
 
     @staticmethod

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -256,17 +256,15 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
                 ignored_names.add(node.node_name)
         return ignored_names
 
-    @staticmethod
-    def get_weight_nodes(nncf_graph: NNCFGraph) -> List[NNCFNode]:
+    def get_weight_nodes(self, nncf_graph: NNCFGraph) -> List[NNCFNode]:
         return [
             node
             for node in nncf_graph.get_all_nodes()
             if isinstance(node.layer_attributes, OVLayerAttributes) and node.metatype in OPERATIONS_WITH_WEIGHTS
         ]
 
-    @staticmethod
-    def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
-        assert node.metatype in OVMinMaxAlgoBackend().mat_mul_metatypes
+    def is_matmul_with_constant(self, node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        assert node.metatype in self.mat_mul_metatypes
         return node.layer_attributes is not None
 
     @staticmethod

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -264,8 +264,7 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
         ]
 
     def is_matmul_with_constant(self, node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
-        assert node.metatype in self.mat_mul_metatypes
-        return node.layer_attributes is not None
+        return node.metatype in self.mat_mul_metatypes and node.layer_attributes is not None
 
     @staticmethod
     def get_weight_name(nncf_graph: NNCFGraph, target_point: OVTargetPoint) -> str:

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -266,6 +266,7 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
 
     @staticmethod
     def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        assert node.metatype in OVMinMaxAlgoBackend().mat_mul_metatypes
         return node.layer_attributes is not None
 
     @staticmethod

--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -66,11 +66,9 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
         TargetType.POST_LAYER_OPERATION: TargetType.OPERATOR_POST_HOOK,
     }
 
-    MAT_MUL_METATYPES = [om.PTLinearMetatype, om.PTMatMulMetatype, om.PTAddmmMetatype]
-
     @property
     def mat_mul_metatypes(self) -> List[OperatorMetatype]:
-        return self.MAT_MUL_METATYPES
+        return [om.PTLinearMetatype, om.PTMatMulMetatype, om.PTAddmmMetatype]
 
     @property
     def post_processing_metatypes(self) -> List[OperatorMetatype]:
@@ -382,7 +380,7 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
         weight_nodes = []
         for node in weight_nodes_candidates:
             if (
-                node.metatype in PTMinMaxAlgoBackend.MAT_MUL_METATYPES
+                node.metatype in PTMinMaxAlgoBackend().mat_mul_metatypes
                 and not PTMinMaxAlgoBackend.is_matmul_with_constant(node, nncf_graph)
             ):
                 continue
@@ -391,4 +389,5 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
 
     @staticmethod
     def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        assert node.metatype in PTMinMaxAlgoBackend().mat_mul_metatypes
         return len(get_weight_tensor_port_ids(node, nncf_graph)) > 0

--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -381,13 +381,14 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
         ]
         weight_nodes = []
         for node in weight_nodes_candidates:
-            if node.metatype in PTMinMaxAlgoBackend.MAT_MUL_METATYPES and not PTMinMaxAlgoBackend.is_constant_matmul(
-                node, nncf_graph
+            if (
+                node.metatype in PTMinMaxAlgoBackend.MAT_MUL_METATYPES
+                and not PTMinMaxAlgoBackend.is_matmul_with_constant(node, nncf_graph)
             ):
                 continue
             weight_nodes.append(node)
         return weight_nodes
 
     @staticmethod
-    def is_constant_matmul(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+    def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         return len(get_weight_tensor_port_ids(node, nncf_graph)) > 0

--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -370,8 +370,7 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
     def get_ignored_names_by_layer_attributes(nncf_graph: NNCFGraph) -> Set[str]:
         return set()
 
-    @staticmethod
-    def get_weight_nodes(nncf_graph: NNCFGraph) -> List[NNCFNode]:
+    def get_weight_nodes(self, nncf_graph: NNCFGraph) -> List[NNCFNode]:
         weight_nodes_candidates = [
             node
             for node in nncf_graph.get_all_nodes()
@@ -379,15 +378,11 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
         ]
         weight_nodes = []
         for node in weight_nodes_candidates:
-            if (
-                node.metatype in PTMinMaxAlgoBackend().mat_mul_metatypes
-                and not PTMinMaxAlgoBackend.is_matmul_with_constant(node, nncf_graph)
-            ):
+            if node.metatype in self.mat_mul_metatypes and not self.is_matmul_with_constant(node, nncf_graph):
                 continue
             weight_nodes.append(node)
         return weight_nodes
 
-    @staticmethod
-    def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
-        assert node.metatype in PTMinMaxAlgoBackend().mat_mul_metatypes
+    def is_matmul_with_constant(self, node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        assert node.metatype in self.mat_mul_metatypes
         return len(get_weight_tensor_port_ids(node, nncf_graph)) > 0

--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -384,5 +384,4 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
         return weight_nodes
 
     def is_matmul_with_constant(self, node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
-        assert node.metatype in self.mat_mul_metatypes
-        return len(get_weight_tensor_port_ids(node, nncf_graph)) > 0
+        return node.metatype in self.mat_mul_metatypes and len(get_weight_tensor_port_ids(node, nncf_graph)) > 0

--- a/nncf/quantization/algorithms/min_max/torch_fx_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_fx_backend.py
@@ -56,15 +56,13 @@ from nncf.torch.tensor_statistics.collectors import PT_REDUCERS_MAP
 
 class FXMinMaxAlgoBackend(MinMaxAlgoBackend):
 
-    MAT_MUL_METATYPES = [om.PTLinearMetatype, om.PTMatMulMetatype]
-
     @property
     def preserved_metatypes(self) -> List[OperatorMetatype]:
         return []
 
     @property
     def mat_mul_metatypes(self) -> List[OperatorMetatype]:
-        return self.MAT_MUL_METATYPES
+        return [om.PTLinearMetatype, om.PTMatMulMetatype]
 
     @property
     def post_processing_metatypes(self) -> List[OperatorMetatype]:
@@ -358,7 +356,7 @@ class FXMinMaxAlgoBackend(MinMaxAlgoBackend):
         weight_nodes = []
         for node in weight_nodes_candidates:
             if (
-                node.metatype in FXMinMaxAlgoBackend.MAT_MUL_METATYPES
+                node.metatype in FXMinMaxAlgoBackend().mat_mul_metatypes
                 and not FXMinMaxAlgoBackend.is_matmul_with_constant(node, nncf_graph)
             ):
                 continue
@@ -367,4 +365,5 @@ class FXMinMaxAlgoBackend(MinMaxAlgoBackend):
 
     @staticmethod
     def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        assert node.metatype in FXMinMaxAlgoBackend().mat_mul_metatypes
         return len(get_weight_tensor_port_ids(node, nncf_graph)) > 0

--- a/nncf/quantization/algorithms/min_max/torch_fx_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_fx_backend.py
@@ -346,8 +346,7 @@ class FXMinMaxAlgoBackend(MinMaxAlgoBackend):
     def get_ignored_names_by_layer_attributes(nncf_graph: NNCFGraph) -> Set[str]:
         return set()
 
-    @staticmethod
-    def get_weight_nodes(nncf_graph: NNCFGraph) -> List[NNCFNode]:
+    def get_weight_nodes(self, nncf_graph: NNCFGraph) -> List[NNCFNode]:
         weight_nodes_candidates = [
             node
             for node in nncf_graph.get_all_nodes()
@@ -355,15 +354,11 @@ class FXMinMaxAlgoBackend(MinMaxAlgoBackend):
         ]
         weight_nodes = []
         for node in weight_nodes_candidates:
-            if (
-                node.metatype in FXMinMaxAlgoBackend().mat_mul_metatypes
-                and not FXMinMaxAlgoBackend.is_matmul_with_constant(node, nncf_graph)
-            ):
+            if node.metatype in self.mat_mul_metatypes and not self.is_matmul_with_constant(node, nncf_graph):
                 continue
             weight_nodes.append(node)
         return weight_nodes
 
-    @staticmethod
-    def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
-        assert node.metatype in FXMinMaxAlgoBackend().mat_mul_metatypes
+    def is_matmul_with_constant(self, node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        assert node.metatype in self.mat_mul_metatypes
         return len(get_weight_tensor_port_ids(node, nncf_graph)) > 0

--- a/nncf/quantization/algorithms/min_max/torch_fx_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_fx_backend.py
@@ -56,13 +56,15 @@ from nncf.torch.tensor_statistics.collectors import PT_REDUCERS_MAP
 
 class FXMinMaxAlgoBackend(MinMaxAlgoBackend):
 
+    MAT_MUL_METATYPES = [om.PTLinearMetatype, om.PTMatMulMetatype]
+
     @property
     def preserved_metatypes(self) -> List[OperatorMetatype]:
         return []
 
     @property
     def mat_mul_metatypes(self) -> List[OperatorMetatype]:
-        return [om.PTLinearMetatype, om.PTMatMulMetatype]
+        return self.MAT_MUL_METATYPES
 
     @property
     def post_processing_metatypes(self) -> List[OperatorMetatype]:
@@ -348,8 +350,20 @@ class FXMinMaxAlgoBackend(MinMaxAlgoBackend):
 
     @staticmethod
     def get_weight_nodes(nncf_graph: NNCFGraph) -> List[NNCFNode]:
-        return [
+        weight_nodes_candidates = [
             node
             for node in nncf_graph.get_all_nodes()
             if issubclass(node.metatype, om.PTOperatorMetatype) and node.metatype.weight_port_ids
         ]
+        weight_nodes = []
+        for node in weight_nodes_candidates:
+            if node.metatype in FXMinMaxAlgoBackend.MAT_MUL_METATYPES and not FXMinMaxAlgoBackend.is_constant_matmul(
+                node, nncf_graph
+            ):
+                continue
+            weight_nodes.append(node)
+        return weight_nodes
+
+    @staticmethod
+    def is_constant_matmul(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+        return len(get_weight_tensor_port_ids(node, nncf_graph)) > 0

--- a/nncf/quantization/algorithms/min_max/torch_fx_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_fx_backend.py
@@ -360,5 +360,4 @@ class FXMinMaxAlgoBackend(MinMaxAlgoBackend):
         return weight_nodes
 
     def is_matmul_with_constant(self, node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
-        assert node.metatype in self.mat_mul_metatypes
-        return len(get_weight_tensor_port_ids(node, nncf_graph)) > 0
+        return node.metatype in self.mat_mul_metatypes and len(get_weight_tensor_port_ids(node, nncf_graph)) > 0

--- a/nncf/quantization/algorithms/min_max/torch_fx_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_fx_backend.py
@@ -357,13 +357,14 @@ class FXMinMaxAlgoBackend(MinMaxAlgoBackend):
         ]
         weight_nodes = []
         for node in weight_nodes_candidates:
-            if node.metatype in FXMinMaxAlgoBackend.MAT_MUL_METATYPES and not FXMinMaxAlgoBackend.is_constant_matmul(
-                node, nncf_graph
+            if (
+                node.metatype in FXMinMaxAlgoBackend.MAT_MUL_METATYPES
+                and not FXMinMaxAlgoBackend.is_matmul_with_constant(node, nncf_graph)
             ):
                 continue
             weight_nodes.append(node)
         return weight_nodes
 
     @staticmethod
-    def is_constant_matmul(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
+    def is_matmul_with_constant(node: NNCFNode, nncf_graph: NNCFGraph) -> bool:
         return len(get_weight_tensor_port_ids(node, nncf_graph)) > 0

--- a/tests/onnx/quantization/test_quantizer_config.py
+++ b/tests/onnx/quantization/test_quantizer_config.py
@@ -11,20 +11,30 @@
 
 import pytest
 
+from nncf.common.utils.backend import BackendType
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXAddLayerMetatype
+from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXConstantMetatype
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXConvolutionMetatype
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXDepthwiseConvolutionMetatype
+from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXMatMulMetatype
+from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXMulLayerMetatype
+from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXSoftmaxMetatype
+from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXTransposeMetatype
 from nncf.onnx.graph.nncf_graph_builder import ONNXLayerAttributes
 from nncf.quantization.algorithms.min_max.onnx_backend import ONNXMinMaxAlgoBackend
 from tests.cross_fw.test_templates.models import NNCFGraphToTest
 from tests.cross_fw.test_templates.models import NNCFGraphToTestDepthwiseConv
 from tests.cross_fw.test_templates.models import NNCFGraphToTestSumAggregation
+from tests.cross_fw.test_templates.models import NNCFGraphTransformer
 from tests.cross_fw.test_templates.test_quantizer_config import TemplateTestQuantizerConfig
 
 
 class TestQuantizerConfig(TemplateTestQuantizerConfig):
     def get_algo_backend(self):
         return ONNXMinMaxAlgoBackend()
+
+    def get_backend_type(self):
+        return BackendType.ONNX
 
     @pytest.fixture
     def single_conv_nncf_graph(self) -> NNCFGraphToTest:
@@ -58,4 +68,17 @@ class TestQuantizerConfig(TemplateTestQuantizerConfig):
             input_layer_attrs=ONNXLayerAttributes(),
             output_layer_attrs=ONNXLayerAttributes(),
             const_layer_attrs=ONNXLayerAttributes(),
+        )
+
+    @pytest.fixture
+    def transformer_nncf_graph(self) -> NNCFGraphToTest:
+        return NNCFGraphTransformer(
+            matmul_metatype=ONNXMatMulMetatype,
+            softmax_metatype=ONNXSoftmaxMetatype,
+            mul_metatype=ONNXMulLayerMetatype,
+            const_metatype=ONNXConstantMetatype,
+            transpose_metatype=ONNXTransposeMetatype,
+            matmul_layer_weighted_attrs=ONNXLayerAttributes({"name": "edge_name", "shape": (1, 1, 1, 1)}),
+            matmul_layer_non_weighted_attrs=ONNXLayerAttributes(),
+            default_layer_attrs=ONNXLayerAttributes(),
         )

--- a/tests/openvino/native/quantization/test_quantizer_config.py
+++ b/tests/openvino/native/quantization/test_quantizer_config.py
@@ -11,20 +11,30 @@
 
 import pytest
 
+from nncf.common.utils.backend import BackendType
 from nncf.openvino.graph.layer_attributes import OVLayerAttributes
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVConstantMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVConvolutionMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVDepthwiseConvolutionMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVMatMulMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVMultiplyMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVSoftmaxMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVSumMetatype
+from nncf.openvino.graph.metatypes.openvino_metatypes import OVTransposeMetatype
 from nncf.quantization.algorithms.min_max.openvino_backend import OVMinMaxAlgoBackend
 from tests.cross_fw.test_templates.models import NNCFGraphToTest
 from tests.cross_fw.test_templates.models import NNCFGraphToTestDepthwiseConv
 from tests.cross_fw.test_templates.models import NNCFGraphToTestSumAggregation
+from tests.cross_fw.test_templates.models import NNCFGraphTransformer
 from tests.cross_fw.test_templates.test_quantizer_config import TemplateTestQuantizerConfig
 
 
 class TestQuantizerConfig(TemplateTestQuantizerConfig):
     def get_algo_backend(self):
         return OVMinMaxAlgoBackend()
+
+    def get_backend_type(self):
+        return BackendType.OPENVINO
 
     @pytest.fixture
     def single_conv_nncf_graph(self) -> NNCFGraphToTest:
@@ -39,3 +49,14 @@ class TestQuantizerConfig(TemplateTestQuantizerConfig):
     def conv_sum_aggregation_nncf_graph(self) -> NNCFGraphToTestSumAggregation:
         conv_layer_attrs = OVLayerAttributes({0: {"name": "dummy", "shape": (4, 4, 4, 4), "dtype": "f32"}})
         return NNCFGraphToTestSumAggregation(OVConvolutionMetatype, OVSumMetatype, conv_layer_attrs)
+
+    @pytest.fixture
+    def transformer_nncf_graph(self) -> NNCFGraphToTest:
+        return NNCFGraphTransformer(
+            matmul_metatype=OVMatMulMetatype,
+            softmax_metatype=OVSoftmaxMetatype,
+            mul_metatype=OVMultiplyMetatype,
+            const_metatype=OVConstantMetatype,
+            transpose_metatype=OVTransposeMetatype,
+            matmul_layer_weighted_attrs=OVLayerAttributes({}),
+        )

--- a/tests/post_training/data/ptq_reference_data.yaml
+++ b/tests/post_training/data/ptq_reference_data.yaml
@@ -51,7 +51,7 @@ torchvision/vit_b_16_backend_FP32:
 torchvision/vit_b_16_backend_OV:
   metric_value: 0.80948
 torchvision/vit_b_16_backend_FX_TORCH:
-  metric_value: 0.80702
+  metric_value: 0.80922
 torchvision/swin_v2_s_backend_FP32:
   metric_value: 0.83712
 torchvision/swin_v2_s_backend_OV:

--- a/tests/torch/fx/test_quantizer_config.py
+++ b/tests/torch/fx/test_quantizer_config.py
@@ -11,10 +11,13 @@
 
 import pytest
 
+import nncf.torch.graph.operator_metatypes as om
+from nncf.common.utils.backend import BackendType
 from nncf.quantization.algorithms.min_max.torch_fx_backend import FXMinMaxAlgoBackend
 from tests.cross_fw.test_templates.models import NNCFGraphToTest
 from tests.cross_fw.test_templates.models import NNCFGraphToTestDepthwiseConv
 from tests.cross_fw.test_templates.models import NNCFGraphToTestSumAggregation
+from tests.cross_fw.test_templates.models import NNCFGraphTransformer
 from tests.cross_fw.test_templates.test_quantizer_config import TemplateTestQuantizerConfig
 from tests.torch.fx.helpers import get_depthwise_conv_nncf_graph
 from tests.torch.fx.helpers import get_single_conv_nncf_graph
@@ -24,6 +27,9 @@ from tests.torch.fx.helpers import get_sum_aggregation_nncf_graph
 class TestQuantizerConfig(TemplateTestQuantizerConfig):
     def get_algo_backend(self):
         return FXMinMaxAlgoBackend()
+
+    def get_backend_type(self):
+        return BackendType.TORCH_FX
 
     @pytest.fixture
     def single_conv_nncf_graph(self) -> NNCFGraphToTest:
@@ -36,3 +42,13 @@ class TestQuantizerConfig(TemplateTestQuantizerConfig):
     @pytest.fixture
     def conv_sum_aggregation_nncf_graph(self) -> NNCFGraphToTestSumAggregation:
         return get_sum_aggregation_nncf_graph()
+
+    @pytest.fixture
+    def transformer_nncf_graph(self) -> NNCFGraphToTest:
+        return NNCFGraphTransformer(
+            matmul_metatype=om.PTMatMulMetatype,
+            softmax_metatype=om.PTSoftmaxMetatype,
+            mul_metatype=om.PTMulMetatype,
+            const_metatype=om.PTConstNoopMetatype,
+            transpose_metatype=om.PTTransposeMetatype,
+        )

--- a/tests/torch/ptq/test_quantizer_config.py
+++ b/tests/torch/ptq/test_quantizer_config.py
@@ -11,10 +11,14 @@
 
 import pytest
 
+import nncf.torch.graph.operator_metatypes as om
+from nncf.common.utils.backend import BackendType
 from nncf.quantization.algorithms.min_max.torch_backend import PTMinMaxAlgoBackend
+from nncf.torch.graph.graph import PTNNCFGraph
 from tests.cross_fw.test_templates.models import NNCFGraphToTest
 from tests.cross_fw.test_templates.models import NNCFGraphToTestDepthwiseConv
 from tests.cross_fw.test_templates.models import NNCFGraphToTestSumAggregation
+from tests.cross_fw.test_templates.models import NNCFGraphTransformer
 from tests.cross_fw.test_templates.test_quantizer_config import TemplateTestQuantizerConfig
 from tests.torch.ptq.helpers import get_depthwise_conv_nncf_graph
 from tests.torch.ptq.helpers import get_single_conv_nncf_graph
@@ -24,6 +28,9 @@ from tests.torch.ptq.helpers import get_sum_aggregation_nncf_graph
 class TestQuantizerConfig(TemplateTestQuantizerConfig):
     def get_algo_backend(self):
         return PTMinMaxAlgoBackend()
+
+    def get_backend_type(self):
+        return BackendType.TORCH
 
     @pytest.fixture
     def single_conv_nncf_graph(self) -> NNCFGraphToTest:
@@ -36,3 +43,14 @@ class TestQuantizerConfig(TemplateTestQuantizerConfig):
     @pytest.fixture
     def conv_sum_aggregation_nncf_graph(self) -> NNCFGraphToTestSumAggregation:
         return get_sum_aggregation_nncf_graph()
+
+    @pytest.fixture
+    def transformer_nncf_graph(self) -> NNCFGraphToTest:
+        return NNCFGraphTransformer(
+            matmul_metatype=om.PTMatMulMetatype,
+            softmax_metatype=om.PTSoftmaxMetatype,
+            mul_metatype=om.PTMulMetatype,
+            const_metatype=om.PTConstNoopMetatype,
+            transpose_metatype=om.PTTransposeMetatype,
+            nncf_graph_cls=PTNNCFGraph,
+        )


### PR DESCRIPTION
### Changes

* Weights nodes collection is updated for PT/FX backends
* Constant matmul check is updated for PT/FX/ONNX backends

### Reason for changes

To unify self attention quantization across all backends and align with the OV quantization

### Related tickets

#2766 

### Tests

* test_model_type_transformer_quantization_config
* post_training_quantization/485/ + post_training_quantization/486/ is finished successfully 
