### PR TITLE
[QAT Lora 4/N] Strip for LoRA modules

### DIFF
--- a/nncf/__init__.py
+++ b/nncf/__init__.py
@@ -40,6 +40,7 @@ from nncf.parameters import DropType as DropType
 from nncf.parameters import ModelType as ModelType
 from nncf.parameters import QuantizationMode as QuantizationMode
 from nncf.parameters import SensitivityMetric as SensitivityMetric
+from nncf.parameters import StripFormat as StripFormat
 from nncf.parameters import TargetDevice as TargetDevice
 from nncf.quantization import QuantizationPreset as QuantizationPreset
 from nncf.quantization import compress_weights as compress_weights

--- a/nncf/api/compression.py
+++ b/nncf/api/compression.py
@@ -19,6 +19,7 @@ from nncf.common.graph.transformations.layout import TransformationLayout
 from nncf.common.statistics import NNCFStatistics
 from nncf.common.utils.api_marker import api
 from nncf.common.utils.backend import copy_model
+from nncf.parameters import StripFormat
 
 TModel = TypeVar("TModel")
 
@@ -236,7 +237,9 @@ class CompressionAlgorithmController(ABC):
             need to keep track of statistics on each training batch/step/iteration.
         """
 
-    def strip_model(self, model: TModel, do_copy: bool = False) -> TModel:
+    def strip_model(
+        self, model: TModel, do_copy: bool = False, strip_format: StripFormat = StripFormat.NATIVE
+    ) -> TModel:
         """
         Strips auxiliary layers that were used for the model compression, as it's
         only needed for training. The method is used before exporting the model
@@ -244,6 +247,7 @@ class CompressionAlgorithmController(ABC):
 
         :param model: The compressed model.
         :param do_copy: Modify copy of the model, defaults to False.
+        :param strip format: Describes the format in which model is saved after strip.
         :return: The stripped model.
         """
         if do_copy:
@@ -256,16 +260,17 @@ class CompressionAlgorithmController(ABC):
         """
         self._model = self.strip_model(self._model)
 
-    def strip(self, do_copy: bool = True) -> TModel:  # type: ignore[type-var]
+    def strip(self, do_copy: bool = True, strip_format: StripFormat = StripFormat.NATIVE) -> TModel:  # type: ignore[type-var]
         """
-        Returns the model object with as much custom NNCF additions as possible removed
-        while still preserving the functioning of the model object as a compressed model.
+        Removes auxiliary layers and operations added during the compression process, resulting in a clean
+        model ready for deployment. The functionality of the model object is still preserved as a compressed model.
 
         :param do_copy: If True (default), will return a copy of the currently associated model object. If False,
           will return the currently associated model object "stripped" in-place.
+        :param strip format: Describes the format in which model is saved after strip.
         :return: The stripped model.
         """
