### PR TITLE
Type mismatch in onnx quantize_with_accuracy_control validation_fn

### DIFF
--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -188,23 +188,6 @@ def native_quantize_impl(
     return quantized_model
 
 
-def wrap_validation_fn(validation_fn):
-    """
-    Wraps validation function to support case when it only returns metric value.
-
-    :param validation_fn: Validation function to wrap.
-    :return: Wrapped validation function.
-    """
-
-    def wrapper(*args, **kwargs):
-        retval = validation_fn(*args, **kwargs)
-        if isinstance(retval, tuple):
-            return retval
-        return retval, None
-
-    return wrapper
-
-
 @tracked_function(
     NNCF_OV_CATEGORY, [CompressionStartedWithQuantizeApi(), "target_device", "preset", "max_drop", "drop_type"]
 )
@@ -228,9 +211,6 @@ def quantize_with_accuracy_control_impl(
     Implementation of the `quantize_with_accuracy_control()` method for the OpenVINO backend via the
     OpenVINO Runtime API.
     """
-
-    validation_fn = wrap_validation_fn(validation_fn)
-
     if advanced_accuracy_restorer_parameters is None:
         advanced_accuracy_restorer_parameters = AdvancedAccuracyRestorerParameters()
 

--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -188,10 +188,27 @@ def native_quantize_impl(
     return quantized_model
 
 
+def wrap_validation_fn(validation_fn):
+    """
+    Wraps validation function to support case when it only returns metric value.
+
+    :param validation_fn: Validation function to wrap.
+    :return: Wrapped validation function.
+    """
+
+    def wrapper(*args, **kwargs):
+        retval = validation_fn(*args, **kwargs)
+        if isinstance(retval, tuple):
+            return retval
+        return retval, None
+
+    return wrapper
+
+
 @tracked_function(
     NNCF_OV_CATEGORY, [CompressionStartedWithQuantizeApi(), "target_device", "preset", "max_drop", "drop_type"]
 )
-def native_quantize_with_accuracy_control_impl(
+def quantize_with_accuracy_control_impl(
     model: ov.Model,
     calibration_dataset: Dataset,
     validation_dataset: Dataset,
@@ -211,6 +228,9 @@ def native_quantize_with_accuracy_control_impl(
     Implementation of the `quantize_with_accuracy_control()` method for the OpenVINO backend via the
     OpenVINO Runtime API.
     """
+
+    validation_fn = wrap_validation_fn(validation_fn)
+
     if advanced_accuracy_restorer_parameters is None:
         advanced_accuracy_restorer_parameters = AdvancedAccuracyRestorerParameters()
 
@@ -362,65 +382,6 @@ def quantize_impl(
         model_type=model_type,
         ignored_scope=ignored_scope,
         advanced_parameters=advanced_parameters,
-    )
-
-
-def wrap_validation_fn(validation_fn):
-    """
-    Wraps validation function to support case when it only returns metric value.
-
-    :param validation_fn: Validation function to wrap.
-    :return: Wrapped validation function.
-    """
-
-    def wrapper(*args, **kwargs):
-        retval = validation_fn(*args, **kwargs)
-        if isinstance(retval, tuple):
-            return retval
-        return retval, None
-
-    return wrapper
-
-
-def quantize_with_accuracy_control_impl(
-    model: ov.Model,
-    calibration_dataset: Dataset,
-    validation_dataset: Dataset,
-    validation_fn: Callable[[Any, Iterable[Any]], float],
-    max_drop: float = 0.01,
-    drop_type: DropType = DropType.ABSOLUTE,
-    preset: Optional[QuantizationPreset] = None,
-    target_device: TargetDevice = TargetDevice.ANY,
-    subset_size: int = 300,
-    fast_bias_correction: bool = True,
-    model_type: Optional[ModelType] = None,
-    ignored_scope: Optional[IgnoredScope] = None,
-    advanced_quantization_parameters: Optional[AdvancedQuantizationParameters] = None,
-    advanced_accuracy_restorer_parameters: Optional[AdvancedAccuracyRestorerParameters] = None,
-) -> ov.Model:
-    """
-    Implementation of the `quantize_with_accuracy_control()` method for the OpenVINO backend.
-    """
-
-    quantize_with_accuracy_control_fn = native_quantize_with_accuracy_control_impl
-
-    val_func = wrap_validation_fn(validation_fn)
-
-    return quantize_with_accuracy_control_fn(
-        model,
-        calibration_dataset,
-        validation_dataset,
-        val_func,
-        max_drop,
-        drop_type,
-        preset,
-        target_device,
-        subset_size,
-        fast_bias_correction,
-        model_type,
-        ignored_scope,
-        advanced_quantization_parameters,
-        advanced_accuracy_restorer_parameters,
     )
 
 


### PR DESCRIPTION
### Changes

- Align type hints for the `quantize_with_accuracy_control()` method

### Reason for changes

Issue: https://github.com/openvinotoolkit/nncf/issues/2957