### PR TITLE
[Torch Fx] Migrate example to torch.export.export_for_training

### DIFF
--- a/examples/post_training_quantization/torch_fx/resnet18/main.py
+++ b/examples/post_training_quantization/torch_fx/resnet18/main.py
@@ -194,7 +194,7 @@ def main():
     example_input = torch.ones(*input_shape).to(device)
 
     with disable_patching():
-        fx_model = torch.export.export(model.eval(), args=(example_input,)).module()
+        fx_model = torch.export.export_for_training(model.eval(), args=(example_input,)).module()
         quantized_fx_model = nncf.quantize(fx_model, quantization_dataset)
         quantized_fx_model = torch.compile(quantized_fx_model, backend="openvino")
 


### PR DESCRIPTION
### Changes

Migrate torch.export.export in examples to torch.export.export_for_training
