### PR TITLE
[ruff] Enable pydoc rules

### DIFF
--- a/nncf/common/composite_compression.py
+++ b/nncf/common/composite_compression.py
@@ -75,7 +75,6 @@ class CompositeCompressionLoss(CompressionLoss):
 
         :return: The compression loss value.
         """
-
         if len(self._child_losses) == 0:
             msg = "Cannot calculate the loss value because the number of child loss is 0."
             raise nncf.InternalError(msg)

--- a/nncf/common/graph/graph.py
+++ b/nncf/common/graph/graph.py
@@ -343,7 +343,6 @@ class NNCFGraph:
         :param node: Consumer node.
         :return: List of producers nodes of provided node.
         """
-
         nx_node_keys = self._nx_graph.pred[self._node_id_to_key_dict[node.node_id]]
         return [self._nodes[key] for key in nx_node_keys]
 
@@ -723,7 +722,6 @@ class NNCFGraph:
         `match` list
         :return: NNCFGraphPatternIO object describing the inputs and outputs of the matched subgraph
         """
-
         in_edge_boundary, out_edge_boundary = NNCFGraph._get_edge_boundaries(match, self._nx_graph)
         boundary = in_edge_boundary + out_edge_boundary
         input_nncf_edges = []

--- a/nncf/common/graph/graph_matching.py
+++ b/nncf/common/graph/graph_matching.py
@@ -57,6 +57,7 @@ def _is_subgraph_matching_strict(graph: nx.DiGraph, pattern: nx.DiGraph, subgrap
     3) External successors or predecessors of the nodes which are not starting and last.
     If any of these conditions is True, than returns False, otherwise - True.
     The checks are skipped for NON_PATTERN_NODE_TYPE.
+
     Example:
     This subgraph matching is not strict.
     (conv2d + BN + ReLU pattern):
@@ -71,6 +72,7 @@ def _is_subgraph_matching_strict(graph: nx.DiGraph, pattern: nx.DiGraph, subgrap
            (cat)----/
              |
             ...
+
     :param graph: The model graph.
     :param pattern: The matched pattern.
     :param subgraph: A subgraph of the model graph including the nodes outside the pattern.

--- a/nncf/common/graph/patterns/patterns.py
+++ b/nncf/common/graph/patterns/patterns.py
@@ -101,7 +101,6 @@ class GraphPattern:
         :param other: GraphPattern that will be added.
         :return: resulted GraphPattern.
         """
-
         final_pattern = GraphPattern()
         for self_subgraph in self.get_weakly_connected_subgraphs():
             for other_subgraph in other.get_weakly_connected_subgraphs():

