### PR TITLE
[OpenVINOQuantizer] return annotated model

### DIFF
--- a/nncf/experimental/torch/fx/quantization/quantizer/openvino_quantizer.py
+++ b/nncf/experimental/torch/fx/quantization/quantizer/openvino_quantizer.py
@@ -154,6 +154,7 @@ class OpenVINOQuantizer(TorchAOQuantizer):
         for node, annotation in node_vs_torch_annotation.items():
             assert QUANT_ANNOTATION_KEY not in node.meta
             node.meta[QUANT_ANNOTATION_KEY] = annotation
+        return model
 
     @staticmethod
     def _get_unified_scales_root_quantizer_id(


### PR DESCRIPTION
### Changes

Mode return is added to `annotate` method of the OpenVINOQuantizer

### Reason for changes

To align with the signature
