### PR TITLE
Rework tensor dispatcher

### DIFF
--- a/nncf/common/tensor_statistics/statistics.py
+++ b/nncf/common/tensor_statistics/statistics.py
@@ -12,7 +12,7 @@
 from abc import ABC
 from abc import abstractmethod
 from collections import Counter
-from typing import Any, Dict, TypeVar, cast
+from typing import Any, Dict, TypeVar
 
 from nncf.tensor import Tensor
 from nncf.tensor import functions as fns
@@ -27,7 +27,7 @@ class TensorStatistic(ABC):
 
     @staticmethod
     def tensor_eq(tensor1: Tensor, tensor2: Tensor, rtol: float = 1e-6) -> bool:
-        return cast(bool, fns.allclose(tensor1, tensor2))
+        return fns.allclose(tensor1, tensor2, rtol=rtol)
 
     @abstractmethod
     def __eq__(self, other: Any) -> bool:

--- a/nncf/tensor/README.md
+++ b/nncf/tensor/README.md
@@ -123,7 +123,7 @@ tensor_a[0:2]  # Tensor(array([[1],[2]]))
 2. Add function to functions module
 
     ```python
-    @functools.singledispatch
+    @tensor_dispatcher
     def foo(a: TTensor, arg1: Type) -> TTensor:
         """
         __description__
@@ -132,20 +132,6 @@ tensor_a[0:2]  # Tensor(array([[1],[2]]))
         :param arg1: __description__
         :return: __description__
         """
-        if isinstance(a, tensor.Tensor):
-            return tensor.Tensor(foo(a.data, axis))
-        return NotImplemented(f"Function `foo` is not implemented for {type(a)}")
-    ```
-
-    **NOTE** For the case when the first argument has type `List[Tensor]`, use the `_dispatch_list` function. This function dispatches function by first element in the first argument.
-
-    ```python
-    @functools.singledispatch
-    def foo(x: List[Tensor], axis: int = 0) -> Tensor:
-        if isinstance(x, List):
-            unwrapped_x = [i.data for i in x]
-            return Tensor(_dispatch_list(foo, unwrapped_x, axis=axis))
-        raise NotImplementedError(f"Function `foo` is not implemented for {type(x)}")
     ```
 
 3. Add backend specific implementation of method to corresponding module:
@@ -153,15 +139,15 @@ tensor_a[0:2]  # Tensor(array([[1],[2]]))
     - `functions/numpy_*.py`
 
         ```python
-        @_register_numpy_types(fns.foo)
-        def _(a: TType, arg1: Type) -> np.ndarray:
+        @fns.foo.register
+        def _(a: T_NUMPY_ARRAY, arg1: Type) -> T_NUMPY_ARRAY:
             return np.foo(a, arg1)
         ```
 
     - `functions/torch_*.py`
 
         ```python
-        @fns.foo.register(torch.Tensor)
+        @fns.foo.register
         def _(a: torch.Tensor, arg1: Type) -> torch.Tensor:
             return torch.foo(a, arg1)
         ```

--- a/nncf/tensor/definitions.py
+++ b/nncf/tensor/definitions.py
@@ -12,6 +12,12 @@
 from dataclasses import dataclass
 from enum import Enum
 from enum import auto
+from typing import Optional, Tuple, Union
+
+T_SHAPE_ARRAY = Tuple[int, ...]
+T_SHAPE = Union[int, T_SHAPE_ARRAY]
+T_AXIS = Optional[T_SHAPE]
+T_NUMBER = Union[int, float, bool]
 
 
 class TensorBackend(Enum):
@@ -40,7 +46,7 @@ class TensorDataType(Enum):
     uint4 = auto()
     int4 = auto()
 
-    def is_float(self):
+    def is_float(self) -> bool:
         """
         :return: True if the tensor data type is a floating-point type, else False.
         """

--- a/nncf/tensor/functions/__init__.py
+++ b/nncf/tensor/functions/__init__.py
@@ -67,7 +67,7 @@ from nncf.tensor.functions.numeric import zeros as zeros
 from nncf.tensor.functions.numeric import zeros_like as zeros_like
 
 
-def _initialize_backends():
+def _initialize_backends() -> None:
     import contextlib
 
     import nncf.tensor.functions.numpy_io

--- a/nncf/tensor/functions/dispatcher.py
+++ b/nncf/tensor/functions/dispatcher.py
@@ -8,82 +8,268 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import functools
-from typing import Callable, Dict, List
+import inspect
+import types
+from collections import deque
+from collections.abc import Sequence as SequenceABC
+from functools import wraps
+from inspect import getfullargspec
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    MutableMapping,
+    Protocol,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
-import numpy as np
+from typing_extensions import ParamSpec
 
-import nncf
 from nncf.tensor import Tensor
 from nncf.tensor.definitions import TensorBackend
 
+F = TypeVar("F", bound=Callable[..., Any])
+R = TypeVar("R", covariant=True)
+P = ParamSpec("P")
 
-def tensor_guard(func: callable):
-    """
-    A decorator that ensures that the first argument to the decorated function is a Tensor.
-    """
 
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        if isinstance(args[0], Tensor):
-            return func(*args, **kwargs)
-        msg = f"Function `{func.__name__}` is not implemented for {type(args[0])}"
+class DispatchCallable(Protocol[P, R]):
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...
+
+    def register(self, rfunc: F) -> F: ...
+
+    registry: MutableMapping[type, Callable[..., Any]]
+
+
+def tensor_dispatcher(func: Callable[P, R]) -> DispatchCallable[P, R]:
+    """
+    Single-dispatch generic function decorator.
+
+    Dispatcher to select implementation of function according the type of the first argument.
+
+    :param func: Function to decorate.
+    :return: Decorated function.
+    """
+    registry: dict[type, Callable[..., Any]] = {}
+    signature = inspect.signature(func)
+    pos_to_unwrap, name_to_unwrap = _find_arguments_to_unwrap(signature.parameters)
+
+    def dispatch(type_: type) -> Callable[..., Any]:
+        """
+        Try to find type in registry if not found try to find a parent class in registry.
+
+        :param type_: Type to find in registry.
+        :return: Function from registry.
+        """
+        ret_fn = registry.get(type_)
+        if ret_fn is not None:
+            return registry[type_]
+        # If input type is subclass of expected type, save it in registry for future use
+        for key in registry:
+            if issubclass(type_, key):
+                registry[type_] = registry[key]
+                return registry[key]
+        msg = f"Function `{func.__name__}` is not implemented for {type_}"
         raise NotImplementedError(msg)
 
-    return wrapper
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        """
+        Wrapper function for dispatching the appropriate function based on the argument type.
+
+        :param *args: Variable length argument list.
+        :param **kwargs: Arbitrary keyword arguments.
+        :return: The result of the dispatched function.
+        """
+        func_type = _get_arg_type(args[0])
+        args = tuple(_unwrap_tensors(x) if i in pos_to_unwrap else x for i, x in enumerate(args))
+        kwargs = {n: _unwrap_tensors(x) if n in name_to_unwrap else x for n, x in kwargs.items()}
+        dispatched_func = dispatch(func_type)
+        ret = dispatched_func(*args, **kwargs)
+        return _wrap_output(ret, signature.return_annotation)
+
+    def register(rfunc: F) -> F:
+        """
+        Register a function to the dispatcher registry.
+
+        :param rfunc (callable): The function to be registered.
+        :return: The registered function.
+        """
+        _check_signature(func, rfunc)
+        spec = getfullargspec(func)
+        type_alias = get_type_hints(rfunc).get(spec.args[0])
+        types = _get_register_types(type_alias)
+        for t in types:
+            registry[t] = rfunc
+        return rfunc
+
+    wrapper.register = register  # type: ignore[attr-defined]
+    wrapper.registry = registry  # type: ignore[attr-defined]
+    return cast(DispatchCallable[P, R], wrapper)
 
 
-def dispatch_list(fn: "functools._SingleDispatchCallable", tensor_list: List[Tensor], *args, **kwargs):
+def _find_arguments_to_unwrap(
+    parameters: types.MappingProxyType[str, inspect.Parameter]
+) -> Tuple[List[int], List[str]]:
     """
-    Dispatches the function to the type of the wrapped data of the first element in tensor_list.
+    Get the arguments to unwrap from a given function.
 
-    :param fn: A function wrapped by `functools.singledispatch`.
-    :param tensor_list: List of Tensors.
-    :return: The result value of the function call.
+    :param params: The parameters of the function.
+    :return: A tuple containing two lists - the indexes of the arguments to unwrap and their names.
     """
-    unwrapped_list = [i.data for i in tensor_list]
-    return fn.dispatch(type(unwrapped_list[0]))(unwrapped_list, *args, **kwargs)
+    indexes: List[int] = []
+    names: List[str] = []
+    for idx, (name, param) in enumerate(parameters.items()):
+        if inspect.Parameter.empty is param.annotation:
+            msg = f"Argument {name} has no annotation"
+            raise RuntimeError(msg)
+        if Tensor in _get_register_types(param.annotation):
+            indexes.append(idx)
+            names.append(name)
+    return indexes, names
 
 
-def dispatch_dict(fn: "functools._SingleDispatchCallable", tensor_dict: Dict[str, Tensor], *args, **kwargs):
+def _check_signature(func: Callable[..., Any], rfunc: Callable[..., Any]) -> None:
     """
-    Dispatches the function to the type of the wrapped data of the any element in tensor_dict.
+    Check the signature of the dispatched function compared with expected signature.
 
-    :param fn: A function wrapped by `functools.singledispatch`.
-    :param tensor_dict: Dict of Tensors.
-    :return: The result value of the function call.
+    :param func: The original function.
+    :param rfunc: The dispatched function.
     """
-    unwrapped_dict = {}
-    tensor_backend = None
-    for key, tensor in tensor_dict.items():
-        if tensor_backend is None:
-            tensor_backend = type(tensor.data)
-        else:
-            if tensor_backend is not type(tensor.data):
-                msg = "All tensors in the dictionary should have the same backend"
-                raise nncf.InternalError(msg)
-        unwrapped_dict[key] = tensor.data
+    sign_func = getfullargspec(func)
+    sign_rfunc = getfullargspec(rfunc)
 
-    return fn.dispatch(tensor_backend)(unwrapped_dict, *args, **kwargs)
+    def _raise_error(text: str, expected: Any, actual: Any) -> None:
+        """
+        Raises a RuntimeError with detailed information about the error.
+        """
+        file_line = f"{inspect.getsourcefile(rfunc)}:{inspect.getsourcelines(rfunc)[1]}"
+        msg = (
+            f"Differ {text} for dispatched a function {func.__name__} in {rfunc.__module__}.\n"
+            f"Path: {file_line}\n"
+            f"Expected: {expected}\n"
+            f"Actual:   {actual}"
+        )
+        raise RuntimeError(msg)
+
+    # Check names of argument
+    if sign_func.args != sign_rfunc.args or sign_func.kwonlyargs != sign_rfunc.kwonlyargs:
+        _raise_error(
+            "names of arguments",
+            f"{sign_func.args} {sign_func.kwonlyargs}",
+            f"{sign_rfunc.args} {sign_rfunc.kwonlyargs}",
+        )
+
+    # Check that default values is same
+    if sign_func.defaults != sign_rfunc.defaults:
+        _raise_error("default values", sign_func.defaults, sign_rfunc.defaults)
+
+    # Check number of annotated arguments
+    if len(sign_func.annotations.items()) != len(sign_rfunc.annotations.items()):
+        _raise_error("count of annotated arguments", sign_func.annotations, sign_rfunc.annotations)
+
+    # Check annotation for arguments that not expect Tensor as input
+    for (name, ann), rann in zip(sign_func.annotations.items(), sign_rfunc.annotations.values()):
+        if Tensor not in _get_register_types(ann) and ann != rann:
+            _raise_error(f"annotations for argument '{name}'", ann, rann)
 
 
-def register_numpy_types(singledispatch_fn):
+def _get_arg_type(arg: Any) -> type:
     """
-    Decorator to register function to singledispatch for numpy classes.
+    Get the type of the argument.
 
-    :param singledispatch_fn: singledispatch function.
+    :param arg: The argument to get the type of.
+    """
+    if isinstance(arg, Tensor):
+        return type(arg.data)
+    if isinstance(arg, Sequence):
+        return _get_arg_type(arg[0])
+    if isinstance(arg, dict) and arg:
+        return _get_arg_type(next(iter(arg.values())))
+    return type(arg)
+
+
+def _get_register_types(type_alias: Any) -> list[type]:
+    """
+    Retrieves the register types from the given type alias.
+
+    :param type_alias: The type alias to retrieve register types from.
+    :return: A list of register types.
     """
 
