### PR TITLE
Add GroupNorm to the OV list of ignored ops for ModelType.TRANSFORMER

### DIFF
--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -228,6 +228,7 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
                 om.OVSumMetatype,
                 om.OVSquaredDifferenceMetatype,
                 om.OVMVNMetatype,
+                om.OVGroupNormalizationMetatype,
                 om.OVBatchNormMetatype,
                 om.OVDivideMetatype,
                 om.OVSqrtMetatype,


### PR DESCRIPTION
### Changes

Add `OVGroupNormalizationMetatype` to the list of op types ignored with `ModelType.TRANSFORMER`.

For PT backend it is already present. For ONNX backend there is no such metatype.

### Reason for changes

It was observed that with update to OV 2024.4 some models are converted in such a way that in places where there was an MVN node before, now is a GroupNorm node. Since GroupNorm is not ignored, it leads to FQs being placed for them.

### Related tickets

152427
