### PR TITLE
Some fixes

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -10,8 +10,7 @@ onnx==1.17.0
 onnxruntime==1.19.2
 
 # TensorFlow
-tensorflow==2.12.1; python_version < '3.9'
-tensorflow==2.15.1; python_version >= '3.9'
+tensorflow==2.15.1
 
 # Tests and examples
 pytest==8.0.2

--- a/docs/PyPiPublishing.md
+++ b/docs/PyPiPublishing.md
@@ -80,24 +80,22 @@ For more information about NNCF, see:
 
 ## Installation Guide<a id="installation-guide"></a>
 
-NNCF can be installed as a regular PyPI package:
+For detailed installation instructions, refer to the [Installation](https://github.com/openvinotoolkit/nncf/docs/Installation.md) guide.
+
+NNCF can be installed as a regular PyPI package via pip:
 
 ```bash
 pip install nncf
 ```
 
-For detailed installation instructions, refer to the
-[Installation](https://github.com/openvinotoolkit/nncf/blob/develop/docs/Installation.md) guide.
+NNCF is also available via [conda](https://anaconda.org/conda-forge/nncf):
 
-### System Requirements
+```bash
+conda install -c conda-forge nncf
+```
 
-- Ubuntu 18.04 or later (64-bit)
-- Python 3.9 or later
-- Supported frameworks:
-  - PyTorch >=2.2, <2.5
-  - TensorFlow >=2.8.4, <=2.15.1
-  - ONNX ==1.16.0
-  - OpenVINO >=2022.3.0
+System requirements of NNCF correspond to the used backend. System requirements for each backend and
+the matrix of corresponding versions can be found in [installation.md](./docs/Installation.md).
 
 ## Third-party Repository Integration<a id="third-party-repository-integration"></a>
 

--- a/docs/PyPiPublishing.md
+++ b/docs/PyPiPublishing.md
@@ -80,7 +80,7 @@ For more information about NNCF, see:
 
 ## Installation Guide<a id="installation-guide"></a>
 
-For detailed installation instructions, refer to the [Installation](https://github.com/openvinotoolkit/nncf/docs/Installation.md) guide.
+For detailed installation instructions, refer to the [Installation](https://github.com/openvinotoolkit/nncf/blob/develop/docs/Installation.md) guide.
 
 NNCF can be installed as a regular PyPI package via pip:
 
@@ -95,7 +95,7 @@ conda install -c conda-forge nncf
 ```
 
 System requirements of NNCF correspond to the used backend. System requirements for each backend and
-the matrix of corresponding versions can be found in [installation.md](./docs/Installation.md).
+the matrix of corresponding versions can be found in [installation.md](https://github.com/openvinotoolkit/nncf/blob/develop/docs/Installation.md).
 
 ## Third-party Repository Integration<a id="third-party-repository-integration"></a>
 

--- a/examples/post_training_quantization/tensorflow/mobilenet_v2/requirements.txt
+++ b/examples/post_training_quantization/tensorflow/mobilenet_v2/requirements.txt
@@ -1,5 +1,4 @@
-tensorflow~=2.12.0; python_version < '3.9'
-tensorflow~=2.15.1; python_version >= '3.9'
+tensorflow==2.15.1
 tensorflow-datasets
 tqdm
 openvino==2024.6


### PR DESCRIPTION
### Changes

- remove `tensorflow==2.12.1; python_version < '3.9'`, according with drop support python 3.8 https://github.com/openvinotoolkit/nncf/pull/2919
 - align PyPiPublishing.md with https://github.com/openvinotoolkit/nncf/pull/3111
