### PR TITLE
[DO NOT MERGE] Bump actions/setup-python to see if the network issue will go

### DIFF
--- a/.github/workflows/call_precommit.yml
+++ b/.github/workflows/call_precommit.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           lfs: true
-      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: ${{ inputs.python_version }}
           cache: pip


### PR DESCRIPTION
The `Request timeout` error during `setup-python` step can't be traced in the infrastructure logs. Trying to find out the root cause.