### PR TITLE
[FX] Support weight quantization for operations where `weight_port_id` != 1

### DIFF
--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -461,11 +461,11 @@ class MinMaxQuantization(Algorithm):
         
         channel_axes = ()
         if qconfig.per_channel:
-            if is_weight:
-                channel_axes = self._backend_entity.get_weight_quantization_axes(node, target_point, len(shape))
-            else:
-                channel_axes = (1,)
+            channel_axes = (
+                self._backend_entity.get_weight_quantization_axes(node, target_point, len(shape)) if is_weight else (1,)
+            )
 
+        # Weight statistics is constant, so only one collection is enough.
         range_estimator_params = self._get_range_estimator_parameters(target_point, qconfig)
         num_samples = self._subset_size if not is_weight else 1
         batchwise_statistics = batchwise_statistics and not is_weight

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -439,9 +439,9 @@ class MinMaxQuantization(Algorithm):
 
     def _get_stat_collector(
         self,
-        graph: NNCFGraph,
+        nncf_graph: NNCFGraph,
         target_point: TargetPoint,
-        qconfig: QuantizerConfig,
+        quantizer_config: QuantizerConfig,
         batchwise_statistics: bool,
     ) -> TensorCollector:
         """
@@ -451,16 +451,17 @@ class MinMaxQuantization(Algorithm):
         :param target_point: Target point indicates where statistics should be collected.
         :param quantizer_config: Configuration of a quantizer layer,
         defining the configuration of created statistic collector.
-        :param num_samples: Number of samples to collect from the 'target_point'.
-        :return: Statistic Collector.
+        :param batchwise_statistics: Determines whether quantizer statistics should be calculated
+            for each item of the batch or for the entire batch.
+        :return: TensorCollector for the statistics calculation.
         """
         is_weight = target_point.is_weight_target_point()
-        node = graph.get_node_by_name(target_point.target_node_name)
-        shape = self._backend_entity.get_target_point_shape(graph, node, target_point)
+        node = nncf_graph.get_node_by_name(target_point.target_node_name)
+        shape = self._backend_entity.get_target_point_shape(nncf_graph, node, target_point)
         
         # Get channel axes considering ConvTranspose layers
         channel_axes = ()
-        if qconfig.per_channel:
+        if quantizer_config.per_channel:
             if is_weight:
                 if node.metatype.__name__.startswith("PTConvTranspose"):
                     channel_axes = (1,)  # Output channels for transpose conv
@@ -477,13 +478,13 @@ class MinMaxQuantization(Algorithm):
             all_axes = set(range(len(shape)))
             reduction_axes = tuple(all_axes - set(channel_axes))
 
-        range_estimator_params = self._get_range_estimator_parameters(target_point, qconfig)
+        range_estimator_params = self._get_range_estimator_parameters(target_point, quantizer_config)
         num_samples = self._subset_size if not is_weight else 1
 
         batchwise_statistics = batchwise_statistics and not is_weight
 
         collector_params = RangeInitCollectorParams(
-            is_weights=is_weight, scheme=qconfig.mode, per_channel=qconfig.per_channel
+            is_weights=is_weight, scheme=quantizer_config.mode, per_channel=quantizer_config.per_channel
         )
         reduction_axes, aggregation_axes = None, None
         if shape is not None:

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -444,29 +444,31 @@ class MinMaxQuantization(Algorithm):
         qconfig: QuantizerConfig,
         batchwise_statistics: bool,
     ) -> TensorCollector:
-        """
-        Creates and returns a statistic collector based on the quantizer's configuration.
 
-        :param graph: NNCFGraph instance.
-        :param target_point: Target point indicates where statistics should be collected.
-        :param qconfig: Configuration of a quantizer layer,
-        defining the configuration of created statistic collector.
-        :param batchwise_statistics: Determines whether quantizer statistics should be calculated
-            for each item of the batch or for the entire batch.
-        :return: Statistic Collector.
-        """
         is_weight = target_point.is_weight_target_point()
         node = graph.get_node_by_name(target_point.target_node_name)
         shape = self._backend_entity.get_target_point_shape(graph, node, target_point)
-        range_estimator_params = self._get_range_estimator_parameters(target_point, qconfig)
-
+        
+        # Get channel axes considering ConvTranspose layers
         channel_axes = ()
         if qconfig.per_channel:
-            channel_axes = (
-                self._backend_entity.get_weight_quantization_axes(node, target_point, len(shape)) if is_weight else (1,)
-            )
+            if is_weight:
+                if node.metatype.__name__.startswith("PTConvTranspose"):
+                    channel_axes = (1,)  # Output channels for transpose conv
+                else:
+                    channel_axes = self._backend_entity.get_weight_quantization_axes(
+                        node, target_point, len(shape)
+                    )
+            else:
+                channel_axes = (1,)
 
-        # Weight statistics is constant, so only one collection is enough.
+        # Align statistics collection with scale shape
+        reduction_axes, aggregation_axes = None, None
+        if shape is not None and channel_axes:
+            all_axes = set(range(len(shape)))
+            reduction_axes = tuple(all_axes - set(channel_axes))
+
+        range_estimator_params = self._get_range_estimator_parameters(target_point, qconfig)
         num_samples = self._subset_size if not is_weight else 1
 
         batchwise_statistics = batchwise_statistics and not is_weight

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -458,6 +458,7 @@ class MinMaxQuantization(Algorithm):
         is_weight = target_point.is_weight_target_point()
         node = graph.get_node_by_name(target_point.target_node_name)
         shape = self._backend_entity.get_target_point_shape(graph, node, target_point)
