### PR TITLE
Change decompressor result dtype

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/torch_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/torch_backend.py
@@ -291,17 +291,16 @@ class PTWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
             # creates weight decompressor
             if compression_config.mode == CompressWeightsMode.INT8_SYM:
-                decompressor = INT8SymmetricWeightsDecompressor(compressed_weight.scale.data, result_dtype=weight.dtype)
+                decompressor = INT8SymmetricWeightsDecompressor(compressed_weight.scale.data)
             elif compression_config.mode == CompressWeightsMode.INT8_ASYM:
                 decompressor = INT8AsymmetricWeightsDecompressor(
-                    compressed_weight.scale.data, compressed_weight.zero_point.data, result_dtype=weight.dtype
+                    compressed_weight.scale.data, compressed_weight.zero_point.data
                 )
             elif compression_config.mode == CompressWeightsMode.INT4_SYM:
                 decompressor = INT4SymmetricWeightsDecompressor(
                     scale=compressed_weight.scale.data,
                     compressed_weight_shape=compressed_weight.tensor.shape,
                     result_shape=weight.shape,
-                    result_dtype=weight.dtype,
                 )
             elif compression_config.mode == CompressWeightsMode.INT4_ASYM:
                 decompressor = INT4AsymmetricWeightsDecompressor(
@@ -309,7 +308,6 @@ class PTWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                     zero_point=compressed_weight.zero_point.data,
                     compressed_weight_shape=compressed_weight.tensor.shape,
                     result_shape=weight.shape,
-                    result_dtype=weight.dtype,
                 )
 
             # pack tensor

--- a/nncf/quantization/algorithms/weight_compression/torch_fx_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/torch_fx_backend.py
@@ -215,19 +215,16 @@ class FXWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
             # creates weight decompressor
             if compression_config.mode == CompressWeightsMode.INT8_SYM:
-                decompressor = INT8SymmetricWeightsDecompressor(
-                    compressed_weight.scale.data, result_dtype=weight.data.dtype
-                )
+                decompressor = INT8SymmetricWeightsDecompressor(compressed_weight.scale.data)
             elif compression_config.mode == CompressWeightsMode.INT8_ASYM:
                 decompressor = INT8AsymmetricWeightsDecompressor(
-                    compressed_weight.scale.data, compressed_weight.zero_point.data, result_dtype=weight.data.dtype
+                    compressed_weight.scale.data, compressed_weight.zero_point.data
                 )
             elif compression_config.mode == CompressWeightsMode.INT4_SYM:
                 decompressor = INT4SymmetricWeightsDecompressor(
                     scale=compressed_weight.scale.data,
                     compressed_weight_shape=compressed_weight.tensor.shape,
                     result_shape=weight.shape,
-                    result_dtype=weight.data.dtype,
                 )
             elif compression_config.mode == CompressWeightsMode.INT4_ASYM:
                 decompressor = INT4AsymmetricWeightsDecompressor(
@@ -235,7 +232,6 @@ class FXWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                     zero_point=compressed_weight.zero_point.data,
                     compressed_weight_shape=compressed_weight.tensor.shape,
                     result_shape=weight.shape,
-                    result_dtype=weight.data.dtype,
                 )
 
             # pack tensor

--- a/nncf/torch/quantization/layers.py
+++ b/nncf/torch/quantization/layers.py
@@ -1100,16 +1100,14 @@ class INT8AsymmetricWeightsDecompressor(BaseWeightsDecompressor):
     Applies asymmetric decompression of compressed weights in the forward pass
     """
 
-    def __init__(self, scale: torch.Tensor, zero_point: torch.Tensor, result_dtype: Optional[torch.dtype] = None):
+    def __init__(self, scale: torch.Tensor, zero_point: torch.Tensor):
         """
         :param scale: A scale in quantization scheme
         :param zero_point: A zero point in quantization scheme
-        :param result_dtype: (Optional) A data type that result should be cast to
         """
         super().__init__()
         self.register_buffer("_scale", scale.type(dtype=torch.float16))
         self.register_buffer("_zero_point", self.pack_weight(zero_point))
-        self.result_dtype = result_dtype
 
     @property
     def quantization_mode(self) -> QuantizationMode:
@@ -1126,7 +1124,7 @@ class INT8AsymmetricWeightsDecompressor(BaseWeightsDecompressor):
 
     def forward(self, x) -> torch.Tensor:
         result = decompress_asymmetric(x, self._scale, self._zero_point)
-        result = result.type(dtype=self.result_dtype) if self.result_dtype is not None else result
+        result = result.type(dtype=torch.float32)
         return result
 
 
@@ -1135,14 +1133,12 @@ class INT8SymmetricWeightsDecompressor(BaseWeightsDecompressor):
     Applies symmetric decompression of compressed weights in the forward pass
     """
 
-    def __init__(self, scale: torch.Tensor, result_dtype: Optional[torch.dtype] = None):
+    def __init__(self, scale: torch.Tensor):
         """
         :param scale: A scale in quantization scheme
-        :param result_dtype: (Optional) A data type that result should be cast to
         """
         super().__init__()
         self.register_buffer("_scale", scale.type(dtype=torch.float16))
