### PR TITLE
[Docs] smooth_quant_alpha parameter

### DIFF
--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -211,7 +211,7 @@ class AdvancedQuantizationParameters:
         It regulates the calculation of the smooth scale. The default value stored in AdvancedSmoothQuantParameters.
         A negative value for each field switches off type smoothing. In case of inaccurate results,
         fields may be adjusted in the range from 0 to 1 or set -1 to disable smoothing for type.
-    :type smooth_quant_alpha: AdvancedSmoothQuantParameters
+    :type smooth_quant_alpha: nncf.quantization.advanced_parameters.AdvancedSmoothQuantParameters
     :param smooth_quant_alpha: Deprecated SmoothQuant-related parameter.
     :type smooth_quant_alpha: float
     :param backend_params: Backend-specific parameters.


### PR DESCRIPTION
### Changes

AdvancedSmoothQuantParameters -> nncf.quantization.advanced_parameters.AdvancedSmoothQuantParameters

### Reason for changes
smooth_quant_alpha is not clickable. https://openvinotoolkit.github.io/nncf/autoapi/nncf/quantization/advanced_parameters/index.html#nncf.quantization.advanced_parameters.QuantizationParameters

![image](https://github.com/user-attachments/assets/c2f0d4ea-41b2-4e7a-98d2-b417dfbbcd84)

### Related tickets

N/A

### Tests

N/A
