### PR TITLE
Removed xfail for tinyllama_data_aware_gptq_backend_OV

### DIFF
--- a/tests/post_training/data/wc_reference_data.yaml
+++ b/tests/post_training/data/wc_reference_data.yaml
@@ -26,7 +26,6 @@ tinyllama_data_aware_gptq_backend_OV:
   metric_value: 0.87134
   num_int4: 94
   num_int8: 124
-  metrics_xfail_reason: "Issue-148819"
 tinyllama_scale_estimation_per_channel_backend_OV:
   metric_value: 0.81389
   num_int4: 188


### PR DESCRIPTION
### Changes

https://github.com/openvinotoolkit/nncf/pull/2784 contains a fix that makes the layered scheduler deterministic.

### Reason for changes

The test has become stable.

### Related tickets

ref: 148819

### Tests

11th Gen Intel(R) Core(TM) i9-11900K @ 3.50GHz  /ptq_single_model/11067/
Intel(R) Xeon(R) Gold 6338 CPU @ 2.00GHz /ptq_single_model/11075/
