### PR TITLE
[test_examples] Install WWB version compatible with nightly openvino-genai

### DIFF
--- a/tests/cross_fw/examples/test_examples.py
+++ b/tests/cross_fw/examples/test_examples.py
@@ -95,7 +95,13 @@ def test_examples(
 
     if ov_version_override is not None:
         ov_version_cmd_line = f"{pip_with_venv} install {ov_version_override}"
+        uninstall_cmd_line = f"{pip_with_venv} uninstall --yes openvino-genai openvino_tokenizers"
+        extra_index_url = f"https://storage.openvinotoolkit.org/simple/wheels/nightly"
+        wwb_module_string = f"whowhatbench@git+https://github.com/openvinotoolkit/openvino.genai.git#subdirectory=tools/who_what_benchmark"
+        wwb_override_cmd_line = f"{pip_with_venv} install --pre --extra-index-url {extra_index_url} {wwb_module_string}"
         subprocess.run(ov_version_cmd_line, check=True, shell=True)
+        subprocess.run(uninstall_cmd_line, check=True, shell=True)
+        subprocess.run(wwb_override_cmd_line, check=True, shell=True)
 
     subprocess.run(f"{pip_with_venv} list", check=True, shell=True)
 

--- a/tests/cross_fw/examples/test_examples.py
+++ b/tests/cross_fw/examples/test_examples.py
@@ -96,8 +96,8 @@ def test_examples(
     if ov_version_override is not None:
         ov_version_cmd_line = f"{pip_with_venv} install {ov_version_override}"
         uninstall_cmd_line = f"{pip_with_venv} uninstall --yes openvino-genai openvino_tokenizers"
-        extra_index_url = f"https://storage.openvinotoolkit.org/simple/wheels/nightly"
-        wwb_module_string = f"whowhatbench@git+https://github.com/openvinotoolkit/openvino.genai.git#subdirectory=tools/who_what_benchmark"
+        extra_index_url = "https://storage.openvinotoolkit.org/simple/wheels/nightly"
+        wwb_module_string = "whowhatbench@git+https://github.com/openvinotoolkit/openvino.genai.git#subdirectory=tools/who_what_benchmark"
         wwb_override_cmd_line = f"{pip_with_venv} install --pre --extra-index-url {extra_index_url} {wwb_module_string}"
         subprocess.run(ov_version_cmd_line, check=True, shell=True)
         subprocess.run(uninstall_cmd_line, check=True, shell=True)


### PR DESCRIPTION
### Changes

`whowhatbench` tool depends on `openvino-genai` module, but it takes it from PyPI by default, so it depends on released OpenVINO version, so it install it and we're getting this in validation cycles:
```
ImportError: libopenvino.so.2500: cannot open shared object file: No such file or directory
```

This PR hacks `test_examples.py` (`llm_tune_params` test to be exact) to install nightly versions of `openvino-genai` and `whowhatbench`
