### PR TITLE
[Release] Set environment variable on LNL CPUs before compression model compilation

### DIFF
--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -182,7 +182,7 @@ def is_openvino_available() -> bool:
 def is_openvino_at_least(version_str: str) -> bool:
     """
     Check if OpenVINO version is at least the specified one.
-    
+
     :param version_str: The version string to compare with the installed OpenVINO version. For example "2025.1".
     :return: True if the installed OpenVINO version is at least the specified one, False otherwise.
     """

--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -183,6 +183,7 @@ def is_openvino_available() -> bool:
 def is_openvino_at_least(version_str: str) -> bool:
     """
     Check if OpenVINO version is at least the specified one.
+    
     :param version_str: The version string to compare with the installed OpenVINO version. For example "2025.1".
     :return: True if the installed OpenVINO version is at least the specified one, False otherwise.
     """

--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -22,7 +22,7 @@ try:
     import openvino  # type: ignore # noqa: F401
 
     _OPENVINO_AVAILABLE = True
-    _OPENVINO_VERSION = version.parse(version.parse(openvino.__version__).base_version)
+    _OPENVINO_VERSION = version.parse(openvino.__version__.split("-")[0])
 except ImportError:
     _OPENVINO_AVAILABLE = False
     _OPENVINO_VERSION = None

--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -12,6 +12,8 @@ from copy import deepcopy
 from enum import Enum
 from typing import Any, Callable, TypeVar
 
+from packaging import version
+
 import nncf
 
 TModel = TypeVar("TModel")
@@ -20,8 +22,10 @@ try:
     import openvino  # type: ignore # noqa: F401
 
     _OPENVINO_AVAILABLE = True
+    _OPENVINO_VERSION = version.parse(version.parse(openvino.__version__).base_version)
 except ImportError:
     _OPENVINO_AVAILABLE = False
+    _OPENVINO_VERSION = None
 
 
 class BackendType(Enum):
