### PR TITLE
[NNCF] (#3249) Remove backend-specific methods from common layer attributes

### DIFF
--- a/nncf/common/graph/utils.py
+++ b/nncf/common/graph/utils.py
@@ -178,3 +178,15 @@ def get_target_dim_for_compression_legacy(
         if layer_attributes.transpose:
             return 1
         return 0
+
+
+def get_bias_shape_legacy(
+    layer_attributes: WeightedLayerAttributes) -> int:
+    """
+    Returns hard-coded bias shape only for Torch and Tensorflow models.
+
+    :param layer_attributes: layer attributes of NNCFNode.
+    :return: bias shape.
+    """
+    if isinstance(layer_attributes, LinearLayerAttributes):
+        return layer_attributes.out_features if layer_attributes.with_bias is True else 0

--- a/nncf/common/graph/utils.py
+++ b/nncf/common/graph/utils.py
@@ -159,3 +159,22 @@ def get_weight_shape_legacy(
 
     if isinstance(layer_attributes, GroupNormLayerAttributes):
         return [layer_attributes.num_channels]
+
+
+def get_target_dim_for_compression_legacy(
+    layer_attributes: WeightedLayerAttributes) -> int:
+    """
+    Returns hard-coded target dim for compression only for Torch and Tensorflow models.
+
+    :param layer_attributes: layer attributes of NNCFNode.
+    :return: target dim for compression.
+    """
+    if isinstance(layer_attributes, (GenericWeightedLayerAttributes,
+                LinearLayerAttributes, GroupNormLayerAttributes)):
+        return 0
+
+    if isinstance(layer_attributes, ConvolutionLayerAttributes):
+        # Always quantize per each "out" channel
+        if layer_attributes.transpose:
+            return 1
+        return 0

--- a/nncf/common/graph/utils.py
+++ b/nncf/common/graph/utils.py
@@ -132,3 +132,30 @@ def get_reduction_axes(
     for channel_axis in sorted(channel_axes, reverse=True):
         del reduction_axes[channel_axis]
     return tuple(reduction_axes)
+
+
+def get_weight_shape_legacy(
+    layer_attributes: WeightedLayerAttributes) -> List[int]:
+    """
+    Returns hard-coded weights shape layout only for Torch and Tensorflow models.
+
+    :param layer_attributes: layer attributes of NNCFNode.
+    :return: weights shape layout.
+    """
+    if isinstance(layer_attributes, GenericWeightedLayerAttributes):
+        return layer_attributes.weight_shape
+
+    if isinstance(layer_attributes, LinearLayerAttributes):
+        return[layer_attributes.out_features, layer_attributes.in_features]
+
+    if isinstance(layer_attributes, ConvolutionLayerAttributes):
+        if not layer_attributes.transpose:
+            return [layer_attributes.out_channels,
+                    layer_attributes.in_channels // layer_attributes.groups,
+                    *layer_attributes.kernel_size]
+        return [layer_attributes.in_channels,
+                layer_attributes.out_channels // layer_attributes.groups,
+                *layer_attributes.kernel_size]
+
+    if isinstance(layer_attributes, GroupNormLayerAttributes):
+        return [layer_attributes.num_channels]

--- a/nncf/experimental/common/pruning/nodes_grouping.py
+++ b/nncf/experimental/common/pruning/nodes_grouping.py
@@ -18,6 +18,7 @@ from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.layer_attributes import ConvolutionLayerAttributes
 from nncf.common.graph.layer_attributes import LinearLayerAttributes
+from nncf.common.graph.utils import get_target_dim_for_compression_legacy
 from nncf.common.pruning.mask_propagation import MaskPropagationAlgorithm
 from nncf.common.pruning.utils import PruningOperationsMetatypeRegistry
 from nncf.experimental.common.graph.netron import save_for_netron
@@ -76,7 +77,7 @@ def get_pruning_groups(
     roots = {}
     for node in all_nodes_to_prune:
         assert isinstance(node.layer_attributes, (LinearLayerAttributes, ConvolutionLayerAttributes))
-        pruning_dim = node.layer_attributes.get_target_dim_for_compression()
+        pruning_dim = get_target_dim_for_compression_legacy(node.layer_attributes)
         output_tensors_shapes = [x.tensor_shape for x in graph.get_output_edges(node)]
         assert not len(set(output_tensors_shapes)) > 1, node.node_name
         output_tensors_shape = output_tensors_shapes[0]

--- a/nncf/experimental/tensorflow/quantization/algorithm.py
+++ b/nncf/experimental/tensorflow/quantization/algorithm.py
@@ -18,6 +18,7 @@ from nncf.common.graph.transformations.commands import TargetPoint
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.transformations.commands import TransformationPriority
 from nncf.common.graph.utils import get_first_nodes_of_type
+from nncf.common.graph.utils import get_weight_shape_legacy
 from nncf.common.logging import nncf_logger
 from nncf.common.quantization.quantizer_setup import ActivationQuantizationInsertionPoint
 from nncf.common.quantization.quantizer_setup import QuantizationPointId
@@ -133,7 +134,7 @@ def _get_tensor_specs(
         assert len(metatype.weight_definitions) == 1
 
         channel_axes = metatype.weight_definitions[0].channel_axes
-        weight_shape = node.layer_attributes.get_weight_shape()
+        weight_shape = get_weight_shape_legacy(node.layer_attributes)
         tensor_specs.append((weight_shape, channel_axes))
     else:
         data_format = node.layer_attributes.get_data_format()

--- a/nncf/experimental/torch/sparsity/movement/layers.py
+++ b/nncf/experimental/torch/sparsity/movement/layers.py
@@ -18,6 +18,8 @@ from torch import nn
 
 import nncf
 from nncf.common.graph import NNCFNode
+from nncf.common.graph.utils import get_weight_shape_legacy
+from nncf.common.graph.utils import get_bias_shape_legacy
 from nncf.experimental.torch.sparsity.movement.functions import binary_mask_by_threshold
 from nncf.torch.layer_utils import COMPRESSION_MODULES
 from nncf.torch.layer_utils import CompressionParameter
@@ -167,7 +169,7 @@ class MovementSparsifier(nn.Module):
         self._importance_threshold = -math.inf
         self._importance_regularization_factor = 0.0
 
-        weight_shape: List[int] = target_module_node.layer_attributes.get_weight_shape()
+        weight_shape: List[int] = get_weight_shape_legacy(target_module_node.layer_attributes)
         assert len(weight_shape) == 2, "Unsupported module with weight shape not in 2D."
         self.weight_ctx = BinaryMask(weight_shape)
         self.sparse_factors = self._get_sparse_factors(weight_shape, sparse_cfg)
@@ -185,7 +187,7 @@ class MovementSparsifier(nn.Module):
         self.weight_ctx.binary_mask = self._calc_training_binary_mask()
 
         if self.prune_bias:
-            bias_shape = target_module_node.layer_attributes.get_bias_shape()
+            bias_shape = get_bias_shape_legacy(target_module_node.layer_attributes)
             self.bias_ctx = BinaryMask(bias_shape)
             bias_importance_shape = weight_importance_shape[0]
             self.bias_importance = CompressionParameter(

--- a/nncf/experimental/torch/sparsity/movement/structured_mask_handler.py
+++ b/nncf/experimental/torch/sparsity/movement/structured_mask_handler.py
@@ -18,6 +18,8 @@ import torch.nn.functional as F
 
 from nncf.common.graph.graph import NNCFNodeName
 from nncf.common.graph.layer_attributes import LinearLayerAttributes
+from nncf.common.graph.utils import get_weight_shape_legacy
+from nncf.common.graph.utils import get_bias_shape_legacy
 from nncf.common.logging import nncf_logger
 from nncf.experimental.common.pruning.nodes_grouping import get_pruning_groups
 from nncf.experimental.common.pruning.nodes_grouping import select_largest_groups
@@ -209,9 +211,9 @@ class StructuredMaskContext:
         """
         node = self.sparsifier_operand.target_module_node
         assert isinstance(node.layer_attributes, tuple(EXPECTED_NODE_LAYER_ATTRS))
-        weight_shape: Tuple[int, int] = tuple(node.layer_attributes.get_weight_shape())
+        weight_shape: Tuple[int, int] = tuple(get_weight_shape_legacy(node.layer_attributes))
         bias_shape: Tuple[int] = (
-            (node.layer_attributes.get_bias_shape(),) if self.sparsifier_operand.prune_bias else (0,)
+            (get_bias_shape_legacy(node.layer_attributes),) if self.sparsifier_operand.prune_bias else (0,)
         )
 
         pruned_weight_shape = list(weight_shape)

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -35,6 +35,8 @@ from nncf.common.graph.patterns.manager import PatternsManager
 from nncf.common.graph.patterns.manager import TargetDevice
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.utils import get_first_nodes_of_type
+from nncf.common.graph.utils import get_weight_shape_legacy
+from nncf.common.graph.utils import get_target_dim_for_compression_legacy
 from nncf.common.hardware.config import HWConfig
 from nncf.common.hardware.config import HWConfigType
 from nncf.common.hardware.config import get_hw_config_type
@@ -773,10 +775,10 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
                 layer_attributes = target_node.layer_attributes
                 assert isinstance(layer_attributes, WeightedLayerAttributes)
                 scale_shape = get_scale_shape(
-                    layer_attributes.get_weight_shape(),
+                    get_weight_shape_legacy(layer_attributes),
                     is_weights=True,
                     per_channel=qconfig.per_channel,
-                    channel_idx=layer_attributes.get_target_dim_for_compression(),
+                    channel_idx=get_target_dim_for_compression_legacy(layer_attributes),
                 )
             else:
                 input_shape = target_model_graph.get_input_shape_for_insertion_point(insertion_point)
@@ -1182,7 +1184,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
             )
             module_node = target_model_graph.get_node_by_name(primary_ip.target_node_name)
             layer_attributes = module_node.layer_attributes
-            input_shape = layer_attributes.get_weight_shape()
+            input_shape = get_weight_shape_legacy(layer_attributes)
             self._quantizers_input_shapes[primary_qid] = tuple(input_shape)
         else:
             primary_qid = NonWeightQuantizerId(primary_ip.target_node_name, primary_ip.input_port_id)

--- a/nncf/torch/quantization/init_range.py
+++ b/nncf/torch/quantization/init_range.py
@@ -18,6 +18,8 @@ import torch
 
 import nncf
 from nncf.common.graph.layer_attributes import WeightedLayerAttributes
+from nncf.common.graph.utils import get_weight_shape_legacy
+from nncf.common.graph.utils import get_target_dim_for_compression_legacy
 from nncf.common.quantization.initialization.range import RangeInitCollectorParams
 from nncf.common.quantization.initialization.range import RangeInitConfig
 from nncf.common.quantization.initialization.range import RangeInitParams
@@ -226,8 +228,8 @@ class StatCollectorGenerator:
             module_node = target_nncf_graph.get_node_by_name(qp.insertion_point.target_node_name)
             layer_attributes = module_node.layer_attributes
             assert isinstance(layer_attributes, WeightedLayerAttributes)
-            input_shape = layer_attributes.get_weight_shape()
-            channel_idx = layer_attributes.get_target_dim_for_compression()
+            input_shape = get_weight_shape_legacy(layer_attributes)
+            channel_idx = get_target_dim_for_compression_legacy(layer_attributes)
         else:
             input_shape = target_nncf_graph.get_input_shape_for_insertion_point(qp.insertion_point)
             channel_idx = 1  # channel dim for activations


### PR DESCRIPTION
### Changes

1. Moved and renamed backend-specific class methods from common layer
attributes in nncf/common/graph/layer_attributes.py to self-contained 
functions in nncf/common/graph/utils.py
- layer_attributes.get_weight_shape -> 
get_weight_shape_legacy(layer_attributes: WeightedLayerAttributes)
- layer_attributes.get_target_dim_for_compression -> 
get_target_dim_for_compression_legacy(layer_attributes: WeightedLayerAttributes)
- layer_attributes.get_bias_shape -> 
get_bias_shape_legacy(layer_attributes: WeightedLayerAttributes)
2. Calls to above class methods were replaced with calls to their
corresponding legacy functions in the following locations
- /nncf/experimental/torch/sparsity/movement/ folder
  - layers.py
  - structured_mask_handler.py
- /nncf/experimental/tensorflow/quantization/ folder
  - algorithm.py
- /nncf/experimental/common/pruning/ folder
  - nodes_grouping.py
- /nncf/torch/quantization folder
  - algo.py
  - init_range.py

### Reason for changes

(#3249) Torch and Tensorflow backend-specific methods need to be removed 
from common layer attributes and all related calls need to be replaced 
by their corresponding legacy function calls