### PR TITLE
Bump version of linters in pre-commit 

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -7,3 +7,4 @@ MD034: false  # Bare URL used
 MD036: false  # Emphasis used instead of a heading
 MD037: false  # Spaces inside emphasis markers
 MD041: false  # First line
+MD045: false  # no-alt-text

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         files: '^.*\.py'
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.0
     hooks:
       - id: isort
         name: isort (python)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: ruff
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.33.0
+    rev: v0.43.0
     hooks:
       - id: markdownlint
         args: [--config=.markdownlint.yaml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.10.0
     hooks:
       - id: black
         files: '^.*\.py'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.3.7
+    rev: v0.9.2
     hooks:
       - id: ruff
 

--- a/nncf/common/logging/track_progress.py
+++ b/nncf/common/logging/track_progress.py
@@ -69,11 +69,11 @@ class WeightedProgress(Progress):
     def update(self, task_id: TaskID, **kwargs: Any) -> None:
         task = self._tasks[task_id]
 
-        advance = kwargs.get("advance", None)
+        advance = kwargs.get("advance")
         if advance is not None:
             kwargs["advance"] = self.weighted_advance(task, advance)
 
-        completed = kwargs.get("completed", None)
+        completed = kwargs.get("completed")
         if completed is not None:
             kwargs["completed"] = self.get_weighted_completed(task, completed)
 
@@ -88,7 +88,7 @@ class WeightedProgress(Progress):
     def reset(self, task_id: TaskID, **kwargs: Any) -> None:
         task = self._tasks[task_id]
 
-        completed = kwargs.get("completed", None)
+        completed = kwargs.get("completed")
         if completed is not None:
             kwargs["completed"] = self.get_weighted_completed(task, completed)
 

--- a/tests/torch/ptq/test_wrap_model.py
+++ b/tests/torch/ptq/test_wrap_model.py
@@ -70,7 +70,7 @@ def test_wrap_model_with_example_input(example_input, model_cls):
     nncf_network = wrap_model(model, example_input)
 
     def check_type(x):
-        assert type(x) == torch.Tensor
+        assert type(x) is torch.Tensor
         return x
 
     objwalk(example_input, lambda x: True, check_type)

--- a/tests/torch/test_serialization.py
+++ b/tests/torch/test_serialization.py
@@ -158,7 +158,7 @@ def _check_pre_post_ops(modified_model, recovered_model):
 
 
 def _check_hook_are_equal(hook, recovered_hook):
-    assert type(hook) == type(recovered_hook)
+    assert type(hook) is type(recovered_hook)
     if isinstance(hook, DummyOpWithState):
         assert hook.get_config() == recovered_hook.get_config()
         return

--- a/tests/torch2/function_hook/test_function_hook_mode.py
+++ b/tests/torch2/function_hook/test_function_hook_mode.py
@@ -107,7 +107,7 @@ def test_execute_post_hooks(example_outputs: Union[torch.Tensor, List[torch.Tens
     ctx = FunctionHookMode(nn.Identity(), hook_storage)
     op_meta = OpMeta("/relu/0", torch.relu)
     ret_val = ctx.execute_post_hooks(example_outputs, op_meta)
-    assert type(example_outputs) == type(ret_val)
+    assert type(example_outputs) is type(ret_val)
 
     assert hook_port_0.call_count == 1
     if isinstance(example_outputs, torch.Tensor):


### PR DESCRIPTION
### Changes

black - 24.10.0
isort - 5.13.0
ruff - v0.9.2
markdownlint - 0.43.0 
