### PR TITLE
Fix DeprecationWarning: invalid escape sequence '\ ' in docstrings

### DIFF
--- a/nncf/experimental/torch/fx/transformations.py
+++ b/nncf/experimental/torch/fx/transformations.py
@@ -688,7 +688,7 @@ def fq_weights_transformation(model: torch.fx.GraphModule) -> None:
 
 
 def compress_post_quantize_transformation(model: torch.fx.GraphModule) -> None:
-    """
+    r"""
     Applies transformation to compress the weights to Int8 after the quantization step.
     Starts by removing the Quantize/De-Quantize nodes for weight nodes by matching the pattern
     to be like follows:

--- a/nncf/openvino/graph/model_builder.py
+++ b/nncf/openvino/graph/model_builder.py
@@ -59,14 +59,14 @@ class OVModelBuilder:
         output_ids: List[Tuple[str, int]],
         node_mapping: Dict[str, ov.Node],
     ) -> List[ov.Node]:
-        """
+        r"""
         A method for aggregating layers to be further cloned.
         Aggregation is designed in such a way that layers are listed from right to left,
         as they pass from bottom to top. This is done in order to find all constants in the model and
         to start graph creation from them (as well as Parameter layers), because
         OpenVINO graph is created from top-down and cannot be created otherwise.
 
-        Legend: w - weigths, c - convert, il/ih - input low/high, ol/oh - output low/high
+        Legend: w - weights, c - convert, il/ih - input low/high, ol/oh - output low/high
         (w)
          |
         (c) (il) (ih) (ol) (oh)
@@ -115,11 +115,11 @@ class OVModelBuilder:
         output_ids: List[Tuple[str, int]],
         node_mapping: Dict[str, ov.Node],
     ) -> ov.Model:
-        """
+        r"""
         The basic method of the algorithm. This method uses an aggregated list of layers to be recreated.
         Let us take a graph of this kind as an example:
 
-        Legend: w - weigths, c - convert, il/ih - input low/high, ol/oh - output low/high
+        Legend: w - weights, c - convert, il/ih - input low/high, ol/oh - output low/high
         (w)
          |
         (c) (il) (ih) (ol) (oh)


### PR DESCRIPTION
### Changes

As in the title 
