### PR TITLE
Fix file comparison on windows

### DIFF
--- a/tests/common/graph/test_dot_file_rw.py
+++ b/tests/common/graph/test_dot_file_rw.py
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import filecmp
+
 from copy import deepcopy
 from pathlib import Path
 

--- a/tests/common/graph/test_dot_file_rw.py
+++ b/tests/common/graph/test_dot_file_rw.py
@@ -47,7 +47,9 @@ def test_writing_does_not_modify_original_graph(tmp_path: Path, ref_graph: nx.Di
 def test_colons_are_replaced_in_written_dot_file(tmp_path: Path, ref_graph: nx.DiGraph):
     tmp_path_to_graph = tmp_path / "graph.dot"
     write_dot_graph(ref_graph, tmp_path_to_graph)
-    assert filecmp.cmp(tmp_path_to_graph, REF_DOT_REPRESENTATION_GRAPH_PATH)
+    ref = REF_DOT_REPRESENTATION_GRAPH_PATH.read_text()
+    act = tmp_path_to_graph.read_text()
+    assert ref == act
 
 
 def test_read_dot_file_gives_graph_with_colons(tmp_path: Path, ref_graph: nx.DiGraph):


### PR DESCRIPTION
### Changes

Compare content of files instead of `filecmp.cmp`

### Reason for changes 
 
```
>       assert filecmp.cmp(tmp_path_to_graph, REF_DOT_REPRESENTATION_GRAPH_PATH)
E       AssertionError: assert False
```

Files is differ because used differ line separators for WIN in UNIX.


### Tests

nightly/job/windows/job/precommit_common/40/