@@ -174,3 +178,15 @@ def is_openvino_available() -> bool:
     :return: True if openvino package is installed, False otherwise.
     """
     return _OPENVINO_AVAILABLE
+
+
+def is_openvino_at_least(version_str: str) -> bool:
+    """
+    Check if OpenVINO version is at least the specified one.
+    :param version_str: The version string to compare with the installed OpenVINO version. For example "2025.1".
+    :return: True if the installed OpenVINO version is at least the specified one, False otherwise.
+    """
+    if not _OPENVINO_AVAILABLE:
+        return False
+
+    return version.parse(version_str) <= _OPENVINO_VERSION

--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -25,7 +25,6 @@ try:
     _OPENVINO_VERSION = version.parse(openvino.__version__.split("-")[0])
 except ImportError:
     _OPENVINO_AVAILABLE = False
-    _OPENVINO_VERSION = version.parse("0.0")
 
 
 class BackendType(Enum):

--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -25,7 +25,7 @@ try:
     _OPENVINO_VERSION = version.parse(openvino.__version__.split("-")[0])
 except ImportError:
     _OPENVINO_AVAILABLE = False
-    _OPENVINO_VERSION = None
+    _OPENVINO_VERSION = version.parse("0.0")
 
 
 class BackendType(Enum):

--- a/nncf/common/utils/cpu_info.py
+++ b/nncf/common/utils/cpu_info.py
@@ -1,9 +1,23 @@
-import cpuinfo
+# Copyright (c) 2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
 
+import cpuinfo
 
-def _is_lnl_cpu() -> bool:
-    return re.search(r'Ultra \d 2\d{2}V', cpuinfo.get_cpu_info()["brand_raw"]) is not None
+_IS_LNL_CPU = None
 
 
-IS_LNL_CPU = _is_lnl_cpu()
+def is_lnl_cpu() -> bool:
+    global _IS_LNL_CPU
+    if _IS_LNL_CPU is None:
+        _IS_LNL_CPU = re.search(r"Ultra \d 2\d{2}V", cpuinfo.get_cpu_info()["brand_raw"]) is not None
+    return _IS_LNL_CPU

--- a/nncf/common/utils/cpu_info.py
+++ b/nncf/common/utils/cpu_info.py
@@ -19,5 +19,5 @@ _IS_LNL_CPU = None
 def is_lnl_cpu() -> bool:
     global _IS_LNL_CPU
     if _IS_LNL_CPU is None:
-        _IS_LNL_CPU = re.search(r"Ultra \d 2\d{2}V", cpuinfo.get_cpu_info()["brand_raw"]) is not None
+        _IS_LNL_CPU = re.search(r"Ultra \d 2\d{2}", cpuinfo.get_cpu_info()["brand_raw"]) is not None
     return _IS_LNL_CPU

--- a/nncf/common/utils/cpu_info.py
+++ b/nncf/common/utils/cpu_info.py
@@ -1,0 +1,9 @@
+import cpuinfo
+import re
+
+
+def _is_lnl_cpu() -> bool:
+    return re.search(r'Ultra \d 2\d{2}V', cpuinfo.get_cpu_info()["brand_raw"]) is not None
+
+
+IS_LNL_CPU = _is_lnl_cpu()

--- a/nncf/common/utils/cpu_info.py
+++ b/nncf/common/utils/cpu_info.py
@@ -11,7 +11,7 @@
 
 import re
 
-import cpuinfo
+import cpuinfo  # type: ignore
 
 _IS_LNL_CPU = None
 

--- a/nncf/common/utils/helpers.py
+++ b/nncf/common/utils/helpers.py
@@ -12,6 +12,7 @@ import datetime
 import itertools
 import os
 import os.path as osp
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, Hashable, Iterable, List, Optional, TypeVar, Union
 
@@ -75,3 +76,22 @@ def product_dict(d: Dict[TKey, List[Any]]) -> Iterable[Dict[TKey, Any]]:
     vals = d.values()
     for instance in itertools.product(*vals):
         yield dict(zip(keys, instance))
+
+
+@contextmanager
+def set_env_variable(key: str, value: str):
+    """
+    Temporarily sets an environment variable.
+
+    :param key: Environment variable name.
+    :param value: Environment variable value.
+    """
+    old_value = os.environ.get(key)
+    os.environ[key] = value
+    try:
+        yield
+    finally:
+        if old_value is not None:
+            os.environ[key] = old_value
+        else:
+            del os.environ[key]

--- a/nncf/common/utils/helpers.py
+++ b/nncf/common/utils/helpers.py
@@ -14,7 +14,7 @@ import os
 import os.path as osp
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Hashable, Iterable, List, Optional, TypeVar, Union
+from typing import Any, Dict, Hashable, Iterable, Iterator, List, Optional, TypeVar, Union
 
 from tabulate import tabulate
 
@@ -79,7 +79,7 @@ def product_dict(d: Dict[TKey, List[Any]]) -> Iterable[Dict[TKey, Any]]:
 
 
 @contextmanager
-def set_env_variable(key: str, value: str):
+def set_env_variable(key: str, value: str) -> Iterator[None]:
     """
     Temporarily sets an environment variable.
 

--- a/nncf/openvino/optimized_functions/models.py
+++ b/nncf/openvino/optimized_functions/models.py
@@ -22,6 +22,7 @@ from openvino._pyopenvino.properties.hint import inference_precision
 from openvino.runtime import Node
 from openvino.runtime import opset13 as opset
 
+from nncf.common.utils.backend import is_openvino_at_least
 from nncf.common.utils.caching import ResultsCache
 from nncf.common.utils.caching import cache_results
 from nncf.common.utils.cpu_info import is_lnl_cpu
@@ -118,7 +119,7 @@ def clear_ov_model_cache():
 
 
 def _compile_ov_model(model: ov.Model, device_name: str, config: Dict[str, str]) -> ov.CompiledModel:
-    if is_lnl_cpu():
+    if is_lnl_cpu() and not is_openvino_at_least("2025.1"):
         with set_env_variable("DNNL_MAX_CPU_ISA", "AVX2_VNNI"):
             compiled_model = ov.compile_model(model, device_name=device_name, config=config)
     else:

