### PR TITLE
Exit memory monitor with the same exit code as subprocess

### DIFF
--- a/tools/memory_monitor.py
+++ b/tools/memory_monitor.py
@@ -15,6 +15,7 @@ import queue
 import subprocess
 import threading
 import time
+import sys
 from enum import Enum
 from functools import lru_cache
 from functools import partial
@@ -362,6 +363,7 @@ if __name__ == "__main__":
 
     with subprocess.Popen(" ".join(args.executable), shell=True) as p:
         p.wait()
+        exit_code = p.returncode
 
         # Stop addition of new values as soon as possible
         for mm in memory_monitors:
@@ -380,3 +382,5 @@ if __name__ == "__main__":
             summary_data.append([mm.memory_type.value, fz, f"{int(max(memory_values))} {mm.memory_unit.value}"])
     print("\nMemory summary:")
     print(tabulate(summary_data, headers=["Memory type", "From zero", "Peak value"]))
+
+    sys.exit(exit_code)


### PR DESCRIPTION
### Changes

- memory monitor should exit with the same exit code as subprocess run for measurements

### Reason for changes

- we got some issues in validation, where convert-cli failed and pipelines still passed, as memory_monitor returned  with exit code 0

### Related tickets

CVS-161453
