### PR TITLE
no zp for lm_head in ov-nightly

### DIFF
--- a/tests/post_training/data/wc_reference_data.yaml
+++ b/tests/post_training/data/wc_reference_data.yaml
@@ -21,7 +21,7 @@ tinyllama_data_aware_awq_scale_estimation_stateful_backend_OV:
 tinyllama_int8_data_free_backend_TORCH:
   metric_value: 0.95624
   num_int4: 0
-  num_int8: 312
+  num_int8: 311
 tinyllama_data_aware_gptq_scale_estimation_stateful_backend_OV:
   metric_value: 0.86503
   num_int4: 94
@@ -47,4 +47,4 @@ tinyllama_awq_backup_mode_none_backend_OV:
 tinyllama_int4_data_free_backend_TORCH:
   metric_value: 0.73873
   num_int4: 114
-  num_int8: 84
+  num_int8: 83


### PR DESCRIPTION
### Changes

<!--- What was changed (briefly), how to reproduce (if applicable), what the reviewers should focus on -->

### Reason for changes

int4 compressed model with 2024.6 vs 2025:
![image](https://github.com/user-attachments/assets/859fbba9-fd3d-4d7f-af1d-89557ddc8b7e)

### Related tickets

<!--- Post the numerical ID of the ticket, if available -->

### Tests

no degradation found in weekly build 64
the changes in OV don't affect accuracy
