### PR TITLE
[TorchFX][Conformance test] Migration to `torch.export.export`

### DIFF
--- a/nncf/experimental/torch/fx/nncf_graph_builder.py
+++ b/nncf/experimental/torch/fx/nncf_graph_builder.py
@@ -185,7 +185,7 @@ class GraphConverter:
         output_port_id = 0
         tensor_shape = None
         if source_node.op in ("get_attr",):
-            tensor_shape = tuple(getattr(model, source_node.target).shape)
+            tensor_shape = tuple(get_tensor_constant_from_node(source_node, model).shape)
         elif "val" in source_node.meta:
             if source_nncf_node.metatype is om.PTBatchNormMetatype:
                 tensor = source_node.meta["val"][0]

--- a/tests/post_training/data/ptq_reference_data.yaml
+++ b/tests/post_training/data/ptq_reference_data.yaml
@@ -57,7 +57,7 @@ torchvision/swin_v2_s_backend_FP32:
 torchvision/swin_v2_s_backend_OV:
   metric_value: 0.83638
 torchvision/swin_v2_s_backend_FX_TORCH:
-  metric_value: 0.8296
+  metric_value: 0.8360
 timm/crossvit_9_240_backend_CUDA_TORCH:
   metric_value: 0.689
 timm/crossvit_9_240_backend_FP32:


### PR DESCRIPTION
### Changes

* tests/post_training/pipelines/image_classification_torchvision.py supports both `capture_pre_autograd_model` and `torch.export.export(...).module()` export paths
* Micro fix in NNCFGraph

### Reason for changes

* capture_pre_autograd_graph introduces accuracy drop for the swin_v2_s model (Improvement: Metric value is better than reference 0.836 > 0.8296)
* Incorrect constant collection fails on models exported via `torch.export.export(...).module()`

### Related tickets

#2766 

### Tests

post_training_quantization/490/