-    def inner(func):
-        singledispatch_fn.register(np.ndarray)(func)
-        singledispatch_fn.register(np.generic)(func)
-        singledispatch_fn.register(float)(func)
-        return func
+    def _unpack_types(t: Any) -> list[type]:
+        """
+        Recursively find types.
+        """
+        origin = get_origin(t)
+        if origin is Union or origin is list or origin is tuple or origin is SequenceABC:
+            ret = []
+            for tt in get_args(t):
+                ret.extend(_unpack_types(tt))
+            return ret
+        if origin is dict:
+            # unpack only values for dict
+            return _unpack_types(get_args(t)[1])
+        if not isinstance(t, types.GenericAlias):
+            return [t]
+        return [origin]
 
-    return inner
+    return _unpack_types(type_alias)
 
 
-def get_numeric_backend_fn(fn_name: str, backend: TensorBackend) -> Callable:
+def _unwrap_tensors(data: Any) -> Any:
+    """
+    Unwraps tensors in the given data structure.
+
+    :param data: The input data structure.
+    :return: The unwrapped data structure.
+    """
+    if isinstance(data, Tensor):
+        return data.data
+    if isinstance(data, (list, tuple, deque)):
+        # Deque converted to list to keep time on conversion, it's not change behavior for existed functions
+        is_tuple = isinstance(data, tuple)
+        data = list(data)
+        for i, arg in enumerate(data):
+            data[i] = _unwrap_tensors(arg)
+        if is_tuple:
+            data = tuple(data)
+        return data
+    if isinstance(data, dict):
+        return {k: _unwrap_tensors(v) for k, v in data.items()}
+    return data
+
+
+def _wrap_output(ret_val: Any, ret_ann: Any) -> Any:
+    """
+    Wrap outputs of function according return annotation.
+
+    :param ret_val: Return value of function.
+    :param ret_ann: Return annotation of function.
+    :return: Modified outputs.
+    """
+    if ret_ann is Tensor:
+        return Tensor(ret_val)
+    if ret_ann == List[Tensor]:
+        return [Tensor(x) for x in ret_val]
+    if ret_ann == Tuple[Tensor, ...]:
+        return tuple(Tensor(x) for x in ret_val)
+    if get_origin(ret_ann) is tuple:
+        return tuple(Tensor(x) if a is Tensor else x for x, a in zip(ret_val, get_args(ret_ann)))
+    if ret_ann == Dict[str, Tensor]:
+        return {k: Tensor(v) for k, v in ret_val.items()}
+    return ret_val
+
+
+def get_numeric_backend_fn(fn_name: str, backend: TensorBackend) -> Callable[..., Any]:
     """
     Returns a numeric function based on the provided function name and backend type.
 
@@ -99,9 +285,11 @@ def get_numeric_backend_fn(fn_name: str, backend: TensorBackend) -> Callable:
         from nncf.tensor.functions import torch_numeric
 
         return getattr(torch_numeric, fn_name)
+    msg = f"Unsupported backend type: {backend}"
+    raise ValueError(msg)
 
 
-def get_io_backend_fn(fn_name: str, backend: TensorBackend) -> Callable:
+def get_io_backend_fn(fn_name: str, backend: TensorBackend) -> Callable[..., Any]:
     """
     Returns a io function based on the provided function name and backend type.
 
@@ -117,3 +305,5 @@ def get_io_backend_fn(fn_name: str, backend: TensorBackend) -> Callable:
         from nncf.tensor.functions import torch_io
 
         return getattr(torch_io, fn_name)
+    msg = f"Unsupported backend type: {backend}"
+    raise ValueError(msg)

--- a/nncf/tensor/functions/io.py
+++ b/nncf/tensor/functions/io.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -17,8 +16,8 @@ from nncf.common.utils.os import fail_if_symlink
 from nncf.tensor import Tensor
 from nncf.tensor.definitions import TensorBackend
 from nncf.tensor.definitions import TensorDeviceType
-from nncf.tensor.functions.dispatcher import dispatch_dict
 from nncf.tensor.functions.dispatcher import get_io_backend_fn
