### PR TITLE
Avoid import nncf in tests/cross_fw/shared/json.py 

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -98,7 +98,6 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@ed94116c4d30d2091601b81f339a2eaa1c2ba0a6 # v1.4.1
       - name: Install NNCF and test requirements
         run: |
-          pip install -e .
           pip install -r tests/cross_fw/examples/requirements.txt
       - name: Print installed modules
         run: pip list

--- a/nncf/tensor/functions/numeric.py
+++ b/nncf/tensor/functions/numeric.py
@@ -935,8 +935,11 @@ def tensor(
 @tensor_guard
 def as_numpy_tensor(a: Tensor) -> Tensor:
     """
-    Change backend of the tensor to numpy. Leads to data copying when tensor data type is bf16, u4 or i4. Otherwise,
-    there is no data copying.
+    Convert tensor to numpy.
+    In certain cases, this conversion may involve data copying, depending on the
+    data type or device. Specifically:
+      - OV: if tensors data type is bf16, u4 or i4.
+      - PT: if tensors on the GPU or data type is not supported on Numpy.
 
     :param a: Tensor to change backend for.
     :return: Tensor in numpy backend.

--- a/nncf/tensor/functions/torch_numeric.py
+++ b/nncf/tensor/functions/torch_numeric.py
@@ -484,3 +484,8 @@ def tensor(
     device = convert_to_torch_device(device)
     dtype = convert_to_torch_dtype(dtype)
     return torch.tensor(data, dtype=dtype, device=device)
+
+
+@numeric.as_numpy_tensor.register(torch.Tensor)
+def _(a: torch.Tensor) -> np.ndarray:
+    return a.detach().cpu().numpy()

--- a/nncf/tensor/functions/torch_numeric.py
+++ b/nncf/tensor/functions/torch_numeric.py
@@ -488,4 +488,4 @@ def tensor(
 
 @numeric.as_numpy_tensor.register(torch.Tensor)
 def _(a: torch.Tensor) -> np.ndarray:
-    return a.detach().cpu().numpy()
+    return a.cpu().detach().numpy()

--- a/tests/cross_fw/shared/json.py
+++ b/tests/cross_fw/shared/json.py
@@ -15,13 +15,6 @@ from typing import Dict
 
 import numpy as np
 
-from nncf.tensor import Tensor
-
-try:
-    import torch
-except ModuleNotFoundError:
-    torch = None
-
 
 def load_json(stats_path: Path):
     with open(stats_path, encoding="utf8") as json_file:
@@ -32,16 +25,12 @@ class NumpyEncoder(json.JSONEncoder):
     """Special json encoder for numpy types"""
 
     def default(self, o):
-        if isinstance(o, Tensor):
-            o = o.data
         if isinstance(o, np.integer):
             return int(o)
         if isinstance(o, np.floating):
             return float(o)
         if isinstance(o, np.ndarray):
             return o.tolist()
-        if isinstance(o, torch.Tensor):
-            return o.cpu().detach().numpy().tolist()
         return json.JSONEncoder.default(self, o)
 
 

--- a/tests/cross_fw/test_templates/fq_params/fq_params.json
+++ b/tests/cross_fw/test_templates/fq_params/fq_params.json
@@ -16,9 +16,9 @@
     "weights_symmetric_sign_True_per_ch_False_narrow_range_False_hf_range_True": {
         "levels": 256,
         "input_low": -2.0340540409088135,
-        "input_high": 2.0022718596646167,
+        "input_high": 2.002271890640259,
         "output_low": -2.0340540409088135,
-        "output_high": 2.0022718596646167
+        "output_high": 2.002271890640259
     },
     "weights_symmetric_sign_True_per_ch_False_narrow_range_False_hf_range_False": {
         "levels": 256,

--- a/tests/cross_fw/test_templates/fq_params/fq_params.json
+++ b/tests/cross_fw/test_templates/fq_params/fq_params.json
@@ -16,9 +16,9 @@
     "weights_symmetric_sign_True_per_ch_False_narrow_range_False_hf_range_True": {
         "levels": 256,
         "input_low": -2.0340540409088135,
-        "input_high": 2.002271890640259,
+        "input_high": 2.0022718596646167,
         "output_low": -2.0340540409088135,
-        "output_high": 2.002271890640259
+        "output_high": 2.0022718596646167
     },
     "weights_symmetric_sign_True_per_ch_False_narrow_range_False_hf_range_False": {
         "levels": 256,

--- a/tests/cross_fw/test_templates/template_test_nncf_tensor.py
+++ b/tests/cross_fw/test_templates/template_test_nncf_tensor.py
@@ -1749,3 +1749,12 @@ class TemplateTestNNCFTensorOperators:
             backend_tensor = backend_tensor.astype(dtype)
         assert fns.allclose(nncf_tensor, backend_tensor)
         assert nncf_tensor.dtype == backend_tensor.dtype
+
+    def test_as_numpy_tensor(self):
+        tensor1 = Tensor(self.to_tensor([1.0, 2.0]))
+        tensor2 = tensor1.as_numpy_tensor()
+        assert tensor2.backend == TensorBackend.numpy
+        assert tensor1.dtype == tensor2.dtype
+        assert tensor1.shape == tensor2.shape
+        assert tensor2.device == TensorDeviceType.CPU
+        assert fns.allclose(tensor1, tensor2)

--- a/tests/cross_fw/test_templates/test_calculate_quantizer_parameters.py
+++ b/tests/cross_fw/test_templates/test_calculate_quantizer_parameters.py
@@ -62,7 +62,13 @@ def read_ref_fq_params(q_group, q_config, narrow_range, hf_range):
     return ref_quantize_params
 
 
-def dump_fq_params(fq_params, q_group, q_config, narrow_range, hf_range):
+def dump_fq_params(
+    fq_params: FakeQuantizeParameters,
+    q_group: QuantizerGroup,
+    q_config: QuantizerConfig,
+    narrow_range: bool,
+    hf_range: bool,
+):
     key = get_test_reference_key(q_group, q_config, narrow_range, hf_range)
     all_fq_params = load_json(FQ_CALCULATED_PARAMETERS_PATH)
     fq_params_dict = parse_fq_params_to_dict(fq_params)
@@ -70,13 +76,13 @@ def dump_fq_params(fq_params, q_group, q_config, narrow_range, hf_range):
     dump_to_json(FQ_CALCULATED_PARAMETERS_PATH, all_fq_params)
 
 
-def parse_fq_params_to_dict(fq_params):
+def parse_fq_params_to_dict(fq_params: FakeQuantizeParameters):
     return {
         "levels": fq_params.levels,
-        "input_low": fq_params.input_low,
-        "input_high": fq_params.input_high,
-        "output_low": fq_params.output_low,
-        "output_high": fq_params.output_high,
+        "input_low": fq_params.input_low.as_numpy_tensor().data,
+        "input_high": fq_params.input_high.as_numpy_tensor().data,
+        "output_low": fq_params.output_low.as_numpy_tensor().data,
+        "output_high": fq_params.output_high.as_numpy_tensor().data,
     }
 
 
@@ -227,7 +233,8 @@ class TemplateTestFQParams(ABC):
         )
         if not case_to_test.should_fail:
             fq_params = calculate_quantizer_parameters(statistics, q_config, quant_group, narrow_range, half_range)
-            # Uncomment lines below to generate reference for new models.
+            # Use OpenVINO backend to collect new reference files.
+            # Uncomment lines below to generate reference for new parameters.
             # dump_fq_params(fq_params, quant_group, q_config, narrow_range, half_range)
             ref_fq_params = read_ref_fq_params(quant_group, q_config, narrow_range, half_range)
             compare_fq_parameters(fq_params, ref_fq_params)


### PR DESCRIPTION
### Changes

- Remove import nncf in tests/cross_fw/shared/json.py
- Remove install nncf in test_examples on windows
- Add as_numpy_tensor for TORCH backend

### Reason for changes

https://github.com/openvinotoolkit/nncf/actions/runs/13103780497


### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/13121758899