### PR TITLE
[PT2] rework ForwardWithHooks

### DIFF
--- a/nncf/experimental/torch2/function_hook/graph/build_graph_mode.py
+++ b/nncf/experimental/torch2/function_hook/graph/build_graph_mode.py
@@ -373,6 +373,6 @@ def build_graph(model: nn.Module, *args: Any, **kwargs: Any) -> nx.MultiDiGraph:
             with GraphBuilderMode(model=model, hook_storage=get_hook_storage(model)) as ctx:
                 args, kwargs = ctx.process_model_inputs(args, kwargs)
                 wrapped_forward = cast(ForwardWithHooks, model.forward)
-                outputs = wrapped_forward._func(*args, **kwargs)
+                outputs = wrapped_forward.orig_forward(*args, **kwargs)
                 outputs = ctx.process_model_outputs(outputs)
     return ctx.graph

--- a/nncf/experimental/torch2/function_hook/hook_executor_mode.py
+++ b/nncf/experimental/torch2/function_hook/hook_executor_mode.py
@@ -41,6 +41,8 @@ IGNORED_FN_NAMES = [
     "size",
     "is_floating_point",
     "_set_grad_enabled",
+    "_parse_to",
+    "_has_compatible_shallow_copy_type",
 ]
 
 

--- a/nncf/experimental/torch2/function_hook/wrapper.py
+++ b/nncf/experimental/torch2/function_hook/wrapper.py
@@ -13,9 +13,8 @@ from __future__ import annotations
 
 import inspect
 import types
-from functools import partial
 from types import MethodType
-from typing import Any, Callable, Dict, Tuple, TypeVar, cast
+from typing import Any, Callable, Dict, Optional, Tuple, TypeVar, cast
 
 from torch import nn
 
@@ -32,63 +31,52 @@ TModel = TypeVar("TModel", bound=nn.Module)
 class ForwardWithHooks:
     """Class to wrap forward function of nn.Module, to forward function of the model with enabled FunctionHookMode"""
 
-    __slots__ = "_func", "__dict__", "__weakref__"
-    _func: Callable[..., Any]
+    __slots__ = "_orig_forward", "_model", "__dict__", "__weakref__"
+    _orig_forward: Callable[..., Any]
+    _model: nn.Module
 
-    def __new__(cls, orig_forward: Callable[..., Any]) -> ForwardWithHooks:
-        if not callable(orig_forward):
-            msg = "the first argument must be callable"
-            raise TypeError(msg)
-
-        if isinstance(orig_forward, ForwardWithHooks):
+    def __new__(cls, model: nn.Module, orig_forward: Optional[Callable[..., Any]] = None) -> ForwardWithHooks:
+        if isinstance(model.forward, ForwardWithHooks):
             msg = "Func already wrapped"
             raise TypeError(msg)
 
         self = super().__new__(cls)
 
-        self._func = orig_forward
+        self._orig_forward = model.forward if orig_forward is None else orig_forward
+        self._model = model
         return self
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        if hasattr(self._func, "__self__"):
-            # For bound method module is stored in the __self__
-            model = cast(nn.Module, self._func.__self__)  # type: ignore[attr-defined]
-        elif isinstance(self._func, partial):
-            # For using partial to override the forward method, module is stored in the args[0] and mapped to self arg.
-            model = cast(nn.Module, self._func.args[0])  # type: ignore[attr-defined]
-        else:
-            msg = "Forward function should be a bound function or partial with first argument as model."
-            raise nncf.InternalError(msg)
-
-        with FunctionHookMode(model=model, hook_storage=get_hook_storage(model)) as ctx:
+        with FunctionHookMode(model=self.model, hook_storage=get_hook_storage(self.model)) as ctx:
             args, kwargs = ctx.process_model_inputs(args, kwargs)
-            outputs = self._func(*args, **kwargs)
+            outputs = self.orig_forward(*args, **kwargs)
             outputs = ctx.process_model_outputs(outputs)
             return outputs
 
     def __repr__(self) -> str:
-        return f"ForwardWithHooks.{repr(self._func)}"
+        return f"ForwardWithHooks.{repr(self.orig_forward)}"
 
-    def __reduce__(self) -> Tuple[Callable[..., Any], Tuple[Any, ...], Tuple[Any, ...]]:
-        return type(self), (self._func,), (self._func, self.__dict__ or None)
+    def __reduce__(self) -> Any:
+        return type(self), (self.model, self.orig_forward), (self.model, self.orig_forward, self.__dict__ or None)
 
-    def __setstate__(self, state: Tuple[Any, Any]) -> None:
+    def __setstate__(self, state: Any) -> None:
         if not isinstance(state, tuple):
             msg = "argument to __setstate__ must be a tuple"
             raise TypeError(msg)
-        if len(state) != 2:
-            msg = f"expected 2 items in state, got {len(state)}"
+        if len(state) != 3:
+            msg = f"expected 3 items in state, got {len(state)}"
             raise TypeError(msg)
