### PR TITLE
set pythonpath for pytest

### DIFF
--- a/examples/torch/common/restricted_pickle_module.py
+++ b/examples/torch/common/restricted_pickle_module.py
@@ -38,8 +38,8 @@ class Unpickler(pickle.Unpickler):
         "torch.nn": {"Module"},
         "torch.optim.adam": {"Adam"},
         "nncf.api.compression": {"CompressionStage", "CompressionLevel"},
-        "numpy.core.multiarray": {"scalar"},
-        "numpy._core.multiarray.scalar": {"scalar"},
+        "numpy.core.multiarray": {"scalar"},  # numpy<2
+        "numpy._core.multiarray": {"scalar"},  # numpy>=2
         "numpy": {"dtype"},
         "_codecs": {"encode"},
     }

--- a/examples/torch/common/restricted_pickle_module.py
+++ b/examples/torch/common/restricted_pickle_module.py
@@ -39,6 +39,7 @@ class Unpickler(pickle.Unpickler):
         "torch.optim.adam": {"Adam"},
         "nncf.api.compression": {"CompressionStage", "CompressionLevel"},
         "numpy.core.multiarray": {"scalar"},
+        "numpy._core.multiarray.scalar": {"scalar"},
         "numpy": {"dtype"},
         "_codecs": {"encode"},
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,3 +149,6 @@ notice-rgx = """\
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
+
+[tool.pytest.ini_options]
+pythonpath = "."

--- a/tests/cross_fw/shared/paths.py
+++ b/tests/cross_fw/shared/paths.py
@@ -20,7 +20,8 @@ GITHUB_REPO_URL = "https://github.com/openvinotoolkit/nncf/"
 
 DATASET_DEFINITIONS_PATH = TEST_ROOT / "cross_fw" / "shared" / "data" / "dataset_definitions.yml"
 
-ROOT_PYTHONPATH_ENV = os.environ.copy().update({"PYTHONPATH": str(PROJECT_ROOT)})
+ROOT_PYTHONPATH_ENV = os.environ.copy()
+ROOT_PYTHONPATH_ENV["PYTHONPATH"] = f"{PROJECT_ROOT}:{ROOT_PYTHONPATH_ENV.get('PYTHONPATH', '')}".strip(":")
 
 
 def get_accuracy_aware_checkpoint_dir_path(model_specific_run_dir: Path) -> Path:

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -15,7 +15,7 @@ accelerate==0.28.0
 transformers==4.38.2
 
 # Required for movement_sparsity tests
-datasets==2.14.7
+datasets==3.0.1
 evaluate==0.3.0
 openvino
 timm==0.9.2


### PR DESCRIPTION
### Changes

- setup pythonpath for pytests
- support numpy2 for unplicker
- bump datasets to support numpy2 
- fix ROOT_PYTHONPATH_ENV that was always None
 