### PR TITLE
limit version of matplot (#3147)

### DIFF
--- a/examples/quantization_aware_training/torch/anomalib/requirements.txt
+++ b/examples/quantization_aware_training/torch/anomalib/requirements.txt
@@ -1,2 +1,3 @@
 anomalib[core,openvino]==1.0.1
 setuptools<=72.1.0
+matplotlib<3.10.0


### PR DESCRIPTION
### Changes

Limit version of matplot for quantization_aware_training_torch_anomalib example

### Reason for changes

```
  File "/tmp/pytest-of-runner/pytest-0/test_examples_quantization_awa0/venv/lib/python3.10/site-packages/anomalib/utils/visualization/image.py", line 172, in _visualize_batch
    yield GeneratorResult(image=self.visualize_image(image_result), file_name=file_name)
  File "/tmp/pytest-of-runner/pytest-0/test_examples_quantization_awa0/venv/lib/python3.10/site-packages/anomalib/utils/visualization/image.py", line 184, in visualize_image
    return self._visualize_full(image_result)
  File "/tmp/pytest-of-runner/pytest-0/test_examples_quantization_awa0/venv/lib/python3.10/site-packages/anomalib/utils/visualization/image.py", line 239, in _visualize_full
    return image_grid.generate()
  File "/tmp/pytest-of-runner/pytest-0/test_examples_quantization_awa0/venv/lib/python3.10/site-packages/anomalib/utils/visualization/image.py", line 328, in generate
    img = np.frombuffer(self.figure.canvas.tostring_rgb(), dtype=np.uint8)
AttributeError: 'FigureCanvasAgg' object has no attribute 'tostring_rgb'. Did you mean: 'tostring_argb'?
```
