### PR TITLE
[PT2] Detect missed inputs for noed based on TensorMeta in arguments

### DIFF
--- a/nncf/torch/graph/graph.py
+++ b/nncf/torch/graph/graph.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from itertools import chain
 from typing import Dict, List, Tuple
 
 import nncf
@@ -16,6 +17,9 @@ from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode
 from nncf.common.graph import NNCFNodeName
 from nncf.common.graph.layer_attributes import MultipleInputLayerAttributes
+from nncf.experimental.common.check_feature import is_experimental_torch_tracing_enabled
+from nncf.experimental.torch2.function_hook.graph.graph_utils import TensorMeta
+from nncf.experimental.torch2.function_hook.nncf_graph.layer_attributes import PT2OpLayerAttributes
 from nncf.torch.dynamic_graph.scope import Scope
 from nncf.torch.graph.transformations.commands import PTTargetPoint
 
@@ -102,16 +106,33 @@ class PTNNCFGraph(NNCFGraph):
         :return: List of NNCFNodes that are identified as disconnected.
         """
         input_nodes = set()
-        for node in self.get_all_nodes():
-            num_expected_input_edges = None
-            if hasattr(node.metatype, "num_expected_input_edges"):
-                num_expected_input_edges = node.metatype.num_expected_input_edges
-            if node.layer_attributes is not None and isinstance(node.layer_attributes, MultipleInputLayerAttributes):
-                num_expected_input_edges = node.layer_attributes.num_inputs
-            if num_expected_input_edges:
-                input_edges = self.get_input_edges(node)
-                if len(input_edges) < num_expected_input_edges:
-                    # If node has missed input edges we assume this node is an input node
-                    # that was disconnected from an activation input.
+        if is_experimental_torch_tracing_enabled():
+            # Check expected number of input edges by counting TensorMeta in op_args and op_kwargs.
+            for node in self.get_all_nodes():
+                input_edges = len(self.get_input_edges(node))
+                if not isinstance(node.layer_attributes, PT2OpLayerAttributes):
+                    continue
+                num_expected_input_edges = 0
+                for val in chain(node.layer_attributes.op_args, node.layer_attributes.op_kwargs.values()):
+                    if isinstance(val, TensorMeta):
+                        num_expected_input_edges += 1
+                    if isinstance(val, (list, tuple)):
+                        num_expected_input_edges += sum(isinstance(v, TensorMeta) for v in val)
+                if input_edges < num_expected_input_edges:
                     input_nodes.add(node)
+        else:
+            for node in self.get_all_nodes():
+                num_expected_input_edges = None
+                if hasattr(node.metatype, "num_expected_input_edges"):
+                    num_expected_input_edges = node.metatype.num_expected_input_edges
+                if node.layer_attributes is not None and isinstance(
+                    node.layer_attributes, MultipleInputLayerAttributes
+                ):
+                    num_expected_input_edges = node.layer_attributes.num_inputs
+                if num_expected_input_edges:
+                    input_edges = self.get_input_edges(node)
+                    if len(input_edges) < num_expected_input_edges:
+                        # If node has missed input edges we assume this node is an input node
+                        # that was disconnected from an activation input.
+                        input_nodes.add(node)
         return list(input_nodes)


### PR DESCRIPTION
### Changes

For new tracing detect missed inputs based on count of TensorMeta instance in op inputs.

### Reason for changes

Failed on detection missed input for concat nodes.

