### PR TITLE
Fix fail on macos 

### DIFF
--- a/tests/openvino/native/test_node_utils.py
+++ b/tests/openvino/native/test_node_utils.py
@@ -15,6 +15,7 @@ import pytest
 from openvino.runtime import opset13 as opset
 
 from nncf.common.graph.graph import NNCFNode
+from nncf.common.utils.os import is_macos
 from nncf.openvino.graph.layer_attributes import OVLayerAttributes
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVMatMulMetatype
 from nncf.openvino.graph.nncf_graph_builder import GraphConverter
@@ -165,4 +166,6 @@ def test_non_convertable_division(a, b, convertable, ref_result):
     model = ov.Model([division], [a_param, b_param])
     compiled_model = ov.compile_model(model, device_name="CPU")
     actual_result = compiled_model([a, b])[0]
-    np.testing.assert_allclose(actual_result, ref_result, atol=0, rtol=0)
+
+    atol = 5e-07 if is_macos() else 0.0
+    np.testing.assert_allclose(actual_result, ref_result, atol=atol)


### PR DESCRIPTION
### Changes

Set atol for test_non_convertable_division test on MacOS

### Reason for changes

https://github.com/openvinotoolkit/nncf/actions/runs/12969549430/job/36208496733

```
FAILED tests/openvino/native/test_node_utils.py::test_non_convertable_division[0.058599039912223816-15-True-0.003906603] - AssertionError: 
Not equal to tolerance rtol=0, atol=0

Mismatched elements: 1 / 1 (100%)
Max absolute difference among violations: 3.5297126e-07
Max relative difference among violations: 9.035248e-05
 ACTUAL: array([0.003906], dtype=float32)
 DESIRED: array([0.003907], dtype=float32)
FAILED tests/openvino/native/test_node_utils.py::test_non_convertable_division[0.058599039912223816-15-False-0.003906602505594492] - AssertionError: 
Not equal to tolerance rtol=0, atol=0

Mismatched elements: 1 / 1 (100%)
Max absolute difference among violations: 3.525056e-07
Max relative difference among violations: 9.023329e-05
 ACTUAL: array([0.003906], dtype=float32)
 DESIRED: array([0.003907], dtype=float32)
```