-        return self.strip_model(self.model, do_copy)  # type: ignore
+        return self.strip_model(self.model, do_copy, strip_format)  # type: ignore
 
     @abstractmethod
     def export_model(

--- a/nncf/common/composite_compression.py
+++ b/nncf/common/composite_compression.py
@@ -23,6 +23,7 @@ from nncf.common.statistics import NNCFStatistics
 from nncf.common.utils.backend import BackendType
 from nncf.common.utils.backend import copy_model
 from nncf.common.utils.backend import get_backend
+from nncf.parameters import StripFormat
 
 
 class CompositeCompressionLoss(CompressionLoss):
@@ -276,12 +277,12 @@ class CompositeCompressionAlgorithmController(CompressionAlgorithmController):
             stripped_model = ctrl.strip_model(stripped_model)
         self._model = stripped_model
 
-    def strip(self, do_copy: bool = True) -> TModel:  # type: ignore
+    def strip(self, do_copy: bool = True, strip_format: StripFormat = StripFormat.NATIVE) -> TModel:  # type: ignore
         model = self.model
         if do_copy:
             model = copy_model(model)
         for ctrl in self.child_ctrls:
-            model = ctrl.strip_model(model, do_copy=False)
+            model = ctrl.strip_model(model, do_copy=False, strip_format=strip_format)
         return model  # type: ignore
 
     @property

--- a/nncf/common/strip.py
+++ b/nncf/common/strip.py
@@ -16,6 +16,7 @@ import nncf
 from nncf.common.utils.api_marker import api
 from nncf.common.utils.backend import BackendType
 from nncf.common.utils.backend import get_backend
+from nncf.parameters import StripFormat
 from nncf.telemetry.decorator import tracked_function
 from nncf.telemetry.events import MODEL_BASED_CATEGORY
 from nncf.telemetry.extractors import FunctionCallTelemetryExtractor
@@ -25,25 +26,26 @@ TModel = TypeVar("TModel")
 
 @api(canonical_alias="nncf.strip")
 @tracked_function(category=MODEL_BASED_CATEGORY, extractors=[FunctionCallTelemetryExtractor("nncf.strip")])
-def strip(model: TModel, do_copy: bool = True) -> TModel:
+def strip(model: TModel, do_copy: bool = True, strip_format: StripFormat = StripFormat.NATIVE) -> TModel:
     """
-    Returns the model object with as much custom NNCF additions as possible removed
-    while still preserving the functioning of the model object as a compressed model.
+    Removes auxiliary layers and operations added during the compression process, resulting in a clean
+    model ready for deployment. The functionality of the model object is still preserved as a compressed model.
 
     :param model: The compressed model.
     :param do_copy: If True (default), will return a copy of the currently associated model object. If False,
       will return the currently associated model object "stripped" in-place.
+    :param strip format: Describes the format in which model is saved after strip.
     :return: The stripped model.
     """
     model_backend = get_backend(model)
     if model_backend == BackendType.TORCH:
         from nncf.torch.strip import strip as strip_pt
 
-        return strip_pt(model, do_copy)  # type: ignore
+        return strip_pt(model, do_copy, strip_format)  # type: ignore
     elif model_backend == BackendType.TENSORFLOW:
         from nncf.tensorflow.strip import strip as strip_tf
 
-        return strip_tf(model, do_copy)  # type: ignore
+        return strip_tf(model, do_copy, strip_format)  # type: ignore
 
-    msg = f"Method `strip` does not support for {model_backend.value} backend."
+    msg = f"Method `strip` does not support {model_backend.value} backend."
     raise nncf.UnsupportedBackendError(msg)

--- a/nncf/experimental/tensorflow/quantization/algorithm.py
+++ b/nncf/experimental/tensorflow/quantization/algorithm.py
@@ -35,6 +35,7 @@ from nncf.experimental.tensorflow.nncf_network import NNCFNetwork
 from nncf.experimental.tensorflow.quantization.init_range import RangeInitializerV2
 from nncf.experimental.tensorflow.quantization.init_range import TFRangeInitParamsV2
 from nncf.experimental.tensorflow.quantization.quantizers import create_quantizer
+from nncf.parameters import StripFormat
 from nncf.tensorflow.algorithm_selector import TF_COMPRESSION_ALGORITHMS
 from nncf.tensorflow.graph.metatypes.tf_ops import TFOpWithWeightsMetatype
 from nncf.tensorflow.graph.transformations.commands import TFInsertionCommand
@@ -353,7 +354,9 @@ class QuantizationBuilderV2(QuantizationBuilder):
 
 
 class QuantizationControllerV2(QuantizationController):
-    def strip_model(self, model: NNCFNetwork, do_copy: bool = False) -> NNCFNetwork:
+    def strip_model(
+        self, model: NNCFNetwork, do_copy: bool = False, strip_format: StripFormat = StripFormat.NATIVE
+    ) -> NNCFNetwork:
         if do_copy:
             model = copy_model(model)
         return model

--- a/nncf/parameters.py
+++ b/nncf/parameters.py
@@ -119,6 +119,23 @@ class CompressionFormat(StrEnum):
     FQ_LORA = "fake_quantize_with_lora"
 
 
+@api(canonical_alias="nncf.StripFormat")
+class StripFormat(StrEnum):
+    """
+    Describes the format in which model is saved after strip: operation that removes auxiliary layers and
+    operations added during the compression process, resulting in a clean model ready for deployment.
+    The functionality of the model object is still preserved as a compressed model.
+
+    :param NATIVE: Returns the model with as much custom NNCF additions as possible,
+    :param DQ: Replaces FakeQuantize operations with dequantization subgraph and compressed weights in low-bit
+        precision using fake quantize parameters. This is the default format for deployment of models with compressed
+        weights.
+    """
+
+    NATIVE = "native"
+    DQ = "dequantize"
+
+
 @api(canonical_alias="nncf.BackupMode")
 class BackupMode(StrEnum):
     """

--- a/nncf/parameters.py
+++ b/nncf/parameters.py
@@ -126,7 +126,7 @@ class StripFormat(StrEnum):
     operations added during the compression process, resulting in a clean model ready for deployment.
     The functionality of the model object is still preserved as a compressed model.
 
-    :param NATIVE: Returns the model with as much custom NNCF additions as possible,
+    :param NATIVE: Returns the model with as much custom NNCF additions as possible.
     :param DQ: Replaces FakeQuantize operations with dequantization subgraph and compressed weights in low-bit
         precision using fake quantize parameters. This is the default format for deployment of models with compressed
         weights.

--- a/nncf/tensorflow/algorithm_selector.py
+++ b/nncf/tensorflow/algorithm_selector.py
@@ -22,6 +22,7 @@ from nncf.common.schedulers import StubCompressionScheduler
 from nncf.common.statistics import NNCFStatistics
 from nncf.common.utils.backend import copy_model
 from nncf.common.utils.registry import Registry
+from nncf.parameters import StripFormat
 from nncf.tensorflow.api.compression import TFCompressionAlgorithmBuilder
 from nncf.tensorflow.loss import TFZeroCompressionLoss
 
@@ -60,7 +61,7 @@ class NoCompressionAlgorithmController(BaseCompressionAlgorithmController):
     def statistics(self, quickly_collected_only: bool = False) -> NNCFStatistics:
         return NNCFStatistics()
 
-    def strip(self, do_copy: bool = True) -> tf.keras.Model:
+    def strip(self, do_copy: bool = True, strip_format: StripFormat = StripFormat.NATIVE) -> tf.keras.Model:
         model = self.model
         if do_copy:
             model = copy_model(self.model)

--- a/nncf/tensorflow/pruning/base_algorithm.py
+++ b/nncf/tensorflow/pruning/base_algorithm.py
@@ -35,6 +35,7 @@ from nncf.config.schemata.defaults import PRUNE_BATCH_NORMS
 from nncf.config.schemata.defaults import PRUNE_DOWNSAMPLE_CONVS
 from nncf.config.schemata.defaults import PRUNE_FIRST_CONV
 from nncf.config.schemata.defaults import PRUNING_INIT
+from nncf.parameters import StripFormat
 from nncf.tensorflow.api.compression import TFCompressionAlgorithmBuilder
 from nncf.tensorflow.graph.converter import TFModelConverterFactory
 from nncf.tensorflow.graph.metatypes.keras_layers import TFBatchNormalizationLayerMetatype
@@ -359,6 +360,8 @@ class BasePruningAlgoController(BaseCompressionAlgorithmController, ABC):
 
         return pruned_layers_summary
 
-    def strip_model(self, model: tf.keras.Model, do_copy: bool = False) -> tf.keras.Model:
+    def strip_model(
+        self, model: tf.keras.Model, do_copy: bool = False, strip_format: StripFormat = StripFormat.NATIVE
+    ) -> tf.keras.Model:
         # Transform model for pruning creates copy of the model.
         return strip_model_from_masks(model, self._op_names)

--- a/nncf/tensorflow/quantization/algorithm.py
+++ b/nncf/tensorflow/quantization/algorithm.py
@@ -56,6 +56,7 @@ from nncf.config.schemata.defaults import QUANTIZATION_OVERFLOW_FIX
 from nncf.config.schemata.defaults import QUANTIZE_INPUTS
 from nncf.config.schemata.defaults import QUANTIZE_OUTPUTS
 from nncf.config.schemata.defaults import TARGET_DEVICE
+from nncf.parameters import StripFormat
 from nncf.tensorflow.algorithm_selector import TF_COMPRESSION_ALGORITHMS
 from nncf.tensorflow.api.compression import TFCompressionAlgorithmBuilder
 from nncf.tensorflow.graph.converter import TFModelConverter
@@ -753,7 +754,9 @@ class QuantizationController(BaseCompressionAlgorithmController):
         """
         return self._loss
 
-    def strip_model(self, model: tf.keras.Model, do_copy: bool = False) -> tf.keras.Model:
+    def strip_model(
+        self, model: tf.keras.Model, do_copy: bool = False, strip_format: StripFormat = StripFormat.NATIVE
+    ) -> tf.keras.Model:
         if do_copy:
             model = copy_model(model)
         apply_overflow_fix(model, self._op_names)

--- a/nncf/tensorflow/sparsity/base_algorithm.py
+++ b/nncf/tensorflow/sparsity/base_algorithm.py
@@ -12,6 +12,7 @@ import tensorflow as tf
 
 from nncf.common.compression import BaseCompressionAlgorithmController
 from nncf.common.sparsity.controller import SparsityController
+from nncf.parameters import StripFormat
 from nncf.tensorflow.graph.metatypes import keras_layers as layer_metatypes
 from nncf.tensorflow.sparsity.utils import strip_model_from_masks
 
@@ -47,6 +48,8 @@ class BaseSparsityController(BaseCompressionAlgorithmController, SparsityControl
         super().__init__(target_model)
         self._op_names = op_names
 
-    def strip_model(self, model: tf.keras.Model, do_copy: bool = False) -> tf.keras.Model:
+    def strip_model(
+        self, model: tf.keras.Model, do_copy: bool = False, strip_format: StripFormat = StripFormat.NATIVE
+    ) -> tf.keras.Model:
         # Transform model for sparsity creates copy of the model.
         return strip_model_from_masks(model, self._op_names)

--- a/nncf/tensorflow/strip.py
+++ b/nncf/tensorflow/strip.py
@@ -13,7 +13,9 @@ from typing import Dict
 
 import tensorflow as tf
 
+import nncf
 from nncf.common.utils.backend import copy_model
+from nncf.parameters import StripFormat
 from nncf.tensorflow.graph.model_transformer import TFModelTransformer
 from nncf.tensorflow.graph.transformations.commands import TFOperationWithWeights
 from nncf.tensorflow.graph.transformations.commands import TFRemovalCommand
@@ -28,15 +30,21 @@ from nncf.tensorflow.sparsity.rb.operation import RBSparsifyingWeight
 from nncf.tensorflow.sparsity.utils import apply_mask
 
 
-def strip(model: tf.keras.Model, do_copy: bool = True) -> tf.keras.Model:
+def strip(
+    model: tf.keras.Model, do_copy: bool = True, strip_format: StripFormat = StripFormat.NATIVE
+) -> tf.keras.Model:
     """
     Implementation of the nncf.strip() function for the TF backend
 
     :param model: The compressed model.
     :param do_copy: If True (default), will return a copy of the currently associated model object. If False,
       will return the currently associated model object "stripped" in-place.
+    :param strip format: Describes the format in which model is saved after strip.
     :return: The stripped model.
     """
+    if strip_format != StripFormat.NATIVE:
+        msg = f"Tensorflow does not support for {strip_format} strip format."
+        raise nncf.UnsupportedBackendError(msg)
     if not isinstance(model, tf.keras.Model):
         return model
 

--- a/nncf/torch/algo_selector.py
+++ b/nncf/torch/algo_selector.py
@@ -19,6 +19,7 @@ from nncf.common.schedulers import StubCompressionScheduler
 from nncf.common.statistics import NNCFStatistics
 from nncf.common.utils.backend import copy_model
 from nncf.common.utils.registry import Registry
+from nncf.parameters import StripFormat
 from nncf.torch.compression_method_api import PTCompressionAlgorithmBuilder
 from nncf.torch.compression_method_api import PTCompressionAlgorithmController
 from nncf.torch.compression_method_api import PTCompressionLoss
@@ -81,7 +82,7 @@ class NoCompressionAlgorithmController(PTCompressionAlgorithmController):
     def statistics(self, quickly_collected_only: bool = False) -> NNCFStatistics:
         return NNCFStatistics()
 
-    def strip(self, do_copy: bool = True) -> NNCFNetwork:
+    def strip(self, do_copy: bool = True, strip_format: StripFormat = StripFormat.NATIVE) -> NNCFNetwork:
         model = self.model
         if do_copy:
             model = copy_model(self.model)

--- a/nncf/torch/nncf_network.py
+++ b/nncf/torch/nncf_network.py
@@ -39,6 +39,7 @@ from nncf.common.insertion_point_graph import InsertionPointGraph
 from nncf.common.insertion_point_graph import PostHookInsertionPoint
 from nncf.common.insertion_point_graph import PreHookInsertionPoint
 from nncf.common.utils.debug import is_debug
+from nncf.parameters import StripFormat
 from nncf.telemetry import tracked_function
 from nncf.telemetry.events import NNCF_PT_CATEGORY
 from nncf.telemetry.extractors import FunctionCallTelemetryExtractor
@@ -966,12 +967,14 @@ class NNCFNetworkInterface(torch.nn.Module):
     def set_compression_controller(self, ctrl: CompressionAlgorithmController):
         self.compression_controller = ctrl
 
-    def strip(self, do_copy: bool = True) -> "NNCFNetwork":
+    def strip(self, do_copy: bool = True, strip_format: StripFormat = StripFormat.NATIVE) -> "NNCFNetwork":
         """
-        Returns the model object with as much custom NNCF additions as possible removed
-        while still preserving the functioning of the model object as a compressed model.
+        Removes auxiliary layers and operations added during the compression process, resulting in a clean
+        model ready for deployment. The functionality of the model object is still preserved as a compressed model.
+
         :param do_copy: If True (default), will return a copy of the currently associated model object. If False,
           will return the currently associated model object "stripped" in-place.
+        :param strip format: Describes the format in which model is saved after strip.
         :return: The stripped model.
         """
         if self.compression_controller is None:
@@ -979,8 +982,8 @@ class NNCFNetworkInterface(torch.nn.Module):
             from nncf.torch.quantization.strip import strip_quantized_model
 
             model = deepcopy(self._model_ref) if do_copy else self._model_ref
-            return strip_quantized_model(model)
-        return self.compression_controller.strip(do_copy)
+            return strip_quantized_model(model, strip_format=strip_format)
+        return self.compression_controller.strip(do_copy, strip_format=strip_format)
 
     def get_reused_parameters(self):
         """

--- a/nncf/torch/pruning/filter_pruning/algo.py
+++ b/nncf/torch/pruning/filter_pruning/algo.py
@@ -45,6 +45,7 @@ from nncf.common.utils.backend import copy_model
 from nncf.common.utils.debug import is_debug
 from nncf.common.utils.os import safe_open
 from nncf.config.extractors import extract_bn_adaptation_init_params
+from nncf.parameters import StripFormat
 from nncf.torch.algo_selector import PT_COMPRESSION_ALGORITHMS
 from nncf.torch.compression_method_api import PTCompressionAlgorithmController
 from nncf.torch.graph.operator_metatypes import PTModuleConv1dMetatype
@@ -693,7 +694,9 @@ class FilterPruningController(BasePruningAlgoController):
             )
         self._bn_adaptation.run(self.model)
 
-    def strip_model(self, model: NNCFNetwork, do_copy: bool = False) -> NNCFNetwork:
+    def strip_model(
+        self, model: NNCFNetwork, do_copy: bool = False, strip_format: StripFormat = StripFormat.NATIVE
+    ) -> NNCFNetwork:
         if do_copy:
             model = copy_model(model)
 

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -77,6 +77,7 @@ from nncf.config.schemata.defaults import QUANTIZE_INPUTS
 from nncf.config.schemata.defaults import QUANTIZE_OUTPUTS
 from nncf.experimental.common.tensor_statistics.statistics import MinMaxTensorStatistic
 from nncf.experimental.common.tensor_statistics.statistics import TensorStatistic
+from nncf.parameters import StripFormat
 from nncf.torch.algo_selector import PT_COMPRESSION_ALGORITHMS
 from nncf.torch.algo_selector import ZeroCompressionLoss
 from nncf.torch.compression_method_api import PTCompressionAlgorithmBuilder
@@ -1478,10 +1479,12 @@ class QuantizationController(QuantizationControllerBase):
         nncf_stats.register("quantization", stats)
         return nncf_stats
 
-    def strip_model(self, model: NNCFNetwork, do_copy: bool = False) -> NNCFNetwork:
+    def strip_model(
+        self, model: NNCFNetwork, do_copy: bool = False, strip_format: StripFormat = StripFormat.NATIVE
+    ) -> NNCFNetwork:
         if do_copy:
             model = copy_model(model)
-        model = strip_quantized_model(model)
+        model = strip_quantized_model(model, strip_format)
         return model
 
 

--- a/nncf/torch/sparsity/base_algo.py
+++ b/nncf/torch/sparsity/base_algo.py
@@ -28,6 +28,7 @@ from nncf.common.sparsity.controller import SparsityController
 from nncf.common.sparsity.schedulers import SparsityScheduler
 from nncf.common.utils.api_marker import api
 from nncf.common.utils.backend import copy_model
+from nncf.parameters import StripFormat
 from nncf.torch.algo_selector import ZeroCompressionLoss
 from nncf.torch.compression_method_api import PTCompressionAlgorithmBuilder
 from nncf.torch.compression_method_api import PTCompressionAlgorithmController
@@ -128,7 +129,9 @@ class BaseSparsityAlgoController(PTCompressionAlgorithmController, SparsityContr
     def compression_stage(self) -> CompressionStage:
         return CompressionStage.FULLY_COMPRESSED
 
-    def strip_model(self, model: NNCFNetwork, do_copy: bool = False) -> NNCFNetwork:
+    def strip_model(
+        self, model: NNCFNetwork, do_copy: bool = False, strip_format: StripFormat = StripFormat.NATIVE
+    ) -> NNCFNetwork:
         if do_copy:
             model = copy_model(model)
 

--- a/nncf/torch/strip.py
+++ b/nncf/torch/strip.py
@@ -10,16 +10,18 @@
 # limitations under the License.
 
 
+from nncf.parameters import StripFormat
 from nncf.torch.nncf_network import NNCFNetwork
 
 
-def strip(model: NNCFNetwork, do_copy: bool = True) -> NNCFNetwork:
+def strip(model: NNCFNetwork, do_copy: bool = True, strip_format: StripFormat = StripFormat.NATIVE) -> NNCFNetwork:
     """
-    Returns the model object with as much custom NNCF additions as possible removed
-    while still preserving the functioning of the model object as a compressed model.
+    Removes auxiliary layers and operations added during the compression process, resulting in a clean
+    model ready for deployment. The functionality of the model object is still preserved as a compressed model.
 
     :param do_copy: If True (default), will return a copy of the currently associated model object. If False,
-      will return the currently associated model object "stripped" in-place.
+        will return the currently associated model object "stripped" in-place.
+    :param strip format: Describes the format in which model is saved after strip.
     :return: The stripped model.
     """
-    return model.nncf.strip(do_copy)
+    return model.nncf.strip(do_copy, strip_format)

--- a/tests/torch/helpers.py
+++ b/tests/torch/helpers.py
@@ -773,3 +773,14 @@ class HookChecker:
             assert len(actual_hooks) == len(ref_hooks)
             for actual_hook, ref_hook in zip(actual_hooks, ref_hooks):
                 assert actual_hook is ref_hook
+
+
+class LinearModel(nn.Module):
+    def __init__(self, input_shape=List[int]):
+        super().__init__()
+        with set_torch_seed():
+            self.linear = nn.Linear(input_shape[1], input_shape[0], bias=False)
+            self.linear.weight.data = torch.randn(input_shape) - 0.5
+
+    def forward(self, x):
+        return self.linear(x)

--- a/tests/torch/quantization/test_strip.py
+++ b/tests/torch/quantization/test_strip.py
@@ -25,6 +25,7 @@ from nncf.common.quantization.structs import QuantizationScheme as QuantizationM
 from nncf.config import NNCFConfig
 from nncf.parameters import CompressWeightsMode
 from nncf.parameters import StripFormat
+from nncf.quantization.advanced_parameters import AdvancedCompressionParameters
 from nncf.torch.graph.transformations.commands import ExtraCompressionModuleType
 from nncf.torch.quantization.layers import AsymmetricQuantizer
 from nncf.torch.quantization.layers import BaseQuantizer
@@ -380,6 +381,7 @@ def test_nncf_strip_lora_model(mode, decompressor_class, torch_dtype, atol, mock
         mode=mode,
         dataset=nncf.Dataset(dataset),
         compression_format=nncf.CompressionFormat.FQ_LORA,
+        advanced_parameters=AdvancedCompressionParameters(lora_adapter_rank=1),
     )
     if mode in [CompressWeightsMode.INT4_SYM, CompressWeightsMode.INT4_ASYM]:
         compression_kwargs.update(dict(ratio=1, group_size=4, all_layers=True))

--- a/tests/torch/quantization/test_strip.py
+++ b/tests/torch/quantization/test_strip.py
@@ -337,7 +337,7 @@ def test_nncf_strip_api(strip_type, do_copy):
         (CompressWeightsMode.INT4_ASYM, torch.float16, 5e-4),
         (CompressWeightsMode.INT4_ASYM, torch.bfloat16, 1e-2),
         (CompressWeightsMode.INT4_SYM, torch.float32, 5e-4),
-        (CompressWeightsMode.INT4_SYM, torch.float16, 5e-4),
+        (CompressWeightsMode.INT4_SYM, torch.float16, 1e-3),  # torch.compile introduces bigger diff for sym
         (CompressWeightsMode.INT4_SYM, torch.bfloat16, 1e-2),
         (CompressWeightsMode.INT8_SYM, torch.bfloat16, 5e-2),  # int8 uses per-channel vs int4 group-wise
         (CompressWeightsMode.INT8_ASYM, torch.bfloat16, 5e-2),  # int8 uses per-channel vs int4 group-wise

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -24,3 +24,7 @@ timm==0.9.2
 # Required for torch/fx tests
 torchvision
 fastdownload==0.0.7
+
+sentence-transformers>=2.2.2
+optimum-intel==1.22.0
+optimum==1.24.0


### PR DESCRIPTION
### Changes

- Introduced strip method for LoRA modules as a new strip format = `StripFormat.DQ`. The old format named `StripFormat.NATIVE`. 
- Continuation of https://github.com/openvinotoolkit/nncf/pull/3331

### Reason for changes

- To able IR model conversion

### Related tickets

- 159708

### Tests

- test_fq_lora_tuning
- test_nncf_strip_lora_model