### PR TITLE
[GHA] Replacement tartifact actions

### DIFF
--- a/.github/workflows/api_changes_check.yml
+++ b/.github/workflows/api_changes_check.yml
@@ -26,9 +26,13 @@ jobs:
       issues: write
     steps:
       - name: Download built HTML doc as artifact from previous step
-        uses: alehechka/download-tartifact@1195216b256562056097b175df17b167557f8681 # v2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: html_doc_artifact
+      - run: |
+          tar -xvf artifact.tar
+          rm artifact.tar
+        shell: 'bash'
       - name: Checkout latest doc_pages branch tip
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:

--- a/.github/workflows/build_and_publish_doc.yml
+++ b/.github/workflows/build_and_publish_doc.yml
@@ -26,15 +26,29 @@ jobs:
     steps:
       - name: Checkout main repo  # the github-pages-deploy-action seems to require this step
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
       - name: Download HTML doc build artifact
-        uses: alehechka/download-tartifact@1195216b256562056097b175df17b167557f8681 # v2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: html_doc_artifact
+      - name: Extract artifact
+        shell: 'bash'
+        run: |
+          tar -xvf artifact.tar
+          rm artifact.tar
+
       - name: Download schema doc build artifact
-        uses: alehechka/download-tartifact@1195216b256562056097b175df17b167557f8681 # v2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: schema_doc_artifact
           path: html_build/html
+      - name: Extract artifact
+        shell: 'bash'
+        working-directory: html_build/html
+        run: |
+          tar -xvf artifact.tar
+          rm artifact.tar
+
       - name: Publish built docs on Github Pages branch ${{ env.GH_PAGES_BRANCH }}
         uses: JamesIves/github-pages-deploy-action@5c6e9e9f3672ce8fd37b9856193d2a537941e66c # v4.6.1
         with:

--- a/.github/workflows/build_html_doc.yml
+++ b/.github/workflows/build_html_doc.yml
@@ -27,8 +27,10 @@ jobs:
       - name: Build API docs
         run: |
           sphinx-build -M html docs/api/source html_build
-      - name: Upload built HTMLs as job artifact
-        uses: alehechka/upload-tartifact@a055d3a102b9ed9cfff1263bc713295047d0197e # v2
+      - name: Archive built HTMLs
+        shell: bash
+        run: tar -czf artifact.tar html_build/html
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b #v4.5.0
         with:
           name: html_doc_artifact
-          path: html_build/html
+          path: artifact.tar

--- a/.github/workflows/build_schema_page.yml
+++ b/.github/workflows/build_schema_page.yml
@@ -27,8 +27,12 @@ jobs:
           # the sphinx can generate valid links in the TOC for the JSON schema across all pages.
           generate-schema-doc --deprecated-from-description schema.json schema/index.html
 
+      - name: Archive built schema
+        shell: bash
+        run: tar -czf artifact.tar schema
+
       - name: Upload result as artifact
-        uses: alehechka/upload-tartifact@a055d3a102b9ed9cfff1263bc713295047d0197e # v2
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b #v4.5.0
         with:
           name: schema_doc_artifact
-          path: schema
+          path: artifact.tar


### PR DESCRIPTION
### Changes

Use `actions/upload-artifact` and `actions/download-artifact` instead of `alehechka/upload-tartifact` and `alehechka/download-tartifact`

### Reason for changes

```
[Deprecation notice: v1, v2, and v3 of the artifact actions](https://github.com/openvinotoolkit/nncf/actions/runs/12696443147/workflow)
The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "html_doc_artifact". Please update your workflow to use v4 of the artifact actions. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```
```
Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact).
```
