### PR TITLE
[PT] change api for get_config and load_from_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,9 @@ Here is an example of Accuracy Aware Quantization pipeline where model weights a
 
 ```python
 import nncf
+import nncf.torch
 import torch
 from torchvision import datasets, models
-from nncf.torch import get_config, load_from_config
 
 # Instantiate your uncompressed model
 model = models.mobilenet_v2()
@@ -272,7 +272,7 @@ quantized_model = nncf.quantize(model, calibration_dataset)
 # Save quantization modules and the quantized model parameters
 checkpoint = {
     'state_dict': model.state_dict(),
-    'nncf_config': get_config(model),
+    'nncf_config': nncf.torch.get_config(model),
     ... # the rest of the user-defined objects to save
 }
 torch.save(checkpoint, path_to_checkpoint)
@@ -284,7 +284,7 @@ resuming_checkpoint = torch.load(path_to_checkpoint)
 nncf_config = resuming_checkpoint['nncf_config']
 state_dict = resuming_checkpoint['state_dict']
 
-quantized_model = load_from_config(model, nncf_config, example_input)
+quantized_model = nncf.torch.load_from_config(model, nncf_config, example_input)
 model.load_state_dict(state_dict)
 # ... the rest of the usual PyTorch-powered training pipeline
 ```

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Here is an example of Accuracy Aware Quantization pipeline where model weights a
 import nncf
 import torch
 from torchvision import datasets, models
+from nncf.torch import get_config, load_from_config
 
 # Instantiate your uncompressed model
 model = models.mobilenet_v2()
@@ -271,7 +272,7 @@ quantized_model = nncf.quantize(model, calibration_dataset)
 # Save quantization modules and the quantized model parameters
 checkpoint = {
     'state_dict': model.state_dict(),
-    'nncf_config': model.nncf.get_config(),
+    'nncf_config': get_config(model),
     ... # the rest of the user-defined objects to save
 }
 torch.save(checkpoint, path_to_checkpoint)
@@ -283,7 +284,7 @@ resuming_checkpoint = torch.load(path_to_checkpoint)
 nncf_config = resuming_checkpoint['nncf_config']
 state_dict = resuming_checkpoint['state_dict']
 
-quantized_model = nncf.torch.load_from_config(model, nncf_config, example_input)
+quantized_model = load_from_config(model, nncf_config, example_input)
 model.load_state_dict(state_dict)
 # ... the rest of the usual PyTorch-powered training pipeline
 ```

--- a/docs/usage/training_time_compression/quantization_aware_training/Usage.md
+++ b/docs/usage/training_time_compression/quantization_aware_training/Usage.md
@@ -75,7 +75,7 @@ ov_quantized_model = ov.convert_model(stripped_model)
 
 The complete information about compression is defined by a compressed model and a NNCF config.
 The model characterizes the weights and topology of the network. The NNCF config - how to restore additional modules introduced by NNCF.
-The NNCF config can be obtained by `quantized_model.nncf.get_config()` on saving and passed to the
+The NNCF config can be obtained by `nncf.torch.get_config(quantized_model)` on saving and passed to the
 `nncf.torch.load_from_config` helper function to load additional modules from the given NNCF config.
 The quantized model saving allows to load quantized modules to the target model in a new python process and
 requires only example input for the target module, corresponding NNCF config and the quantized model state dict.
@@ -84,8 +84,8 @@ requires only example input for the target module, corresponding NNCF config and
 # save part
 quantized_model = nncf.quantize(model, calibration_dataset)
 checkpoint = {
-    'state_dict':quantized_model.state_dict(),
-    'nncf_config': quantized_model.nncf.get_config(),
+    'state_dict': quantized_model.state_dict(),
+    'nncf_config': nncf.torch.get_config(quantized_model),
     ...
 }
 torch.save(checkpoint, path)

--- a/docs/usage/training_time_compression/quantization_aware_training/Usage.md
+++ b/docs/usage/training_time_compression/quantization_aware_training/Usage.md
@@ -81,25 +81,24 @@ The quantized model saving allows to load quantized modules to the target model 
 requires only example input for the target module, corresponding NNCF config and the quantized model state dict.
 
 ```python
+import nncf.torch
+
 # save part
-from nncf.torch import get_config
 
 checkpoint = {
     'state_dict': quantized_model.state_dict(),
-    'nncf_config': get_config(quantized_model),
+    'nncf_config': nncf.torch.get_config(quantized_model),
     ...
 }
 torch.save(checkpoint, path)
 
 # load part
-from nncf.torch import load_from_config
-
 resuming_checkpoint = torch.load(path)
 
 nncf_config = resuming_checkpoint['nncf_config']
 state_dict = resuming_checkpoint['state_dict']
 
-quantized_model = load_from_config(model, nncf_config, dummy_input)
+quantized_model = nncf.torch.load_from_config(model, nncf_config, dummy_input)
 quantized_model.load_state_dict(state_dict)
 ```
 

--- a/docs/usage/training_time_compression/quantization_aware_training/Usage.md
+++ b/docs/usage/training_time_compression/quantization_aware_training/Usage.md
@@ -84,7 +84,7 @@ requires only example input for the target module, corresponding NNCF config and
 import nncf.torch
 
 # save part
-
+quantized_model = nncf.quantize(model, calibration_dataset)
 checkpoint = {
     'state_dict': quantized_model.state_dict(),
     'nncf_config': nncf.torch.get_config(quantized_model),

--- a/docs/usage/training_time_compression/quantization_aware_training/Usage.md
+++ b/docs/usage/training_time_compression/quantization_aware_training/Usage.md
@@ -75,28 +75,31 @@ ov_quantized_model = ov.convert_model(stripped_model)
 
 The complete information about compression is defined by a compressed model and a NNCF config.
 The model characterizes the weights and topology of the network. The NNCF config - how to restore additional modules introduced by NNCF.
-The NNCF config can be obtained by `nncf.torch.get_config(quantized_model)` on saving and passed to the
+The NNCF config can be obtained by `nncf.torch.get_config` on saving and passed to the
 `nncf.torch.load_from_config` helper function to load additional modules from the given NNCF config.
 The quantized model saving allows to load quantized modules to the target model in a new python process and
 requires only example input for the target module, corresponding NNCF config and the quantized model state dict.
 
 ```python
 # save part