+from nncf.tensor.functions.dispatcher import tensor_dispatcher
 
 
 def load_file(
@@ -41,7 +40,7 @@ def load_file(
     return {key: Tensor(val) for key, val in loaded_dict.items()}
 
 
-@functools.singledispatch
+@tensor_dispatcher
 def save_file(
     data: Dict[str, Tensor],
     file_path: Path,
@@ -52,8 +51,3 @@ def save_file(
     :param data: A dictionary where the keys are tensor names and the values are Tensor objects.
     :param file_path: The path to the file where the tensor data will be saved.
     """
-    fail_if_symlink(file_path)
-    if isinstance(data, dict):
-        return dispatch_dict(save_file, data, file_path)
-    msg = f"Function `save_file` is not implemented for {type(data)}"
-    raise NotImplementedError(msg)

--- a/nncf/tensor/functions/linalg.py
+++ b/nncf/tensor/functions/linalg.py
@@ -9,18 +9,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
-from typing import Optional, Tuple, Union
+from typing import Literal, Optional, Tuple, Union
 
 from nncf.tensor import Tensor
-from nncf.tensor.functions.dispatcher import tensor_guard
+from nncf.tensor.functions.dispatcher import tensor_dispatcher
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def norm(
     a: Tensor,
-    ord: Optional[Union[str, float, int]] = None,
+    ord: Union[Literal["fro", "nuc"], float, None] = None,
     axis: Optional[Union[int, Tuple[int, ...]]] = None,
     keepdims: bool = False,
 ) -> Tensor:
@@ -61,11 +59,9 @@ def norm(
         as dimensions with size one. Default: False.
     :return: Norm of the matrix or vector.
     """
-    return Tensor(norm(a.data, ord, axis, keepdims))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def cholesky(a: Tensor, upper: bool = False) -> Tensor:
     """
     Computes the Cholesky decomposition of a complex Hermitian or real symmetric
@@ -81,11 +77,9 @@ def cholesky(a: Tensor, upper: bool = False) -> Tensor:
         Default is lower-triangular.
     :return: Upper- or lower-triangular Cholesky factor of `a`.
     """
-    return Tensor(cholesky(a.data, upper))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def cholesky_inverse(a: Tensor, upper: bool = False) -> Tensor:
     """
     Computes the inverse of a complex Hermitian or real symmetric positive-definite matrix given
@@ -97,11 +91,9 @@ def cholesky_inverse(a: Tensor, upper: bool = False) -> Tensor:
         upper triangular. Default: False.
     :return: The inverse of matrix given its Cholesky decomposition.
     """
-    return Tensor(cholesky_inverse(a.data, upper))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def inv(a: Tensor) -> Tensor:
     """
     Computes the inverse of a matrix.
@@ -110,11 +102,9 @@ def inv(a: Tensor) -> Tensor:
         consisting of invertible matrices.
     :return: The inverse of the input tensor.
     """
-    return Tensor(inv(a.data))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def pinv(a: Tensor) -> Tensor:
     """
     Compute the (Moore-Penrose) pseudo-inverse of a matrix.
@@ -122,11 +112,9 @@ def pinv(a: Tensor) -> Tensor:
     :param a: The input tensor of shape (*, M, N) where * is zero or more batch dimensions.
     :return: The pseudo-inverse of input tensor.
     """
-    return Tensor(pinv(a.data))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def lstsq(a: Tensor, b: Tensor, driver: Optional[str] = None) -> Tensor:
     """
     Compute least-squares solution to equation Ax = b.
@@ -136,12 +124,10 @@ def lstsq(a: Tensor, b: Tensor, driver: Optional[str] = None) -> Tensor:
     :param driver: name of the LAPACK/MAGMA method to be used for solving the least-squares problem.
     :return: a tensor of size (N,) or (N, K), such that the 2-norm |b - A x| is minimized.
     """
-    return Tensor(lstsq(a.data, b.data, driver))
 
 
-@functools.singledispatch
-@tensor_guard
-def svd(a: Tensor, full_matrices: Optional[bool] = True) -> Tensor:
+@tensor_dispatcher
+def svd(a: Tensor, full_matrices: Optional[bool] = True) -> Tuple[Tensor, Tensor, Tensor]:
     """
     Factorizes the matrix a into two unitary matrices U and Vh, and a 1-D array s of singular values
     (real, non-negative) such that a == U @ S @ Vh, where S is a suitably shaped matrix of zeros with main diagonal s.
@@ -156,5 +142,3 @@ def svd(a: Tensor, full_matrices: Optional[bool] = True) -> Tensor:
         S - The singular values, sorted in non-increasing order. Of shape (K,), with K = min(M, N).
         Vh - Unitary matrix having right singular vectors as rows. Of shape (N, N) or (K, N) depending on full_matrices.
     """
-    U, S, Vh = svd(a.data, full_matrices=full_matrices)
-    return (Tensor(U), Tensor(S), Tensor(Vh))

--- a/nncf/tensor/functions/numeric.py
+++ b/nncf/tensor/functions/numeric.py
@@ -9,26 +9,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
-from collections import deque
-from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, List, Literal, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
 from nncf.tensor import Tensor
-from nncf.tensor import unwrap_tensor_data
+from nncf.tensor.definitions import T_AXIS
+from nncf.tensor.definitions import T_SHAPE
+from nncf.tensor.definitions import T_SHAPE_ARRAY
 from nncf.tensor.definitions import TensorBackend
 from nncf.tensor.definitions import TensorDataType
 from nncf.tensor.definitions import TensorDeviceType
 from nncf.tensor.definitions import TypeInfo
-from nncf.tensor.functions.dispatcher import dispatch_list
 from nncf.tensor.functions.dispatcher import get_numeric_backend_fn
-from nncf.tensor.functions.dispatcher import tensor_guard
+from nncf.tensor.functions.dispatcher import tensor_dispatcher
 from nncf.tensor.tensor import TTensor
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def device(a: Tensor) -> TensorDeviceType:
     """
     Return the device of the tensor.
@@ -36,11 +34,9 @@ def device(a: Tensor) -> TensorDeviceType:
     :param a: The input tensor.
     :return: The device of the tensor.
     """
-    return device(a.data)
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def backend(a: Tensor) -> TensorBackend:
     """
     Return the backend of the tensor.
@@ -48,11 +44,9 @@ def backend(a: Tensor) -> TensorBackend:
     :param a: The input tensor.
     :return: The backend of the tensor.
     """
-    return backend(a.data)
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def squeeze(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> Tensor:
     """
     Remove axes of length one from a.
@@ -63,11 +57,9 @@ def squeeze(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> Te
       This is always a itself or a view into a. Note that if all axes are squeezed,
       the result is a 0d array and not a scalar.
     """
-    return Tensor(squeeze(a.data, axis=axis))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def flatten(a: Tensor) -> Tensor:
     """
     Return a copy of the tensor collapsed into one dimension.
@@ -75,41 +67,35 @@ def flatten(a: Tensor) -> Tensor:
     :param a: The input tensor.
     :return: A copy of the input tensor, flattened to one dimension.
     """
-    return Tensor(flatten(a.data))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def max(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False) -> Tensor:
     """
     Return the maximum of an array or maximum along an axis.
 
     :param a: The input tensor.
     :param axis: Axis or axes along which to operate. By default, flattened input is used.
-    :param keepdim: If this is set to True, the axes which are reduced are left in the result as dimensions with size
+    :param keepdims: If this is set to True, the axes which are reduced are left in the result as dimensions with size
         one. With this option, the result will broadcast correctly against the input array. False, by default.
     :return: Maximum of a.
     """
-    return Tensor(max(a.data, axis, keepdims))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def min(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False) -> Tensor:
     """
     Return the minimum of an array or minimum along an axis.
 
     :param a: The input tensor.
     :param axis: Axis or axes along which to operate. By default, flattened input is used.
-    :param keepdim: If this is set to True, the axes which are reduced are left in the result as dimensions with size
+    :param keepdims: If this is set to True, the axes which are reduced are left in the result as dimensions with size
         one. With this option, the result will broadcast correctly against the input array. False, by default.
     :return: Minimum of a.
     """
-    return Tensor(min(a.data, axis, keepdims))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def abs(a: Tensor) -> Tensor:
     """
     Calculate the absolute value element-wise.
@@ -117,12 +103,10 @@ def abs(a: Tensor) -> Tensor:
     :param a: The input tensor.
     :return: A tensor containing the absolute value of each element in x.
     """
-    return Tensor(abs(a.data))
 
 
-@functools.singledispatch
-@tensor_guard
-def astype(a: Tensor, data_type: TensorDataType) -> Tensor:
+@tensor_dispatcher
+def astype(a: Tensor, dtype: TensorDataType) -> Tensor:
     """
     Copy of the tensor, cast to a specified type.
 
@@ -131,11 +115,9 @@ def astype(a: Tensor, data_type: TensorDataType) -> Tensor:
 
     :return: Copy of the tensor in specified type.
     """
-    return Tensor(astype(a.data, data_type))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def dtype(a: Tensor) -> TensorDataType:
     """
     Return data type of the tensor.
@@ -143,12 +125,10 @@ def dtype(a: Tensor) -> TensorDataType:
     :param a: The input tensor.
     :return: The data type of the tensor.
     """
-    return dtype(a.data)
 
 
-@functools.singledispatch
-@tensor_guard
-def reshape(a: Tensor, shape: Tuple[int, ...]) -> Tensor:
+@tensor_dispatcher
+def reshape(a: Tensor, shape: T_SHAPE) -> Tensor:
     """
     Gives a new shape to a tensor without changing its data.
 
@@ -156,12 +136,10 @@ def reshape(a: Tensor, shape: Tuple[int, ...]) -> Tensor:
     :param shape: The new shape should be compatible with the original shape.
     :return: Reshaped tensor.
     """
-    return Tensor(reshape(a.data, shape))
 
 
-@functools.singledispatch
-@tensor_guard
-def all(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> Tensor:
+@tensor_dispatcher
+def all(a: Tensor, axis: T_AXIS = None) -> Tensor:
     """
     Test whether all tensor elements along a given axis evaluate to True.
 
@@ -169,11 +147,9 @@ def all(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> Tensor
     :param axis: Axis or axes along which a logical AND reduction is performed.
     :return: A new tensor.
     """
-    return Tensor(all(a.data, axis=axis))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def allclose(
     a: Tensor, b: Union[Tensor, float], rtol: float = 1e-05, atol: float = 1e-08, equal_nan: bool = False
 ) -> bool:
@@ -189,12 +165,10 @@ def allclose(
       Defaults to False.
     :return: True if the two arrays are equal within the given tolerance, otherwise False.
     """
-    return allclose(a.data, unwrap_tensor_data(b), rtol=rtol, atol=atol, equal_nan=equal_nan)
 
 
-@functools.singledispatch
-@tensor_guard
-def any(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> Tensor:
+@tensor_dispatcher
+def any(a: Tensor, axis: T_AXIS = None) -> Tensor:
     """
     Test whether any tensor elements along a given axis evaluate to True.
 
@@ -202,12 +176,10 @@ def any(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> Tensor
     :param axis: Axis or axes along which a logical OR reduction is performed.
     :return: A new tensor.
     """
-    return Tensor(any(a.data, axis))
 
 
-@functools.singledispatch
-@tensor_guard
-def count_nonzero(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> Tensor:
+@tensor_dispatcher
+def count_nonzero(a: Tensor, axis: T_AXIS = None) -> Tensor:
     """
     Counts the number of non-zero values in the tensor input.
 
@@ -216,11 +188,9 @@ def count_nonzero(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None)
     :return: Number of non-zero values in the tensor along a given axis.
       Otherwise, the total number of non-zero values in the tensor is returned.
     """
-    return Tensor(count_nonzero(a.data, axis))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def isempty(a: Tensor) -> bool:
     """
     Return True if input tensor is empty.
@@ -228,11 +198,9 @@ def isempty(a: Tensor) -> bool:
     :param a: The input tensor.
     :return: True if tensor is empty, otherwise False.
     """
-    return isempty(a.data)
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def isclose(
     a: Tensor, b: Union[Tensor, float], rtol: float = 1e-05, atol: float = 1e-08, equal_nan: bool = False
 ) -> Tensor:
@@ -248,19 +216,9 @@ def isclose(
       Defaults to False.
     :return: Returns a boolean tensor of where a and b are equal within the given tolerance.
     """
-    return Tensor(
-        isclose(
-            a.data,
-            unwrap_tensor_data(b),
-            rtol=rtol,
-            atol=atol,
-            equal_nan=equal_nan,
-        )
-    )
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def maximum(x1: Tensor, x2: Union[Tensor, float]) -> Tensor:
     """
     Element-wise maximum of tensor elements.
@@ -269,11 +227,9 @@ def maximum(x1: Tensor, x2: Union[Tensor, float]) -> Tensor:
     :param x2: The second input tensor.
     :return: Output tensor.
     """
-    return Tensor(maximum(x1.data, unwrap_tensor_data(x2)))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def minimum(x1: Tensor, x2: Union[Tensor, float]) -> Tensor:
     """
     Element-wise minimum of tensor elements.
@@ -282,11 +238,9 @@ def minimum(x1: Tensor, x2: Union[Tensor, float]) -> Tensor:
     :param x2: The second input tensor.
     :return: Output tensor.
     """
-    return Tensor(minimum(x1.data, unwrap_tensor_data(x2)))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def ones_like(a: Tensor) -> Tensor:
     """
     Return a tensor of ones with the same shape and type as a given tensor.
@@ -294,11 +248,9 @@ def ones_like(a: Tensor) -> Tensor:
     :param a: The shape and data-type of a define these same attributes of the returned tensor.
     :return: Tensor of ones with the same shape and type as a.
     """
-    return Tensor(ones_like(a.data))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def where(condition: Tensor, x: Union[Tensor, float], y: Union[Tensor, float]) -> Tensor:
     """
     Return elements chosen from x or y depending on condition.
@@ -308,17 +260,9 @@ def where(condition: Tensor, x: Union[Tensor, float], y: Union[Tensor, float]) -
     :param y: Value at indices where condition is False.
     :return: A tensor with elements from x where condition is True, and elements from y elsewhere.
     """
-    return Tensor(
-        where(
-            condition.data,
-            unwrap_tensor_data(x),
-            unwrap_tensor_data(y),
-        )
-    )
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def zeros_like(a: Tensor) -> Tensor:
     """
     Return an tensor of zeros with the same shape and type as a given tensor.
@@ -326,25 +270,20 @@ def zeros_like(a: Tensor) -> Tensor:
     :param input: The shape and data-type of a define these same attributes of the returned tensor.
     :return: tensor of zeros with the same shape and type as a.
     """
-    return Tensor(zeros_like(a.data))
 
 
-@functools.singledispatch
-def stack(x: List[Tensor], axis: int = 0) -> Tensor:
+@tensor_dispatcher
+def stack(x: Sequence[Tensor], axis: int = 0) -> Tensor:
     """
-    Stacks a list of Tensors rank-R tensors into one Tensor rank-(R+1) tensor.
+    Stacks a sequence of Tensors rank-R tensors into one Tensor rank-(R+1) tensor.
 
-    :param x: List of Tensors.
+    :param x: Sequence of Tensors.
     :param axis: The axis to stack along.
     :return: Stacked Tensor.
     """
-    if isinstance(x, (list, deque)):
-        return Tensor(dispatch_list(stack, x, axis=axis))
-    msg = f"Function `stack` is not implemented for {type(x)}"
-    raise NotImplementedError(msg)
 
 
-@functools.singledispatch
+@tensor_dispatcher
 def concatenate(x: List[Tensor], axis: int = 0) -> Tensor:
     """
     Join a sequence of arrays along an existing axis.
@@ -353,28 +292,20 @@ def concatenate(x: List[Tensor], axis: int = 0) -> Tensor:
     :param axis: The axis along which the arrays will be joined. Default is 0.
     :return: The concatenated array.
     """
-    if isinstance(x, (list, deque)):
-        return Tensor(dispatch_list(concatenate, x, axis=axis))
-    msg = f"Function `concatenate` is not implemented for {type(x)}"
-    raise NotImplementedError(msg)
 
 
-@functools.singledispatch
-@tensor_guard
-def unstack(a: Tensor, axis: int = 0) -> List[Tensor]:
+@tensor_dispatcher
+def unstack(x: Tensor, axis: int = 0) -> List[Tensor]:
     """
     Unstack a Tensor into list.
 
-    :param a: Tensor to unstack.
+    :param x: Tensor to unstack.
     :param axis: The axis to unstack along.
     :return: List of Tensor.
     """
-    res = unstack(a.data, axis=axis)
-    return [Tensor(i) for i in res]
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def moveaxis(a: Tensor, source: Union[int, Tuple[int, ...]], destination: Union[int, Tuple[int, ...]]) -> Tensor:
     """
     Move axes of an array to new positions.
@@ -384,14 +315,10 @@ def moveaxis(a: Tensor, source: Union[int, Tuple[int, ...]], destination: Union[
     :param destination: Destination positions for each of the original axes. These must also be unique.
     :return: Array with moved axes.
     """
-    return Tensor(moveaxis(a.data, source, destination))
 
 
-@functools.singledispatch
-@tensor_guard
-def mean(
-    a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False, dtype: TensorDataType = None
-) -> Tensor:
+@tensor_dispatcher
+def mean(a: Tensor, axis: T_AXIS = None, keepdims: bool = False, dtype: Optional[TensorDataType] = None) -> Tensor:
     """
     Compute the arithmetic mean along the specified axis.
 
@@ -401,12 +328,10 @@ def mean(
     :param dtype: Type to use in computing the mean.
     :return: Array with moved axes.
     """
-    return Tensor(mean(a.data, axis, keepdims, dtype))
 
 
-@functools.singledispatch
-@tensor_guard
-def median(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False) -> Tensor:
+@tensor_dispatcher
+def median(a: Tensor, axis: T_AXIS = None, keepdims: bool = False) -> Tensor:
     """
     Compute the arithmetic median along the specified axis.
 
@@ -415,12 +340,10 @@ def median(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdi
     :param keepdims: Destination positions for each of the original axes. These must also be unique.
     :return: Array with moved axes.
     """
-    return Tensor(median(a.data, axis, keepdims))
 
 
-@functools.singledispatch
-@tensor_guard
-def round(a: Tensor, decimals=0) -> Tensor:
+@tensor_dispatcher
+def round(a: Tensor, decimals: int = 0) -> Tensor:
     """
     Evenly round to the given number of decimals.
 
@@ -429,11 +352,9 @@ def round(a: Tensor, decimals=0) -> Tensor:
       it specifies the number of positions to the left of the decimal point.
     :return: An array of the same type as a, containing the rounded values.
     """
-    return Tensor(round(a.data, decimals))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def power(a: Tensor, exponent: Union[Tensor, float]) -> Tensor:
     """
     Takes the power of each element in input with exponent and returns a tensor with the result.
@@ -445,15 +366,13 @@ def power(a: Tensor, exponent: Union[Tensor, float]) -> Tensor:
     :param exponent: Exponent value.
     :return: The result of the power of each element in input with given exponent.
     """
-    return Tensor(power(a.data, unwrap_tensor_data(exponent)))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def quantile(
     a: Tensor,
     q: Union[float, List[float]],
-    axis: Optional[Union[int, Tuple[int]]] = None,
+    axis: T_AXIS = None,
     keepdims: bool = False,
 ) -> Tensor:
     """
@@ -468,15 +387,13 @@ def quantile(
     :return: An tensor with quantiles, the first axis of the result corresponds
         to the quantiles, other axes of the result correspond to the quantiles values.
     """
-    return Tensor(quantile(a.data, q, axis, keepdims))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def percentile(
     a: Tensor,
     q: Union[float, List[float]],
-    axis: Union[int, Tuple[int, ...], List[int]],
+    axis: T_AXIS,
     keepdims: bool = False,
 ) -> Tensor:
     """
@@ -490,12 +407,10 @@ def percentile(
         as dimensions with size one.
     :returns: The percentile(s) of the tensor elements.
     """
-    return Tensor(percentile(a.data, q, axis, keepdims))
 
 
-@functools.singledispatch
-@tensor_guard
-def _binary_op_nowarn(a: Tensor, b: Union[Tensor, float], operator_fn: Callable) -> Tensor:
+@tensor_dispatcher
+def _binary_op_nowarn(a: Tensor, b: Union[Tensor, float], operator_fn: Callable[..., Any]) -> Tensor:
     """
     Applies a binary operation with disable warnings.
 
@@ -504,12 +419,10 @@ def _binary_op_nowarn(a: Tensor, b: Union[Tensor, float], operator_fn: Callable)
     :param operator_fn: The binary operation function.
     :return: The result of the binary operation.
     """
-    return Tensor(_binary_op_nowarn(a.data, unwrap_tensor_data(b), operator_fn))
 
 
-@functools.singledispatch
-@tensor_guard
-def _binary_reverse_op_nowarn(a: Tensor, b: Union[Tensor, float], operator_fn: Callable) -> Tensor:
+@tensor_dispatcher
+def _binary_reverse_op_nowarn(a: Tensor, b: Union[Tensor, float], operator_fn: Callable[..., Any]) -> Tensor:
     """
     Applies a binary reverse operation with disable warnings.
 
@@ -518,11 +431,9 @@ def _binary_reverse_op_nowarn(a: Tensor, b: Union[Tensor, float], operator_fn: C
     :param operator_fn: The binary operation function.
     :return: The result of the binary operation.
     """
-    return Tensor(_binary_reverse_op_nowarn(a.data, unwrap_tensor_data(b), operator_fn))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def finfo(a: Tensor) -> TypeInfo:
     """
     Returns machine limits for tensor type.
@@ -530,11 +441,9 @@ def finfo(a: Tensor) -> TypeInfo:
     :param a: Tensor.
     :return: TypeInfo.
     """
-    return finfo(a.data)
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def clip(a: Tensor, a_min: Union[Tensor, float], a_max: Union[Tensor, float]) -> Tensor:
     """
     Clips all elements in input into the range [ a_min, a_max ]
@@ -545,11 +454,9 @@ def clip(a: Tensor, a_min: Union[Tensor, float], a_max: Union[Tensor, float]) ->
     :return: A clipped tensor with the elements of a, but where values < a_min are replaced with a_min,
         and those > a_max with a_max.
     """
-    return Tensor(clip(a.data, unwrap_tensor_data(a_min), unwrap_tensor_data(a_max)))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def as_tensor_like(a: Tensor, data: Any) -> Tensor:
     """
     Converts the data into a tensor with the same data representation and hosted on the same device
@@ -560,11 +467,9 @@ def as_tensor_like(a: Tensor, data: Any) -> Tensor:
     :return: A tensor with the same data representation and hosted on the same device as a,
         and which has been initialized with data.
     """
-    return Tensor(as_tensor_like(a.data, data))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def item(a: Tensor) -> Union[int, float, bool]:
     """
     Returns the value of this tensor as a standard Python number. This only works for tensors with one element.
@@ -572,13 +477,9 @@ def item(a: Tensor) -> Union[int, float, bool]:
     :param a: Tensor.
     :return: The value of this tensor as a standard Python number
     """
-    if isinstance(a.data, (int, float, bool)):
-        return a.data
-    return item(a.data)
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def sum(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False) -> Tensor:
     """
     Sum of tensor elements over a given axis.
@@ -590,11 +491,9 @@ def sum(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims:
         with size one.
     :return: Returns the sum of all elements in the input tensor in the given axis.
     """
-    return Tensor(sum(a.data, axis, keepdims))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def multiply(x1: Tensor, x2: Union[Tensor, float]) -> Tensor:
     """
     Multiply arguments element-wise.
@@ -603,11 +502,9 @@ def multiply(x1: Tensor, x2: Union[Tensor, float]) -> Tensor:
     :param x2: The second input tensor or number.
     :return: The product of x1 and x2, element-wise.
     """
-    return Tensor(multiply(x1.data, unwrap_tensor_data(x2)))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def var(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False, ddof: int = 0) -> Tensor:
     """
     Compute the variance along the specified axis.
@@ -621,11 +518,9 @@ def var(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims:
         By default ddof is zero.
     :return: A new tensor containing the variance.
     """
-    return Tensor(var(a.data, axis, keepdims, ddof))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def size(a: Tensor) -> int:
     """
     Return number of elements in the tensor.
@@ -633,11 +528,9 @@ def size(a: Tensor) -> int:
     :param a: The input tensor
     :return: The size of the input tensor.
     """
-    return size(a.data)
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def matmul(x1: Tensor, x2: Union[Tensor, float]) -> Tensor:
     """
     Matrix multiplication.
@@ -646,25 +539,21 @@ def matmul(x1: Tensor, x2: Union[Tensor, float]) -> Tensor:
     :param x2: The second input tensor or number.
     :return: The product of x1 and x2, matmul.
     """
-    return Tensor(matmul(x1.data, unwrap_tensor_data(x2)))
 
 
-@functools.singledispatch
-@tensor_guard
-def unsqueeze(a: Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> Tensor:
+@tensor_dispatcher
+def unsqueeze(a: Tensor, axis: int) -> Tensor:
     """
     Add axes of length one to a.
 
     :param a: The input tensor.
-    :param axis: Selects a subset of the entries of length one in the shape.
+    :param axis: The index at which to insert the singleton dimension.
     :return: The input array, but with expanded shape with len 1 defined in axis.
     """
-    return Tensor(unsqueeze(a.data, axis=axis))
 
 
-@functools.singledispatch
-@tensor_guard
-def transpose(a: Tensor, axes: Optional[Tuple[int, ...]] = None) -> Tensor:
+@tensor_dispatcher
+def transpose(a: Tensor, axes: Optional[T_SHAPE_ARRAY] = None) -> Tensor:
     """
     Returns an array with axes transposed.
 
@@ -672,11 +561,9 @@ def transpose(a: Tensor, axes: Optional[Tuple[int, ...]] = None) -> Tensor:
     :param axes: List of permutations or None.
     :return: A tensor with permuted axes.
     """
-    return Tensor(transpose(a.data, axes=axes))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def argsort(a: Tensor, axis: int = -1, descending: bool = False, stable: bool = False) -> Tensor:
     """
     Returns the indices that would sort an array.
@@ -688,11 +575,9 @@ def argsort(a: Tensor, axis: int = -1, descending: bool = False, stable: bool = 
         If False, the relative order of values which compare equal is not guaranteed. True is slower.
     :return: A tensor of indices that sort a along the specified axis.
     """
-    return Tensor(argsort(a.data, axis=axis, descending=descending, stable=stable))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def diag(a: Tensor, k: int = 0) -> Tensor:
     """
     Returns the indices that would sort an array.
@@ -702,11 +587,9 @@ def diag(a: Tensor, k: int = 0) -> Tensor:
         for diagonals below the main diagonal.
     :return: A tensor with the extracted diagonal.
     """
-    return Tensor(diag(a.data, k=k))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def logical_or(x1: Tensor, x2: Tensor) -> Tensor:
     """
     Computes the element-wise logical OR of the given input tensors.
@@ -716,12 +599,10 @@ def logical_or(x1: Tensor, x2: Tensor) -> Tensor:
     :param x2: The tensor to compute or with.
     :return: Result of elementwise or operation between input_ and other tensor.
     """
-    return Tensor(logical_or(x1.data, unwrap_tensor_data(x2)))
 
 
-@functools.singledispatch
-@tensor_guard
-def masked_mean(x: Tensor, mask: Tensor, axis: Union[int, Tuple[int, ...], List[int]], keepdims=False) -> Tensor:
+@tensor_dispatcher
+def masked_mean(x: Tensor, mask: Tensor, axis: T_AXIS, keepdims: bool = False) -> Tensor:
     """
     Computes the masked mean of elements across given dimensions of Tensor.
 
@@ -733,12 +614,10 @@ def masked_mean(x: Tensor, mask: Tensor, axis: Union[int, Tuple[int, ...], List[
         as dimensions with size one.
     :return: Reduced Tensor.
     """
-    return Tensor(masked_mean(x.data, mask.data, axis, keepdims))
 
 
-@functools.singledispatch
-@tensor_guard
-def masked_median(x: Tensor, mask: Tensor, axis: Union[int, Tuple[int, ...], List[int]], keepdims=False) -> Tensor:
+@tensor_dispatcher
+def masked_median(x: Tensor, mask: Tensor, axis: T_AXIS, keepdims: bool = False) -> Tensor:
     """
     Computes the masked median of elements across given dimensions of Tensor.
 
@@ -750,26 +629,21 @@ def masked_median(x: Tensor, mask: Tensor, axis: Union[int, Tuple[int, ...], Lis
         as dimensions with size one.
     :return: Reduced Tensor.
     """
-    return Tensor(masked_median(x.data, mask.data, axis, keepdims))
 
 
-@functools.singledispatch
-@tensor_guard
-def expand_dims(a: Tensor, axis: Union[int, Tuple[int, ...], List[int]]) -> Tensor:
+@tensor_dispatcher
+def expand_dims(a: Tensor, axis: T_SHAPE) -> Tensor:
     """
     Expand the shape of an array.
     Insert a new axis that will appear at the axis position in the expanded array shape.
 
     :param a: Input array.
     :param axis: Position in the expanded axes where the new axis (or axes) is placed.
-
     :return: View of a with the number of dimensions increased.
     """
-    return Tensor(expand_dims(a.data, axis))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def clone(a: Tensor) -> Tensor:
     """
     Return a copy of the tensor.
@@ -777,12 +651,12 @@ def clone(a: Tensor) -> Tensor:
     :param a: The input tensor.
     :return: The copied tensor.
     """
-    return Tensor(clone(a.data))
 
 
-@functools.singledispatch
-@tensor_guard
-def searchsorted(a: Tensor, v: Tensor, side: str = "left", sorter: Optional[Tensor] = None) -> Tensor:
+@tensor_dispatcher
+def searchsorted(
+    a: Tensor, v: Tensor, side: Literal["left", "right"] = "left", sorter: Optional[Tensor] = None
+) -> Tensor:
     """
     Find indices where elements should be inserted to maintain order.
 
@@ -797,7 +671,6 @@ def searchsorted(a: Tensor, v: Tensor, side: str = "left", sorter: Optional[Tens
     :param sorter: Optional array of integer indices that sort array a into ascending order, defaults to None.
     :return: Tensor of insertion points with the same shape as v.
     """
-    return Tensor(searchsorted(a.data, v.data, side, unwrap_tensor_data(sorter)))
 
 
 def zeros(
@@ -873,7 +746,7 @@ def arange(
     return Tensor(get_numeric_backend_fn("arange", backend)(*args, dtype=dtype, device=device))
 
 
-def from_numpy(ndarray: np.ndarray, *, backend: TensorBackend) -> Tensor:
+def from_numpy(ndarray: np.ndarray[Any, Any], *, backend: TensorBackend) -> Tensor:
     """
     Creates a Tensor from a numpy.ndarray, sharing the memory with the given NumPy array.
 
@@ -886,8 +759,7 @@ def from_numpy(ndarray: np.ndarray, *, backend: TensorBackend) -> Tensor:
     return Tensor(get_numeric_backend_fn("from_numpy", backend)(ndarray))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def log2(a: Tensor) -> Tensor:
     """
     Base-2 logarithm of a.
@@ -895,11 +767,9 @@ def log2(a: Tensor) -> Tensor:
     :param a: The input tensor.
     :return: A tensor containing the base-2 logarithm of each element in a.
     """
-    return Tensor(log2(a.data))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def ceil(a: Tensor) -> Tensor:
     """
     Return the ceiling of the input, element-wise.
@@ -907,7 +777,6 @@ def ceil(a: Tensor) -> Tensor:
     :param a: Input data.
     :return: An array of the same type as a, containing the ceiling values.
     """
-    return Tensor(ceil(a.data))
 
 
 def tensor(
@@ -931,8 +800,7 @@ def tensor(
     return Tensor(get_numeric_backend_fn("tensor", backend)(data, dtype=dtype, device=device))
 
 
-@functools.singledispatch
-@tensor_guard
+@tensor_dispatcher
 def as_numpy_tensor(a: Tensor) -> Tensor:
     """
     Convert tensor to numpy.
@@ -944,4 +812,3 @@ def as_numpy_tensor(a: Tensor) -> Tensor:
     :param a: Tensor to change backend for.
     :return: Tensor in numpy backend.
     """
-    return Tensor(as_numpy_tensor(a.data))

--- a/nncf/tensor/functions/numpy_io.py
+++ b/nncf/tensor/functions/numpy_io.py
@@ -9,23 +9,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Optional
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
 
 import numpy as np
+from numpy.typing import NDArray
 from safetensors.numpy import load_file as np_load_file
 from safetensors.numpy import save_file as np_save_file
 
+from nncf.common.utils.os import fail_if_symlink
 from nncf.tensor.definitions import TensorDeviceType
 from nncf.tensor.functions import io as io
-from nncf.tensor.functions.dispatcher import register_numpy_types
 from nncf.tensor.functions.numpy_numeric import validate_device
 
+T_NUMPY_ARRAY = NDArray[Any]
+T_NUMPY = Union[T_NUMPY_ARRAY, np.generic]  # type: ignore [type-arg]
 
-def load_file(file_path: str, *, device: Optional[TensorDeviceType] = None) -> Dict[str, np.ndarray]:
+
+def load_file(file_path: str, *, device: Optional[TensorDeviceType] = None) -> Dict[str, T_NUMPY_ARRAY]:
     validate_device(device)
     return np_load_file(file_path)
 
 
-@register_numpy_types(io.save_file)
-def _(data: Dict[str, np.ndarray], file_path: str) -> None:
-    return np_save_file(data, file_path)
+@io.save_file.register
+def _(data: Dict[str, T_NUMPY], file_path: Path) -> None:
+    fail_if_symlink(file_path)
+    np_save_file(data, file_path)  # type: ignore [arg-type]

--- a/nncf/tensor/functions/numpy_linalg.py
+++ b/nncf/tensor/functions/numpy_linalg.py
@@ -9,35 +9,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Tuple, Union
+from typing import Any, Literal, Optional, Union
 
 import numpy as np
+from numpy.typing import NDArray
 from scipy.linalg import lstsq
 
+from nncf.tensor.definitions import T_AXIS
 from nncf.tensor.functions import linalg
-from nncf.tensor.functions.dispatcher import register_numpy_types
+
+T_NUMPY_ARRAY = NDArray[Any]
 
 
-@register_numpy_types(linalg.norm)
+@linalg.norm.register
 def _(
-    a: Union[np.ndarray, np.generic],
-    ord: Optional[Union[str, float, int]] = None,
-    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    a: T_NUMPY_ARRAY,
+    ord: Union[Literal["fro", "nuc"], float, None] = None,
+    axis: T_AXIS = None,
     keepdims: bool = False,
-) -> np.ndarray:
+) -> T_NUMPY_ARRAY:
     return np.array(np.linalg.norm(a, ord=ord, axis=axis, keepdims=keepdims))
 
 
-@register_numpy_types(linalg.cholesky)
-def _(a: Union[np.ndarray, np.generic], upper: bool = False) -> np.ndarray:
+@linalg.cholesky.register
+def _(a: T_NUMPY_ARRAY, upper: bool = False) -> T_NUMPY_ARRAY:
     lt = np.linalg.cholesky(a)
     if upper:
         return np.conjugate(np.swapaxes(lt, -2, -1))
     return lt
 
 
-@register_numpy_types(linalg.cholesky_inverse)
-def _(a: Union[np.ndarray, np.generic], upper: bool = False) -> np.ndarray:
+@linalg.cholesky_inverse.register
+def _(a: T_NUMPY_ARRAY, upper: bool = False) -> T_NUMPY_ARRAY:
     c = np.linalg.inv(a)
     ct = np.conjugate(np.swapaxes(c, -2, -1))
     if upper:
@@ -45,21 +48,21 @@ def _(a: Union[np.ndarray, np.generic], upper: bool = False) -> np.ndarray:
     return np.matmul(ct, c)
 
 
-@register_numpy_types(linalg.inv)
-def _(a: Union[np.ndarray, np.generic]) -> np.ndarray:
+@linalg.inv.register
+def _(a: T_NUMPY_ARRAY) -> T_NUMPY_ARRAY:
     return np.linalg.inv(a)
 
 
-@register_numpy_types(linalg.pinv)
-def _(a: Union[np.ndarray, np.generic]) -> np.ndarray:
+@linalg.pinv.register
+def _(a: T_NUMPY_ARRAY) -> T_NUMPY_ARRAY:
     return np.linalg.pinv(a)
 
 
-@register_numpy_types(linalg.lstsq)
-def _(a: Union[np.ndarray, np.generic], b: Union[np.ndarray, np.generic], driver: Optional[str] = None) -> np.ndarray:
+@linalg.lstsq.register
+def _(a: T_NUMPY_ARRAY, b: T_NUMPY_ARRAY, driver: Optional[str] = None) -> T_NUMPY_ARRAY:
     return lstsq(a, b, lapack_driver=driver)[0]
 
 
-@register_numpy_types(linalg.svd)
-def _(a: Union[np.ndarray, np.generic], full_matrices: Optional[bool] = True) -> np.ndarray:
-    return np.linalg.svd(a, compute_uv=True, full_matrices=full_matrices)
+@linalg.svd.register
+def _(a: T_NUMPY_ARRAY, full_matrices: Optional[bool] = True) -> T_NUMPY_ARRAY:
+    return np.linalg.svd(a, compute_uv=True, full_matrices=full_matrices)  # type: ignore[call-overload]

--- a/nncf/tensor/functions/openvino_numeric.py
+++ b/nncf/tensor/functions/openvino_numeric.py
@@ -8,10 +8,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
-import numpy as np
 import openvino as ov
+from numpy.typing import NDArray
 
 from nncf.tensor import Tensor
 from nncf.tensor import TensorDataType
@@ -19,7 +19,7 @@ from nncf.tensor.definitions import TensorBackend
 from nncf.tensor.definitions import TensorDeviceType
 from nncf.tensor.functions import numeric
 
-DTYPE_MAP = {
+DTYPE_MAP: Dict[TensorDataType, ov.Type] = {
     TensorDataType.float16: ov.Type.f16,
     TensorDataType.bfloat16: ov.Type.bf16,
     TensorDataType.float32: ov.Type.f32,
@@ -35,17 +35,17 @@ DTYPE_MAP = {
 DTYPE_MAP_REV = {v: k for k, v in DTYPE_MAP.items()}
 
 
-@numeric.device.register(ov.Tensor)
+@numeric.device.register
 def _(a: ov.Tensor) -> TensorDeviceType:
     return TensorDeviceType.CPU
 
 
-@numeric.backend.register(ov.Tensor)
+@numeric.backend.register
 def _(a: ov.Tensor) -> TensorBackend:
     return TensorBackend.ov
 
 
-@numeric.astype.register(ov.Tensor)
+@numeric.astype.register
 def _(a: ov.Tensor, dtype: TensorDataType) -> ov.Tensor:
     if a.get_element_type() in [ov.Type.bf16, ov.Type.i4, ov.Type.u4] or dtype in [
         TensorDataType.bfloat16,
@@ -54,26 +54,26 @@ def _(a: ov.Tensor, dtype: TensorDataType) -> ov.Tensor:
     ]:
         # Cannot cast to/from bfloat16, uint4, int4 directly
         return _astype_ov(a, dtype)
-    return ov.Tensor(numeric.astype(a.data, dtype))
+    return ov.Tensor(numeric.astype(a.data, dtype).data)
 
 
-@numeric.dtype.register(ov.Tensor)
+@numeric.dtype.register
 def _(a: ov.Tensor) -> TensorDataType:
     return DTYPE_MAP_REV[a.get_element_type()]
 
 
-@numeric.size.register(ov.Tensor)
+@numeric.size.register
 def _(a: ov.Tensor) -> int:
     return a.size
 
 
-@numeric.reshape.register(ov.Tensor)
+@numeric.reshape.register
 def _(a: ov.Tensor, shape: Union[int, Tuple[int, ...]]) -> ov.Tensor:
     return ov.Tensor(a.data.reshape(shape), shape, a.get_element_type())
 
 
-@numeric.as_numpy_tensor.register(ov.Tensor)
-def _(a: ov.Tensor) -> np.ndarray:
+@numeric.as_numpy_tensor.register
+def _(a: ov.Tensor) -> NDArray[Any]:
     # Cannot convert bfloat16, uint4, int4 to numpy directly
     a_dtype = DTYPE_MAP_REV[a.get_element_type()]
     if a_dtype in [TensorDataType.bfloat16, TensorDataType.uint4, TensorDataType.int4]:
@@ -89,6 +89,7 @@ def _(a: ov.Tensor) -> np.ndarray:
 def _astype_ov(a: ov.Tensor, dtype: TensorDataType) -> ov.Tensor:
     """
     Cast to a different data type using an OpenVINO model.
+
     :param a: Tensor to cast.
     :param dtype: Data type to cast to.
     :return: Casted openvino tensor.

--- a/nncf/tensor/functions/torch_linalg.py
+++ b/nncf/tensor/functions/torch_linalg.py
@@ -8,39 +8,40 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional, Tuple, Union
+from typing import Literal, Optional, Union
 
 import torch
 
+from nncf.tensor.definitions import T_AXIS
 from nncf.tensor.functions import linalg
 
 
-@linalg.norm.register(torch.Tensor)
+@linalg.norm.register
 def _(
     a: torch.Tensor,
-    ord: Optional[Union[str, float, int]] = None,
-    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    ord: Union[Literal["fro", "nuc"], float, None] = None,
+    axis: T_AXIS = None,
     keepdims: bool = False,
 ) -> torch.Tensor:
     return torch.linalg.norm(a, ord=ord, dim=axis, keepdims=keepdims)
 
 
-@linalg.cholesky.register(torch.Tensor)
+@linalg.cholesky.register
 def _(a: torch.Tensor, upper: bool = False) -> torch.Tensor:
     return torch.linalg.cholesky(a, upper=upper)
 
 
-@linalg.cholesky_inverse.register(torch.Tensor)
+@linalg.cholesky_inverse.register
 def _(a: torch.Tensor, upper: bool = False) -> torch.Tensor:
     return torch.cholesky_inverse(a, upper=upper)
 
 
-@linalg.inv.register(torch.Tensor)
+@linalg.inv.register
 def _(a: torch.Tensor) -> torch.Tensor:
     return torch.linalg.inv(a)
 
 
-@linalg.pinv.register(torch.Tensor)
+@linalg.pinv.register
 def _(a: torch.Tensor) -> torch.Tensor:
     # Consider using torch.linalg.lstsq() if possible for multiplying a matrix on the left by the pseudo-inverse, as:
     # torch.linalg.lstsq(A, B).solution == A.pinv() @ B
@@ -49,11 +50,11 @@ def _(a: torch.Tensor) -> torch.Tensor:
     return torch.linalg.pinv(a)
 
 
-@linalg.lstsq.register(torch.Tensor)
+@linalg.lstsq.register
 def _(a: torch.Tensor, b: torch.Tensor, driver: Optional[str] = None) -> torch.Tensor:
     return torch.linalg.lstsq(a, b, driver=driver).solution
 
 
-@linalg.svd.register(torch.Tensor)
+@linalg.svd.register
 def _(a: torch.Tensor, full_matrices: Optional[bool] = True) -> torch.Tensor:
     return torch.linalg.svd(a, full_matrices=full_matrices)

--- a/nncf/tensor/functions/torch_numeric.py
+++ b/nncf/tensor/functions/torch_numeric.py
@@ -9,13 +9,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, List, Literal, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
+from numpy.typing import NDArray
 
 from nncf.tensor import TensorDataType
 from nncf.tensor import TensorDeviceType
+from nncf.tensor.definitions import T_AXIS
+from nncf.tensor.definitions import T_NUMBER
+from nncf.tensor.definitions import T_SHAPE
+from nncf.tensor.definitions import T_SHAPE_ARRAY
 from nncf.tensor.definitions import TensorBackend
 from nncf.tensor.definitions import TypeInfo
 from nncf.tensor.functions import numeric as numeric
@@ -38,84 +43,84 @@ DTYPE_MAP_REV = {v: k for k, v in DTYPE_MAP.items()}
 DEVICE_MAP_REV = {v: k for k, v in DEVICE_MAP.items()}
 
 
-def convert_to_torch_device(device: TensorDeviceType) -> str:
+def convert_to_torch_device(device: Optional[TensorDeviceType]) -> Optional[str]:
     return DEVICE_MAP[device] if device is not None else None
 
 
-def convert_to_torch_dtype(dtype: TensorDataType) -> torch.dtype:
+def convert_to_torch_dtype(dtype: Optional[TensorDataType]) -> Optional[torch.dtype]:
     return DTYPE_MAP[dtype] if dtype is not None else None
 
 
-@numeric.device.register(torch.Tensor)
+@numeric.device.register
 def _(a: torch.Tensor) -> TensorDeviceType:
     return DEVICE_MAP_REV[a.device.type]
 
 
-@numeric.backend.register(torch.Tensor)
+@numeric.backend.register
 def _(a: torch.Tensor) -> TensorBackend:
     return TensorBackend.torch
 
 
-@numeric.squeeze.register(torch.Tensor)
-def _(a: torch.Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> torch.Tensor:
+@numeric.squeeze.register
+def _(a: torch.Tensor, axis: T_AXIS = None) -> torch.Tensor:
     if axis is None:
         return a.squeeze()
-    if isinstance(axis, Tuple) and any(a.shape[i] != 1 for i in axis):
+    if isinstance(axis, tuple) and any(a.shape[i] != 1 for i in axis):
         # Make Numpy behavior, torch.squeeze skips axes that are not equal to one..
         msg = "Cannot select an axis to squeeze out which has size not equal to one"
         raise ValueError(msg)
     return a.squeeze(axis)
 
 
-@numeric.flatten.register(torch.Tensor)
+@numeric.flatten.register
 def _(a: torch.Tensor) -> torch.Tensor:
     return a.flatten()
 
 
-@numeric.max.register(torch.Tensor)
-def _(a: torch.Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdim: bool = False) -> torch.Tensor:
+@numeric.max.register
+def _(a: torch.Tensor, axis: T_AXIS = None, keepdims: bool = False) -> torch.Tensor:
     # Analog of numpy.max is torch.amax
     if axis is None:
         return torch.amax(a)
-    return torch.amax(a, dim=axis, keepdim=keepdim)
+    return torch.amax(a, dim=axis, keepdim=keepdims)
 
 
-@numeric.min.register(torch.Tensor)
-def _(a: torch.Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdim: bool = False) -> torch.Tensor:
+@numeric.min.register
+def _(a: torch.Tensor, axis: T_AXIS = None, keepdims: bool = False) -> torch.Tensor:
     # Analog of numpy.min is torch.amin
     if axis is None:
         return torch.amin(a)
-    return torch.amin(a, dim=axis, keepdim=keepdim)
+    return torch.amin(a, dim=axis, keepdim=keepdims)
 
 
-@numeric.abs.register(torch.Tensor)
+@numeric.abs.register
 def _(a: torch.Tensor) -> torch.Tensor:
     return torch.absolute(a)
 
 
-@numeric.astype.register(torch.Tensor)
+@numeric.astype.register
 def _(a: torch.Tensor, dtype: TensorDataType) -> torch.Tensor:
     return a.type(DTYPE_MAP[dtype])
 
 
-@numeric.dtype.register(torch.Tensor)
+@numeric.dtype.register
 def _(a: torch.Tensor) -> TensorDataType:
     return DTYPE_MAP_REV[a.dtype]
 
 
-@numeric.reshape.register(torch.Tensor)
-def _(a: torch.Tensor, shape: Tuple[int, ...]) -> torch.Tensor:
+@numeric.reshape.register
+def _(a: torch.Tensor, shape: T_SHAPE) -> torch.Tensor:
     return a.reshape(shape)
 
 
-@numeric.all.register(torch.Tensor)
-def _(a: torch.Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> torch.Tensor:
+@numeric.all.register
+def _(a: torch.Tensor, axis: T_AXIS = None) -> torch.Tensor:
     if axis is None:
         return torch.all(a)
     return torch.all(a, dim=axis)
 
 
-@numeric.allclose.register(torch.Tensor)
+@numeric.allclose.register
 def _(
     a: torch.Tensor, b: Union[torch.Tensor, float], rtol: float = 1e-05, atol: float = 1e-08, equal_nan: bool = False
 ) -> bool:
@@ -124,24 +129,24 @@ def _(
     return torch.allclose(a, b.to(dtype=a.dtype), rtol=rtol, atol=atol, equal_nan=equal_nan)
 
 
-@numeric.any.register(torch.Tensor)
-def _(a: torch.Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> torch.Tensor:
+@numeric.any.register
+def _(a: torch.Tensor, axis: T_AXIS = None) -> torch.Tensor:
     if axis is None:
         return torch.any(a)
     return torch.any(a, dim=axis)
 
 
-@numeric.count_nonzero.register(torch.Tensor)
-def _(a: torch.Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> torch.Tensor:
+@numeric.count_nonzero.register
+def _(a: torch.Tensor, axis: T_AXIS = None) -> torch.Tensor:
     return torch.count_nonzero(a, dim=axis)
 
 
-@numeric.isempty.register(torch.Tensor)
+@numeric.isempty.register
 def _(a: torch.Tensor) -> bool:
     return a.numel() == 0
 
 
-@numeric.isclose.register(torch.Tensor)
+@numeric.isclose.register
 def _(
     a: torch.Tensor, b: Union[torch.Tensor, float], rtol: float = 1e-05, atol: float = 1e-08, equal_nan: bool = False
 ) -> torch.Tensor:
@@ -150,74 +155,76 @@ def _(
     return torch.isclose(a, b.to(dtype=a.dtype), atol=atol, rtol=rtol, equal_nan=equal_nan)
 
 
-@numeric.maximum.register(torch.Tensor)
+@numeric.maximum.register
 def _(x1: torch.Tensor, x2: Union[torch.Tensor, float]) -> torch.Tensor:
     if not isinstance(x2, torch.Tensor):
         x2 = torch.tensor(x2, device=x1.data.device)
     return torch.maximum(x1, x2)
 
 
-@numeric.minimum.register(torch.Tensor)
+@numeric.minimum.register
 def _(x1: torch.Tensor, x2: Union[torch.Tensor, float]) -> torch.Tensor:
     if not isinstance(x2, torch.Tensor):
         x2 = torch.tensor(x2, device=x1.data.device)
     return torch.minimum(x1, x2)
 
 
-@numeric.ones_like.register(torch.Tensor)
+@numeric.ones_like.register
 def _(a: torch.Tensor) -> torch.Tensor:
     return torch.ones_like(a)
 
 
-@numeric.where.register(torch.Tensor)
+@numeric.where.register
 def _(
     condition: torch.Tensor, x: Union[torch.Tensor, float, bool], y: Union[torch.Tensor, float, bool]
 ) -> torch.Tensor:
     return torch.where(condition, x, y)
 
 
-@numeric.zeros_like.register(torch.Tensor)
+@numeric.zeros_like.register
 def _(a: torch.Tensor) -> torch.Tensor:
     return torch.zeros_like(a)
 
 
-@numeric.stack.register(torch.Tensor)
-def _(x: List[torch.Tensor], axis: int = 0) -> List[torch.Tensor]:
+@numeric.stack.register
+def _(x: Sequence[torch.Tensor], axis: int = 0) -> torch.Tensor:
+    if not isinstance(x, (tuple, list)):
+        x = list(x)
     return torch.stack(x, dim=axis)
 
 
-@numeric.concatenate.register(torch.Tensor)
-def _(x: List[torch.Tensor], axis: int = 0) -> List[torch.Tensor]:
+@numeric.concatenate.register
+def _(x: List[torch.Tensor], axis: int = 0) -> torch.Tensor:
     return torch.concatenate(x, dim=axis)
 
 
-@numeric.unstack.register(torch.Tensor)
+@numeric.unstack.register
 def _(x: torch.Tensor, axis: int = 0) -> List[torch.Tensor]:
     if not list(x.shape):
         x = x.unsqueeze(0)
-    return torch.unbind(x, dim=axis)
+    return list(torch.unbind(x, dim=axis))
 
 
-@numeric.moveaxis.register(torch.Tensor)
-def _(a: torch.Tensor, source: Union[int, Tuple[int, ...]], destination: Union[int, Tuple[int, ...]]) -> torch.Tensor:
-    return torch.moveaxis(a, source, destination)
+@numeric.moveaxis.register
+def _(a: torch.Tensor, source: T_SHAPE, destination: T_SHAPE) -> torch.Tensor:
+    return torch.moveaxis(a, source, destination)  # type: ignore[arg-type]
 
 
-@numeric.mean.register(torch.Tensor)
+@numeric.mean.register
 def _(
     a: torch.Tensor,
-    axis: Union[int, Tuple[int, ...]] = None,
+    axis: T_AXIS = None,
     keepdims: bool = False,
     dtype: Optional[TensorDataType] = None,
 ) -> torch.Tensor:
-    dtype = convert_to_torch_dtype(dtype)
-    return torch.mean(a, dim=axis, keepdim=keepdims, dtype=dtype)
+    pt_dtype = convert_to_torch_dtype(dtype)
+    return torch.mean(a, dim=axis, keepdim=keepdims, dtype=pt_dtype)
 
 
-@numeric.median.register(torch.Tensor)
-def _(
+@numeric.median.register
+def median(
     a: torch.Tensor,
-    axis: Union[int, Tuple[int, ...]] = None,
+    axis: T_AXIS = None,
     keepdims: bool = False,
 ) -> torch.Tensor:
     # See https://github.com/pytorch/pytorch/issues/61582
@@ -228,21 +235,21 @@ def _(
     return quantile(a, q=0.5, axis=axis, keepdims=keepdims)
 
 
-@numeric.round.register(torch.Tensor)
-def _(a: torch.Tensor, decimals=0) -> torch.Tensor:
+@numeric.round.register
+def _(a: torch.Tensor, decimals: int = 0) -> torch.Tensor:
     return torch.round(a, decimals=decimals)
 
 
-@numeric.power.register(torch.Tensor)
+@numeric.power.register
 def _(a: torch.Tensor, exponent: Union[torch.Tensor, float]) -> torch.Tensor:
     return torch.pow(a, exponent=exponent)
 
 
-@numeric.quantile.register(torch.Tensor)
+@numeric.quantile.register
 def quantile(
     a: torch.Tensor,
     q: Union[float, List[float]],
-    axis: Optional[Union[int, Tuple[int]]] = None,
+    axis: T_AXIS = None,
     keepdims: bool = False,
 ) -> torch.Tensor:
     device = a.device
@@ -260,134 +267,128 @@ def quantile(
     ).to(device)
 
 
-@numeric.percentile.register(torch.Tensor)
+@numeric.percentile.register
 def _(
     a: torch.Tensor,
     q: Union[float, List[float]],
-    axis: Union[int, Tuple[int, ...], List[int]],
+    axis: T_AXIS,
     keepdims: bool = False,
-) -> List[Union[torch.Tensor, np.generic]]:
+) -> torch.Tensor:
     q = [x / 100 for x in q] if isinstance(q, (list, tuple)) else q / 100
-    return numeric.quantile(a, q=q, axis=axis, keepdims=keepdims)
+    return quantile(a, q=q, axis=axis, keepdims=keepdims)
 
 
-@numeric._binary_op_nowarn.register(torch.Tensor)
-def _(a: torch.Tensor, b: Union[torch.Tensor, float], operator_fn: Callable) -> torch.Tensor:
+@numeric._binary_op_nowarn.register
+def _(a: torch.Tensor, b: Union[torch.Tensor, float], operator_fn: Callable[..., Any]) -> torch.Tensor:
     return operator_fn(a, b)
 
 
-@numeric._binary_reverse_op_nowarn.register(torch.Tensor)
-def _(a: torch.Tensor, b: Union[torch.Tensor, float], operator_fn: Callable) -> torch.Tensor:
+@numeric._binary_reverse_op_nowarn.register
+def _(a: torch.Tensor, b: Union[torch.Tensor, float], operator_fn: Callable[..., Any]) -> torch.Tensor:
     return operator_fn(b, a)
 
 
-@numeric.clip.register(torch.Tensor)
+@numeric.clip.register
 def _(a: torch.Tensor, a_min: Union[torch.Tensor, float], a_max: Union[torch.Tensor, float]) -> torch.Tensor:
-    return torch.clip(a, a_min, a_max)
+    return torch.clip(a, a_min, a_max)  # type: ignore[arg-type]
 
 
-@numeric.finfo.register(torch.Tensor)
+@numeric.finfo.register
 def _(a: torch.Tensor) -> TypeInfo:
     ti = torch.finfo(a.dtype)
     return TypeInfo(ti.eps, ti.max, ti.min)
 
 
-@numeric.as_tensor_like.register(torch.Tensor)
+@numeric.as_tensor_like.register
 def _(a: torch.Tensor, data: Any) -> torch.Tensor:
     return torch.as_tensor(data, device=a.device)
 
 
-@numeric.item.register(torch.Tensor)
-def _(a: torch.Tensor) -> Union[int, float, bool]:
+@numeric.item.register
+def _(a: torch.Tensor) -> T_NUMBER:
     return a.item()
 
 
-@numeric.sum.register(torch.Tensor)
-def _(a: torch.Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False) -> torch.Tensor:
+@numeric.sum.register
+def _(a: torch.Tensor, axis: T_AXIS = None, keepdims: bool = False) -> torch.Tensor:
     return torch.sum(a, dim=axis, keepdim=keepdims)
 
 
-@numeric.multiply.register(torch.Tensor)
+@numeric.multiply.register
 def _(x1: torch.Tensor, x2: Union[torch.Tensor, float]) -> torch.Tensor:
     return torch.multiply(x1, x2)
 
 
-@numeric.var.register(torch.Tensor)
-def _(
-    a: torch.Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False, ddof: int = 0
-) -> torch.Tensor:
+@numeric.var.register
+def _(a: torch.Tensor, axis: T_AXIS = None, keepdims: bool = False, ddof: int = 0) -> torch.Tensor:
     return torch.var(a, dim=axis, keepdim=keepdims, correction=ddof)
 
 
-@numeric.size.register(torch.Tensor)
+@numeric.size.register
 def _(a: torch.Tensor) -> int:
     return torch.numel(a)
 
 
-@numeric.matmul.register(torch.Tensor)
+@numeric.matmul.register
 def _(x1: torch.Tensor, x2: torch.Tensor) -> torch.Tensor:
     return torch.matmul(x1, x2)
 
 
-@numeric.unsqueeze.register(torch.Tensor)
-def _(a: torch.Tensor, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> torch.Tensor:
+@numeric.unsqueeze.register
+def _(a: torch.Tensor, axis: int) -> torch.Tensor:
     return torch.unsqueeze(a, dim=axis)
 
 
-@numeric.transpose.register(torch.Tensor)
-def _(a: torch.Tensor, axes: Optional[Tuple[int, ...]] = None) -> torch.Tensor:
+@numeric.transpose.register
+def _(a: torch.Tensor, axes: Optional[T_SHAPE_ARRAY] = None) -> torch.Tensor:
     if axes is None:
         return a.t()
     return torch.permute(a, axes)
 
 
-@numeric.argsort.register(torch.Tensor)
-def _(a: torch.Tensor, axis: int = -1, descending=False, stable=False) -> torch.Tensor:
+@numeric.argsort.register
+def _(a: torch.Tensor, axis: int = -1, descending: bool = False, stable: bool = False) -> torch.Tensor:
     return torch.argsort(a, dim=axis, descending=descending, stable=stable)
 
 
-@numeric.diag.register(torch.Tensor)
+@numeric.diag.register
 def _(a: torch.Tensor, k: int = 0) -> torch.Tensor:
     return torch.diag(a, diagonal=k)
 
 
-@numeric.logical_or.register(torch.Tensor)
+@numeric.logical_or.register
 def _(x1: torch.Tensor, x2: torch.Tensor) -> torch.Tensor:
     return torch.logical_or(x1, x2)
 
 
-@numeric.masked_mean.register(torch.Tensor)
-def _(
-    x: torch.Tensor, mask: Optional[torch.Tensor], axis: Union[int, Tuple[int, ...], List[int]], keepdims=False
-) -> torch.Tensor:
+@numeric.masked_mean.register
+def _(x: torch.Tensor, mask: Optional[torch.Tensor], axis: T_AXIS, keepdims: bool = False) -> torch.Tensor:
     if mask is None:
-        return torch.mean(x, axis=axis, keepdims=keepdims)
+        return torch.mean(x, dim=axis, keepdim=keepdims)
     masked_x = x.masked_fill(mask, torch.nan)
     ret = torch.nanmean(masked_x, dim=axis, keepdim=keepdims)
     return torch.nan_to_num(ret)
 
 
-@numeric.masked_median.register(torch.Tensor)
-def _(
-    x: torch.Tensor, mask: Optional[torch.Tensor], axis: Union[int, Tuple[int, ...], List[int]], keepdims=False
-) -> torch.Tensor:
+@numeric.masked_median.register
+def _(x: torch.Tensor, mask: Optional[torch.Tensor], axis: T_AXIS, keepdims: bool = False) -> torch.Tensor:
     if mask is None:
-        return numeric.median(x, axis=axis, keepdims=keepdims)
+        return median(x, axis=axis, keepdims=keepdims)
 
     # See https://github.com/pytorch/pytorch/issues/61582
     if not isinstance(axis, int):
         device = x.device
-        masked_x = np.ma.array(x.detach().cpu().numpy(), mask=mask.detach().cpu().numpy())
-        result = torch.tensor(np.ma.median(masked_x, axis=axis, keepdims=keepdims))
+        np_masked_x = np.ma.array(x.detach().cpu().numpy(), mask=mask.detach().cpu().numpy())  # type: ignore[no-untyped-call]
+        result = torch.tensor(np.ma.median(np_masked_x, axis=axis, keepdims=keepdims))  # type: ignore[no-untyped-call]
         return result.type(x.dtype).to(device)
-    masked_x = x.masked_fill(mask, torch.nan)
-    ret = torch.nanquantile(masked_x, q=0.5, dim=axis, keepdims=keepdims)
+    pt_masked_x = x.masked_fill(mask, torch.nan)
+    ret = torch.nanquantile(pt_masked_x, q=0.5, dim=axis, keepdim=keepdims)
     return torch.nan_to_num(ret)
 
 
-@numeric.expand_dims.register(torch.Tensor)
-def _(a: torch.Tensor, axis: Union[int, Tuple[int, ...], List[int]]) -> np.ndarray:
-    if type(axis) not in (tuple, list):
+@numeric.expand_dims.register
+def _(a: torch.Tensor, axis: T_SHAPE) -> torch.Tensor:
+    if not isinstance(axis, (tuple, list)):
         axis = (axis,)
 
     if len(set(axis)) != len(axis):
@@ -408,13 +409,15 @@ def _(a: torch.Tensor, axis: Union[int, Tuple[int, ...], List[int]]) -> np.ndarr
     return a.reshape(shape)
 
 
-@numeric.clone.register(torch.Tensor)
+@numeric.clone.register
 def _(a: torch.Tensor) -> torch.Tensor:
     return a.clone()
 
 
-@numeric.searchsorted.register(torch.Tensor)
-def _(a: torch.Tensor, v: torch.Tensor, side: str = "left", sorter: Optional[torch.Tensor] = None) -> torch.Tensor:
+@numeric.searchsorted.register
+def _(
+    a: torch.Tensor, v: torch.Tensor, side: Literal["left", "right"] = "left", sorter: Optional[torch.Tensor] = None
+) -> torch.Tensor:
     if side not in ["right", "left"]:
         msg = f"Invalid value for 'side': {side}. Expected 'right' or 'left'."
         raise ValueError(msg)
@@ -430,9 +433,9 @@ def zeros(
     dtype: Optional[TensorDataType] = None,
     device: Optional[TensorDeviceType] = None,
 ) -> torch.Tensor:
-    device = convert_to_torch_device(device)
-    dtype = convert_to_torch_dtype(dtype)
-    return torch.zeros(*shape, dtype=dtype, device=device)
+    pt_device = convert_to_torch_device(device)
+    pt_dtype = convert_to_torch_dtype(dtype)
+    return torch.zeros(*shape, dtype=pt_dtype, device=pt_device)
 
 
 def eye(
@@ -442,10 +445,10 @@ def eye(
     dtype: Optional[TensorDataType] = None,
     device: Optional[TensorDeviceType] = None,
 ) -> torch.Tensor:
-    device = convert_to_torch_device(device)
-    dtype = convert_to_torch_dtype(dtype)
+    pt_device = convert_to_torch_device(device)
+    pt_dtype = convert_to_torch_dtype(dtype)
     p_args = (n,) if m is None else (n, m)
-    return torch.eye(*p_args, dtype=dtype, device=device)
+    return torch.eye(*p_args, dtype=pt_dtype, device=pt_device)
 
 
 def arange(
@@ -456,21 +459,21 @@ def arange(
     dtype: Optional[TensorDataType] = None,
     device: Optional[TensorDeviceType] = None,
 ) -> torch.Tensor:
-    device = convert_to_torch_device(device)
-    dtype = convert_to_torch_dtype(dtype)
-    return torch.arange(start, end, step, dtype=dtype, device=device)
+    pt_device = convert_to_torch_device(device)
+    pt_dtype = convert_to_torch_dtype(dtype)
+    return torch.arange(start, end, step, dtype=pt_dtype, device=pt_device)
 
 
-def from_numpy(ndarray: np.ndarray) -> torch.Tensor:
+def from_numpy(ndarray: NDArray[Any]) -> torch.Tensor:
     return torch.from_numpy(ndarray)
 
 
-@numeric.log2.register(torch.Tensor)
+@numeric.log2.register
 def _(a: torch.Tensor) -> torch.Tensor:
     return torch.log2(a)
 
 
-@numeric.ceil.register(torch.Tensor)
+@numeric.ceil.register
 def _(a: torch.Tensor) -> torch.Tensor:
     return torch.ceil(a)
 
@@ -481,11 +484,11 @@ def tensor(
     dtype: Optional[TensorDataType] = None,
     device: Optional[TensorDeviceType] = None,
 ) -> torch.Tensor:
-    device = convert_to_torch_device(device)
-    dtype = convert_to_torch_dtype(dtype)
-    return torch.tensor(data, dtype=dtype, device=device)
+    pt_device = convert_to_torch_device(device)
+    pt_dtype = convert_to_torch_dtype(dtype)
+    return torch.tensor(data, dtype=pt_dtype, device=pt_device)
 
 
-@numeric.as_numpy_tensor.register(torch.Tensor)
-def _(a: torch.Tensor) -> np.ndarray:
+@numeric.as_numpy_tensor.register
+def _(a: torch.Tensor) -> NDArray[Any]:
     return a.cpu().detach().numpy()

--- a/nncf/tensor/tensor.py
+++ b/nncf/tensor/tensor.py
@@ -11,15 +11,18 @@
 from __future__ import annotations
 
 import operator
-from typing import Any, Dict, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, Iterator, Optional, Tuple, Union, cast
 
 import nncf
 from nncf.common.utils.backend import BackendType
+from nncf.tensor.definitions import T_AXIS
+from nncf.tensor.definitions import T_NUMBER
+from nncf.tensor.definitions import T_SHAPE
 from nncf.tensor.definitions import TensorBackend
 from nncf.tensor.definitions import TensorDataType
 from nncf.tensor.definitions import TensorDeviceType
 
-TTensor = TypeVar("TTensor")
+TTensor = Any
 
 
 class Tensor:
@@ -40,28 +43,28 @@ class Tensor:
 
     @property
     def ndim(self) -> int:
-        return self.data.ndim
+        return cast(int, self.data.ndim)
 
     @property
     def device(self) -> TensorDeviceType:
-        return _call_function("device", self)
+        return cast(TensorDeviceType, _call_function("device", self))
 
     @property
     def dtype(self) -> TensorDataType:
-        return _call_function("dtype", self)
+        return cast(TensorDataType, _call_function("dtype", self))
 
     @property
     def backend(self) -> TensorBackend:
-        return _call_function("backend", self)
+        return cast(TensorBackend, _call_function("backend", self))
 
     @property
     def size(self) -> int:
-        return _call_function("size", self)
+        return cast(int, _call_function("size", self))
 
     def __bool__(self) -> bool:
         return bool(self.data)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Tensor]:
         return TensorIterator(self.data)
 
     def __getitem__(self, index: Union[Tensor, int, Tuple[Union[Tensor, int], ...]]) -> Tensor:
@@ -76,69 +79,72 @@ class Tensor:
     def __repr__(self) -> str:
         return f"nncf.Tensor({repr(self.data)})"
 
+    def __len__(self) -> int:
+        return len(self.data)
+
     # built-in operations
 
-    def __add__(self, other: Union[Tensor, float]) -> Tensor:
+    def __add__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         return Tensor(self.data + unwrap_tensor_data(other))
 
-    def __radd__(self, other: Union[Tensor, float]) -> Tensor:
+    def __radd__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         return Tensor(unwrap_tensor_data(other) + self.data)
 
-    def __iadd__(self, other: Union[Tensor, float]) -> Tensor:
+    def __iadd__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         self._data += unwrap_tensor_data(other)
         return self
 
-    def __sub__(self, other: Union[Tensor, float]) -> Tensor:
+    def __sub__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         return Tensor(self.data - unwrap_tensor_data(other))
 
-    def __rsub__(self, other: Union[Tensor, float]) -> Tensor:
+    def __rsub__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         return Tensor(unwrap_tensor_data(other) - self.data)
 
-    def __isub__(self, other: Union[Tensor, float]) -> Tensor:
+    def __isub__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         self._data -= unwrap_tensor_data(other)
         return self
 
-    def __mul__(self, other: Union[Tensor, float]) -> Tensor:
+    def __mul__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         return Tensor(self.data * unwrap_tensor_data(other))
 
-    def __rmul__(self, other: Union[Tensor, float]) -> Tensor:
+    def __rmul__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         return Tensor(unwrap_tensor_data(other) * self.data)
 
-    def __imul__(self, other: Union[Tensor, float]) -> Tensor:
+    def __imul__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         self._data *= unwrap_tensor_data(other)
         return self
 
-    def __pow__(self, other: Union[Tensor, float]) -> Tensor:
+    def __pow__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         return Tensor(self.data ** unwrap_tensor_data(other))
 
-    def __rpow__(self, other: Union[Tensor, float]) -> Tensor:
+    def __rpow__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         return Tensor(unwrap_tensor_data(other) ** self.data)
 
-    def __ipow__(self, other: Union[Tensor, float]) -> Tensor:
+    def __ipow__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         self._data **= unwrap_tensor_data(other)
         return self
 
-    def __truediv__(self, other: Union[Tensor, float]) -> Tensor:
-        return _call_function("_binary_op_nowarn", self, other, operator.truediv)
+    def __truediv__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
+        return cast(Tensor, _call_function("_binary_op_nowarn", self, other, operator.truediv))
 
-    def __rtruediv__(self, other: Union[Tensor, float]) -> Tensor:
-        return _call_function("_binary_reverse_op_nowarn", self, other, operator.truediv)
+    def __rtruediv__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
+        return cast(Tensor, _call_function("_binary_reverse_op_nowarn", self, other, operator.truediv))
 
-    def __itruediv__(self, other: Union[Tensor, float]) -> Tensor:
+    def __itruediv__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         self._data /= unwrap_tensor_data(other)
         return self
 
-    def __floordiv__(self, other: Union[Tensor, float]) -> Tensor:
-        return _call_function("_binary_op_nowarn", self, other, operator.floordiv)
+    def __floordiv__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
+        return cast(Tensor, _call_function("_binary_op_nowarn", self, other, operator.floordiv))
 
-    def __rfloordiv__(self, other: Union[Tensor, float]) -> Tensor:
-        return _call_function("_binary_reverse_op_nowarn", self, other, operator.floordiv)
+    def __rfloordiv__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
+        return cast(Tensor, _call_function("_binary_reverse_op_nowarn", self, other, operator.floordiv))
 
-    def __ifloordiv__(self, other: Union[Tensor, float]) -> Tensor:
-        self._data /= unwrap_tensor_data(other)
+    def __ifloordiv__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
+        self._data //= unwrap_tensor_data(other)
         return self
 
-    def __matmul__(self, other: Union[Tensor, float]) -> Tensor:
+    def __matmul__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         return Tensor(self.data @ unwrap_tensor_data(other))
 
     def __neg__(self) -> Tensor:
@@ -146,61 +152,61 @@ class Tensor:
 
     # Comparison operators
 
-    def __lt__(self, other: Union[Tensor, float]) -> Tensor:
+    def __lt__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         return Tensor(self.data < unwrap_tensor_data(other))
 
-    def __le__(self, other: Union[Tensor, float]) -> Tensor:
+    def __le__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         return Tensor(self.data <= unwrap_tensor_data(other))
 
-    def __eq__(self, other: Union[Tensor, float]) -> Tensor:
+    def __eq__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:  # type: ignore[override]
         return Tensor(self.data == unwrap_tensor_data(other))
 
-    def __ne__(self, other: Union[Tensor, float]) -> Tensor:
+    def __ne__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:  # type: ignore[override]
         return Tensor(self.data != unwrap_tensor_data(other))
 
-    def __gt__(self, other: Union[Tensor, float]) -> Tensor:
+    def __gt__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         return Tensor(self.data > unwrap_tensor_data(other))
 
-    def __ge__(self, other: Union[Tensor, float]) -> Tensor:
+    def __ge__(self, other: Union[Tensor, T_NUMBER]) -> Tensor:
         return Tensor(self.data >= unwrap_tensor_data(other))
 
     # Tensor functions
 
-    def squeeze(self, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> Tensor:
-        return _call_function("squeeze", self, axis)
+    def squeeze(self, axis: T_AXIS = None) -> Tensor:
+        return cast(Tensor, _call_function("squeeze", self, axis))
 
     def flatten(self) -> Tensor:
-        return _call_function("flatten", self)
+        return cast(Tensor, _call_function("flatten", self))
 
-    def max(self, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: Optional[bool] = False) -> Tensor:
-        return _call_function("max", self, axis, keepdims)
+    def max(self, axis: T_AXIS = None, keepdims: Optional[bool] = False) -> Tensor:
+        return cast(Tensor, _call_function("max", self, axis, keepdims))
 
-    def min(self, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: Optional[bool] = False) -> Tensor:
-        return _call_function("min", self, axis, keepdims)
+    def min(self, axis: T_AXIS = None, keepdims: Optional[bool] = False) -> Tensor:
+        return cast(Tensor, _call_function("min", self, axis, keepdims))
 
     def abs(self) -> Tensor:
-        return _call_function("abs", self)
+        return cast(Tensor, _call_function("abs", self))
 
     def isempty(self) -> bool:
-        return _call_function("isempty", self)
+        return cast(bool, _call_function("isempty", self))
 
     def astype(self, dtype: TensorDataType) -> Tensor:
-        return _call_function("astype", self, dtype)
+        return cast(Tensor, _call_function("astype", self, dtype))
 
-    def reshape(self, shape: Tuple[int, ...]) -> Tensor:
-        return _call_function("reshape", self, shape)
+    def reshape(self, shape: T_SHAPE) -> Tensor:
+        return cast(Tensor, _call_function("reshape", self, shape))
 
-    def item(self) -> float:
-        return _call_function("item", self)
+    def item(self) -> T_NUMBER:
+        return cast(T_NUMBER, _call_function("item", self))
 
-    def clone(self) -> float:
-        return _call_function("clone", self)
+    def clone(self) -> Tensor:
+        return cast(Tensor, _call_function("clone", self))
 
     def as_numpy_tensor(self) -> Tensor:
-        return _call_function("as_numpy_tensor", self)
+        return cast(Tensor, _call_function("as_numpy_tensor", self))
 
 
-def _call_function(func_name: str, *args):
+def _call_function(func_name: str, *args: Any) -> Any:
     """
     Call function from functions.py to avoid circular imports.
 
@@ -213,10 +219,10 @@ def _call_function(func_name: str, *args):
     return fn(*args)
 
 
-class TensorIterator:
+class TensorIterator(Iterator[Tensor]):
     """Iterator for Tensor class"""
 
-    def __init__(self, tensor):
+    def __init__(self, tensor: Tensor) -> None:
         self._tensor = tensor
         self._index = 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,15 @@ files = [
     "nncf/quantization/range_estimator.py",
     "nncf/quantization/telemetry_extractors.py",
     "nncf/telemetry/",
+    "nncf/tensor/",
     "nncf/*py",
 ]
+disable_error_code = ["import-untyped"]
+
+[[tool.mypy.overrides]]
+module = "nncf.tensor.functions.*"
+disable_error_code = ["empty-body", "no-any-return"]
+
 
 [tool.ruff]
 line-length = 120

--- a/tests/common/tensor/test_disaptcher.py
+++ b/tests/common/tensor/test_disaptcher.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import deque
+from typing import Dict, List, Tuple, Union
+
+import pytest
+
+from nncf.tensor import Tensor
+from nncf.tensor.functions.dispatcher import _get_arg_type
+from nncf.tensor.functions.dispatcher import _get_register_types
+from nncf.tensor.functions.dispatcher import _unwrap_tensors
+from nncf.tensor.functions.dispatcher import _wrap_output
+
+
+@pytest.mark.parametrize(
+    "data, ref",
+    (
+        (1, 1),
+        (Tensor(1), 1),
+        ([1, 1], [1, 1]),
+        ([Tensor(1), Tensor(1)], [1, 1]),
+        ((1, 1), (1, 1)),
+        ((Tensor(1), Tensor(1)), (1, 1)),
+        ({"a": 1, "b": 1}, {"a": 1, "b": 1}),
+        ({"a": Tensor(1), "b": [Tensor(1)], "c": (Tensor(1), 1)}, {"a": 1, "b": [1], "c": (1, 1)}),
+    ),
+)
+def test_unwrap_tensors(data, ref):
+    assert _unwrap_tensors(data) == ref
+
+
+@pytest.mark.parametrize(
+    "data, ret_ann, ref",
+    (
+        (1, int, 1),
+        (1, Tensor, Tensor(1)),
+        ([1, 1], List[int], [1, 1]),
+        ([1, 1], List[Tensor], [Tensor(1), Tensor(1)]),
+        ((1, 1), Tuple[Tensor, int], (Tensor(1), 1)),
+    ),
+)
+def test_wrap_output(data, ret_ann, ref):
+    assert _wrap_output(data, ret_ann) == ref
+
+
+@pytest.mark.parametrize(
+    "data, ref",
+    (
+        (1, int),
+        (Tensor(1), int),
+        ([1, 1], int),
+        ([Tensor(1), Tensor(1)], int),
+        ((1, 1), int),
+        ((Tensor("1"), Tensor("2")), str),
+        ({"a": 1}, int),
+        ({"a": Tensor(1.0)}, float),
+        (deque([1, 2]), int),
+    ),
+)
+def test_get_arg_type(data, ref):
+    assert _get_arg_type(data) == ref
+
+
+@pytest.mark.parametrize(
+    "data, ref",
+    (
+        (float, [float]),
+        (Union[float, str], [float, str]),
+        (List[float], [float]),
+        (List[Union[float, str]], [float, str]),
+        (Dict[str, int], [int]),
+        (Dict[str, Union[float, int]], [float, int]),
+    ),
+)
+def test_get_register_types(data, ref):
+    assert _get_register_types(data) == ref


### PR DESCRIPTION
### Changes

Introduce tensor_dispatcher instead of functools.singledispatch

- Simplified adding a new function
- Dispatch mechanism based on signature 
- Check names of arguments and annotation 
- Enable mypy for `nncf/tensor`
- Keep signature of function
![image](https://github.com/user-attachments/assets/bc53a27e-49ab-4cd6-816b-07e12e431f60)

### Reason for changes

No signature of functions
![image](https://github.com/user-attachments/assets/7bbb4ec0-4323-49b0-bd2b-dd3ea8fe149b)
Impossible use mypy without cast.


