### PR TITLE
Fixed weight compression for float16/bfloat16 Torch models

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/scale_estimation.py
+++ b/nncf/quantization/algorithms/weight_compression/scale_estimation.py
@@ -185,6 +185,7 @@ class ScaleEstimation:
 
         s, X = process_stats(statistics, subset_size)
 
+        X = X.astype(TensorDataType.float32)
         weight = weight.astype(TensorDataType.float32)
         eps = fns.finfo(weight).eps
 


### PR DESCRIPTION
### Changes

Adapted AWQ and Scale Estimation algorithm for the case when weights and activations are float16 and bfloat16.

### Reason for changes

Otherwise, compression fails with errors like that:
`
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: c10::BFloat16 != float
`

### Related tickets

n/a

### Tests

- tests/torch/ptq/test_weights_compression.py::test_half_precision_models
- PTWC https://github.com/openvinotoolkit/nncf/actions/runs/13680175191
- PTWC Performance 

| 51 build on develop |  52 build on PR |
:-------------------------:|:-------------------------:
 ![image](https://github.com/user-attachments/assets/3d5b9c96-cf4c-47a2-89e8-f1b6b4f48113) | ![image](https://github.com/user-attachments/assets/0b943e42-f407-4cd5-9e4a-3215561ea9e9)


