### PR TITLE
Fix deprecation warning

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/backend.py
+++ b/nncf/quantization/algorithms/weight_compression/backend.py
@@ -162,7 +162,7 @@ class WeightCompressionAlgoBackend(ABC):
     def insert_adapters(
         self, wc_params: WeightCompressionParameters, lora_A: Tensor, lora_B: Tensor, int8_lora: bool
     ) -> None:
-        """
+        r"""
         Expands a model's execution graph following the Low-Rank Adaptation (LoRA) concept.
 
         It inserts two additional Linear layers with weight matrices of low rank that are executed in parallel to the


### PR DESCRIPTION
### Changes

Use raw string for docstring with `\`

### Reason for changes

```
nncf/quantization/algorithms/weight_compression/backend.py:165
  /home/runner/work/nncf/nncf/nncf/quantization/algorithms/weight_compression/backend.py:165: DeprecationWarning: invalid escape sequence '\ '
    """
```

