### PR TITLE
Set weight without overriding convert node

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -149,28 +149,19 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
     def set_weight(
         self, node_with_weight: NNCFNode, weight_port_id: int, model: ov.Model, graph: NNCFGraph, weight: Tensor
     ):
-        node_with_const = self.name_to_node_mapping[node_with_weight.node_name]
+        const_op_friendly_name = node_with_weight.layer_attributes.constant_attributes[weight_port_id]["name"]
+        const_op = self.name_to_node_mapping[const_op_friendly_name]
 
-        const_port = node_with_const.input(weight_port_id)
-        const_node = node_with_const.input_value(weight_port_id).get_node()
+        dtype = const_op.get_element_type()
+        name = const_op.get_friendly_name()
+        new_const_op = create_ov_const_from_tensor(weight, dtype, name)
+        self.name_to_node_mapping[const_op_friendly_name] = new_const_op
 
-        shared_memory = True
-        if const_node.get_element_type() == ov.Type.bf16:
-            # Shared memory does not work for BF16 precision
-            shared_memory = False
-
-        new_const_node = ov.runtime.op.Constant(weight.data, shared_memory=shared_memory)
-        new_const_node.set_friendly_name(const_node.get_friendly_name())
-        const_port.replace_source_output(new_const_node.output(0))
-
-        const_name = node_with_weight.layer_attributes.constant_attributes[weight_port_id]["name"]
-        self.name_to_node_mapping[const_name] = new_const_node
-
-        new_output = new_const_node.output(0)
-        for target_input in const_node.output(0).get_target_inputs():
+        new_output = new_const_op.output(0)
+        for target_input in const_op.output(0).get_target_inputs():
             target_input.replace_source_output(new_output)
 
-        del const_node
+        del const_op
 
     def insert_adapters(
         self, wc_params: WeightCompressionParameters, lora_A: Tensor, lora_B: Tensor, int8_lora: bool

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -23,6 +23,7 @@ from openvino.runtime import opset13 as opset
 import nncf
 from nncf import CompressWeightsMode
 from nncf import SensitivityMetric
+from nncf.common.factory import NNCFGraphFactory
 from nncf.common.utils.debug import nncf_debug
 from nncf.data.dataset import Dataset
 from nncf.experimental.common.tensor_statistics.collectors import AggregatorBase
@@ -37,6 +38,7 @@ from nncf.quantization.advanced_parameters import AdvancedLoraCorrectionParamete
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionConfig
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionParameters
 from nncf.quantization.algorithms.weight_compression.mixed_precision import MIXED_PRECISION_CRITERIA
+from nncf.quantization.algorithms.weight_compression.openvino_backend import OVWeightCompressionAlgoBackend
 from nncf.quantization.algorithms.weight_compression.weight_lowering import do_int_quantization
 from nncf.quantization.algorithms.weight_compression.weight_lowering import get_integer_quantization_error
 from nncf.quantization.algorithms.weight_compression.weight_lowering import reshape_weight_for_grouped_quantization
@@ -774,25 +776,46 @@ def check_compressed_matmul_subgraph(start_node, activation_dtype, weight_dtype,
 
 
 @pytest.mark.parametrize(
-    "activation_dtype, weight_dtype",
+    "weight_dtype, activation_dtype",
     [
         (ov.Type.f32, ov.Type.f32),
-        (ov.Type.f32, ov.Type.f16),
-        (ov.Type.f32, ov.Type.bf16),
+        (ov.Type.f16, ov.Type.f32),
+        (ov.Type.bf16, ov.Type.f32),
         (ov.Type.f16, ov.Type.f16),
         (ov.Type.bf16, ov.Type.bf16),
     ],
+    ids=[
+        "w32a32",
+        "w16a32",
+        "wb16a32",
+        "w16a16",
+        "wb16a16",
+    ],
 )
-def test_compression_for_different_dtypes(activation_dtype, weight_dtype):
-    model = IdentityMatmul(weights_dtype=weight_dtype, activation_dtype=activation_dtype).ov_model
+class TestActivationWeightDtype:
+    @staticmethod
+    def test_compression_for_different_dtypes(weight_dtype, activation_dtype):
+        model = IdentityMatmul(weights_dtype=weight_dtype, activation_dtype=activation_dtype).ov_model
 
-    compressed_model = compress_weights(
-        model, mode=CompressWeightsMode.INT4_SYM, ratio=1, group_size=1, all_layers=True
-    )
+        compressed_model = compress_weights(
+            model, mode=CompressWeightsMode.INT4_SYM, ratio=1, group_size=1, all_layers=True
+        )
+        name_to_node_map = {op.get_friendly_name(): op for op in compressed_model.get_ops()}
+        scale_multiply_node = name_to_node_map["weights/fq_weights_1"]
+        check_compressed_matmul_subgraph(scale_multiply_node, activation_dtype, weight_dtype)
 
-    name_to_node_map = {op.get_friendly_name(): op for op in compressed_model.get_ops()}
-    scale_multiply_node = name_to_node_map["weights/fq_weights_1"]
-    check_compressed_matmul_subgraph(scale_multiply_node, activation_dtype, weight_dtype)
+    @staticmethod
+    def test_set_weight(weight_dtype, activation_dtype, tmp_path):
+        model = GatherAndMatmulShareData(weights_dtype=weight_dtype, activation_dtype=activation_dtype).ov_model
+        ov_backend = OVWeightCompressionAlgoBackend(model)
+        graph = NNCFGraphFactory.create(model)
+        node_key = "5 MatMul_2"
+        weight_node = graph.get_node_by_key(node_key)
+        weight_port_id = 1
+        weight = ov_backend.get_weight(weight_node, weight_port_id, model, graph)
+        scaled_weight = weight * 2
+        ov_backend.set_weight(weight_node, weight_port_id, model, graph, scaled_weight)
+        ov.save_model(model, tmp_path / "model.xml", compress_to_fp16=True)
 
 
 DATASET_SIZE = 5


### PR DESCRIPTION
### Changes

Assign the weight to the constant operation, rather than the first operation following the matrix multiplication.

### Reason for changes

In the past, the weights were assigned to the first operation after the Matmul, and this approach functioned properly when the weights were in float32 format. However, with the introduction of the ability to use float16/bfloat16 weights in AWQ, as described in the pull request #3330, the set_weights function no longer operates correctly. The first operation in the process is a `Convert`, which is replaced by a constant, and this causes an error:

```
RuntimeError: Check 'element::Type::merge(result_et, get_input_element_type(0), get_input_element_type(1))' failed at src\core\src\op\matmul.cpp:113:
While validating node 'opset1::MatMul MatMul_1657124 (opset1::Multiply __module.model.layers.0.post_attention_layernorm/aten::mul/Multiply_1[0]:f32[?,?,4096], opset1::Reshape Reshape_511646[0]:f16[14336,4096]) -&gt; (dynamic[...])' with friendly_name 'MatMul_1657124':
```

![image](https://github.com/user-attachments/assets/2aa4b1a0-bdf0-42fa-ab55-aba1d404d83a)

### Related tickets

163980
 should also fix tests in Optimum: 

### Tests

- [x] test_set_weight
- [x] `tests/openvino/test_quantization.py::OVWeightCompressionTest::test_ovmodel_4bit_auto_compression_with_config_07` and `tests/openvino/test_quantization.py::OVWeightCompressionTest::test_ovmodel_4bit_auto_compression_with_config_08` in Optimum have started to work, but failed before: https://github.com/huggingface/optimum-intel/actions/runs/13713350054/job/38353813210

