### PR TITLE
[MinMax] set_ignored_scope method

### DIFF
--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -334,6 +334,14 @@ class MinMaxQuantization(Algorithm):
         )
         self._unified_scale_groups = []
 
+    def set_ignored_scope(self, ignored_scope: IgnoredScope) -> None:
+        """
+        Set target ignored scope for the MinMax algorithm.
+
+        :param ignored_scope: The ignored scope to set to the MinMax algorithm.
+        """
+        self._ignored_scope = ignored_scope
+
     @property
     def available_backends(self) -> List[BackendType]:
         return [BackendType.ONNX, BackendType.OPENVINO, BackendType.TORCH, BackendType.TORCH_FX]

--- a/tests/cross_fw/test_templates/test_min_max.py
+++ b/tests/cross_fw/test_templates/test_min_max.py
@@ -13,12 +13,23 @@ from typing import Tuple
 
 import pytest
 
+import nncf
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.layer_attributes import BaseLayerAttributes
 from nncf.common.graph.transformations.commands import TargetPoint
 from nncf.common.graph.transformations.commands import TargetType
+from nncf.quantization.algorithms.min_max.algorithm import MinMaxQuantization
 from nncf.quantization.algorithms.min_max.backend import MinMaxAlgoBackend
+
+
+def test_set_ignored_scope():
+    algorithm = MinMaxQuantization()
+    assert algorithm._ignored_scope == nncf.IgnoredScope()
+    ref_ignored_scope = nncf.IgnoredScope(names=["add_1"], patterns=["linear*"], types=["conv"])
+    algorithm.set_ignored_scope(ref_ignored_scope)
+    assert algorithm._ignored_scope is ref_ignored_scope
+
 
 CONV_WEIGHT_SHAPE = (3, 10, 4, 4)
 DEPTHWISECONV_WEIGHT_SHAPE = (5, 10, 20, 7, 7)


### PR DESCRIPTION
### Changes

`set_ignored_scope` method in the MinMax algorithm is introduced

### Reason for changes

To allow later ignored scope settings (requires for the executorch implementation)


### Tests

tests/cross_fw/test_templates/test_min_max.py: test_set_ignored_scope
