### PR TITLE
[QAT Lora 6/N] torch.compile for reference implementation

### DIFF
--- a/nncf/torch/quantization/reference.py
+++ b/nncf/torch/quantization/reference.py
@@ -111,5 +111,5 @@ class ReferenceQuantize:
 
 class ReferenceQuantizedFunctions:
     _executor = ReferenceQuantize(backend_type=ReferenceBackendType.TORCH)
-    Quantize_forward = _executor.forward
-    Quantize_backward = _executor.backward
+    Quantize_forward = torch.compile(_executor.forward)
+    Quantize_backward = torch.compile(_executor.backward)

--- a/nncf/torch/quantization/reference.py
+++ b/nncf/torch/quantization/reference.py
@@ -16,6 +16,7 @@ import numpy as np
 import torch
 
 import nncf
+from nncf import nncf_logger
 from nncf.torch.utils import sum_like
 
 GeneralizedTensor = TypeVar("GeneralizedTensor", torch.Tensor, np.ndarray)
@@ -111,5 +112,14 @@ class ReferenceQuantize:
 
 class ReferenceQuantizedFunctions:
     _executor = ReferenceQuantize(backend_type=ReferenceBackendType.TORCH)
-    Quantize_forward = torch.compile(_executor.forward)
-    Quantize_backward = torch.compile(_executor.backward)
+    try:
+        Quantize_forward = torch.compile(_executor.forward)
+        Quantize_backward = torch.compile(_executor.backward)
+    except Exception as e:
+        nncf_logger.warning(
+            f"Could not use torch.compile with reference functions. "
+            f"Falling back on not compiled versions - "
+            f"Reason: {str(e)}"
+        )
+        Quantize_forward = _executor.forward
+        Quantize_backward = _executor.backward

--- a/nncf/torch/quantization/reference.py
+++ b/nncf/torch/quantization/reference.py
@@ -16,7 +16,6 @@ import numpy as np
 import torch
 
 import nncf
-from nncf import nncf_logger
 from nncf.torch.utils import sum_like
 
 GeneralizedTensor = TypeVar("GeneralizedTensor", torch.Tensor, np.ndarray)
@@ -112,14 +111,5 @@ class ReferenceQuantize:
 
 class ReferenceQuantizedFunctions:
     _executor = ReferenceQuantize(backend_type=ReferenceBackendType.TORCH)
-    try:
-        Quantize_forward = torch.compile(_executor.forward)
-        Quantize_backward = torch.compile(_executor.backward)
-    except Exception as e:
-        nncf_logger.warning(
-            f"Could not use torch.compile with reference functions. "
-            f"Falling back on not compiled versions - "
-            f"Reason: {str(e)}"
-        )
-        Quantize_forward = _executor.forward
-        Quantize_backward = _executor.backward
+    Quantize_forward = torch.compile(_executor.forward)
+    Quantize_backward = torch.compile(_executor.backward)


### PR DESCRIPTION
### Changes

- Added `torch.compile` for `forward` & `backward` in reference implementation.

### Reason for changes

- Training speed-up from 7 minutes to 5 minutes for 1 epoch of phi3.5 qat-lora tuning

### Related tickets

- 163973

### Tests

- TBD
