### PR TITLE
[PTQ] Remove HWConfig hardcode from calculate_quantizer_parameters

### DIFF
--- a/nncf/common/quantization/quantizers.py
+++ b/nncf/common/quantization/quantizers.py
@@ -20,8 +20,8 @@ def calculate_symmetric_level_ranges(num_bits: int, signed: bool, narrow_range: 
     :param signed: The flag specifying type of the symmetric quantization scheme
         if it is True then the symmetric quantization scheme is the signed and
         the un-signed otherwise.
-    :param narrow_range: The flag specifying quantization range if it is True
-        then [1; 2^num_bits - 1] and [0; 2^num_bits - 1] otherwise.
+    :param narrow_range: True if the range of quantized values is reduced by 1 compared to the
+        naive case, False otherwise.
     :return: A Tuple
         level_low - the low quant number
         level_high - the high quant number

--- a/nncf/quantization/fake_quantize.py
+++ b/nncf/quantization/fake_quantize.py
@@ -323,7 +323,7 @@ def _calculate_scaled_parameters(
     num_bits = quantizer_config.num_bits
     level_low, level_high = calculate_symmetric_level_ranges(num_bits - 1, signed=True, narrow_range=False)
     levels = get_num_levels(level_low, level_high)
-    input_low, input_high = symmetric_range(min_values, max_values, levels, quantizer_config, narrow_range=True)
+    input_low, input_high = symmetric_range(min_values, max_values, levels, quantizer_config, narrow_range)
 
     export_level_low, export_level_high = calculate_symmetric_level_ranges(
         num_bits, signed=True, narrow_range=narrow_range

--- a/nncf/quantization/fake_quantize.py
+++ b/nncf/quantization/fake_quantize.py
@@ -323,7 +323,6 @@ def _calculate_scaled_parameters(
     num_bits = quantizer_config.num_bits
     level_low, level_high = calculate_symmetric_level_ranges(num_bits - 1, signed=True, narrow_range=False)
     levels = get_num_levels(level_low, level_high)
-    # TODO: confirm that hardcoded narrow_range=True is a correct value
     input_low, input_high = symmetric_range(min_values, max_values, levels, quantizer_config, narrow_range=True)
 
     export_level_low, export_level_high = calculate_symmetric_level_ranges(

--- a/tests/cross_fw/shared/json.py
+++ b/tests/cross_fw/shared/json.py
@@ -15,6 +15,13 @@ from typing import Dict
 
 import numpy as np
 
+from nncf.tensor import Tensor
+
+try:
+    import torch
+except ModuleNotFoundError:
+    torch = None
+
 
 def load_json(stats_path: Path):
     with open(stats_path, "r", encoding="utf8") as json_file:
@@ -25,12 +32,16 @@ class NumpyEncoder(json.JSONEncoder):
     """Special json encoder for numpy types"""
 
     def default(self, o):
+        if isinstance(o, Tensor):
+            o = o.data
         if isinstance(o, np.integer):
             return int(o)
         if isinstance(o, np.floating):
             return float(o)
         if isinstance(o, np.ndarray):
             return o.tolist()
+        if isinstance(o, torch.Tensor):
+            return o.cpu().detach().numpy().tolist()
         return json.JSONEncoder.default(self, o)
 
 

--- a/tests/cross_fw/test_templates/fq_params/fq_params.json
+++ b/tests/cross_fw/test_templates/fq_params/fq_params.json
@@ -15,9 +15,9 @@
     },
     "weights_symmetric_sign_True_per_ch_False_narrow_range_False_hf_range_True": {
         "levels": 256,
-        "input_low": -2.0022718596646167,
+        "input_low": -2.0340540409088135,
         "input_high": 2.0022718596646167,
-        "output_low": -2.0022718596646167,
+        "output_low": -2.0340540409088135,
         "output_high": 2.0022718596646167
     },
     "weights_symmetric_sign_True_per_ch_False_narrow_range_False_hf_range_False": {

--- a/tests/cross_fw/test_templates/fq_params/fq_params.json
+++ b/tests/cross_fw/test_templates/fq_params/fq_params.json
@@ -1,30 +1,30 @@
 {
-    "weights_symmetric_sign_None_per_ch_False_narrow_range_True_hf_range_True": {
+    "weights_symmetric_sign_True_per_ch_False_narrow_range_True_hf_range_True": {
         "levels": 255,
         "input_low": -1.994419813156128,
         "input_high": 1.994419813156128,
         "output_low": -1.994419813156128,
         "output_high": 1.994419813156128
     },
-    "weights_symmetric_sign_None_per_ch_False_narrow_range_True_hf_range_False": {
+    "weights_symmetric_sign_True_per_ch_False_narrow_range_True_hf_range_False": {
         "levels": 255,
         "input_low": -0.997209906578064,
         "input_high": 0.997209906578064,
         "output_low": -0.997209906578064,
         "output_high": 0.997209906578064
     },
-    "weights_symmetric_sign_None_per_ch_False_narrow_range_False_hf_range_True": {
+    "weights_symmetric_sign_True_per_ch_False_narrow_range_False_hf_range_True": {
         "levels": 256,
         "input_low": -2.0022718596646167,
         "input_high": 2.0022718596646167,
         "output_low": -2.0022718596646167,
         "output_high": 2.0022718596646167
     },
-    "weights_symmetric_sign_None_per_ch_False_narrow_range_False_hf_range_False": {
+    "weights_symmetric_sign_True_per_ch_False_narrow_range_False_hf_range_False": {
         "levels": 256,
-        "input_low": -0.997209906578064,
+        "input_low": -1.0050619840621948,
         "input_high": 0.997209906578064,
-        "output_low": -0.997209906578064,
+        "output_low": -1.0050619840621948,
         "output_high": 0.997209906578064
     },
     "weights_asymmetric_sign_None_per_ch_False_narrow_range_False_hf_range_False": {

--- a/tests/cross_fw/test_templates/test_calculate_quantizer_parameters.py
+++ b/tests/cross_fw/test_templates/test_calculate_quantizer_parameters.py
@@ -92,28 +92,28 @@ class CaseFQParams:
 TO_TEST = [
     # WEIGHT QUANTIZER CONFIGURATIONS
     CaseFQParams(
-        q_config=QuantizerConfig(num_bits=8, mode=QuantizationMode.SYMMETRIC),
+        q_config=QuantizerConfig(num_bits=8, mode=QuantizationMode.SYMMETRIC, signedness_to_force=True),
         q_group=QuantizerGroup.WEIGHTS,
         narrow_range=True,
         half_range=True,
         should_fail=False,
     ),
     CaseFQParams(
-        q_config=QuantizerConfig(num_bits=8, mode=QuantizationMode.SYMMETRIC),
+        q_config=QuantizerConfig(num_bits=8, mode=QuantizationMode.SYMMETRIC, signedness_to_force=True),
         q_group=QuantizerGroup.WEIGHTS,
         narrow_range=True,
         half_range=False,
         should_fail=False,
     ),
     CaseFQParams(
-        q_config=QuantizerConfig(num_bits=8, mode=QuantizationMode.SYMMETRIC),
+        q_config=QuantizerConfig(num_bits=8, mode=QuantizationMode.SYMMETRIC, signedness_to_force=True),
         q_group=QuantizerGroup.WEIGHTS,
         narrow_range=False,
         half_range=True,
         should_fail=False,
     ),
     CaseFQParams(
-        q_config=QuantizerConfig(num_bits=8, mode=QuantizationMode.SYMMETRIC),
+        q_config=QuantizerConfig(num_bits=8, mode=QuantizationMode.SYMMETRIC, signedness_to_force=True),
         q_group=QuantizerGroup.WEIGHTS,
         narrow_range=False,
         half_range=False,
@@ -197,7 +197,11 @@ class TemplateTestFQParams(ABC):
     def to_nncf_tensor(self, t: np.array):
         raise NotImplementedError
 
-    @pytest.mark.parametrize("case_to_test", TO_TEST)
+    @pytest.mark.parametrize(
+        "case_to_test",
+        TO_TEST,
+        ids=[get_test_reference_key(c.q_group, c.q_config, c.narrow_range, c.half_range) for c in TO_TEST],
+    )
     def test_calculate_quantizer_parameters(self, case_to_test):
         q_config = case_to_test.q_config
         quant_group = case_to_test.q_group


### PR DESCRIPTION
### Changes

* `symmetric_range` and  `asymmetric_range` functions were refactored to avoid dependency on quantization group
* input configs of `test_calculate_quantizer_parameters` were updated to align with real cases computed by the solver with `cpu.json` HW config (all symmetric weights configs have `signedness_to_force=True` in actual code)

### Reason for changes

`symmetric_range` and  `asymmetric_range` functions are using prior knowledge about HW config (if symmetric and weights -> input_low = -input_high) but could just use the qconfig attributes (signed == True and narrow_range == True -> input_low = -input_high) . New quantizers from the #3231 does not obey hardcoded OpenVINO HW config rules (X86 quantizer require narrow_range false for symmetric weights, for example), thus support of the new quantizers requires more general `calculate_quantizer_parameters` function


### Related tickets

https://github.com/openvinotoolkit/nncf/issues/3231

### Tests

* test_calculate_quantizer_parameters is updated
