### PR TITLE
set kv cache in f16

### DIFF
--- a/examples/llm_compression/openvino/tiny_llama/main.py
+++ b/examples/llm_compression/openvino/tiny_llama/main.py
@@ -67,7 +67,9 @@ def main():
     )
     model.save_pretrained(OUTPUT_DIR)
 
-    model = OVModelForCausalLM.from_pretrained(OUTPUT_DIR, ov_config={"DYNAMIC_QUANTIZATION_GROUP_SIZE": "0"})
+    model = OVModelForCausalLM.from_pretrained(
+        OUTPUT_DIR, ov_config={"DYNAMIC_QUANTIZATION_GROUP_SIZE": "0", "KV_CACHE_PRECISION": "f16"}
+    )
     input_ids = tokenizer("What is PyTorch?", return_tensors="pt").to(device=model.device)
 
     start_t = time.time()

--- a/examples/llm_compression/openvino/tiny_llama_find_hyperparams/main.py
+++ b/examples/llm_compression/openvino/tiny_llama_find_hyperparams/main.py
@@ -249,6 +249,7 @@ def main():
         "NUM_STREAMS": "1",
         "CACHE_DIR": "",
         "DYNAMIC_QUANTIZATION_GROUP_SIZE": "0",
+        "KV_CACHE_PRECISION": "f16",
     }
     model = OVModelForCausalLM.from_pretrained(
         model_id,

--- a/tests/post_training/pipelines/lm_weight_compression.py
+++ b/tests/post_training/pipelines/lm_weight_compression.py
@@ -271,7 +271,12 @@ class LMWeightCompression(BaseTestPipeline):
         if os.getenv("NNCF_TEST_REGEN_DOT") is not None:
             print("Collection ground-truth reference data")
             model_gold = OVModelForCausalLM.from_pretrained(
-                self.fp32_model_dir, trust_remote_code=True, load_in_8bit=False, compile=False, stateful=is_stateful
+                self.fp32_model_dir,
+                trust_remote_code=True,
+                load_in_8bit=False,
+                compile=False,
+                stateful=is_stateful,
+                ov_config={"KV_CACHE_PRECISION": "f16"},
             )
             evaluator = Evaluator(base_model=model_gold, tokenizer=self.preprocessor, metrics=("similarity",))
             evaluator.dump_gt(str(gt_data_path))
@@ -290,7 +295,7 @@ class LMWeightCompression(BaseTestPipeline):
                 load_in_8bit=False,
                 compile=False,
                 stateful=is_stateful,
-                ov_config={"DYNAMIC_QUANTIZATION_GROUP_SIZE": "0"},
+                ov_config={"DYNAMIC_QUANTIZATION_GROUP_SIZE": "0", "KV_CACHE_PRECISION": "f16"},
             )
         print("Evaluation of the target model")
         _, all_metrics = evaluator.score(compressed_model_hf)


### PR DESCRIPTION
### Changes

explicitly disable kv cache compression to u8, f16 precision is used instead.

### Reason for changes

PTWC nightly has a different metrics (ticket 157594). 
It happens, because since https://github.com/openvinotoolkit/openvino/pull/27454 KV Cache compressed to u8 by default and it affects accuracy of fp32 models (ticket 157571). 

Propose using kv cache in the f16 in order to handle issues in nncf rather than in ov (there's still an open issue with kv cache compression, and it can be modified in the nearest future)

### Related tickets

157571
157594

### Tests

- [x] openvino-nightly/job/post_training_weight_compression/56
![image](https://github.com/user-attachments/assets/0772a8e5-0f92-4f53-8ac0-e16841bd8193)
- [x] https://github.com/openvinotoolkit/nncf/actions/runs/11934079602
- [x] job/weekly/job/openvino-nightly/job/test_examples/77