-        self.result_dtype = result_dtype
 
     @property
     def quantization_mode(self) -> QuantizationMode:
@@ -1156,7 +1152,7 @@ class INT8SymmetricWeightsDecompressor(BaseWeightsDecompressor):
 
     def forward(self, x) -> torch.Tensor:
         result = decompress_symmetric(x, self._scale)
-        result = result.type(dtype=self.result_dtype) if self.result_dtype is not None else result
+        result = result.type(dtype=torch.float32)
         return result
 
 
@@ -1167,14 +1163,12 @@ class INT4AsymmetricWeightsDecompressor(BaseWeightsDecompressor):
         zero_point: torch.Tensor,
         compressed_weight_shape: Tuple[int, ...],
         result_shape: Optional[Tuple[int, ...]] = None,
-        result_dtype: Optional[torch.dtype] = None,
     ):
         """
         :param scale: A scale in quantization scheme
         :param zero_point: A zero point in quantization scheme
         :param compressed_weight_shape: A compressed weight shape
         :param result_shape: (Optional) A shape that result should be reshaped
-        :param result_dtype: (Optional) A data type that result should be cast to
         """
         super().__init__()
         self.register_buffer("_scale", scale.type(dtype=torch.float16))
@@ -1184,7 +1178,6 @@ class INT4AsymmetricWeightsDecompressor(BaseWeightsDecompressor):
 
         self.compressed_weight_shape = compressed_weight_shape
         self.result_shape = result_shape
-        self.result_dtype = result_dtype
 
     @property
     def quantization_mode(self) -> QuantizationMode:
@@ -1205,7 +1198,7 @@ class INT4AsymmetricWeightsDecompressor(BaseWeightsDecompressor):
 
         result = decompress_asymmetric(x, self._scale, zero_point)
         result = result.reshape(self.result_shape) if self.result_shape is not None else result
-        result = result.type(dtype=self.result_dtype) if self.result_dtype is not None else result
+        result = result.type(dtype=torch.float32)
         return result
 
 
@@ -1215,20 +1208,17 @@ class INT4SymmetricWeightsDecompressor(BaseWeightsDecompressor):
         scale: torch.Tensor,
         compressed_weight_shape: Tuple[int, ...],
         result_shape: Optional[Tuple[int, ...]] = None,
-        result_dtype: Optional[torch.dtype] = None,
     ):
         """
         :param scale: A scale in quantization scheme
         :param compressed_weight_shape: A compressed weight shape
         :param result_shape: (Optional) A shape that result should be reshaped
-        :param result_dtype: (Optional) A data type that result should be cast to
         """
         super().__init__()
         self.register_buffer("_scale", scale.type(dtype=torch.float16))
 
         self.compressed_weight_shape = compressed_weight_shape
         self.result_shape = result_shape
-        self.result_dtype = result_dtype
 
     @property
     def quantization_mode(self) -> QuantizationMode:
@@ -1249,5 +1239,5 @@ class INT4SymmetricWeightsDecompressor(BaseWeightsDecompressor):
 
         result = decompress_symmetric(x, self._scale)
         result = result.reshape(self.result_shape) if self.result_shape is not None else result
-        result = result.type(dtype=self.result_dtype) if self.result_dtype is not None else result
+        result = result.type(dtype=torch.float32)
         return result

--- a/tests/post_training/experimental/sparsify_activations/pipelines.py
+++ b/tests/post_training/experimental/sparsify_activations/pipelines.py
@@ -29,8 +29,6 @@ import nncf
 from nncf.experimental.torch.sparsify_activations import sparsify_activations
 from nncf.experimental.torch.sparsify_activations.sparsify_activations_impl import SparsifyActivationsAlgoBackend
 from nncf.experimental.torch.sparsify_activations.torch_backend import PTSparsifyActivationsAlgoBackend
-from nncf.torch.quantization.layers import INT8AsymmetricWeightsDecompressor
-from nncf.torch.quantization.layers import INT8SymmetricWeightsDecompressor
 from tests.post_training.pipelines.base import PT_BACKENDS
 from tests.post_training.pipelines.base import BackendType
 from tests.post_training.pipelines.base import BaseTestPipeline
@@ -251,9 +249,6 @@ class LMSparsifyActivations(SAPipelineMixin, LMWeightCompression):
         self.path_compressed_ir = self.output_model_dir / self.OV_MODEL_NAME
         if self.backend == BackendType.CUDA_TORCH:
             self.model_hf.float()
-            for module in self.model_hf.nncf.modules():
-                if isinstance(module, (INT8AsymmetricWeightsDecompressor, INT8SymmetricWeightsDecompressor)):
-                    module.result_dtype = torch.float32
             export_from_model(
                 self.model_hf, self.output_model_dir, stateful=False, compression_option="fp32", device="cuda"
             )

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -24,3 +24,6 @@ timm==0.9.2
 # Required for torch/fx tests
 torchvision
 fastdownload==0.0.7
+
+optimum-intel==1.22.0
+optimum==1.24.0


### PR DESCRIPTION
### Changes

- As stated in the title

### Reason for changes

- To allow exporting fp16/bf16 models after NNCF

### Related tickets

- 159708

### Tests

- Updated
