### PR TITLE
Update PTQ reference for 24.5

### DIFF
--- a/tests/post_training/data/ptq_reference_data_2024.5.yaml
+++ b/tests/post_training/data/ptq_reference_data_2024.5.yaml
@@ -1,0 +1,2 @@
+torchvision/mobilenet_v3_small_BC_backend_OV:
+  metric_value: 0.6681


### PR DESCRIPTION
### Changes

- As stated in the title.

### Reason for changes

- OV started to produce more correct SE graphs.
- NNCF SE pattern started to match with the model. The number of FQ layers was reduced from 79 to 61.

### Related tickets

- N/A

### Tests

- openvino-nightly post_training_quantization/68/ - success

Pattern wasn't applied for a model with OV 24.4 because of the Reshape layer:
<img src="https://github.com/user-attachments/assets/5b4eb009-1400-4e21-aa99-5dd77d3cae94" width="250">
There is no Reshape with OV 24.5:
<img src="https://github.com/user-attachments/assets/dd722f9c-be41-4b2c-9afb-900526e218de" width="180">
