### PR TITLE
[OV] Add adaptive poolings metatypes

### DIFF
--- a/nncf/openvino/graph/metatypes/groups.py
+++ b/nncf/openvino/graph/metatypes/groups.py
@@ -13,6 +13,7 @@ from nncf.openvino.graph.metatypes import openvino_metatypes as ov_metatypes
 
 QUANTIZE_AGNOSTIC_OPERATIONS = [
     ov_metatypes.OVMaxPoolMetatype,
+    ov_metatypes.OVAdaptiveMaxPoolMetatype,
     ov_metatypes.OVReduceMaxMetatype,
     ov_metatypes.OVReshapeMetatype,
     ov_metatypes.OVSqueezeMetatype,
@@ -62,6 +63,7 @@ INPUTS_QUANTIZABLE_OPERATIONS = [
     ov_metatypes.OVMaximumMetatype,
     ov_metatypes.OVMinimumMetatype,
     ov_metatypes.OVAvgPoolMetatype,
+    ov_metatypes.OVAdaptiveAvgPoolMetatype,
     ov_metatypes.OVReduceMeanMetatype,
     ov_metatypes.OVMVNMetatype,
     ov_metatypes.OVNormalizeL2Metatype,

--- a/nncf/openvino/graph/metatypes/openvino_metatypes.py
+++ b/nncf/openvino/graph/metatypes/openvino_metatypes.py
@@ -158,9 +158,23 @@ class OVAvgPoolMetatype(OVOpMetatype):
 
 
 @OV_OPERATOR_METATYPES.register()
+class OVAdaptiveAvgPoolMetatype(OVOpMetatype):
+    name = "AdaptiveAvgPoolOp"
+    op_names = ["AdaptiveAvgPool"]
+    hw_config_names = [HWConfigOpName.AVGPOOL]
+
+
+@OV_OPERATOR_METATYPES.register()
 class OVMaxPoolMetatype(OVOpMetatype):
     name = "MaxPoolOp"
     op_names = ["MaxPool"]
+    hw_config_names = [HWConfigOpName.MAXPOOL]
+
+
+@OV_OPERATOR_METATYPES.register()
+class OVAdaptiveMaxPoolMetatype(OVOpMetatype):
+    name = "AdaptiveMaxPoolOp"
+    op_names = ["AdaptiveMaxPool"]
     hw_config_names = [HWConfigOpName.MAXPOOL]
 
 


### PR DESCRIPTION
### Changes

Add https://docs.openvino.ai/2024/documentation/openvino-ir-format/operation-sets/operation-specs/pooling/adaptive-max-pool-8.html and https://docs.openvino.ai/2024/documentation/openvino-ir-format/operation-sets/operation-specs/pooling/adaptive-avg-pool-8.html

Based on the description of the operations I make their treatments for quantization the same as for AvgPool and MaxPool. I checked the correct quantization scheme with this PR for litehernet from ticket 150502
