### PR TITLE
Use wikitext-2-raw-v1 in the examples

### DIFF
--- a/examples/llm_compression/openvino/tiny_llama_find_hyperparams/main.py
+++ b/examples/llm_compression/openvino/tiny_llama_find_hyperparams/main.py
@@ -261,7 +261,7 @@ def main():
         load_in_8bit=False,
     )
     tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
-    dataset = load_dataset("wikitext", "wikitext-2-v1", split="train[:1000]")  # <YOUR_DATASET>
+    dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="train[:1000]")  # <YOUR_DATASET>
     dataset = dataset.filter(lambda example: len(example["text"]) > 128)
     transform_func = partial(tiny_llama_transform_func, tokenizer=tokenizer, ov_model=model.model)
 


### PR DESCRIPTION
### Changes

Use wikitext-2-raw-v1 in the examples

### Reason for changes
Minimize number downloads.

### Related tickets

N/A

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/13715504451