--- a/nncf/openvino/optimized_functions/models.py
+++ b/nncf/openvino/optimized_functions/models.py
@@ -119,7 +119,6 @@ def clear_ov_model_cache():
 
 def _compile_ov_model(model: ov.Model, device_name: str, config: Dict[str, str]) -> ov.CompiledModel:
     if is_lnl_cpu():
-        # TODO (Nikita Savelyev): Remove this in NNCF 2.16
         with set_env_variable("DNNL_MAX_CPU_ISA", "AVX2_VNNI"):
             compiled_model = ov.compile_model(model, device_name=device_name, config=config)
     else:

--- a/nncf/openvino/optimized_functions/models.py
+++ b/nncf/openvino/optimized_functions/models.py
@@ -24,7 +24,7 @@ from openvino.runtime import opset13 as opset
 
 from nncf.common.utils.caching import ResultsCache
 from nncf.common.utils.caching import cache_results
-from nncf.common.utils.cpu_info import IS_LNL_CPU
+from nncf.common.utils.cpu_info import is_lnl_cpu
 from nncf.common.utils.helpers import set_env_variable
 from nncf.openvino.graph.node_utils import convert_op
 from nncf.openvino.graph.node_utils import non_convertable_divide_op
@@ -118,8 +118,8 @@ def clear_ov_model_cache():
 
 
 def _compile_ov_model(model: ov.Model, device_name: str, config: Dict[str, str]) -> ov.CompiledModel:
-    # TODO (Nikita Savelyev): Remove this in NNCF 2.16
-    if IS_LNL_CPU:
+    if is_lnl_cpu():
+        # TODO (Nikita Savelyev): Remove this in NNCF 2.16
         with set_env_variable("DNNL_MAX_CPU_ISA", "AVX2_VNNI"):
             compiled_model = ov.compile_model(model, device_name=device_name, config=config)
     else:

--- a/nncf/openvino/optimized_functions/models.py
+++ b/nncf/openvino/optimized_functions/models.py
@@ -24,6 +24,8 @@ from openvino.runtime import opset13 as opset
 
 from nncf.common.utils.caching import ResultsCache
 from nncf.common.utils.caching import cache_results
+from nncf.common.utils.cpu_info import IS_LNL_CPU
+from nncf.common.utils.helpers import set_env_variable
 from nncf.openvino.graph.node_utils import convert_op
 from nncf.openvino.graph.node_utils import non_convertable_divide_op
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionConfig
@@ -113,6 +115,17 @@ ModelAsNodes = Tuple[List[Parameter], List[Node], OVModelParameters]
 
 def clear_ov_model_cache():
     OV_MODEL_CACHE.clear()
