### PR TITLE
Fix version of datasets for conformance test

### DIFF
--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -18,3 +18,4 @@ tensorflow-io==0.32.0
 timm==0.9.2
 transformers==4.38.2
 whowhatbench @ git+https://github.com/andreyanufr/who_what_benchmark@456d3584ce628f6c8605f37cd9a3ab2db1ebf933
+datasets==2.21.0


### PR DESCRIPTION
### Changes

Set version of datasets package

### Reason for changes

```
Failed: BuilderConfig ParquetConfig(name='sst2', version=0.0.0, data_dir=None, data_files={'train': ['sst2/train-*'], 'validation': ['sst2/validation-*'], 'test': ['sst2/test-*']}, description=None, batch_size=None, columns=None, features=None) doesn't have a 'use_auth_token' key.
```