-quantized_model = nncf.quantize(model, calibration_dataset)
+from nncf.torch import get_config
+
 checkpoint = {
     'state_dict': quantized_model.state_dict(),
-    'nncf_config': nncf.torch.get_config(quantized_model),
+    'nncf_config': get_config(quantized_model),
     ...
 }
 torch.save(checkpoint, path)
 
 # load part
+from nncf.torch import load_from_config
+
 resuming_checkpoint = torch.load(path)
 
 nncf_config = resuming_checkpoint['nncf_config']
 state_dict = resuming_checkpoint['state_dict']
 
-quantized_model = nncf.torch.load_from_config(model, nncf_config, dummy_input)
+quantized_model = load_from_config(model, nncf_config, dummy_input)
 quantized_model.load_state_dict(state_dict)
 ```
 

--- a/examples/quantization_aware_training/torch/resnet18/main.py
+++ b/examples/quantization_aware_training/torch/resnet18/main.py
@@ -34,8 +34,6 @@ from torch.jit import TracerWarning
 import nncf
 import nncf.torch
 from nncf.common.utils.helpers import create_table
-from nncf.torch import get_config
-from nncf.torch import load_from_config
 
 warnings.filterwarnings("ignore", category=TracerWarning)
 warnings.filterwarnings("ignore", category=UserWarning)
@@ -284,7 +282,7 @@ def main():
         # Save the compression checkpoint for model with the best accuracy metric.
         if acc1_int8 > acc1_int8_best:
             state_dict = quantized_model.state_dict()
-            compression_config = get_config(quantized_model)
+            compression_config = nncf.torch.get_config(quantized_model)
             torch.save(
                 {
                     "model_state_dict": state_dict,
@@ -296,7 +294,7 @@ def main():
 
     # Load quantization modules and parameters from best checkpoint to the source model.
     ckpt = torch.load(ROOT / BEST_CKPT_NAME, weights_only=False)
-    quantized_model = load_from_config(
+    quantized_model = nncf.torch.load_from_config(
         deepcopy(model), ckpt["compression_config"], torch.ones((1, 3, IMAGE_SIZE, IMAGE_SIZE)).to(device)
     )
     quantized_model.load_state_dict(ckpt["model_state_dict"])

--- a/nncf/torch/__init__.py
+++ b/nncf/torch/__init__.py
@@ -50,6 +50,7 @@ from nncf.torch.model_creation import create_compressed_model
 from nncf.torch.model_creation import is_wrapped_model
 from nncf.torch.model_creation import wrap_model
 from nncf.torch.model_creation import load_from_config
+from nncf.torch.model_creation import get_config
 from nncf.torch.checkpoint_loading import load_state
 from nncf.torch.initialization import register_default_init_args
 from nncf.torch.layers import register_module

--- a/nncf/torch/model_creation.py
+++ b/nncf/torch/model_creation.py
@@ -29,7 +29,7 @@ from nncf.config.extractors import has_input_info_field
 from nncf.config.telemetry_extractors import CompressionStartedFromConfig
 from nncf.experimental.common.check_feature import is_experimental_torch_tracing_enabled
 from nncf.experimental.torch2.function_hook.serialization import get_config as pt2_get_config
-from nncf.experimental.torch2.function_hook.serialization import load_from_config as p2_load_from_config
+from nncf.experimental.torch2.function_hook.serialization import load_from_config as pt2_load_from_config
 from nncf.telemetry import tracked_function
 from nncf.telemetry.events import NNCF_PT_CATEGORY
 from nncf.telemetry.extractors import FunctionCallTelemetryExtractor
@@ -412,7 +412,7 @@ def load_from_config(model: Module, config: Dict[str, Any], example_input: Optio
     :return: Wrapped model with additional modules recovered from given config.
     """
     if is_experimental_torch_tracing_enabled():
-        return p2_load_from_config(model, config)
+        return pt2_load_from_config(model, config)
 
     if example_input is None:
         msg = "The 'example_input' parameter must be specified."

--- a/tests/torch2/function_hook/test_serialization.py
+++ b/tests/torch2/function_hook/test_serialization.py
@@ -19,8 +19,8 @@ from nncf.experimental.torch2.function_hook import get_hook_storage
 from nncf.experimental.torch2.function_hook import register_post_function_hook
 from nncf.experimental.torch2.function_hook import register_pre_function_hook
 from nncf.experimental.torch2.function_hook import wrap_model
-from nncf.experimental.torch2.function_hook.serialization import get_config
-from nncf.experimental.torch2.function_hook.serialization import load_from_config
+from nncf.torch import get_config
+from nncf.torch import load_from_config
 from tests.torch2.function_hook.helpers import HookWithState
 from tests.torch2.function_hook.helpers import SimpleModel
 


### PR DESCRIPTION
### Changes

Add `get_config` to `nncf/torch/__init__.py`
Use function `get_config` and `load_from_config` for new and old tracing as `from nncf.torch import get_config, load_from_config`


### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/13974357105

