### PR TITLE
[PT2] check overridden forward in _replicate_for_data_parallel

### DIFF
--- a/nncf/experimental/torch2/function_hook/wrapper.py
+++ b/nncf/experimental/torch2/function_hook/wrapper.py
@@ -126,7 +126,7 @@ class ReplicateForDataParallel:
 
         # Ensure that the forwarding method is not overridden. If it is, calling forward()
         # will raise a RuntimeError due to mismatched device assignments, e.g.:
-        #   "Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cuda:0!"
+        # "Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cuda:0!"
         # This happens because __self__ still references the original model for all replicas
         # in an overridden forward method.
 

--- a/nncf/experimental/torch2/function_hook/wrapper.py
+++ b/nncf/experimental/torch2/function_hook/wrapper.py
@@ -122,13 +122,30 @@ class ReplicateForDataParallel:
 
     def __call__(self, *args: Any, **kwargs: Any) -> nn.Module:
         module = cast(nn.Module, self._func.__self__)  # type: ignore[attr-defined]
-        saved_wrapped_forward = module.forward
+        saved_forward_with_hooks = module.forward
+
+        # Ensure that the forwarding method is not overridden. If it is, calling forward()
+        # will raise a RuntimeError due to mismatched device assignments, e.g.:
+        #   "Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cuda:0!"
+        # This happens because __self__ still references the original model for all replicas
+        # in an overridden forward method.
+
+        if not isinstance(saved_forward_with_hooks, ForwardWithHooks):
+            msg = "Not supported overridden forward method, expected ForwardWithHooks"
+            raise nncf.InternalError(msg)
+
+        if not (
+            isinstance(saved_forward_with_hooks._func, types.MethodType)
+            and saved_forward_with_hooks._func.__func__ is module.__class__.forward
+        ):
+            msg = "Not supported overridden forward method of original module"
+            raise nncf.InternalError(msg)
+
         module.__dict__.pop("forward")
 
         replica: nn.Module = self._func(*args, **kwargs)
-
         replica.forward = ForwardWithHooks(replica.forward)
-        module.forward = saved_wrapped_forward
+        module.forward = saved_forward_with_hooks
 
         return replica
 
@@ -176,9 +193,6 @@ def wrap_model(model: TModel) -> TModel:
     :param model: The nn.Module to be wrapped.
     :return: The modified model with the custom behavior injected.
     """
-    if "forward" in model.__dict__:
-        msg = "Wrapper does not supported models with overrided forward function"
-        raise nncf.InternalError(msg)
     model.forward = ForwardWithHooks(model.forward)
     model._replicate_for_data_parallel = ReplicateForDataParallel(model._replicate_for_data_parallel)  # type: ignore
     model.add_module(ATR_HOOK_STORAGE, HookStorage())

--- a/tests/torch2/function_hook/test_train.py
+++ b/tests/torch2/function_hook/test_train.py
@@ -18,6 +18,9 @@ import torch.utils
 from torch import nn
 from torch.nn.parallel import DistributedDataParallel as DDP
 
+import nncf
+from nncf.experimental.torch2.function_hook.wrapper import wrap_model
+from tests.torch2.function_hook.helpers import ConvModel
 from tests.torch2.function_hook.helpers import get_wrapped_simple_model_with_hook
 
 
@@ -47,9 +50,45 @@ def test_train_data_parallel():
     wrapped_model = get_wrapped_simple_model_with_hook().cuda()
     optimizer = torch.optim.Adam(wrapped_model.parameters(), lr=0.1)
     parallel_model = torch.nn.DataParallel(wrapped_model)
-    parallel_model.to("cuda")
     run_one_epoch(parallel_model, optimizer, use_cuda=True)
     assert all(p.grad is not None for p in wrapped_model.parameters())
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2xGPUs")
+@pytest.mark.cuda
+def test_train_data_parallel_with_overridden_forward():
+    model = ConvModel().cuda()
+    orig_forward = model.forward
+
+    def patched_forward(*args, **kwargs):
+        return orig_forward(*args, **kwargs)
+
+    model.forward = patched_forward
+    wrapped_model = wrap_model(model)
+    # Without wrap_model model will raise
+    # RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cuda:0!
+    # In overridden bound method __self__ links to original model for all replicas
+    optimizer = torch.optim.Adam(wrapped_model.parameters(), lr=0.1)
+    parallel_model = torch.nn.DataParallel(wrapped_model)
+    with pytest.raises(nncf.InternalError, match="Not supported overwriting forward method, expected ForwardWithHooks"):
+        run_one_epoch(parallel_model, optimizer, use_cuda=True)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2xGPUs")
+@pytest.mark.cuda
+def test_train_data_parallel_with_overridden_forward_after_wrap_model():
+    model = ConvModel().cuda()
+    wrapped_model = wrap_model(model)
+    orig_forward = model.forward
+
+    def patched_forward(*args, **kwargs):
+        return orig_forward(*args, **kwargs)
+
+    wrapped_model.forward = patched_forward
+    optimizer = torch.optim.Adam(wrapped_model.parameters(), lr=0.1)
+    parallel_model = torch.nn.DataParallel(wrapped_model)
+    with pytest.raises(nncf.InternalError, match="Not supported overwriting forward method of original module"):
+        run_one_epoch(parallel_model, optimizer, use_cuda=True)
 
 
 def _train_ddp(rank, world_size):


### PR DESCRIPTION
### Changes

Move check on overridden forward to _replicate_for_data_parallel, because it's actual only for case with using DataParallel.
For other cases overridden forward can correctly works, depends from user implementation 

