### PR TITLE
[WC][Tests] Update Scale Estimation metric

### DIFF
--- a/tests/post_training/data/wc_reference_data.yaml
+++ b/tests/post_training/data/wc_reference_data.yaml
@@ -28,7 +28,7 @@ tinyllama_data_aware_gptq_scale_estimation_stateful_backend_OV:
   num_int8: 124
   metrics_xfail_reason: "Issue-148819"
 tinyllama_scale_estimation_per_channel_backend_OV:
-  metric_value: 0.80853
+  metric_value: 0.80798
   num_int4: 188
   num_int8: 124
 tinyllama_data_aware_lora_stateful_backend_OV:


### PR DESCRIPTION
### Changes

After moving PTWC tests to Xeon Gold (ticket 153844), we should update the `tinyllama_scale_estimation_per_channel_backend_OV` metric due to unstable accuracy deviations across different CPUs (ticket 152627)

CI job: 233