### PR TITLE
Remove unused weight_modifiable_node_names property

### DIFF
--- a/nncf/common/insertion_point_graph.py
+++ b/nncf/common/insertion_point_graph.py
@@ -73,7 +73,6 @@ class InsertionPointGraph(nx.DiGraph):
     def __init__(
         self,
         nncf_graph: NNCFGraph,
-        weight_modifiable_node_names: List[NNCFNodeName] = None,
         allowed_pre_hook_insertion_points: List[PreHookInsertionPoint] = None,
         allowed_post_hook_insertion_points: List[PostHookInsertionPoint] = None,
     ):
@@ -81,8 +80,6 @@ class InsertionPointGraph(nx.DiGraph):
         Initializes the insertion point graph.
 
         :param nncf_graph: The base NNCFGraph representing the model structure.
-        :param weight_modifiable_node_names: Names of the nodes in `nncf_graph` that correspond to operations with
-          modifiable weights.
         :param allowed_pre_hook_insertion_points: A list of pre-hook insertion points for this graph to allow.
           If left unspecified, every node in `nncf_graph` will be allowed to have a separate pre-hook for each of its
           tensor inputs.
@@ -93,10 +90,6 @@ class InsertionPointGraph(nx.DiGraph):
 
         super().__init__()
         self._base_nx_graph = deepcopy(nncf_graph.get_nx_graph_copy())
-        if weight_modifiable_node_names is None:
-            self._weight_modifiable_node_names = []
-        else:
-            self._weight_modifiable_node_names = weight_modifiable_node_names
 
         if allowed_pre_hook_insertion_points is None:
             allowed_pre_hook_insertion_points = self._get_default_pre_hook_ip_list(nncf_graph)
@@ -235,10 +228,6 @@ class InsertionPointGraph(nx.DiGraph):
                 if post_hook_has_integer_outputs:
                     for follower_node_key in self.successors(from_node_key):
                         self.edges[from_node_key, follower_node_key][self.IS_INTEGER_PATH_EDGE_ATTR] = True
-
-    @property
-    def weight_modifiable_node_names(self) -> List[NNCFNodeName]:
-        return self._weight_modifiable_node_names
 
     @staticmethod
     def _get_default_pre_hook_ip_list(nncf_graph: NNCFGraph) -> List[PreHookInsertionPoint]:

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -604,7 +604,7 @@ class QuantizationBuilder(TFCompressionAlgorithmBuilder):
         custom_layer_node_names: List[NNCFNodeName],
         model: tf.keras.Model,
     ) -> SingleConfigQuantizerSetup:
-        ip_graph = InsertionPointGraph(nncf_graph, [qn.node.node_name for qn in quantizable_weighted_layer_nodes])
+        ip_graph = InsertionPointGraph(nncf_graph)
 
         pattern = TF_HW_FUSED_PATTERNS.get_full_pattern_graph()
         ip_graph = ip_graph.get_ip_graph_with_merged_hw_optimized_operations(pattern)

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -684,7 +684,6 @@ class NNCFNetworkInterface(torch.nn.Module):
 
         ip_graph = InsertionPointGraph(
             self._original_graphs_pair.nncf_graph,
-            weight_modifiable_node_names=weighted_node_names,
             allowed_pre_hook_insertion_points=pre_hooks,
             allowed_post_hook_insertion_points=post_hooks,
         )

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -679,9 +679,6 @@ class NNCFNetworkInterface(torch.nn.Module):
             post_hook_ip = PostHookInsertionPoint(node.node_name)
             post_hooks.append(post_hook_ip)
 
-        weighted_nodes = self.get_weighted_original_graph_nodes()
-        weighted_node_names = [weighted_node.node_name for weighted_node in weighted_nodes]
-
         ip_graph = InsertionPointGraph(
             self._original_graphs_pair.nncf_graph,
             allowed_pre_hook_insertion_points=pre_hooks,

--- a/tests/common/quantization/mock_graphs.py
+++ b/tests/common/quantization/mock_graphs.py
@@ -17,7 +17,6 @@ import networkx as nx
 
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode
-from nncf.common.graph import NNCFNodeName
 from nncf.common.graph.layer_attributes import BaseLayerAttributes
 from nncf.common.graph.layer_attributes import ConvolutionLayerAttributes
 from nncf.common.graph.layer_attributes import Dtype
@@ -359,7 +358,7 @@ def get_mock_model_graph_with_broken_output_edge_pattern(
     return get_nncf_graph_from_mock_nx_graph(mock_nx_graph)
 
 
-def get_ip_graph_for_test(nncf_graph: NNCFGraph, weighted_node_names: List[NNCFNodeName] = None) -> InsertionPointGraph:
+def get_ip_graph_for_test(nncf_graph: NNCFGraph) -> InsertionPointGraph:
     pre_hooks = []
     post_hooks = []
     for node in nncf_graph.get_all_nodes():
@@ -374,11 +373,6 @@ def get_ip_graph_for_test(nncf_graph: NNCFGraph, weighted_node_names: List[NNCFN
         ip = PostHookInsertionPoint(node.node_name)
         post_hooks.append(ip)
 
-    weighted_target_points = None
-    if weighted_node_names is not None:
-        weighted_target_points = []
-        for name in weighted_node_names:
-            weighted_target_points.append(name)
     ip_graph = InsertionPointGraph(
         nncf_graph,
         allowed_pre_hook_insertion_points=pre_hooks,

--- a/tests/common/quantization/mock_graphs.py
+++ b/tests/common/quantization/mock_graphs.py
@@ -381,7 +381,6 @@ def get_ip_graph_for_test(nncf_graph: NNCFGraph, weighted_node_names: List[NNCFN
             weighted_target_points.append(name)
     ip_graph = InsertionPointGraph(
         nncf_graph,
-        weight_modifiable_node_names=weighted_target_points,
         allowed_pre_hook_insertion_points=pre_hooks,
         allowed_post_hook_insertion_points=post_hooks,
     )

--- a/tests/common/quantization/test_quantizer_propagation_graph.py
+++ b/tests/common/quantization/test_quantizer_propagation_graph.py
@@ -1689,9 +1689,7 @@ class TestOutputQuantAsWeightsSetup:
 
     @pytest.fixture
     def model_graph_qpsg(self):
-        ip_graph = get_ip_graph_for_test(
-            MODEL_GRAPH, weighted_node_names=[node.node_name for node in MODEL_GRAPH.get_all_nodes()]
-        )
+        ip_graph = get_ip_graph_for_test(MODEL_GRAPH)
         quant_prop_graph = QPSG(ip_graph)
         return quant_prop_graph
 

--- a/tests/common/quantization/test_quantizer_propagation_solver.py
+++ b/tests/common/quantization/test_quantizer_propagation_solver.py
@@ -1932,7 +1932,7 @@ def test_metatypes_to_ignore(mocker):
         nncf_graph.add_edge_between_nncf_nodes(
             nodes[idx - 1].node_id, nodes[idx].node_id, [1, 1, 1, 1], 0, 0, Dtype.FLOAT
         )
-    ip_graph = InsertionPointGraph(nncf_graph=nncf_graph, weight_modifiable_node_names=["A", "B", "C"])
+    ip_graph = InsertionPointGraph(nncf_graph=nncf_graph)
 
     solver = QuantizerPropagationSolver(
         metatypes_to_ignore=[IGNORED_METATYPE],


### PR DESCRIPTION
### Changes

- Remove unused weight_modifiable_node_names property

### Reason for changes

- Code quality