### PR TITLE
compress_weights telemetry update

### DIFF
--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -51,6 +51,7 @@ from nncf.quantization.quantize_model import quantize_with_tune_hyperparams
 from nncf.quantization.quantize_model import warning_model_no_batchwise_support
 from nncf.quantization.telemetry_extractors import CompressionStartedWithCompressWeightsApi
 from nncf.quantization.telemetry_extractors import CompressionStartedWithQuantizeApi
+from nncf.quantization.telemetry_extractors import CompressionStartedWithQuantizeWithAccuracyControlApi
 from nncf.scopes import IgnoredScope
 from nncf.scopes import validate_ignored_scope
 from nncf.telemetry.decorator import tracked_function
@@ -191,7 +192,8 @@ def native_quantize_impl(
 
 
 @tracked_function(
-    NNCF_OV_CATEGORY, [CompressionStartedWithQuantizeApi(), "target_device", "preset", "max_drop", "drop_type"]
+    NNCF_OV_CATEGORY,
+    [CompressionStartedWithQuantizeWithAccuracyControlApi(), "target_device", "preset", "max_drop", "drop_type"],
 )
 def quantize_with_accuracy_control_impl(
     model: ov.Model,

--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -49,6 +49,7 @@ from nncf.quantization.quantize_model import BATCHWISE_STATISTICS_WARNING
 from nncf.quantization.quantize_model import is_model_no_batchwise_support
 from nncf.quantization.quantize_model import quantize_with_tune_hyperparams
 from nncf.quantization.quantize_model import warning_model_no_batchwise_support
+from nncf.quantization.telemetry_extractors import CompressionStartedWithCompressWeightsApi
 from nncf.quantization.telemetry_extractors import CompressionStartedWithQuantizeApi
 from nncf.scopes import IgnoredScope
 from nncf.scopes import validate_ignored_scope
@@ -366,6 +367,7 @@ def quantize_impl(
     )
 
 
+@tracked_function(NNCF_OV_CATEGORY, [CompressionStartedWithCompressWeightsApi(), "mode"])
 def compress_weights_impl(
     model: ov.Model,
     dataset: Dataset,

--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -369,7 +369,18 @@ def quantize_impl(
     )
 
 
-@tracked_function(NNCF_OV_CATEGORY, [CompressionStartedWithCompressWeightsApi(), "mode"])
+@tracked_function(
+    NNCF_OV_CATEGORY,
+    [
+        CompressionStartedWithCompressWeightsApi(),
+        "mode",
+        "awq",
+        "scale_estimation",
+        "gptq",
+        "lora_correction",
+        "backup_mode",
+    ],
+)
 def compress_weights_impl(
     model: ov.Model,
     dataset: Dataset,

--- a/nncf/quantization/telemetry_extractors.py
+++ b/nncf/quantization/telemetry_extractors.py
@@ -23,3 +23,8 @@ class CompressionStartedWithQuantizeApi(TelemetryExtractor):
 class CompressionStartedWithQuantizeWithAccuracyControlApi(TelemetryExtractor):
     def extract(self, _: Any) -> CollectedEvent:
         return CollectedEvent(name="compression_started", data="quantize_with_accuracy_control_api")
+
+
+class CompressionStartedWithCompressWeightsApi(TelemetryExtractor):
+    def extract(self, _: Any) -> CollectedEvent:
+        return CollectedEvent(name="compression_started", data="compress_weights_api")

--- a/nncf/telemetry/extractors.py
+++ b/nncf/telemetry/extractors.py
@@ -54,4 +54,6 @@ class VerbatimTelemetryExtractor(TelemetryExtractor):
     def extract(self, argvalue: SerializableData) -> CollectedEvent:
         if isinstance(argvalue, Enum):
             argvalue = str(argvalue.value)
+        if isinstance(argvalue, bool):
+            argvalue = "enabled" if argvalue else "disabled"
         return CollectedEvent(name=self._argname, data=argvalue)

--- a/nncf/telemetry/wrapper.py
+++ b/nncf/telemetry/wrapper.py
@@ -92,10 +92,12 @@ class NNCFTelemetry(ITelemetry):
     MEASUREMENT_ID = "G-W5E9RNLD4H"
 
     def __init__(self):
+        self._app_name = "nncf"
+        self._app_version = __version__
         try:
             self._impl = Telemetry(
-                app_name="nncf",
-                app_version=__version__,
+                app_name=self._app_name,
+                app_version=self._app_version,
                 tid=self.MEASUREMENT_ID,
                 backend="ga4",
                 enable_opt_in_dialog=False,
@@ -121,7 +123,16 @@ class NNCFTelemetry(ITelemetry):
     ):
         if event_value is None:
             event_value = 1
-        self._impl.send_event(event_category, event_action, event_label, event_value, force_send, **kwargs)
+        self._impl.send_event(
+            event_category=event_category,
+            event_action=event_action,
+            event_label=event_label,
+            event_value=event_value,
+            app_name=self._app_name,
+            app_version=self._app_version,
+            force_send=force_send,
+            **kwargs,
+        )
 
     @skip_if_raised
     def end_session(self, category: str, **kwargs):

--- a/nncf/torch/quantization/quantize_model.py
+++ b/nncf/torch/quantization/quantize_model.py
@@ -30,6 +30,7 @@ from nncf.quantization.algorithms.post_training.algorithm import PostTrainingQua
 from nncf.quantization.algorithms.weight_compression.algorithm import WeightCompression
 from nncf.quantization.quantize_model import warning_model_no_batchwise_support
 from nncf.quantization.telemetry_extractors import CompressionStartedWithCompressWeightsApi
+from nncf.quantization.telemetry_extractors import CompressionStartedWithQuantizeApi
 from nncf.scopes import IgnoredScope
 from nncf.telemetry.decorator import tracked_function
 from nncf.telemetry.events import NNCF_PT_CATEGORY
@@ -39,6 +40,7 @@ from nncf.torch.model_creation import wrap_model
 DEFAULT_RANGE_TYPE = "mean_min_max"
 
 
+@tracked_function(NNCF_PT_CATEGORY, [CompressionStartedWithQuantizeApi(), "target_device", "preset"])
 def quantize_impl(
     model: torch.nn.Module,
     calibration_dataset: Dataset,

--- a/nncf/torch/quantization/quantize_model.py
+++ b/nncf/torch/quantization/quantize_model.py
@@ -86,7 +86,18 @@ def quantize_impl(
     return quantized_model
 
 
-@tracked_function(NNCF_PT_CATEGORY, [CompressionStartedWithCompressWeightsApi(), "mode"])
+@tracked_function(
+    NNCF_PT_CATEGORY,
+    [
+        CompressionStartedWithCompressWeightsApi(),
+        "mode",
+        "awq",
+        "scale_estimation",
+        "gptq",
+        "lora_correction",
+        "backup_mode",
+    ],
+)
 def compress_weights_impl(
     model: torch.nn.Module,
     dataset: Dataset,

--- a/nncf/torch/quantization/quantize_model.py
+++ b/nncf/torch/quantization/quantize_model.py
@@ -29,7 +29,10 @@ from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
 from nncf.quantization.algorithms.post_training.algorithm import PostTrainingQuantization
 from nncf.quantization.algorithms.weight_compression.algorithm import WeightCompression
 from nncf.quantization.quantize_model import warning_model_no_batchwise_support
+from nncf.quantization.telemetry_extractors import CompressionStartedWithCompressWeightsApi
 from nncf.scopes import IgnoredScope
+from nncf.telemetry.decorator import tracked_function
+from nncf.telemetry.events import NNCF_PT_CATEGORY
 from nncf.torch.graph.operator_metatypes import OPERATIONS_OUTPUT_HAS_NO_BATCH_AXIS
 from nncf.torch.model_creation import wrap_model
 
@@ -81,6 +84,7 @@ def quantize_impl(
     return quantized_model
 
 
+@tracked_function(NNCF_PT_CATEGORY, [CompressionStartedWithCompressWeightsApi(), "mode"])
 def compress_weights_impl(
     model: torch.nn.Module,
     dataset: Dataset,


### PR DESCRIPTION
### Changes

- Added telemetry for the `nncf.compress_weights` backend-specific `impl`;
- Added missed wrapper for the `nncf.qantize` PyTorch `impl`;
- Fixed reported event for `nncf.quantize_with_accuracy_control` OpenVINO `impl`.
- Added missed `app_name`, `app_version` fields for each event.

### Reason for changes

- Telemetry update.

### Related tickets

- 154833

### Tests

- TBD
