### PR TITLE
Added metrics for 2024.5 nightly (#2954)

### DIFF
--- a/tests/post_training/data/wc_reference_data_2024.5.yaml
+++ b/tests/post_training/data/wc_reference_data_2024.5.yaml
@@ -1,0 +1,22 @@
+tinyllama_data_aware_awq_stateful_backend_OV:
+  metric_value: 0.85571
+  num_int4: 94
+  num_int8: 124
+tinyllama_data_aware_awq_scale_estimation_backend_OV:
+  metric_value: 0.86355
+  num_int4: 94
+  num_int8: 124
+tinyllama_data_aware_awq_scale_estimation_stateful_backend_OV:
+  metric_value: 0.86355
+  num_int4: 94
+  num_int8: 124
+tinyllama_data_aware_gptq_backend_OV:
+  metric_value: 0.81664
+  num_int4: 94
+  num_int8: 124
+  metrics_xfail_reason: "Issue-148819"
+tinyllama_scale_estimation_per_channel_backend_OV:
+  metric_value: 0.80798
+  num_int4: 188
+  num_int8: 124
+  metrics_xfail_reason: "Issue-148819"


### PR DESCRIPTION
### Changes

as stated in the title
This PR introduced changes in accuracy:
https://github.com/openvinotoolkit/openvino/pull/26147, but it's coming from float error:

![image](https://github.com/user-attachments/assets/e819a14b-3c74-4568-beef-7b43737128a6)

### Reason for changes

As result validation with openvino nightly failed:

![image](https://github.com/user-attachments/assets/23fe22dd-6ec2-4577-98df-f26732c7962a)

### Related tickets

150613
151260


### Tests

- [x] job/NNCF/job/manual/job/post_training_weight_compression/163/
