### PR TITLE
[Fixed]: Onnx function transform error in onnx ptq

### DIFF
--- a/nncf/onnx/graph/model_transformer.py
+++ b/nncf/onnx/graph/model_transformer.py
@@ -179,6 +179,8 @@ class ONNXModelTransformer(ModelTransformer):
             model_version=model.model_version,
             doc_string=model.doc_string,
         )
+        if hasattr(model, "functions") and getattr(model, "functions"):
+            new_model.functions.extend(model.functions)
         if model.metadata_props:
             values = {p.key: p.value for p in model.metadata_props}
             onnx.helper.set_model_props(new_model, values)


### PR DESCRIPTION
### Changes
Added the function member transfer when constructing the _insert_outputs onnx model.

### Reason for changes
Onnx function is a widely used new feature. In 'torch.onnx.dynamo_export' and 'torch.onnx.export' ('export_modules_as_functions' param), some user modules will be converted to onnx functions. However, the current nncf onnx quantization does not do special processing for it, resulting in the onnx exported by this function converting the user's onnx function into an unimplemented custom operator, causing errors in the subsequent ptq process.

![image](https://github.com/user-attachments/assets/c334f717-36ca-4945-8b84-070be98805db)

