### PR TITLE
remove strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,6 @@ def transform_fn(data_item):
 calibration_dataset = nncf.Dataset(val_dataset, transform_fn)
 # Step 3: Run the quantization pipeline
 quantized_model = nncf.quantize(model, calibration_dataset)
-# Step 4: Remove auxiliary layers and operations added during the quantization process,
-# resulting in a clean, fully quantized model ready for deployment.
-stripped_model = nncf.strip(quantized_model)
 ```
 
 </details>

--- a/docs/usage/training_time_compression/quantization_aware_training/Usage.md
+++ b/docs/usage/training_time_compression/quantization_aware_training/Usage.md
@@ -60,11 +60,7 @@ ov_quantized_model = ov.convert_model(quantized_model.cpu(), example_input=dummy
 # To OpenVINO format
 import openvino as ov
 
-# Removes auxiliary layers and operations added during the quantization process,
-# resulting in a clean, fully quantized model ready for deployment.
-stripped_model = nncf.strip(quantized_model)
-
-ov_quantized_model = ov.convert_model(stripped_model)
+ov_quantized_model = ov.convert_model(quantized_model)
 ```
 
 </details>

--- a/examples/post_training_quantization/tensorflow/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/tensorflow/mobilenet_v2/main.py
@@ -143,10 +143,6 @@ def transform_fn(data_item):
 calibration_dataset = nncf.Dataset(val_dataset, transform_fn)
 tf_quantized_model = nncf.quantize(tf_model, calibration_dataset)
 
-# Removes auxiliary layers and operations added during the quantization process,
-# resulting in a clean, fully quantized model ready for deployment.
-tf_quantized_model = nncf.strip(tf_quantized_model)
-
 ###############################################################################
 # Benchmark performance, calculate compression rate and validate accuracy
 

--- a/examples/quantization_aware_training/tensorflow/mobilenet_v2/main.py
+++ b/examples/quantization_aware_training/tensorflow/mobilenet_v2/main.py
@@ -159,15 +159,11 @@ tf_quantized_model.compile(
 # However, training for more than 1 epoch would further improve the quantized model's accuracy.
 tf_quantized_model.fit(train_dataset, epochs=1, verbose=1)
 
-# Removes auxiliary layers and operations added during the quantization process,
-# resulting in a clean, fully quantized model ready for deployment.
-stripped_model = nncf.strip(tf_quantized_model)
-
 ###############################################################################
 # Benchmark performance, calculate compression rate and validate accuracy
 
 ov_model = ov.convert_model(tf_model)
-ov_quantized_model = ov.convert_model(stripped_model)
+ov_quantized_model = ov.convert_model(tf_quantized_model)
 
 fp32_ir_path = ROOT / "mobilenet_v2_fp32.xml"
 ov.save_model(ov_model, fp32_ir_path, compress_to_fp16=False)


### PR DESCRIPTION
### Changes

- Calling `nncf.strip()` is no longer required for the TF backend, as this function is now integrated into the `ov.convert_model()` method. Therefore, the model can be converted directly using `ov.convert_model()`.