### PR TITLE
Remove levit model from ptq conformance tests

### DIFF
--- a/tests/post_training/data/ptq_reference_data.yaml
+++ b/tests/post_training/data/ptq_reference_data.yaml
@@ -154,16 +154,6 @@ timm/inception_resnet_v2_backend_OV:
   metric_value: 0.80422
 timm/inception_resnet_v2_backend_TORCH:
   metric_value: 0.80334
-timm/levit_128_backend_CUDA_TORCH:
-  metric_value: 0.77812
-timm/levit_128_backend_FP32:
-  metric_value: 0.78474
-timm/levit_128_backend_ONNX:
-  metric_value: 0.7762
-timm/levit_128_backend_OV:
-  metric_value: 0.77644
-timm/levit_128_backend_TORCH:
-  metric_value: 0.77814
 timm/mobilenetv2_050_BC_backend_FP32:
   metric_value: 0.6594
 timm/mobilenetv2_050_BC_backend_ONNX:

--- a/tests/post_training/model_scope.py
+++ b/tests/post_training/model_scope.py
@@ -229,19 +229,20 @@ QUANTIZATION_MODELS = [
         "backends": NNCF_PTQ_BACKENDS,
         "batch_size": 64,
     },
-    {
-        "reported_name": "timm/levit_128",
-        "model_id": "levit_128",
-        "pipeline_cls": ImageClassificationTimm,
-        "compression_params": {
-            "preset": QuantizationPreset.MIXED,
-            "model_type": ModelType.TRANSFORMER,
-            "advanced_parameters": AdvancedQuantizationParameters(
-                smooth_quant_alphas=AdvancedSmoothQuantParameters(matmul=0.05)
-            ),
-        },
-        "backends": NNCF_PTQ_BACKENDS,
-    },
+    # TODO(AlexanderDokuchaev): Enable after bump timm>1.0.14, https://github.com/huggingface/pytorch-image-models/pull/2412/files
+    # {
+    #     "reported_name": "timm/levit_128",
+    #     "model_id": "levit_128",
+    #     "pipeline_cls": ImageClassificationTimm,
+    #     "compression_params": {
+    #         "preset": QuantizationPreset.MIXED,
+    #         "model_type": ModelType.TRANSFORMER,
+    #         "advanced_parameters": AdvancedQuantizationParameters(
+    #             smooth_quant_alphas=AdvancedSmoothQuantParameters(matmul=0.05)
+    #         ),
+    #     },
+    #     "backends": NNCF_PTQ_BACKENDS,
+    # },
     {
         "reported_name": "timm/mobilenetv2_050",
         "model_id": "mobilenetv2_050",

--- a/tests/post_training/model_scope.py
+++ b/tests/post_training/model_scope.py
@@ -229,20 +229,6 @@ QUANTIZATION_MODELS = [
         "backends": NNCF_PTQ_BACKENDS,
         "batch_size": 64,
     },
-    # TODO(AlexanderDokuchaev): Enable after bump timm>1.0.14, https://github.com/huggingface/pytorch-image-models/pull/2412/files
-    # {
-    #     "reported_name": "timm/levit_128",
-    #     "model_id": "levit_128",
-    #     "pipeline_cls": ImageClassificationTimm,
-    #     "compression_params": {
-    #         "preset": QuantizationPreset.MIXED,
-    #         "model_type": ModelType.TRANSFORMER,
-    #         "advanced_parameters": AdvancedQuantizationParameters(
-    #             smooth_quant_alphas=AdvancedSmoothQuantParameters(matmul=0.05)
-    #         ),
-    #     },
-    #     "backends": NNCF_PTQ_BACKENDS,
-    # },
     {
         "reported_name": "timm/mobilenetv2_050",
         "model_id": "mobilenetv2_050",

--- a/tests/post_training/test_quantize_conformance.py
+++ b/tests/post_training/test_quantize_conformance.py
@@ -315,6 +315,8 @@ def test_ptq_quantization(
         pipeline.run()
     except Exception as e:
         err_msg = str(e)
+        if not err_msg:
+            err_msg = "Unknown exception"
         traceback.print_exc()
 
     if pipeline is not None:
@@ -380,6 +382,8 @@ def test_weight_compression(
         pipeline.run()
     except Exception as e:
         err_msg = str(e)
+        if not err_msg:
+            err_msg = "Unknown exception"
         traceback.print_exc()
 
     if pipeline is not None:


### PR DESCRIPTION
### Changes

- Remove levit model_128 
- Fix: no catching exception without message
 
### Reason for changes

```
  File "/home/jenkins/agent/workspace/NNCF/manual/Daemons/PTQ/ptq_single_model/venv/lib/python3.10/site-packages/timm/models/_builder.py", line 393, in build_model_with_cfg
    load_pretrained(
  File "/home/jenkins/agent/workspace/NNCF/manual/Daemons/PTQ/ptq_single_model/venv/lib/python3.10/site-packages/timm/models/_builder.py", line 193, in load_pretrained
    state_dict = filter_fn(state_dict, model)
  File "/home/jenkins/agent/workspace/NNCF/manual/Daemons/PTQ/ptq_single_model/venv/lib/python3.10/site-packages/timm/models/levit.py", line 707, in checkpoint_filter_fn
    assert 'head' in ka or 'stem.conv1.linear' in ka
AssertionError

```