-        func, namespace = state
-        if not callable(func) or (namespace is not None and not isinstance(namespace, dict)):
+        model, orig_forward, namespace = state
+        if not callable(orig_forward) or (namespace is not None and not isinstance(namespace, dict)):
             msg = "invalid partial state"
             raise TypeError(msg)
 
         if namespace is None:
             namespace = {}
 
+        self._model = model
+        self._orig_forward = orig_forward
         self.__dict__ = namespace
-        self._func = func
 
     @property
     def __code__(self) -> types.CodeType:
@@ -96,15 +84,23 @@ class ForwardWithHooks:
 
     @property
     def __globals__(self) -> Dict[str, Any]:
-        return self._func.__globals__
+        return self.orig_forward.__globals__
 
     @property
     def __name__(self) -> str:
-        return self._func.__name__
+        return self.orig_forward.__name__
 
     @property
     def __signature__(self) -> inspect.Signature:
-        return inspect.signature(self._func)
+        return inspect.signature(self.orig_forward)
+
+    @property
+    def orig_forward(self) -> Callable[..., Any]:
+        return self._orig_forward
+
+    @property
+    def model(self) -> nn.Module:
+        return self._model
 
 
 class ReplicateForDataParallel:
@@ -145,16 +141,16 @@ class ReplicateForDataParallel:
             raise nncf.InternalError(msg)
 
         if not (
-            isinstance(saved_forward_with_hooks._func, types.MethodType)
-            and saved_forward_with_hooks._func.__func__ is module.__class__.forward
+            isinstance(saved_forward_with_hooks.orig_forward, types.MethodType)
+            and saved_forward_with_hooks.orig_forward.__func__ is module.__class__.forward
         ):
             msg = "Not supported overridden forward method of original module"
             raise nncf.InternalError(msg)
 
         module.__dict__.pop("forward")
 
-        replica: nn.Module = self._func(*args, **kwargs)
-        replica.forward = ForwardWithHooks(replica.forward)
+        replica: nn.Module = self.func(*args, **kwargs)
+        replica.forward = ForwardWithHooks(replica)
         module.forward = saved_forward_with_hooks
 
         return replica
@@ -203,7 +199,7 @@ def wrap_model(model: TModel) -> TModel:
     :param model: The nn.Module to be wrapped.
     :return: The modified model with the custom behavior injected.
     """
-    model.forward = ForwardWithHooks(model.forward)
+    model.forward = ForwardWithHooks(model)
     model._replicate_for_data_parallel = ReplicateForDataParallel(model._replicate_for_data_parallel)  # type: ignore
     model.add_module(ATR_HOOK_STORAGE, HookStorage())
     return model
@@ -246,7 +242,6 @@ def register_pre_function_hook(model: nn.Module, op_name: str, port_id: int, hoo
     :param op_name: The name of the operation associated with the hook.
     :param port_id: The port ID associated with the hook.
     :param hook: The pre-function hook module to be executed.
-
     :return: A handle that can be used to remove the hook later.
     """
     hook_storage = get_hook_storage(model)

--- a/tests/torch2/function_hook/test_train.py
+++ b/tests/torch2/function_hook/test_train.py
@@ -70,7 +70,7 @@ def test_train_data_parallel_with_overridden_forward():
     # In overridden bound method __self__ links to original model for all replicas
     optimizer = torch.optim.Adam(wrapped_model.parameters(), lr=0.1)
     parallel_model = torch.nn.DataParallel(wrapped_model)
-    with pytest.raises(nncf.InternalError, match="Not supported overwriting forward method, expected ForwardWithHooks"):
+    with pytest.raises(nncf.InternalError, match="Not supported overridden forward"):
         run_one_epoch(parallel_model, optimizer, use_cuda=True)
 
 
@@ -87,7 +87,7 @@ def test_train_data_parallel_with_overridden_forward_after_wrap_model():
     wrapped_model.forward = patched_forward
     optimizer = torch.optim.Adam(wrapped_model.parameters(), lr=0.1)
     parallel_model = torch.nn.DataParallel(wrapped_model)
-    with pytest.raises(nncf.InternalError, match="Not supported overwriting forward method of original module"):
+    with pytest.raises(nncf.InternalError, match="Not supported overridden forward"):
         run_one_epoch(parallel_model, optimizer, use_cuda=True)
 
 


### PR DESCRIPTION
### Changes

Rework ForwardWithHooks to be more flexible to patching forward function. 
Now model collects inside ForwardWithHooks and not used original forward to find model.
Add `_has_compatible_shallow_copy_type` and `_parse_to` to ignored function names.
Fix tests on cuda.

### Reason for changes

```python 
model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-GPTNeoXForCausalLM", torch_dtype=torch.bfloat16, device_map="auto")
model = wrap_model(model)

#    model = cast(nn.Module, self._func.__self__)  # type: ignore[attr-defined]
# AttributeError: 'functools.partial' object has no attribute '__self__'. Did you mean: '__call__'?
```


