### PR TITLE
Alignment behavior of get_ignored_node_names_from_ignored_scope

### DIFF
--- a/nncf/common/graph/graph.py
+++ b/nncf/common/graph/graph.py
@@ -278,7 +278,7 @@ class NNCFGraph:
 
     def get_all_simple_paths(
         self, start_node_name: NNCFNodeName, end_node_name: NNCFNodeName
-    ) -> Generator[List[NNCFNodeName], None, None]:
+    ) -> Generator[List[str], None, None]:
         """
         Generates all simple paths in the NNCFGraph from start node to end node.
         A simple path is a path with no repeated nodes.
@@ -292,9 +292,7 @@ class NNCFGraph:
         end_node = self.get_node_by_name(end_node_name)
         start_node_key = self.get_node_key_by_id(start_node.node_id)
         end_node_key = self.get_node_key_by_id(end_node.node_id)
-        return cast(
-            Generator[List[NNCFNodeName], None, None], nx.all_simple_paths(self._nx_graph, start_node_key, end_node_key)
-        )
+        return cast(Generator[List[str], None, None], nx.all_simple_paths(self._nx_graph, start_node_key, end_node_key))
 
     @staticmethod
     def _get_edge_boundaries(

--- a/nncf/scopes.py
+++ b/nncf/scopes.py
@@ -48,6 +48,11 @@ def get_ignored_node_names_from_subgraph(graph: NNCFGraph, subgraph: Subgraph) -
     ignored_names = set()
     for start_node_name in subgraph.inputs:
         for end_node_name in subgraph.outputs:
+            if start_node_name == end_node_name:
+                # For networkx<3.3 nx.get_all_simple_paths returns empty path for this case
+                node = graph.get_node_by_name(start_node_name)
+                ignored_names.add(node.node_name)
+                continue
             for path in graph.get_all_simple_paths(start_node_name, end_node_name):
                 for node_key in path:
                     node = graph.get_node_by_key(node_key)

--- a/tests/common/test_ignored_scope.py
+++ b/tests/common/test_ignored_scope.py
@@ -64,6 +64,10 @@ IGNORED_SCOPES_TEST_DATA = [
         IgnoredScope(subgraphs=[Subgraph(inputs=["/Linear_1_0"], outputs=["/Linear_3_0"])]),
         ["/Conv_2_0", "/Linear_1_0", "/Linear_2_0", "/Linear_3_0", "/Marked_Conv_3_0"],
     ),
+    (
+        IgnoredScope(subgraphs=[Subgraph(inputs=["/Linear_1_0"], outputs=["/Linear_1_0"])]),
+        ["/Linear_1_0"],
+    ),
 ]
 
 
@@ -78,7 +82,6 @@ WRONG_IGNORED_SCOPES_TEST_DATA = [
     IgnoredScope(["/Conv_0_0", "/Conv_1_0", "/Linear_1_0"]),
     IgnoredScope(patterns=[".*Maarked.*"]),
     IgnoredScope(types=["wrong_type"]),
-    IgnoredScope(subgraphs=[Subgraph(inputs=["/Linear_1_0"], outputs=["/Linear_1_0"])]),
     IgnoredScope(subgraphs=[Subgraph(inputs=["/Linear_3_0"], outputs=["/Linear_1_0"])]),
 ]
 


### PR DESCRIPTION
### Changes

Make correct ignored subgraph in which start and end nodes are the same 

### Reason for changes

Change behavior of nx.all_simple_paths in networkx==3.3.

```python
# netwrokx<3.3
nx.all_simple_paths(graph, "A", "A" )  # [] 
# netwrokx>=3.3
nx.all_simple_paths(graph, "A", "A" )  # ["A"] 
```
 
### Related tickets

<!--- Post the numerical ID of the ticket, if available -->

### Tests

tests/common/test_ignored_scope.py::test_ignored_scopes
tests/common/test_ignored_scope.py::test_wrong_ignored_scopes
