### PR TITLE
check year in copyright

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,9 +1,3 @@
-# Happy New 2025 Copyright Year!
-6a05971d9352e381c7e0719bbf7d95f3cae714fe
-
-# Happy New 2024 Copyright Year!
-4c01098ef72c82026207cdbefd8b4b2c412bcd2c
-
 # pre-commit autoformatting (isort, black)
 de18dbe23246135d3604a8116c3484e98a8ed0cc
 

--- a/nncf/quantization/algorithms/accuracy_control/onnx_backend.py
+++ b/nncf/quantization/algorithms/accuracy_control/onnx_backend.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2025 Intel Corporation
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nncf/quantization/algorithms/smooth_quant/torch_backend.py
+++ b/nncf/quantization/algorithms/smooth_quant/torch_backend.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2025 Intel Corporation
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nncf/quantization/algorithms/weight_compression/awq_patterns.py
+++ b/nncf/quantization/algorithms/weight_compression/awq_patterns.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2025 Intel Corporation
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ extend-select = [
 
 [tool.ruff.lint.flake8-copyright]
 notice-rgx = """\
-# Copyright \\(c\\) (\\d{4}|\\d{4}-\\d{4}) Intel Corporation
+# Copyright \\(c\\) (202[5,6]) Intel Corporation
 # Licensed under the Apache License, Version 2.0 \\(the "License"\\);
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/cross_fw/test_templates/test_unified_scales.py
+++ b/tests/cross_fw/test_templates/test_unified_scales.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Intel Corporation
+# Copyright (c) 2025 Intel Corporation
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/openvino/native/test_unified_scales.py
+++ b/tests/openvino/native/test_unified_scales.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Intel Corporation
+# Copyright (c) 2025 Intel Corporation
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/post_training/pipelines/lm_weight_compression.py
+++ b/tests/post_training/pipelines/lm_weight_compression.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2025 Intel Corporation
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/torch/experimental/search_building_blocks/test_search_building_blocks.py
+++ b/tests/torch/experimental/search_building_blocks/test_search_building_blocks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Intel Corporation
+# Copyright (c) 2025 Intel Corporation
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/torch/fx/test_unified_scales.py
+++ b/tests/torch/fx/test_unified_scales.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Intel Corporation
+# Copyright (c) 2025 Intel Corporation
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/torch/ptq/test_smooth_quant.py
+++ b/tests/torch/ptq/test_smooth_quant.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2025 Intel Corporation
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
### Changes

Added check to 2025 year in copyrights and 2026 to avoid falls until copyrights will not updated in new year.
Remove commits with updating copyrights from .git-blame-ignore-revs, it was useless my pr.

