### PR TITLE
Use openvino instead of cpuinfo to get CPU full name

### DIFF
--- a/nncf/openvino/cpu_info.py
+++ b/nncf/openvino/cpu_info.py
@@ -17,6 +17,10 @@ _IS_LNL_CPU = None
 
 
 def is_lnl_cpu() -> bool:
+    """
+    Checks whether current CPU is an Intel Lunar Lake generation or not.
+    :return: True if current CPU is an Intel Lunar Lake generation, False othwerwise.
+    """
     global _IS_LNL_CPU
     if _IS_LNL_CPU is None:
         cpu_name = ov.Core().get_property("CPU", ov.properties.device.full_name)

--- a/nncf/openvino/cpu_info.py
+++ b/nncf/openvino/cpu_info.py
@@ -19,7 +19,7 @@ _IS_LNL_CPU = None
 def is_lnl_cpu() -> bool:
     """
     Checks whether current CPU is an Intel Lunar Lake generation or not.
-    :return: True if current CPU is an Intel Lunar Lake generation, False othwerwise.
+    :return: True if current CPU is an Intel Lunar Lake generation, False otherwise.
     """
     global _IS_LNL_CPU
     if _IS_LNL_CPU is None:

--- a/nncf/openvino/cpu_info.py
+++ b/nncf/openvino/cpu_info.py
@@ -11,7 +11,7 @@
 
 import re
 
-import cpuinfo  # type: ignore
+import openvino as ov
 
 _IS_LNL_CPU = None
 
@@ -19,5 +19,6 @@ _IS_LNL_CPU = None
 def is_lnl_cpu() -> bool:
     global _IS_LNL_CPU
     if _IS_LNL_CPU is None:
-        _IS_LNL_CPU = re.search(r"Ultra \d 2\d{2}", cpuinfo.get_cpu_info()["brand_raw"]) is not None
+        cpu_name = ov.Core().get_property("CPU", ov.properties.device.full_name)
+        _IS_LNL_CPU = re.search(r"Ultra \d 2\d{2}", cpu_name) is not None
     return _IS_LNL_CPU

--- a/nncf/openvino/optimized_functions/models.py
+++ b/nncf/openvino/optimized_functions/models.py
@@ -25,8 +25,8 @@ from openvino.runtime import opset13 as opset
 from nncf.common.utils.backend import is_openvino_at_least
 from nncf.common.utils.caching import ResultsCache
 from nncf.common.utils.caching import cache_results
-from nncf.common.utils.cpu_info import is_lnl_cpu
 from nncf.common.utils.helpers import set_env_variable
+from nncf.openvino.cpu_info import is_lnl_cpu
 from nncf.openvino.graph.node_utils import convert_op
 from nncf.openvino.graph.node_utils import non_convertable_divide_op
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "packaging>=20.0",
     "pandas>=1.1.5,<2.3",
     "psutil",
-    "py-cpuinfo>=9.0.0",
     "pydot>=1.4.1, <=3.0.4",
     "pymoo>=0.6.0.1",
     "rich>=13.5.2",


### PR DESCRIPTION
### Changes

Use openvino instead of cpuinfo to get CPU full name. Using cpuinfo can result in issues.

![image](https://github.com/user-attachments/assets/06127f53-f0ea-4de8-a7c7-745bd2b50e64)


Related to https://github.com/openvinotoolkit/openvino_notebooks/issues/2810 