### PR TITLE
[ruff] Enable auto fix for ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,12 @@ default_language_version:
   python: python3
 
 repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.6
+    hooks:
+      - id: ruff
+        args: [--fix, --show-fixes]
+
   - repo: https://github.com/psf/black
     rev: 24.10.0
     hooks:
@@ -13,12 +19,6 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.9.2
-    hooks:
-      - id: ruff
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.43.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,6 @@ exclude = [
 
 [tool.ruff.lint]
 preview = true
-ignore-init-module-imports = true
 ignore = [
     "E201", # whitespace-after-open-bracket
     "E203", # whitespace-before-punctuation


### PR DESCRIPTION
### Changes

Enable auto fix for ruff 
Place ruff hook before black and isort, as recommended in https://github.com/astral-sh/ruff-pre-commit
Bump version to 0.9.6
Removed deprecated option `ignore-init-module-imports`

### Reason for changes

To automatically fix founded error if it possible.
