### PR TITLE
Left-overs after moving PTWC tests to Xeon Gold

### DIFF
--- a/tests/post_training/data/wc_reference_data.yaml
+++ b/tests/post_training/data/wc_reference_data.yaml
@@ -36,11 +36,11 @@ tinyllama_data_aware_lora_stateful_backend_OV:
   num_int4: 94
   num_int8: 500
 tinyllama_NF4_scale_estimation_stateful_per_channel_backend_OV:
-  metric_value: 0.87942
+  metric_value: 0.87132
   num_int4: 11
   num_int8: 290
   metrics_xfail_reason: "Issue-148819"
 tinyllama_awq_backup_mode_none_backend_OV:
-  metric_value: 0.84793
+  metric_value: 0.85679
   num_int4: 208
   num_int8: 0


### PR DESCRIPTION
### Changes

After moving PTWC tests to Xeon Gold (ticket 153844), we should update the metrics due to unstable accuracy deviations across different CPUs (ticket 152627).

https://github.com/openvinotoolkit/nncf/pull/3048 updated only `tinyllama_scale_estimation_per_channel_backend_OV`, but 
`tinyllama_awq_backup_mode_none` and `tinyllama_NF4_scale_estimation_stateful_per_channel` were also affected.

### Tests

- [x] CI job: 248
![image](https://github.com/user-attachments/assets/b565d069-3bf6-4c33-be1c-edbe02438839)