+        range_estimator_params = self._get_range_estimator_parameters(target_point, qconfig)
         
         channel_axes = ()
         if qconfig.per_channel:
@@ -466,8 +467,8 @@ class MinMaxQuantization(Algorithm):
             )
 
         # Weight statistics is constant, so only one collection is enough.
-        range_estimator_params = self._get_range_estimator_parameters(target_point, qconfig)
         num_samples = self._subset_size if not is_weight else 1
+
         batchwise_statistics = batchwise_statistics and not is_weight
 
         collector_params = RangeInitCollectorParams(

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -459,7 +459,7 @@ class MinMaxQuantization(Algorithm):
         node = graph.get_node_by_name(target_point.target_node_name)
         shape = self._backend_entity.get_target_point_shape(graph, node, target_point)
         range_estimator_params = self._get_range_estimator_parameters(target_point, qconfig)
-        
+
         channel_axes = ()
         if qconfig.per_channel:
             channel_axes = (

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -444,7 +444,16 @@ class MinMaxQuantization(Algorithm):
         qconfig: QuantizerConfig,
         batchwise_statistics: bool,
     ) -> TensorCollector:
+        """
+        Creates and returns a statistic collector based on the quantizer's configuration.
 
+        :param nncf_graph: NNCFGraph instance.
+        :param target_point: Target point indicates where statistics should be collected.
+        :param quantizer_config: Configuration of a quantizer layer,
+        defining the configuration of created statistic collector.
+        :param num_samples: Number of samples to collect from the 'target_point'.
+        :return: Statistic Collector.
+        """
         is_weight = target_point.is_weight_target_point()
         node = graph.get_node_by_name(target_point.target_node_name)
         shape = self._backend_entity.get_target_point_shape(graph, node, target_point)

--- a/nncf/quantization/algorithms/min_max/torch_fx_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_fx_backend.py
@@ -187,7 +187,7 @@ class FXMinMaxAlgoBackend(MinMaxAlgoBackend):
 
         channel_idx = channel_axes[0] if channel_axes else 0
 
-        if is_weights and not channel_axes:
+        if not len(channel_axes):
             scale_shape = (1,)
         else:
             scale_shape = tuple(get_scale_shape(

--- a/nncf/quantization/algorithms/min_max/torch_fx_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_fx_backend.py
@@ -40,6 +40,7 @@ from nncf.torch.graph.operator_metatypes import ELEMENTWISE_OPERATIONS
 from nncf.torch.graph.transformations.commands import PTSharedFnInsertionCommand
 from nncf.torch.hardware.config import PTHWConfig
 from nncf.torch.model_graph_manager import get_weight_tensor_port_ids
+from nncf.torch.model_graph_manager import get_weight_channel_axes
 from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.quantization.default_quantization import DEFAULT_PT_QUANT_TRAIT_TO_OP_DICT
 from nncf.torch.quantization.layers import QUANTIZATION_MODULES
@@ -177,16 +178,35 @@ class FXMinMaxAlgoBackend(MinMaxAlgoBackend):
         nncf_graph: NNCFGraph, target_point: PTTargetPoint, per_channel: bool
     ) -> Tuple[Tuple[int, ...], Tuple[int, ...], int]:
         is_weights = target_point.is_weight_target_point()
-        if is_weights:
-            # TODO(dlyakhov): support transpose conv/ make channel_idx common
-            channel_idx = 0
-        else:
-            channel_idx = 1  # channel dim for activations
-
         input_shape = nncf_graph.get_input_shape_for_insertion_point(target_point)
-        scale_shape = tuple(
-            get_scale_shape(input_shape, is_weights=is_weights, per_channel=per_channel, channel_idx=channel_idx)
-        )
+        
+        if is_weights:
+            node = nncf_graph.get_node_by_name(target_point.target_node_name)
+            # Get channel axes considering weight port ID
+            channel_axes = get_weight_channel_axes(
+                node.metatype, 
+                len(input_shape), 
+                target_point.input_port_id
+            )
+            if channel_axes:
+                channel_idx = channel_axes[0]
+                scale_shape = tuple(get_scale_shape(
+                    input_shape, 
+                    is_weights=True, 
+                    per_channel=per_channel, 
+                    channel_idx=channel_idx
+                ))
+            else:
+                scale_shape = (1,)
+                channel_idx = 0
+        else:
+            channel_idx = 1
+            scale_shape = tuple(get_scale_shape(
+                input_shape, 
+                is_weights=False, 
+                per_channel=per_channel, 
+                channel_idx=channel_idx
+            ))
 
         return input_shape, scale_shape, channel_idx
 


### PR DESCRIPTION
### Changes

Updated the FX backend’s `_get_input_scale_shape` to use the FX insertion point shape and, when available, the actual weight tensor’s shape to compute the per‑channel scale shape.
Adjusted statistics collector in `_get_stat_collector` so that the reduction and aggregation axes are derived using the same channel axes as used for scale shape computation.

### Related tickets

Issue #3206 

### Tests
All tests run successfully
