### PR TITLE
Replace openvino.runtime with openvino

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The NNCF PTQ is the simplest way to apply 8-bit quantization. To run the algorit
 
 ```python
 import nncf
-import openvino.runtime as ov
+import openvino as ov
 import torch
 from torchvision import datasets, transforms
 

--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -111,7 +111,7 @@ def is_openvino_model(model: Any) -> bool:
     :param model: A target model.
     :return: True if the model is an instance of openvino.runtime.Model, otherwise False.
     """
-    import openvino.runtime as ov  # type: ignore
+    import openvino as ov  # type: ignore
 
     return isinstance(model, ov.Model)
 
@@ -124,7 +124,7 @@ def is_openvino_compiled_model(model: Any) -> bool:
     :param model: A target model.
     :return: True if the model is an instance of openvino.runtime.CompiledModel, otherwise False.
     """
-    import openvino.runtime as ov
+    import openvino as ov
 
     return isinstance(model, ov.CompiledModel)
 

--- a/nncf/openvino/engine.py
+++ b/nncf/openvino/engine.py
@@ -12,7 +12,7 @@
 from typing import Dict, List, Tuple, Union
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 from openvino import Type
 from openvino.properties.hint import inference_precision
 

--- a/nncf/openvino/graph/metatypes/openvino_metatypes.py
+++ b/nncf/openvino/graph/metatypes/openvino_metatypes.py
@@ -12,7 +12,7 @@
 from collections import deque
 from typing import List, Optional, Type
 
-import openvino.runtime as ov
+import openvino as ov
 
 import nncf
 from nncf.common.graph.operator_metatypes import INPUT_NOOP_METATYPES

--- a/nncf/openvino/graph/model_builder.py
+++ b/nncf/openvino/graph/model_builder.py
@@ -11,7 +11,7 @@
 from collections import deque
 from typing import Dict, List, Tuple
 
-import openvino.runtime as ov
+import openvino as ov
 from openvino.runtime import opset13 as opset
 from openvino.runtime.utils.node_factory import NodeFactory
 

--- a/nncf/openvino/graph/model_transformer.py
+++ b/nncf/openvino/graph/model_transformer.py
@@ -14,7 +14,7 @@ from collections import deque
 from typing import Callable, Dict, List, Tuple
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 from openvino._pyopenvino import DescriptorTensor
 from openvino.runtime import opset13 as opset
 

--- a/nncf/openvino/graph/model_utils.py
+++ b/nncf/openvino/graph/model_utils.py
@@ -11,7 +11,7 @@
 from collections import deque
 from typing import List
 
-import openvino.runtime as ov
+import openvino as ov
 
 from nncf.common.factory import ModelTransformerFactory
 from nncf.common.graph.graph import NNCFGraph

--- a/nncf/openvino/graph/nncf_graph_builder.py
+++ b/nncf/openvino/graph/nncf_graph_builder.py
@@ -12,7 +12,7 @@
 from collections import defaultdict
 from typing import List, Type
 
-import openvino.runtime as ov
+import openvino as ov
 
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph.layer_attributes import Dtype

--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -12,7 +12,7 @@
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 import openvino.runtime.op as op
 import openvino.runtime.opset13 as opset
 

--- a/nncf/openvino/graph/transformations/commands.py
+++ b/nncf/openvino/graph/transformations/commands.py
@@ -12,7 +12,7 @@
 from typing import List, Optional, Tuple
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 
 from nncf.common.graph.transformations.commands import Command
 from nncf.common.graph.transformations.commands import TargetPoint

--- a/nncf/openvino/quantization/quantize_ifmodel.py
+++ b/nncf/openvino/quantization/quantize_ifmodel.py
@@ -12,7 +12,7 @@
 from itertools import islice
 from typing import Dict, List, Optional, Tuple
 
-import openvino.runtime as ov
+import openvino as ov
 
 from nncf import Dataset
 from nncf.common import factory

--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -13,7 +13,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Iterable, List, Optional, Tuple, TypeVar, Union
 
-import openvino.runtime as ov
+import openvino as ov
 from openvino._offline_transformations import compress_quantize_weights_transformation
 
 from nncf.common.factory import NNCFGraphFactory

--- a/nncf/openvino/rt_info.py
+++ b/nncf/openvino/rt_info.py
@@ -12,7 +12,7 @@
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional
 
-import openvino.runtime as ov
+import openvino as ov
 
 from nncf.common.logging import nncf_logger
 from nncf.scopes import IgnoredScope

--- a/nncf/openvino/statistics/aggregator.py
+++ b/nncf/openvino/statistics/aggregator.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from typing import Dict
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.transformations.commands import TargetType

--- a/nncf/quantization/algorithms/accuracy_control/openvino_backend.py
+++ b/nncf/quantization/algorithms/accuracy_control/openvino_backend.py
@@ -12,7 +12,7 @@
 from typing import List, Optional
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 from openvino import Type
 from openvino.properties.hint import inference_precision
 

--- a/nncf/quantization/algorithms/bias_correction/openvino_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/openvino_backend.py
@@ -11,7 +11,7 @@
 
 from typing import Dict, Optional, Set, Tuple
 
-import openvino.runtime as ov
+import openvino as ov
 
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode

--- a/nncf/quantization/algorithms/channel_alignment/openvino_backend.py
+++ b/nncf/quantization/algorithms/channel_alignment/openvino_backend.py
@@ -12,7 +12,7 @@
 from typing import Any, Tuple
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 
 import nncf
 from nncf.common.graph import NNCFGraph

--- a/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
@@ -12,7 +12,7 @@
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode

--- a/nncf/quantization/algorithms/layerwise/openvino_backend.py
+++ b/nncf/quantization/algorithms/layerwise/openvino_backend.py
@@ -11,7 +11,7 @@
 
 from typing import Dict, List, Optional
 
-import openvino.runtime as ov
+import openvino as ov
 
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph.transformations.commands import TargetType

--- a/nncf/quantization/algorithms/layerwise/openvino_iterator.py
+++ b/nncf/quantization/algorithms/layerwise/openvino_iterator.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from itertools import islice
 from typing import Dict, List, Optional, Tuple
 
-import openvino.runtime as ov
+import openvino as ov
 
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode

--- a/nncf/quantization/algorithms/smooth_quant/openvino_backend.py
+++ b/nncf/quantization/algorithms/smooth_quant/openvino_backend.py
@@ -12,7 +12,7 @@
 from typing import Callable, List, Tuple
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 
 import nncf
 from nncf.common.graph import NNCFGraph

--- a/tests/cross_fw/sdl/fuzz/quantize_api.py
+++ b/tests/cross_fw/sdl/fuzz/quantize_api.py
@@ -20,7 +20,7 @@ with atheris.instrument_imports():
 from random import randint
 from random import seed
 
-import openvino.runtime as ov
+import openvino as ov
 import torch
 from torchvision import datasets
 from torchvision import transforms

--- a/tests/onnx/quantization/test_ptq_regression.py
+++ b/tests/onnx/quantization/test_ptq_regression.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import numpy as np
 import onnx
-import openvino.runtime as ov
+import openvino as ov
 import pytest
 import torch
 from fastdownload import FastDownload

--- a/tests/openvino/native/models.py
+++ b/tests/openvino/native/models.py
@@ -15,7 +15,7 @@ from functools import partial
 from typing import Callable, Optional, Tuple
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 from openvino.runtime import opset13 as opset
 
 from nncf.common.utils.registry import Registry

--- a/tests/openvino/native/quantization/test_quantization_pipeline.py
+++ b/tests/openvino/native/quantization/test_quantization_pipeline.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 import pytest
 
 import nncf

--- a/tests/openvino/native/quantization/test_quantizer_removal.py
+++ b/tests/openvino/native/quantization/test_quantizer_removal.py
@@ -12,7 +12,7 @@
 from dataclasses import dataclass
 from typing import List
 
-import openvino.runtime as ov
+import openvino as ov
 import pytest
 
 from nncf.common.factory import NNCFGraphFactory

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -14,7 +14,7 @@ import os
 from typing import Callable, List
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 import pandas as pd
 import pytest
 from attr import dataclass

--- a/tests/openvino/native/test_layer_attributes.py
+++ b/tests/openvino/native/test_layer_attributes.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import Callable, Tuple
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 import pytest
 from openvino.runtime import opset13 as opset
 

--- a/tests/openvino/native/test_model_builder.py
+++ b/tests/openvino/native/test_model_builder.py
@@ -11,7 +11,7 @@
 
 from pathlib import Path
 
-import openvino.runtime as ov
+import openvino as ov
 import pytest
 
 from nncf.openvino.graph.model_builder import OVModelBuilder

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Callable, List, Tuple
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 import pytest
 from openvino.runtime import opset13 as opset
 

--- a/tests/openvino/native/test_node_utils.py
+++ b/tests/openvino/native/test_node_utils.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 import pytest
 from openvino.runtime import opset13 as opset
 

--- a/tests/openvino/native/test_statistics_aggregator.py
+++ b/tests/openvino/native/test_statistics_aggregator.py
@@ -12,7 +12,7 @@
 from typing import List, Type
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 import pytest
 from openvino.runtime import opset13 as opset
 

--- a/tests/openvino/test_transform_fn.py
+++ b/tests/openvino/test_transform_fn.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 import pytest
 
 import nncf

--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -27,7 +27,7 @@ from itertools import islice
 from typing import Any, Dict, Iterable, List, Optional, TypeVar
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 import pkg_resources
 from config import Config
 from openvino.runtime import Dimension

--- a/tests/post_training/pipelines/causal_language_model.py
+++ b/tests/post_training/pipelines/causal_language_model.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 
-import openvino.runtime as ov
+import openvino as ov
 import transformers
 from optimum.intel import OVQuantizer
 from optimum.intel.openvino import OVModelForCausalLM

--- a/tests/post_training/pipelines/gpt.py
+++ b/tests/post_training/pipelines/gpt.py
@@ -11,7 +11,7 @@
 
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 import torch
 import transformers
 from optimum.intel import OVQuantizer

--- a/tests/torch/fx/test_smooth_quant.py
+++ b/tests/torch/fx/test_smooth_quant.py
@@ -12,7 +12,7 @@
 from typing import Any, Callable, Dict, Type
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 import pytest
 import torch
 

--- a/tests/torch/ptq/test_smooth_quant.py
+++ b/tests/torch/ptq/test_smooth_quant.py
@@ -12,7 +12,7 @@
 from typing import Callable, Dict, Type
 
 import numpy as np
-import openvino.runtime as ov
+import openvino as ov
 import pytest
 import torch
 

--- a/tools/get_ir_ignored_scope_by_model_id.py
+++ b/tools/get_ir_ignored_scope_by_model_id.py
@@ -13,7 +13,7 @@ import sys
 from argparse import ArgumentParser
 from typing import List, Optional
 
-import openvino.runtime as ov
+import openvino as ov
 
 
 def print_ignored_scope_by_model_name(model_name: str, xml_path: str, bin_path: str) -> None:


### PR DESCRIPTION
### Changes

Replace openvino.runtime with openvino

### Reason for changes

```
DeprecationWarning: The `openvino.runtime` module is deprecated and will be removed in the 2026.0 release. Please replace `openvino.runtime` with `openvino`.
    self.__spec__.loader.exec_module(self)
```

### Related tickets

160761

### Tests