+
+
+def _compile_ov_model(model: ov.Model, device_name: str, config: Dict[str, str]) -> ov.CompiledModel:
+    # TODO (Nikita Savelyev): Remove this in NNCF 2.16
+    if IS_LNL_CPU:
+        with set_env_variable("DNNL_MAX_CPU_ISA", "AVX2_VNNI"):
+            compiled_model = ov.compile_model(model, device_name=device_name, config=config)
+    else:
+        compiled_model = ov.compile_model(model, device_name=device_name, config=config)
+
+    return compiled_model
 
 
 def _infer_ov_model(
@@ -404,7 +417,7 @@ def _build_compress_model(
         return ov_parameters, ov_results, ov_model_params
 
     model = ov.Model(ov_results, ov_parameters)
-    compiled_model = ov.compile_model(model, device_name="CPU", config={inference_precision(): ov.Type.f32})
+    compiled_model = _compile_ov_model(model, device_name="CPU", config={inference_precision(): ov.Type.f32})
 
     return partial(_infer_ov_model, ov_model_params, compiled_model)
 
@@ -458,7 +471,7 @@ def _build_compress_decompress_model(
 
     ov_results = [decompressed_weight] + ov_results if return_compressed_weight else [decompressed_weight]
     model = ov.Model(ov_results, ov_parameters)
-    compiled_model = ov.compile_model(model, device_name="CPU", config={inference_precision(): ov.Type.f32})
+    compiled_model = _compile_ov_model(model, device_name="CPU", config={inference_precision(): ov.Type.f32})
 
     return partial(_infer_ov_model, ov_model_params, compiled_model)
 
@@ -496,6 +509,6 @@ def _build_astype_model(ov_model_params: OVModelParameters, arg_shape: Tuple) ->
     arg = opset.parameter(arg_shape, dtype=DTYPE_MAP_OV[input_dtypes["input"]], name="input")
     res = opset.convert(arg, DTYPE_MAP_OV[output_dtypes["output"]])
     model = ov.Model([res], [arg])
-    compiled_model = ov.compile_model(model, device_name="CPU", config={inference_precision(): ov.Type.f32})
+    compiled_model = _compile_ov_model(model, device_name="CPU", config={inference_precision(): ov.Type.f32})
 
     return partial(_infer_ov_model, ov_model_params, compiled_model)

--- a/nncf/version.py
+++ b/nncf/version.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.15.0.dev0+eb0a1b0d2dirty"
+__version__ = "2.15.0"
 
 
 BKC_TORCH_SPEC = "==2.5.*"

--- a/nncf/version.py
+++ b/nncf/version.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.15.0"
+__version__ = "2.15.0.dev0+eb0a1b0d2dirty"
 
 
 BKC_TORCH_SPEC = "==2.5.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "packaging>=20.0",
     "pandas>=1.1.5,<2.3",
     "psutil",
-    "py-cpuinfo>=9.0.0",    # TODO (Nikita Savelyev): Remove this in NNCF 2.16
+    "py-cpuinfo>=9.0.0",
     "pydot>=1.4.1, <3.0.0",
     "pymoo>=0.6.0.1",
     "rich>=13.5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "packaging>=20.0",
     "pandas>=1.1.5,<2.3",
     "psutil",
+    "py-cpuinfo>=9.0.0",    # TODO (Nikita Savelyev): Remove this in NNCF 2.16
     "pydot>=1.4.1, <3.0.0",
     "pymoo>=0.6.0.1",
     "rich>=13.5.2",

--- a/tests/common/utils/test_helpers.py
+++ b/tests/common/utils/test_helpers.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from nncf.common.utils.helpers import set_env_variable
+
+
+def test_set_env_variable():
+    assert os.environ.get("TEST_VAR") is None
+    with set_env_variable("TEST_VAR", "test_value"):
+        assert os.environ.get("TEST_VAR") == "test_value"
+    assert os.environ.get("TEST_VAR") is None

--- a/tests/common/utils/test_helpers.py
+++ b/tests/common/utils/test_helpers.py
@@ -15,7 +15,15 @@ from nncf.common.utils.helpers import set_env_variable
 
 
 def test_set_env_variable():
+    # Test the case when the variable is not set
     assert os.environ.get("TEST_VAR") is None
     with set_env_variable("TEST_VAR", "test_value"):
         assert os.environ.get("TEST_VAR") == "test_value"
     assert os.environ.get("TEST_VAR") is None
+
+    # Test the case when the variable is already set
+    os.environ["TEST_VAR"] = "original_value"
+    assert os.environ.get("TEST_VAR") == "original_value"
+    with set_env_variable("TEST_VAR", "test_value"):
+        assert os.environ.get("TEST_VAR") == "test_value"
+    assert os.environ.get("TEST_VAR") == "original_value"


### PR DESCRIPTION
### Changes

Set `export DNNL_MAX_CPU_ISA=AVX2_VNNI` during weights compression on LNL CPUs.

### Reason for changes

Fix compression on LNL CPUs.

### Related tickets

161336

### Tests
- https://github.com/openvinotoolkit/nncf/actions/runs/13075940656 ✅ 
- https://github.com/openvinotoolkit/nncf/actions/runs/13075938396 ✅ 
- NNCF/job/nightly/job/sdl/job/nightly_trigger/426/ ✅ 
