### PR TITLE
Remove dead link to examples in optimum-intel 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ learning frameworks.
 - GPU-accelerated layers for faster compressed model fine-tuning.
 - Distributed training support.
 - Git patch for prominent third-party repository ([huggingface-transformers](https://github.com/huggingface/transformers)) demonstrating the process of integrating NNCF into custom training pipelines.
-- Seamless combination of pruning, sparsity, and quantization algorithms. Please refer to [optimum-intel](https://github.com/huggingface/optimum-intel/tree/main/examples/openvino) for examples of
-joint (movement) pruning, quantization, and distillation (JPQD), end-to-end from NNCF optimization to compressed OpenVINO IR.
 - Exporting PyTorch compressed models to ONNX\* checkpoints and TensorFlow compressed models to SavedModel or Frozen Graph format, ready to use with [OpenVINO&trade; toolkit](https://docs.openvino.ai).
 - Support for [Accuracy-Aware model training](./docs/usage/training_time_compression/other_algorithms/Usage.md#accuracy-aware-model-training) pipelines via the [Adaptive Compression Level Training](./docs/accuracy_aware_model_training/AdaptiveCompressionLevelTraining.md) and [Early Exit Training](./docs/accuracy_aware_model_training/EarlyExitTraining.md).
 

--- a/docs/PyPiPublishing.md
+++ b/docs/PyPiPublishing.md
@@ -67,10 +67,6 @@ For more information about NNCF, see:
 - Git patch for prominent third-party repository
   ([huggingface-transformers](https://github.com/huggingface/transformers))
   demonstrating the process of integrating NNCF into custom training pipelines.
-- Seamless combination of pruning, sparsity, and quantization algorithms. Refer
-  to [optimum-intel](https://github.com/huggingface/optimum-intel/tree/main/examples/openvino)
-  for examples of joint (movement) pruning, quantization, and distillation
-  (JPQD), end-to-end from NNCF optimization to compressed OpenVINO IR.
 - Exporting PyTorch compressed models to ONNX\* checkpoints and TensorFlow
   compressed models to SavedModel or Frozen Graph format, ready to use with
   [OpenVINO&trade; toolkit](https://docs.openvino.ai).

--- a/nncf/experimental/torch/sparsity/movement/MovementSparsity.md
+++ b/nncf/experimental/torch/sparsity/movement/MovementSparsity.md
@@ -43,10 +43,6 @@ This diagram is the sparsity level of BERT-base model over the optimization life
 
 Optimized models are compatible with OpenVINO toolchain. Use `compression_controller.export_model("movement_sparsified_model.onnx")` to export model in onnx format. Sparsified parameters in the onnx are in value of zero. Structured sparse structures can be discarded during ONNX translation to OpenVINO IR using [Model Conversion](https://docs.openvino.ai/2025/openvino-workflow/model-preparation/convert-model-to-ir.html) with utilizing [pruning transformation](https://docs.openvino.ai/2025/openvino-workflow/model-optimization-guide/compressing-models-during-training/filter-pruning.html). Corresponding IR is compressed and deployable with [OpenVINO Runtime](https://docs.openvino.ai/2025/openvino-workflow/running-inference.html). To quantify inference performance improvement, both ONNX and IR can be profiled using [Benchmark Tool](https://docs.openvino.ai/2025/get-started/learn-openvino/openvino-samples/benchmark-tool.html).
 
-## Getting Started
-
-Please refer [optimum-intel](https://github.com/huggingface/optimum-intel/tree/main/examples/openvino) for example pipelines on image classification, question answering, etc. The repository also provides examples of joint pruning, quantization and distillation, end-to-end from NNCF optimization to compressed OpenVINO IR.
-
 ## Known Limitation
 
 1. Movement sparsification only supports `torch.nn.Linear` layers.


### PR DESCRIPTION
### Changes

Remove paragraphs with link to `https://github.com/huggingface/optimum-intel/tree/main/examples/openvino` 

### Reason for changes

https://github.com/huggingface/optimum-intel/pull/1167

