### PR TITLE
Fix metric for tinyllama_scale_estimation_per_channel

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -330,8 +330,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
         model = ov.Model([result], parameters)
 
-        ov_config = {"INFERENCE_PRECISION_HINT": "f32"}
-        compiled_model = ov.compile_model(model, device_name="CPU", config=ov_config)
+        compiled_model = ov.compile_model(model, device_name="CPU")
 
         return lambda parameters: compiled_model(parameters)[0]
 
@@ -364,8 +363,7 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
         model = ov.Model([result], parameters)
 
-        ov_config = {"INFERENCE_PRECISION_HINT": "f32"}
-        compiled_model = ov.compile_model(model, device_name="CPU", config=ov_config)
+        compiled_model = ov.compile_model(model, device_name="CPU")
 
         return lambda parameters: compiled_model(parameters)[0]
 

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -330,7 +330,8 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
         model = ov.Model([result], parameters)
 
-        compiled_model = ov.compile_model(model, device_name="CPU")
+        ov_config = {"INFERENCE_PRECISION_HINT": "f32"}
+        compiled_model = ov.compile_model(model, device_name="CPU", config=ov_config)
 
         return lambda parameters: compiled_model(parameters)[0]
 
@@ -363,7 +364,8 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
         model = ov.Model([result], parameters)
 
-        compiled_model = ov.compile_model(model, device_name="CPU")
+        ov_config = {"INFERENCE_PRECISION_HINT": "f32"}
+        compiled_model = ov.compile_model(model, device_name="CPU", config=ov_config)
 
         return lambda parameters: compiled_model(parameters)[0]
 

--- a/nncf/quantization/algorithms/weight_compression/scale_estimation.py
+++ b/nncf/quantization/algorithms/weight_compression/scale_estimation.py
@@ -322,8 +322,8 @@ class ScaleEstimation:
                 zero_mask = zero_scale * zero_mask.astype(original_weight.dtype)
 
         # iterative rectification of scale based on grid search
-        for scale_steps in range(scale_steps):
-            factor = 1.0 - 0.05 * scale_steps
+        for scale_step in range(scale_steps):
+            factor = 1.0 - 0.05 * scale_step
             scaled_scale = factor * scale
 
             input_tensors[1] = scaled_scale.data

--- a/tests/post_training/data/wc_reference_data.yaml
+++ b/tests/post_training/data/wc_reference_data.yaml
@@ -28,10 +28,9 @@ tinyllama_data_aware_gptq_backend_OV:
   num_int8: 124
   metrics_xfail_reason: "Issue-148819"
 tinyllama_scale_estimation_per_channel_backend_OV:
-  metric_value: 0.81389
+  metric_value: 0.80873
   num_int4: 188
   num_int8: 124
-  metrics_xfail_reason: "Issue-148819"
 tinyllama_data_aware_lora_stateful_backend_OV:
   metric_value: 0.83446
   num_int4: 94

--- a/tests/post_training/data/wc_reference_data_2024.4.yaml
+++ b/tests/post_training/data/wc_reference_data_2024.4.yaml
@@ -15,11 +15,6 @@ tinyllama_data_aware_gptq_backend_OV:
   num_int4: 94
   num_int8: 124
   metrics_xfail_reason: "Issue-148819"
-tinyllama_scale_estimation_per_channel_backend_OV:
-  metric_value: 0.80853
-  num_int4: 188
-  num_int8: 124
-  metrics_xfail_reason: "Issue-148819"
 tinyllama_NF4_scale_estimation_stateful_per_channel_backend_OV:
   metric_value: 0.87942
   num_int4: 11

--- a/tests/post_training/data/wc_reference_data_2024.5.yaml
+++ b/tests/post_training/data/wc_reference_data_2024.5.yaml
@@ -7,4 +7,3 @@ tinyllama_NF4_scale_estimation_stateful_per_channel_backend_OV:
   metric_value: 0.87132
   num_int4: 11
   num_int8: 290
-  metrics_xfail_reason: "Issue-148819"

--- a/tests/post_training/data/wc_reference_data_2024.5.yaml
+++ b/tests/post_training/data/wc_reference_data_2024.5.yaml
@@ -3,12 +3,8 @@ tinyllama_data_aware_gptq_backend_OV:
   num_int4: 94
   num_int8: 124
   metrics_xfail_reason: "Issue-148819"
-tinyllama_scale_estimation_per_channel_backend_OV:
-  metric_value: 0.80798
-  num_int4: 188
-  num_int8: 124
-  metrics_xfail_reason: "Issue-148819"
 tinyllama_NF4_scale_estimation_stateful_per_channel_backend_OV:
   metric_value: 0.87132
   num_int4: 11
   num_int8: 290
+  metrics_xfail_reason: "Issue-148819"


### PR DESCRIPTION
### Changes

* Accuracy bug with LLMs across different CPUs was fixed
* The problem was in execution of models from `get_compress_pipeline` and `get_compress_decompress_pipeline`
* TODO: add ticket link

### Reason for changes

<!--- Why should the change be applied -->

### Related tickets

* 148819, 152627
