### PR TITLE
[PT] less atol on windows for test_same_outputs_in_torch_and_exported_onnx

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -16,38 +16,8 @@ on:
       - 'tests/cross_fw/examples/*'  # examples tests runs in separate workflow
 
 jobs:
-  # pytest:
-  #   uses: ./.github/workflows/call_precommit.yml
-  #   with:
-  #     python_version: "3.10.14"
-  #     gpu_enabled: true
-  pytorch-cpu:
-    timeout-minutes: 100
-    runs-on: windows-2019-8-core
-    defaults:
-      run:
-        shell: bash
-    env:
-      DEBIAN_FRONTEND: noninteractive
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          lfs: true
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
-        with:
-          python-version: "3.10"
-      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-
-      - name: Install NNCF and test requirements
-        run: pip install . -r tests/torch/requirements.txt
-      - name: Print installed modules
-        run: pip list
-      - name: Run PyTorch precommit test scope
-        run: |
-          set +e
-          export LIB="${LIB};$(python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")"
-          export LIB="${LIB};$(python -c "import sys; print(sys.prefix + '/libs')")"
-          export INCLUDE="${INCLUDE};$(python -c "import sysconfig; print(sysconfig.get_path('include'))")"
-          pytest tests/torch/sparsity/movement/test_model_saving.py -ra -m "not cuda and not weekly and not nightly and not models_hub"
-        env:
-          NUM_WORKERS: 1  # Parallel tests are falls on build extenstion.
+  pytest:
+    uses: ./.github/workflows/call_precommit.yml
+    with:
+      python_version: "3.10.14"
+      gpu_enabled: true

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -16,8 +16,38 @@ on:
       - 'tests/cross_fw/examples/*'  # examples tests runs in separate workflow
 
 jobs:
-  pytest:
-    uses: ./.github/workflows/call_precommit.yml
-    with:
-      python_version: "3.10.14"
-      gpu_enabled: true
+  # pytest:
+  #   uses: ./.github/workflows/call_precommit.yml
+  #   with:
+  #     python_version: "3.10.14"
+  #     gpu_enabled: true
+  pytorch-cpu:
+    timeout-minutes: 100
+    runs-on: windows-2019-8-core
+    defaults:
+      run:
+        shell: bash
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          lfs: true
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: "3.10"
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - name: Install NNCF and test requirements
+        run: pip install . -r tests/torch/requirements.txt
+      - name: Print installed modules
+        run: pip list
+      - name: Run PyTorch precommit test scope
+        run: |
+          set +e
+          export LIB="${LIB};$(python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")"
+          export LIB="${LIB};$(python -c "import sys; print(sys.prefix + '/libs')")"
+          export INCLUDE="${INCLUDE};$(python -c "import sysconfig; print(sysconfig.get_path('include'))")"
+          pytest tests/torch/sparsity/movement/test_model_saving.py -ra -m "not cuda and not weekly and not nightly and not models_hub"
+        env:
+          NUM_WORKERS: 1  # Parallel tests are falls on build extenstion.

--- a/tests/torch/sparsity/movement/test_model_saving.py
+++ b/tests/torch/sparsity/movement/test_model_saving.py
@@ -29,7 +29,6 @@ from packaging import version
 from scipy.special import softmax
 from transformers.trainer_utils import PREFIX_CHECKPOINT_DIR
 
-from nncf.common.utils.os import is_linux
 from nncf.torch import create_compressed_model
 from nncf.torch.checkpoint_loading import load_state
 from tests.torch.helpers import PTTensorListComparator
@@ -130,8 +129,7 @@ class TestONNXExport:
         compression_ctrl.export_model(onnx_model_path)
         onnx_output_dict = self._get_onnx_model_inference_outputs(onnx_model_path, dataset, recipe)
         onnx_outputs = next(iter(onnx_output_dict.values()))
-        atol = 1e-6 if is_linux() else 1e-5
-        assert np.allclose(softmax(onnx_outputs, axis=-1), softmax(torch_outputs, axis=-1), atol=atol)
+        assert np.allclose(softmax(onnx_outputs, axis=-1), softmax(torch_outputs, axis=-1), atol=1e-5)
 
     @pytest.mark.skipif(
         version.parse(torch.__version__) < version.parse("1.12"),

--- a/tests/torch/sparsity/movement/test_model_saving.py
+++ b/tests/torch/sparsity/movement/test_model_saving.py
@@ -29,6 +29,7 @@ from packaging import version
 from scipy.special import softmax
 from transformers.trainer_utils import PREFIX_CHECKPOINT_DIR
 
+from nncf.common.utils.os import is_linux
 from nncf.torch import create_compressed_model
 from nncf.torch.checkpoint_loading import load_state
 from tests.torch.helpers import PTTensorListComparator
@@ -129,7 +130,8 @@ class TestONNXExport:
         compression_ctrl.export_model(onnx_model_path)
         onnx_output_dict = self._get_onnx_model_inference_outputs(onnx_model_path, dataset, recipe)
         onnx_outputs = next(iter(onnx_output_dict.values()))
-        assert np.allclose(softmax(onnx_outputs, axis=-1), softmax(torch_outputs, axis=-1), atol=1e-6)
+        atol = 1e-6 if is_linux() else 1e-5
+        assert np.allclose(softmax(onnx_outputs, axis=-1), softmax(torch_outputs, axis=-1), atol=atol)
 
     @pytest.mark.skipif(
         version.parse(torch.__version__) < version.parse("1.12"),


### PR DESCRIPTION
### Changes

Use atol=1e-5 in test_same_outputs_in_torch_and_exported_onnx 

### Reason for changes

https://github.com/openvinotoolkit/nncf/actions/runs/13510568468/job/37749802966

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/13533343712/job/37820218205?pr=3311