--- a/nncf/common/insertion_point_graph.py
+++ b/nncf/common/insertion_point_graph.py
@@ -87,7 +87,6 @@ class InsertionPointGraph(nx.DiGraph):  # type: ignore
         If left unspecified, every node in `nncf_graph` will be allowed to have a single post-hook for its output
          (post-hooking separate tensors in an operation's output is not currently supported)
         """
-
         super().__init__()
         self._base_nx_graph = deepcopy(nncf_graph.get_nx_graph_copy())
 
@@ -320,7 +319,6 @@ class InsertionPointGraph(nx.DiGraph):  # type: ignore
         :param full_fusing_pattern: The GraphPatttern object representing a composition of fusing pattern variants.
         :return: The InsertionPointGraph with nodes fused according to pattern matching.
         """
-
         merged_ip_graph = deepcopy(self)
         matches = find_subgraphs_matching_pattern(merged_ip_graph.get_base_nx_graph(), full_fusing_pattern)
         for match in matches:

--- a/nncf/common/logging/track_progress.py
+++ b/nncf/common/logging/track_progress.py
@@ -179,7 +179,6 @@ class track(Generic[ProgressType]):
             it takes to process sequence elements. Useful when processing time is strongly non-uniform.
         :return: An iterable of the values in the sequence.
         """
-
         self.sequence = sequence
         self.weights = weights
         self.total = sum(self.weights) if self.weights is not None else total

--- a/nncf/common/pruning/mask_propagation.py
+++ b/nncf/common/pruning/mask_propagation.py
@@ -94,7 +94,6 @@ class MaskPropagationAlgorithm:
             are supported by the NNCF pruning algorithm.
         :return: Dict of node indices vs the decision made by symbolic mask propagation algorithm.
         """
-
         can_be_closing_convs = self._get_can_closing_convs(prunable_layers_types)
         can_prune_by_dim: Dict[int, PruningAnalysisDecision] = {k: None for k in can_be_closing_convs}  # type: ignore
         for node in self._graph.topological_sort():

--- a/nncf/common/pruning/node_selector.py
+++ b/nncf/common/pruning/node_selector.py
@@ -91,7 +91,6 @@ class PruningNodeSelector:
         :param graph: Graph to work with and their initialization parameters as values.
         :return: Clusterization of pruned nodes.
         """
-
         all_nodes_to_prune = graph.get_nodes_by_types(self._prune_operations_types)  # NNCFNodes here
 
         # 1. Clusters for special ops
@@ -218,7 +217,6 @@ class PruningNodeSelector:
             are supported by the NNCF pruning algorithm
         :return: Pruning node analysis after model analyzer, pruning algo compatibility and pruning dimensions checks.
         """
-
         nodes_of_group_with_non_eq_pruning_dim = self._check_internal_groups_dim(pruned_nodes_clusterization)
         can_prune_after_check_updated = can_prune_after_check.copy()
         for node_id, val in nodes_of_group_with_non_eq_pruning_dim.items():

--- a/nncf/common/quantization/initialization/range.py
+++ b/nncf/common/quantization/initialization/range.py
@@ -87,7 +87,6 @@ class PerLayerRangeInitConfig(RangeInitConfig):
             specified type of range initialization will be applied. It can be
             quantizers group for activations or weights.
         """
-
         super().__init__(
             range_init_config.init_type, range_init_config.num_init_samples, range_init_config.init_type_specific_params
         )

--- a/nncf/common/quantization/quantizer_propagation/graph.py
+++ b/nncf/common/quantization/quantizer_propagation/graph.py
@@ -797,7 +797,6 @@ class QuantizerPropagationStateGraph(nx.DiGraph):  # type: ignore[misc]
         :return: True if all paths from the given node to the first
         input quantizable nodes have an activation quantizer, False otherwise.
         """
-
         nodes_keys_stack = deque(self.successors(node_key))
         while nodes_keys_stack:
             node_key = nodes_keys_stack.popleft()
@@ -1424,7 +1423,6 @@ class QuantizerPropagationStateGraph(nx.DiGraph):  # type: ignore[misc]
         :return: A MultiConfigQuantizerSetup with weights-as-outputs-dependent quantizers removed where possible
             and shared inputs/unified scales group adjusted to reflect the change.
         """
-
         # For the weights-are-outputs quantized operations, need to find out the dependent activation quantizers in
         # the multiconfig setup and see if it is possible to avoid requantization by selecting a common configuration
         # subset. If yes and the activation quantizer becomes unnecessary, need to unify the scales of the weight

--- a/nncf/common/quantization/quantizer_propagation/solver.py
+++ b/nncf/common/quantization/quantizer_propagation/solver.py
@@ -676,7 +676,6 @@ class QuantizerPropagationSolver:
         :param quant_prop_graph: The propagation state graph for `curr_prop_quantizer` to be propagated in.
         :return: The new state of `quant_prop_graph` with `curr_prop_quantizer` propagated one step further.
         """
-
         curr_node_key = curr_prop_quantizer.current_location_node_key
         curr_node = quant_prop_graph.nodes[curr_node_key]
         curr_node_type = curr_node[QuantizerPropagationStateGraph.NODE_TYPE_NODE_ATTR]
@@ -1002,7 +1001,6 @@ class QuantizerPropagationSolver:
           corresponding TargetPoints.
         :return: A list of TargetPoint groups; each group is a list of TargetPoint's.
         """
-
         if linked_scopes_groups_list is None:
             return [[ip] for ip in target_insertion_points]
         retval: List[List[TargetPoint]] = []
@@ -1313,7 +1311,6 @@ class QuantizerPropagationSolver:
           cloned before transition, which impacts the logic of the function.
         :return: The status of the transition determining how it should proceed.
         """
-
         for from_node_key, to_node_key in path:
             from_node = quant_prop_graph.nodes[from_node_key]
 
@@ -1390,7 +1387,6 @@ class QuantizerPropagationSolver:
           of the merged quantizer, if any, and the second element corresponds to configurations of the quantizers
           that would have to remain on the branches (if any).
         """
-
         if self._propagation_strategy == QuantizerPropagationRule.DO_NOT_MERGE_BRANCHES:
             # Do not merge at all
             return None, potential_qconfigs_for_each_branch

--- a/nncf/common/scopes.py
+++ b/nncf/common/scopes.py
@@ -34,7 +34,6 @@ def matches_any(tested_str: str, strs_to_match_to: Union[Iterable[str], str, Non
     :return: A boolean value specifying whether a tested_str should matches at least one element
         in strs_to_match_to.
     """
-
     if strs_to_match_to is None:
         return False
 

--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -136,7 +136,6 @@ def get_backend(model: Any) -> BackendType:
     :param model: The framework-specific model.
     :return: A BackendType representing the correct NNCF backend to be used when working with the framework.
     """
-
     verify_map = {
         is_torch_fx_model: BackendType.TORCH_FX,
         is_torch_model: BackendType.TORCH,

--- a/nncf/common/utils/dot_file_rw.py
+++ b/nncf/common/utils/dot_file_rw.py
@@ -85,7 +85,6 @@ def relabel_graph_for_dot_visualization(nx_graph: nx.Graph, from_reference: bool
     :param nx_graph: NetworkX graph to visualize via dot.
     :return: NetworkX graph with reserved symbols in nodes keys replaced.
     """
-
     nx_graph = copy.deepcopy(nx_graph)
 
     # .dot format reserves ':' character in node names

--- a/nncf/common/utils/patcher.py
+++ b/nncf/common/utils/patcher.py
@@ -40,7 +40,6 @@ class Patcher:
         :param wrapper: Wrapper function to override with.
         :param force: Whether to override previously applied patches or not.
         """
-
         obj_cls, fn_name = self.import_obj(obj_cls)
 
         # wrap only if function does exist

--- a/nncf/config/config.py
+++ b/nncf/config/config.py
@@ -29,12 +29,14 @@ from nncf.config.structures import NNCFExtraConfigStruct
 
 @api(canonical_alias="nncf.NNCFConfig")
 class NNCFConfig(dict[str, Any]):
-    """Contains the configuration parameters required for NNCF to apply the selected algorithms.
+    """
+    Contains the configuration parameters required for NNCF to apply the selected algorithms.
 
     This is a regular dictionary object extended with some utility functions, such as the ability to attach well-defined
     structures to pass non-serializable objects as parameters. It is primarily built from a .json file, or from a
     Python JSON-like dictionary - both data types will be checked against a JSONSchema. See the definition of the
-    schema at https://openvinotoolkit.github.io/nncf/schema/, or by calling NNCFConfig.schema()."""
+    schema at https://openvinotoolkit.github.io/nncf/schema/, or by calling NNCFConfig.schema().
+    """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -47,7 +49,6 @@ class NNCFConfig(dict[str, Any]):
 
         :param nncf_dict: A Python dict with the JSON-style configuration for NNCF.
         """
-
         cls.validate(nncf_dict)
         return cls(deepcopy(nncf_dict))
 

--- a/nncf/config/schema.py
+++ b/nncf/config/schema.py
@@ -151,8 +151,10 @@ NNCF_CONFIG_SCHEMA = {
 def validate_single_compression_algo_schema(
     single_compression_algo_dict: Dict[str, Any], ref_vs_algo_schema: Dict[str, Any]
 ) -> None:
-    """single_compression_algo_dict must conform to BASIC_COMPRESSION_ALGO_SCHEMA (and possibly has other
-    algo-specific properties"""
+    """
+    single_compression_algo_dict must conform to BASIC_COMPRESSION_ALGO_SCHEMA (and possibly has other
+    algo-specific properties
+    """
     algo_name = single_compression_algo_dict["algorithm"]
     if algo_name not in ref_vs_algo_schema:
         msg = f"Incorrect algorithm name - must be one of {str(list(ref_vs_algo_schema.keys()))}"

--- a/nncf/data/generators.py
+++ b/nncf/data/generators.py
@@ -47,7 +47,6 @@ def generate_text_data(
     :param dataset_size: Size of the data.
     :return: List of the text data ready to use.
     """
-
     try:
         import torch
     except ImportError:

--- a/nncf/experimental/common/graph/netron.py
+++ b/nncf/experimental/common/graph/netron.py
@@ -159,7 +159,6 @@ def convert_nncf_dtype_to_ov_dtype(dtype: Dtype) -> str:
     :param dtype: The data type to be converted.
     :return: The openvino dtype string corresponding to the given data type.
     """
-
     dummy_precision_map: Dict[Dtype, str] = {Dtype.INTEGER: "i32", Dtype.FLOAT: "f32"}
 
     return dummy_precision_map[dtype]
@@ -178,7 +177,6 @@ def get_graph_desc(
     :return: A tuple containing lists of NodeDesc and EdgeDesc objects
         representing the nodes and edges of the NNCFGraph.
     """
-
     if get_attributes_fn is None:
         get_attributes_fn = lambda x: {
             "metatype": str(x.metatype.name),
@@ -257,7 +255,6 @@ def save_for_netron(
     :param get_attributes_fn: A function to retrieve additional attributes for nodes.
         Defaults to a function returning {"metatype": str(x.metatype.name)}.
     """
-
     node_descs, edge_descs = get_graph_desc(graph, include_fq_params, get_attributes_fn)
 
     net = ET.Element(Tags.NET, name=graph_name)

--- a/nncf/experimental/common/pruning/block_hierarchy.py
+++ b/nncf/experimental/common/pruning/block_hierarchy.py
@@ -32,7 +32,6 @@ class BlockHierarchy:
         :param roots: list of the root groups
         :return: networkx graph that represents the hierarchy of propagation blocks/groups.
         """
-
         self._id_counter = 0
         self._graph = nx.DiGraph()
         self._visited_block_ids_map: Dict[int, int] = {}

--- a/nncf/experimental/common/tensor_statistics/collectors.py
+++ b/nncf/experimental/common/tensor_statistics/collectors.py
@@ -125,7 +125,6 @@ class AggregatorBase:
         :param window_size: Number of samples from the end of the list of collected samples to aggregate.
         Aggregates all available collected statistics in case parameter is None.
         """
-
         self._aggregation_axes = (0,) if aggregation_axes is None else aggregation_axes
         self._keepdims = True
         self._num_samples = num_samples

--- a/nncf/experimental/quantization/algorithms/post_training/pipeline.py
+++ b/nncf/experimental/quantization/algorithms/post_training/pipeline.py
@@ -62,7 +62,6 @@ def experimental_create_ptq_pipeline(
         for each item of the batch or for the entire batch, default is False.
     :return: An experimental post-training quantization pipeline.
     """
-
     # Build the post-training quantization pipeline.
     pipeline_steps = []
 

--- a/nncf/experimental/tensorflow/graph/converter.py
+++ b/nncf/experimental/tensorflow/graph/converter.py
@@ -286,7 +286,6 @@ class SubclassedConverter(TFModelConverter):
         :param op_names: A list of names for the input operations ()
         :return: A description of nodes and edges which should be included to the NNCF graph.
         """
-
         # Traverse the `graph` and mark all ops reachable from the `input_ops`.
         # The op `u` is reachable from the `input_ops` if a directed path
         # from at least one op in `input_ops` to `u` exists in the `graph.`

--- a/nncf/experimental/torch/fx/model_transformer.py
+++ b/nncf/experimental/torch/fx/model_transformer.py
@@ -77,7 +77,6 @@ class FXModelTransformer(ModelTransformer):
         :param stop_nodes: Given stop nodes.
         :param visited: Set of already visited nodes.
         """
-
         while input_nodes:
             in_node = input_nodes.pop()
             if in_node.name in visited or in_node.name in stop_nodes:
@@ -104,7 +103,6 @@ class FXModelTransformer(ModelTransformer):
             more than one element this function raises an assert.
         :return: Returns a submodel extracted from the given model by the given transformation.
         """
-
         transformation = transformations[-1]
         stop_nodes = set(transformation.input_node_names + transformation.output_node_names)
         visited = set()

--- a/nncf/experimental/torch/fx/quantization/quantize_pt2e.py
+++ b/nncf/experimental/torch/fx/quantization/quantize_pt2e.py
@@ -143,7 +143,8 @@ def quantize_pt2e(
 
 
 def _quant_node_constraint(n: torch.fx.Node) -> bool:
-    """If there is any pure ops between get_attr and quantize op they will be const propagated
+    """
+    If there is any pure ops between get_attr and quantize op they will be const propagated
     e.g. get_attr(weight) -> transpose -> quantize -> dequantize*
     (Note: dequantize op is not going to be constant propagated)
 

--- a/nncf/experimental/torch/fx/transformations.py
+++ b/nncf/experimental/torch/fx/transformations.py
@@ -75,7 +75,7 @@ def _set_new_node_meta(
     model: torch.fx.GraphModule,
 ):
     """
-    Sets correct meta \"val\" value to the new node.
+    Sets correct meta 'val' value to the new node.
 
     :param new_node: The new node.
     :param prev_node: Input node of the new node.
@@ -316,7 +316,6 @@ def insert_one_qdq(model: torch.fx.GraphModule, target_point: PTTargetPoint, qua
         target node.
     :param quantizer: Quantizer module to inherit quantization parameters from.
     """
-
     # Copied from torch.ao.quantization.quantize_pt2e.convert_pt2e
     # 1. extract information for inserting q/dq node from activation_post_process
     node_type = "call_function"
@@ -613,7 +612,6 @@ def _compress_qdq_constant_transformation(model: torch.fx.GraphModule, matches) 
 
     :param: model: Model to apply transformations to.
     """
-
     for match in matches:
         mul_node = match.replacements[0]
         sub_node = match.replacements[1]

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -294,7 +294,7 @@ class ElasticOutputWidthOp(ElasticWidthOp):
     @property
     def width_list(self) -> List[int]:
         """
-        list of all available widths to select from. Each value corresponds to a single element in the search space of
+        List of all available widths to select from. Each value corresponds to a single element in the search space of
         operation. The search space of the model is cartesian product of search spaces of operation.
         If all widths starting from 1 to maximum number of channels with step size 1 are available, the search space
         would be prohibitively large to efficiently train and search.

--- a/nncf/experimental/torch/nas/bootstrapNAS/search/evaluator.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/search/evaluator.py
@@ -216,7 +216,6 @@ class AccuracyEvaluator(BaseEvaluator):
         :param state: dict with state that should be used for updating this evaluator
         :return:
         """
-
         super().update_from_state(state)
         new_dict = state.copy()
         self._is_top1 = new_dict["is_top1"]

--- a/nncf/experimental/torch/nas/bootstrapNAS/training/training_algorithm.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/training/training_algorithm.py
@@ -126,7 +126,6 @@ class EpochBasedTrainingAlgorithm:
         :param tensorboard_writer: The tensorboard object to be used for logging.
         :return: the fine-tuned model and elasticity controller
         """
-
         if train_iters is None:
             train_iters = len(train_loader)
         self._training_ctrl.set_training_lr_scheduler_args(optimizer, train_iters)  # len(train_loader))

--- a/nncf/experimental/torch/search_building_blocks/search_blocks.py
+++ b/nncf/experimental/torch/search_building_blocks/search_blocks.py
@@ -304,7 +304,7 @@ def get_potential_candidate_for_block(search_graph: SearchGraph) -> Tuple[ShapeV
 
 def itemgetter_force_tuple(*indexes):
     """
-    itemgetter wrapper that always returns a tuple. The original function may return both: iterable and a single
+    Itemgetter wrapper that always returns a tuple. The original function may return both: iterable and a single
     non-iterable element, which is not convenient in the general case.
     """
     getter = itemgetter(*indexes)

--- a/nncf/experimental/torch/sparsify_activations/sparsify_activations_impl.py
+++ b/nncf/experimental/torch/sparsify_activations/sparsify_activations_impl.py
@@ -225,7 +225,7 @@ def sparsify_activations(
         representing the layers to match in the model's NNCF graph; the corresponding value
         is a float number in the range [0, 1] representing the target sparsity level.
 
-        Example:
+    Example:
         ..  code-block:: python
             {
                 # Target sparsity is 60% for node "Dummy/Linear[layer]/linear_0" in the model graph
@@ -239,7 +239,6 @@ def sparsify_activations(
         filtered out internally, so there is no need to mention them in `ignored_scope`.
     :return: The sparsified model.
     """
-
     for scope, target_sparsity in target_sparsity_by_scope.items():
         if target_sparsity < 0.0 or target_sparsity > 1.0:
             msg = f'Target sparsity for scope "{scope}" should be in range [0, 1].'

--- a/nncf/experimental/torch/sparsify_activations/target_scope.py
+++ b/nncf/experimental/torch/sparsify_activations/target_scope.py
@@ -21,7 +21,7 @@ from nncf.scopes import get_matched_ignored_scope_info
 
 @dataclass
 class TargetScope(IgnoredScope):
-    """
+    r"""
     Specifies the target portions in a model graph.
 
     Example:

--- a/nncf/experimental/torch/sparsity/movement/scheduler.py
+++ b/nncf/experimental/torch/sparsity/movement/scheduler.py
@@ -60,7 +60,6 @@ class MovementSchedulerParams:
         :param power: The power value of polynomial decay for threshold update during warmup stage.
         :param steps_per_epoch: Number of training steps in one epoch.
         """
-
         if steps_per_epoch is None and warmup_start_epoch < 1:
             msg = (
                 "`warmup_start_epoch` must be >= 1 to enable the auto calculation of "

--- a/nncf/experimental/torch/sparsity/movement/structured_mask_handler.py
+++ b/nncf/experimental/torch/sparsity/movement/structured_mask_handler.py
@@ -187,7 +187,6 @@ class StructuredMaskContext:
          1111    &            1100               &             0000                =    0000
          1111                 1100                             1111                     1100
         """
-
         self.sparsifier_operand.weight_ctx.binary_mask.fill_(1)
         if self.sparsifier_operand.prune_bias:
             self.sparsifier_operand.bias_ctx.binary_mask.fill_(1)

--- a/nncf/experimental/torch2/function_hook/extractor.py
+++ b/nncf/experimental/torch2/function_hook/extractor.py
@@ -133,7 +133,6 @@ def extract_conv(
     :param output_nodes: The name of output node.
     :return: The extracted convolutional layer as an ExtractedFunc module.
     """
-
     # torch.conv*d(
     #   0 - input: Tensor
     #   1 - weight: Tensor
@@ -205,7 +204,6 @@ def extract_model(
     :param output_nodes: List containing names of the output nodes for the submodule.
     :return: An nn.Module containing the extracted submodel, or None if extraction is not supported.
     """
-
     if len(input_nodes) != 1 or len(output_nodes) != 1:
         msg = "input_nodes and output_nodes should contain only one node."
         raise nncf.InternalError(msg)

--- a/nncf/experimental/torch2/function_hook/hook_storage.py
+++ b/nncf/experimental/torch2/function_hook/hook_storage.py
@@ -84,7 +84,6 @@ class HookStorage(nn.Module):
         :param hooks_dict: A dictionary containing existing hooks.
         :return: The next available hook ID as a string. Starts from '0' if no hooks exist.
         """
-
         if not hooks_dict:
             return "0"
         return str(max([int(k) for k in hooks_dict]) + 1)
@@ -102,7 +101,6 @@ class HookStorage(nn.Module):
         :param hook: The hook module to be stored.
         :return: A handle that can be used to remove the hook later.
         """
-
         hook_key = cls._generate_key(op_name, port_id)
         if hook_key not in storage_dict:
             storage_dict[hook_key] = nn.ModuleDict()

--- a/nncf/experimental/torch2/function_hook/wrapper.py
+++ b/nncf/experimental/torch2/function_hook/wrapper.py
@@ -174,7 +174,6 @@ def wrap_model(model: nn.Module) -> nn.Module:
     :param model: The nn.Module to be wrapped.
     :return: The modified model with the custom behavior injected.
     """
-
     if "forward" in model.__dict__:
         msg = "Wrapper does not supported models with overrided forward function"
         raise nncf.InternalError(msg)

--- a/nncf/experimental/torch2/model_transformer.py
+++ b/nncf/experimental/torch2/model_transformer.py
@@ -53,7 +53,6 @@ class PT2ModelTransformer(ModelTransformer[GraphModelWrapper]):
         :param transformation_layout: Transformation commands.
         :return: The new instance of a model with applied transformations.
         """
-
         transformations = transformation_layout.transformations
         aggregated_transformations: Dict[type, List[Command]] = defaultdict(list)
         for transformation in transformations:

--- a/nncf/openvino/graph/model_builder.py
+++ b/nncf/openvino/graph/model_builder.py
@@ -184,7 +184,6 @@ class OVModelBuilder:
         :param node_mapping: Original nodes mapping.
         :return: Builded ov.Model based on parameters.
         """
-
         parameters, results = [], []
         clone_nodes = deque()
 

--- a/nncf/openvino/graph/model_transformer.py
+++ b/nncf/openvino/graph/model_transformer.py
@@ -124,7 +124,6 @@ class OVModelTransformer(ModelTransformer):
         :param transformation_layout: Transformation commands.
         :return: The new instance of a model with applied transformations.
         """
-
         transformations = transformation_layout.transformations
         aggregated_transformations = defaultdict(list)
         for transformation in transformations:
@@ -308,7 +307,6 @@ class OVModelTransformer(ModelTransformer):
         :param data_type: ov.Type instance for data.
         :return: ov.Node instance.
         """
-
         input_low = fake_quantize_params.input_low.data
         input_high = fake_quantize_params.input_high.data
         output_low = fake_quantize_params.output_low.data
@@ -348,7 +346,6 @@ class OVModelTransformer(ModelTransformer):
         :param data_type: ov.Type instance for data.
         :return: ov.Node instance.
         """
-
         scale = fake_convert_params.scale.data
         shift = fake_convert_params.shift.data
 

--- a/nncf/openvino/graph/node_utils.py
+++ b/nncf/openvino/graph/node_utils.py
@@ -191,7 +191,6 @@ def get_result_node_name(output_name: str, port_id: int) -> str:
     :param port_id: Node port.
     :return: Name of Result.
     """
-
     return f"Result_{output_name}.{port_id}"
 
 
@@ -203,7 +202,6 @@ def get_parameter_node_name(parameter_name: str, port_id: int) -> str:
     :param port_id: Node port.
     :return: Name of Parameter.
     """
-
     return f"Parameter_{parameter_name}.{port_id}"
 
 

--- a/nncf/openvino/optimized_functions/models.py
+++ b/nncf/openvino/optimized_functions/models.py
@@ -222,7 +222,6 @@ def get_compress_weight_model(
     :return: A model callable that compresses weights using the given configuration. Or a model as nodes, if
         `return_nodes` is True.
     """
-
     weight_shape, scale_shape, zero_point_shape = _prepare_compression_model_inputs(
         ov_model_params, weight_shape, scale_shape, zero_point_shape, reduction_axes
     )
@@ -264,7 +263,6 @@ def get_compress_decompress_weight_model(
     :return: A model callable that returns a decompressed weight, and optionally compressed weight, scale,
         (and zero point) if `return_compressed_weight` is True.
     """
-
     weight_shape, scale_shape, zero_point_shape = _prepare_compression_model_inputs(
         ov_model_params, weight_shape, scale_shape, zero_point_shape, reduction_axes
     )

--- a/nncf/openvino/quantization/quantize_ifmodel.py
+++ b/nncf/openvino/quantization/quantize_ifmodel.py
@@ -57,7 +57,6 @@ def _make_dataset_for_if_bodies(
     :param subset_size: The size of calibration_dataset.
     :return Dataset: Dataset for child model.
     """
-
     then_dataset, else_dataset = [], []
     calibration_dataset_size = (
         min(subset_size, calibration_dataset.get_length())

--- a/nncf/quantization/algorithms/accuracy_control/evaluator.py
+++ b/nncf/quantization/algorithms/accuracy_control/evaluator.py
@@ -87,7 +87,6 @@ class Evaluator:
 
         :return: Number of passed iterations during last validation process.
         """
-
         return self._num_passed_iterations
 
     def enable_iteration_count(self) -> None:

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -110,7 +110,8 @@ MODE_BASED_DEFAULTS = {
 def _filter_target_points_by_metatypes(
     quantization_target_points: Set[TargetPoint], metatypes: List[OperatorMetatype], nncf_graph: NNCFGraph
 ) -> Set[TargetPoint]:
-    """Returns TargetPoints which are suited to a node having metatype specified in 'metatypes'.
+    """
+    Returns TargetPoints which are suited to a node having metatype specified in 'metatypes'.
 
     :param quantization_target_points: TargetPoints to be filtered.
     :param metatypes: Metatypes that pass filtering.
@@ -1159,7 +1160,6 @@ class MinMaxQuantization(Algorithm):
         :param nncf_graph: NNCFGraph.
         :return: None.
         """
-
         passes_map = {TargetDevice.CPU_SPR: self._apply_spr_pass}
 
         if target_device not in passes_map:
@@ -1244,7 +1244,6 @@ class MinMaxQuantization(Algorithm):
         :param statistics: List of MinMaxTensorStatistic instances.
         :return: Unified MinMaxTensorStatistic value.
         """
-
         max_values, min_values = [], []
         for statistic in statistics:
             max_values.append(statistic.max_values.flatten())

--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -195,7 +195,6 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
 
         :return: Tuple[int, ...]: The shape of the scale to be applied to the input.
         """
-
         is_weights = target_point.is_weight_target_point()
         input_shape = nncf_graph.get_input_shape_for_insertion_point(target_point)
 

--- a/nncf/quantization/algorithms/post_training/pipeline.py
+++ b/nncf/quantization/algorithms/post_training/pipeline.py
@@ -72,7 +72,6 @@ def create_ptq_pipeline(
         fine-tuning the quantization algorithm
     :return: A post-training quantization pipeline.
     """
-
     if advanced_parameters is None:
         advanced_parameters = AdvancedQuantizationParameters()
 

--- a/nncf/quantization/algorithms/smooth_quant/algorithm.py
+++ b/nncf/quantization/algorithms/smooth_quant/algorithm.py
@@ -59,7 +59,6 @@ class SmoothQuant(Algorithm):
             The default value for each layer in the ALPHA_MAP.
             Negative value switches off the algorithm for correspondent nodes.
         """
-
         super().__init__()
         self._subset_size = subset_size
         self._inplace_statistics = inplace_statistics
@@ -189,7 +188,6 @@ class SmoothQuant(Algorithm):
         :param quantile: Base quantile value.
         :return: Calculated base scale value & ratio.
         """
-
         eps = fns.finfo(activations).eps
         scales = fns.power(activations, alpha) / (fns.power(weights, 1 - alpha) + eps)
 
@@ -232,7 +230,6 @@ class SmoothQuant(Algorithm):
         :param act_port: Activation port id.
         :return: List of the TTensor instances.
         """
-
         statistics_for_node = []
         for tensor_collector in statistic_points.get_algo_statistics_for_node(
             node_name,

--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -809,7 +809,6 @@ class WeightCompression(Algorithm):
         :param statistic_points: Statistic points object.
         :return: Collected statistics.
         """
-
         # For each node we store statistics in a WCTensorStatistics data-class. It contains the following fields:
         #   mean_values=[mean_value_1, ..., mean_value_n]
         #   shapes=[shape_1, ..., shape_n]

--- a/nncf/quantization/algorithms/weight_compression/awq.py
+++ b/nncf/quantization/algorithms/weight_compression/awq.py
@@ -110,7 +110,6 @@ class AWQ(Algorithm):
 
         :param model: Backend-specific input model.
         """
-
         model_backend = get_backend(model)
         if model_backend == BackendType.OPENVINO:
             from nncf.quantization.algorithms.weight_compression.openvino_backend import OVAWQAlgoAlgoBackend

--- a/nncf/quantization/fake_quantize.py
+++ b/nncf/quantization/fake_quantize.py
@@ -265,7 +265,6 @@ def calculate_convert_parameters(
     :param activation_scale: Factor for calculated activation scale.
     :return: Parameters of the FakeConvert layer.
     """
-
     destination_type_maximum = {FP8Type.E4M3: 448, FP8Type.E5M2: 57344}
 
     max_values = statistics.max_values

--- a/nncf/scopes.py
+++ b/nncf/scopes.py
@@ -64,7 +64,7 @@ def get_ignored_node_names_from_subgraph(graph: NNCFGraph, subgraph: Subgraph) -
 @api(canonical_alias="nncf.IgnoredScope")
 @dataclass
 class IgnoredScope:
-    """
+    r"""
     Provides an option to specify portions of model to be excluded from compression.
 
     The ignored scope defines model sub-graphs that should be excluded from the compression process such as

--- a/nncf/tensor/functions/linalg.py
+++ b/nncf/tensor/functions/linalg.py
@@ -24,7 +24,7 @@ def norm(
     axis: Optional[Union[int, Tuple[int, ...]]] = None,
     keepdims: bool = False,
 ) -> Tensor:
-    """
+    r"""
     Computes a vector or matrix norm.
 
     The following norms can be calculated:

--- a/nncf/tensor/functions/openvino_numeric.py
+++ b/nncf/tensor/functions/openvino_numeric.py
@@ -93,7 +93,6 @@ def _astype_ov(a: ov.Tensor, dtype: TensorDataType) -> ov.Tensor:
     :param dtype: Data type to cast to.
     :return: Casted openvino tensor.
     """
-
     from nncf.openvino.optimized_functions import astype
 
     return astype(Tensor(a), dtype).data

--- a/nncf/tensorflow/exporter.py
+++ b/nncf/tensorflow/exporter.py
@@ -45,7 +45,6 @@ class TFExporter(Exporter):
                 - `frozen_graph` for export to the Frozen Graph format.
             The Frozen Graph format will be used if `save_format` is not specified.
         """
-
         format_to_export_fn = {
             TFExportFormat.SAVED_MODEL: self._export_to_saved_model,
             TFExportFormat.KERAS_H5: self._export_to_h5,

--- a/nncf/tensorflow/graph/model_transformer.py
+++ b/nncf/tensorflow/graph/model_transformer.py
@@ -61,7 +61,8 @@ class TFModelTransformer(ModelTransformer):
         self._name_mapping = {}
 
     def transform(self, transformation_layout: TFTransformationLayout):
-        """Applies transformations to the Keras model.
+        """
+        Applies transformations to the Keras model.
 
         :param transformation_layout: List of transformations
         :return: The transformed Keras model

--- a/nncf/tensorflow/helpers/model_creation.py
+++ b/nncf/tensorflow/helpers/model_creation.py
@@ -86,7 +86,6 @@ def create_compressed_model(
     :return: A tuple of the compression controller for the requested algorithm(s) and the model object with additional
      modifications necessary to enable algorithm-specific compression during fine-tuning.
     """
-
     warning_deprecated(
         "The 'nncf.tensorflow.create_compressed_model' function is deprecated and will be removed in a "
         "future release.\n"

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -210,7 +210,6 @@ class TFQuantizationSetup:
 
         :return: state of the object
         """
-
         quantization_points_state = [qp.get_state() for qp in self._quantization_points]
         return {
             self._state_names.QUANTIZATION_POINTS: quantization_points_state,

--- a/nncf/tensorflow/sparsity/rb/algorithm.py
+++ b/nncf/tensorflow/sparsity/rb/algorithm.py
@@ -101,7 +101,6 @@ class RBSparsityBuilder(TFCompressionAlgorithmBuilder):
             algorithm-specific compression during fine-tuning.
         :return: The instance of the `RBSparsityController`.
         """
-
         return RBSparsityController(model, self.config, self._op_names)
 
     def initialize(self, model: tf.keras.Model) -> None:

--- a/nncf/torch/checkpoint_loading.py
+++ b/nncf/torch/checkpoint_loading.py
@@ -43,7 +43,6 @@ def load_state(
     :param keys_to_ignore: A list of parameter names that should be skipped from matching process.
     :return: The number of state_dict_to_load entries successfully matched and loaded into model.
     """
-
     model_state_dict = model.state_dict()
 
     from nncf.torch.utils import maybe_convert_legacy_names_in_model_state
@@ -246,7 +245,8 @@ class NormalizedKeys:
 
     @staticmethod
     def _split_unified_parameters(new_key: str) -> List[str]:
-        """covers unified activation quantizers case, e.g.
+        """
+        Covers unified activation quantizers case, e.g.
             external_quantizers.RELU_0;RELU_1;RELU_2.op
         Result of this function is full names of individual parameters:
             external_quantizers.RELU_2.op

--- a/nncf/torch/compression_method_api.py
+++ b/nncf/torch/compression_method_api.py
@@ -111,9 +111,8 @@ class PTCompressionAlgorithmBuilder(BaseCompressionAlgorithmBuilder):
 
     def __init__(self, config: NNCFConfig, should_init: bool = True):
         """
-        Arguments:
-          `config` - a dictionary that contains parameters of compression method
-          `should_init` - if False, trainable parameter initialization will be skipped during building
+        :param config: a dictionary that contains parameters of compression method
+        :param should_init: if False, trainable parameter initialization will be skipped during building
         """
         super().__init__(config, should_init)
         self.compressed_nncf_module_names = self._nncf_module_types_to_compress()

--- a/nncf/torch/dynamic_graph/context.py
+++ b/nncf/torch/dynamic_graph/context.py
@@ -81,9 +81,11 @@ class TracingThreadLocals(threading.local):
 
 
 class CopySafeThreadingVars:
-    """A class holding variables that are related to threading and
+    """
+    A class holding variables that are related to threading and
     thus impossible to deepcopy. The deepcopy will simply return a
-    new object without copying, but won't fail."""
+    new object without copying, but won't fail.
+    """
 
     def __init__(self):
         self.thread_local = TracingThreadLocals()
@@ -240,7 +242,6 @@ class TracingContext:
         be loaded if the model had changed in the meantime in a way that does not impact the major function call
         order (e.g. if comments were added to the .py file with the model)
         """
-
         call_order = self.get_operator_call_count_in_scope(operator_name, self.scope)
 
         op_address = OperationAddress(operator_name, self.scope, call_order)

--- a/nncf/torch/dynamic_graph/trace_functions.py
+++ b/nncf/torch/dynamic_graph/trace_functions.py
@@ -62,7 +62,6 @@ def forward_trace_only(operator: Callable, *args, **kwargs):
     compression, but still have to be accounted for so that the NNCF internal graph representation
     does not become disjoint.
     """
-
     result = operator(*args, **kwargs)
 
     fargs = flatten_args(args, kwargs)
@@ -151,7 +150,6 @@ def trace_tensors(
     :return: Same structure as `operator_output`, but with torch.Tensor entries turned into tensor
         with tracing capabilities instance using TracedTensorMixin.
     """
-
     if isinstance(operator_output, (list, tuple)):
         output_ = []
         for i, x in enumerate(operator_output):

--- a/nncf/torch/dynamic_graph/trace_tensor.py
+++ b/nncf/torch/dynamic_graph/trace_tensor.py
@@ -124,7 +124,6 @@ class TracedTensor(torch.Tensor, TracedTensorMixin):
         Required for PyTorch 1.7.0 compatibility - the handle_torch_function and __torch_function__
         API in general calls this after a wrapped function call; need to preserve the tensor_meta extensions
         """
-
         return self
 
     # NOTE: This disables the __torch_function__ API altogether when using NNCF.
@@ -182,7 +181,6 @@ class TracedParameter(torch.nn.Parameter, TracedTensorMixin):
         Required for PyTorch 1.7.0 compatibility - the handle_torch_function and __torch_function__
         API in general calls this after a wrapped function call; need to preserve the tensor_meta extensions
         """
-
         return self
 
     # NOTE: This disables the __torch_function__ API altogether when using NNCF.

--- a/nncf/torch/engine.py
+++ b/nncf/torch/engine.py
@@ -30,7 +30,6 @@ class PTEngine(Engine):
 
         :param model: Pytorch module to infer.
         """
-
         self._model = model
         if get_backend(model) == BackendType.TORCH:
             self._model.eval()
@@ -44,7 +43,6 @@ class PTEngine(Engine):
         :param input_data: Inputs for the model.
         :return: Model outputs.
         """
-
         if isinstance(input_data, dict):
             return self._model(**input_data)
         if isinstance(input_data, tuple):

--- a/nncf/torch/exporter.py
+++ b/nncf/torch/exporter.py
@@ -118,7 +118,6 @@ class PTExporter(Exporter):
                 - `onnx_<opset_version>` for export to the ONNX format with specific opset version.
             The ONNX format will be used if `save_format` is not specified.
         """
-
         fn_args = {"save_path": save_path}
 
         save_format, extra_args = PTExporter.parse_format(save_format)

--- a/nncf/torch/extractor.py
+++ b/nncf/torch/extractor.py
@@ -201,7 +201,6 @@ def extract_model(model: NNCFNetwork, input_nodes: List[str], output_nodes: List
     :param output_nodes: List containing names of the output nodes for the submodule.
     :return: An nn.Module containing the extracted submodel, or None if extraction is not supported.
     """
-
     if len(input_nodes) != 1 or len(output_nodes) != 1:
         msg = "input_nodes and output_nodes should contain only one node."
         raise nncf.InternalError(msg)

--- a/nncf/torch/initialization.py
+++ b/nncf/torch/initialization.py
@@ -72,7 +72,6 @@ class PTInitializingDataLoader(NNCFDataLoader):
 
         :param dataloader_output - the (args, kwargs) tuple returned by the __next__ method.
         """
-
         raise NotImplementedError
 
 

--- a/nncf/torch/knowledge_distillation/knowledge_distillation_loss.py
+++ b/nncf/torch/knowledge_distillation/knowledge_distillation_loss.py
@@ -92,7 +92,6 @@ class KnowledgeDistillationLoss(PTCompressionLoss):
             container with deterministic traversal.
         :return: knowledge distillation loss value
         """
-
         compressed_model_outputs_nested_obj_indexing = NestedObjectIndex([compressed_model_outputs])
         orig_model_outputs_nested_obj_indexing = NestedObjectIndex([orig_model_outputs])
         compressed_model_loss_outputs_nested_obj_indexing = list(

--- a/nncf/torch/layer_utils.py
+++ b/nncf/torch/layer_utils.py
@@ -29,7 +29,7 @@ class StatefullModuleInterface(ABC):
     Interface that should be implemented for every registered compression module to make it possible
     to save an compression modules state and create an compression module from the saved state.
     Config of the module should be json serializable, no python objects except
-    standart (str, list and etc.) should be present in a compression module config.
+    standard (str, list and etc.) should be present in a compression module config.
     Values for attributes with type torch.nn.Parameter
     is recovered from the model `state_dict`, so there is no need to keep them in the module config.
     Modules should avoid implementation of `__call__` method and use `forward` method instead,
@@ -67,12 +67,11 @@ class _NNCFModuleMixin:
     """
     Default class for modules that will be optimized by NNCF.
 
-        Attributes:
-            op_func_name    Name of corresponding torch function.
-            target_weight_dim_for_compression   Target dimension of weights that will be compressed in some algorithms.
-            ignored_algorithms   List of algorithms that will skip the module.
-            _custom_forward_fn  wrapper of the custom forward function that is called with `self` argument equals to the
-                ProxyModule
+    :param op_func_name: Name of corresponding torch function.
+    :param target_weight_dim_for_compression: Target dimension of weights that will be compressed in some algorithms.
+    :param ignored_algorithms: List of algorithms that will skip the module.
+    :param _custom_forward_fn: Wrapper of the custom forward function that is called with `self` argument equals to the
+        ProxyModule
     """
 
     op_func_name = ""
@@ -141,11 +140,9 @@ class CompressionParameter(nn.Parameter):
 
     def __init__(self, data: torch.Tensor = None, requires_grad: bool = True, compression_lr_multiplier: float = None):
         """
-
-        Args:
-            data: Parameter tensor
-            requires_grad: If the parameter requires gradient
-            compression_lr_multiplier: Multiplier for gradient values
+        :param data: Parameter tensor
+        :param requires_grad: If the parameter requires gradient
+        :param compression_lr_multiplier: Multiplier for gradient values
         """
         super().__init__()
 

--- a/nncf/torch/layers.py
+++ b/nncf/torch/layers.py
@@ -166,7 +166,8 @@ class NNCFConv2d(_NNCFModuleMixin, nn.Conv2d):
         self.groups = num_groups
 
         def _reverse_repeat_tuple(t, n):
-            r"""Reverse the order of `t` and repeat each element for `n` times.
+            """
+            Reverse the order of `t` and repeat each element for `n` times.
 
             This can be used to translate padding arg used by Conv and Pooling modules
             to the ones used by `F.pad`.

--- a/nncf/torch/model_creation.py
+++ b/nncf/torch/model_creation.py
@@ -102,7 +102,6 @@ def create_compressed_model(
         is an instance of CompositeCompressionController) and the model ready for compression parameter training wrapped
         as an object of NNCFNetwork.
     """
-
     warning_deprecated(
         "The 'nncf.torch.create_compressed_model' function is deprecated and will be removed in a future release.\n"
         "To perform post training quantization (PTQ) or quantization aware training (QAT),"
@@ -237,8 +236,8 @@ def create_nncf_network(
         dummy_forward_fn is specified.
     :param wrap_outputs_fn: Same as `wrap_inputs_fn`, but for marking model outputs with
 
-    :return: A model wrapped by NNCFNetwork, which is ready for adding compression."""
-
+    :return: A model wrapped by NNCFNetwork, which is ready for adding compression.
+    """
     if dummy_forward_fn is not None and wrap_inputs_fn is None:
         msg = (
             "A custom dummy forward function was specified, but the corresponding input wrapping function "

--- a/nncf/torch/model_graph_manager.py
+++ b/nncf/torch/model_graph_manager.py
@@ -325,7 +325,6 @@ def get_fake_quantizer(
     :param model: The NNCFNetwork instance.
     :return: Fake Quantizer module if exists, overwise None.
     """
-
     address_map = model.nncf.get_node_to_op_address_mapping()
     op_addr = address_map[node.node_name]
 

--- a/nncf/torch/nested_objects_traversal.py
+++ b/nncf/torch/nested_objects_traversal.py
@@ -120,7 +120,6 @@ def objwalk(obj, unary_predicate: Callable[[Any], bool], apply_fn: Callable, mem
     Walks through the indexable container hierarchy of obj and replaces all sub-objects matching a criterion
     with the result of a given function application.
     """
-
     if memo is None:
         memo = set()
 

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -783,7 +783,6 @@ class NNCFNetworkInterface(torch.nn.Module):
         """
         Returns scopes of the operations in the graph which are executed in evaluation mode.
         """
-
         tracer = GraphTracer(dummy_forward_fn)
         result = []
         eval_graph = tracer.trace_graph(model, as_eval=True)
@@ -1179,7 +1178,6 @@ class NNCFNetwork(torch.nn.Module, metaclass=NNCFNetworkMeta):
         Wraps the original forward call, doing additional actions before and after the call to facilitate model
         graph tracing and calling compression-related hooks.
         """
-
         with self.nncf._compressed_context as ctx:
             ctx.base_module_thread_local_replica = self
 

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -1140,7 +1140,6 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
         insertion commands registering this module for quantization at spots described by
         insertion_points.
         """
-
         target_model_graph = target_model.nncf.get_original_graph()
         if not insertion_points:
             msg = "No insertion points to put quantizers into!"

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -451,9 +451,11 @@ class BaseQuantizer(nn.Module, StatefullModuleInterface, ABC):
 
     @abstractmethod
     def set_levels(self):
-        """Must set the self._level_low and self._level_high buffers according to the current quantizer state
+        """
+        Must set the self._level_low and self._level_high buffers according to the current quantizer state
         and type, and called whenever the state of the quantizer is updated in a way that affects the effective level
-        ranges."""
+        ranges.
+        """
 
     @property
     def is_half_range(self):

--- a/nncf/torch/quantization/strip.py
+++ b/nncf/torch/quantization/strip.py
@@ -75,7 +75,6 @@ def convert_to_torch_fakequantizer(nncf_quantizer: BaseQuantizer) -> FakeQuantiz
     :param quantizer: NNCF Quantizer module.
     :return: Instance of FakeQuantize similar to the input quantizer.
     """
-
     # Call set_ranges in case the basic parameters impacting levels had changed
     nncf_quantizer.set_levels()
 

--- a/nncf/torch/return_types.py
+++ b/nncf/torch/return_types.py
@@ -53,7 +53,6 @@ def maybe_wrap_to_torch_return_type(
     :param wrapped_tensor: Instance of the tensor before it was unwrapped.
     :return: Wrapped tensor in case wrapped_input is wrapped by a torch.return_value container else the tensor.
     """
-
     if isinstance(wrapped_input, _TORCH_RETURN_TYPES):
         # We assume that return_type has only two attributes, the first one is `value`.
         # This assumption is checked by `test_unwrap_wrap_torch_return_type`.

--- a/nncf/torch/tensor_statistics/collectors.py
+++ b/nncf/torch/tensor_statistics/collectors.py
@@ -93,7 +93,6 @@ def get_min_max_statistic_collector(
     :param num_samples: Maximum number of samples to collect.
     :return: Min max statistic collector.
     """
-
     tensor_collector = TensorCollector(_get_wrapped_min_max_tensor_statistic(target_shape=scale_shape))
 
     aggregator_kwargs = {

--- a/nncf/torch/utils.py
+++ b/nncf/torch/utils.py
@@ -420,7 +420,6 @@ def get_model_device(model: torch.nn.Module) -> torch.device:
     :return: The device where the first model parameter reside.
         Default cpu if the model has no parameters.
     """
-
     try:
         device = next(model.parameters()).device
     except StopIteration:
@@ -442,7 +441,6 @@ def is_multidevice(model: torch.nn.Module) -> bool:
     :return: True if the parameters reside on multiple devices, False otherwise.
         Default False if the models has no parameters
     """
-
     device_generator = get_all_model_devices_generator(model)
     try:
         curr_device = next(device_generator)
@@ -463,7 +461,6 @@ def get_model_dtype(model: torch.nn.Module) -> torch.dtype:
     :return: The datatype of the first model parameter.
         Default to torch.float32 if the model has no parameters.
     """
-
     try:
         dtype = next(model.parameters()).dtype
     except StopIteration:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,25 @@ ignore = [
     "UP035", # deprecated-import
     "UP038", # non-pep604-isinstance
     "UP045", # non-pep604-annotation-optional
+    "D100", # undocumented-public-module
+    "D101", # undocumented-public-class
+    "D102", # undocumented-public-method
+    "D103", # undocumented-public-function
+    "D104", # undocumented-public-package
+    "D105", # undocumented-magic-method
+    "D106", # undocumented-public-nested-class
+    "D107", # undocumented-public-init
+    "D200", # unnecessary-multiline-docstring
+    "D203", # incorrect-blank-line-before-class
+    "D205", # missing-blank-line-after-summary
+    "D212", # multi-line-summary-first-line
+    "D400", # missing-trailing-period
+    "D401", # non-imperative-mood
+    "D402", # signature-in-docstring
+    "D404", # docstring-starts-with-this
+    "D413", # missing-blank-line-after-last-section
+    "D415", # missing-terminal-punctuation
+    "D417", # undocumented-param
 ]
 select = [
     "E", # pycodestyle rules
@@ -142,6 +161,7 @@ select = [
     "EM",  # flake8-errmsg
     "INP", # flake8-no-pep420
     "ISC", # flake8-implicit-str-concat
+    "D", # pydocstyle
 ]
 extend-select = [
     "SIM", # https://pypi.org/project/flake8-simplify
@@ -153,7 +173,7 @@ extend-select = [
 "tests/**/*.py" = ["F403"]
 "tests/**/__init__.py" = ["F401"]
 "examples/**/*.py" = ["F403"]
-"!nncf/**.py" = ["INP"]
+"!nncf/**.py" = ["INP", "D"]
 
 [tool.ruff.lint.flake8-copyright]
 notice-rgx = """\


### PR DESCRIPTION
### Changes

Enable rule https://docs.astral.sh/ruff/rules/#pydocstyle-d

ignored rules:
```
  "D100", # undocumented-public-module
  "D101", # undocumented-public-class
  "D102", # undocumented-public-method
  "D103", # undocumented-public-function
  "D104", # undocumented-public-package
  "D105", # undocumented-magic-method
  "D106", # undocumented-public-nested-class
  "D107", # undocumented-public-init
  "D200", # unnecessary-multiline-docstring
  "D203", # incorrect-blank-line-before-class
  "D205", # missing-blank-line-after-summary
  "D212", # multi-line-summary-first-line
  "D400", # missing-trailing-period
  "D401", # non-imperative-mood
  "D402", # signature-in-docstring
  "D404", # docstring-starts-with-this
  "D413", # missing-blank-line-after-last-section
  "D415", # missing-terminal-punctuation
  "D417", # undocumented-param
```
Some rules is not supported because used not supported style or require add or change documentation in too many files
