### PR TITLE
Disable optimized compression on ARM CPUs until the next release

### DIFF
--- a/nncf/openvino/cpu_info.py
+++ b/nncf/openvino/cpu_info.py
@@ -13,7 +13,26 @@ import re
 
 import openvino as ov
 
+_IS_ARM_CPU = None
 _IS_LNL_CPU = None
+
+
+def _get_cpu_name() -> str:
+    """
+    :return: The name of the CPU.
+    """
+    return ov.Core().get_property("CPU", ov.properties.device.full_name)
+
+
+def is_arm_cpu() -> bool:
+    """
+    Checks whether current CPU is an ARM CPU or not.
+    :return: True if current CPU is an ARM CPU, False otherwise.
+    """
+    global _IS_ARM_CPU
+    if _IS_ARM_CPU is None:
+        _IS_ARM_CPU = "arm" in _get_cpu_name().lower()
+    return _IS_ARM_CPU
 
 
 def is_lnl_cpu() -> bool:
@@ -23,6 +42,5 @@ def is_lnl_cpu() -> bool:
     """
     global _IS_LNL_CPU
     if _IS_LNL_CPU is None:
-        cpu_name = ov.Core().get_property("CPU", ov.properties.device.full_name)
-        _IS_LNL_CPU = re.search(r"Ultra \d 2\d{2}", cpu_name) is not None
+        _IS_LNL_CPU = re.search(r"Ultra \d 2\d{2}", _get_cpu_name()) is not None
     return _IS_LNL_CPU

--- a/nncf/quantization/algorithms/weight_compression/weight_lowering.py
+++ b/nncf/quantization/algorithms/weight_compression/weight_lowering.py
@@ -18,7 +18,6 @@ import nncf
 from nncf.common.logging.logger import nncf_logger
 from nncf.common.utils.backend import is_openvino_at_least
 from nncf.common.utils.backend import is_openvino_available
-from nncf.openvino.cpu_info import is_arm_cpu
 from nncf.parameters import CompressWeightsMode
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionConfig
 from nncf.quantization.fake_quantize import calculate_scale_zero_point
@@ -545,12 +544,12 @@ def quantize_dequantize_weight(
 
 
 def _can_run_optimized(input_backend: TensorBackend) -> bool:
-    # Due to a bug in CPU plugin compression models can fail at compilation on ARM CPUs. Ticket: 164135.
-    if input_backend in [TensorBackend.ov, TensorBackend.numpy] and (
-        not is_arm_cpu() or is_openvino_at_least("2025.2")
-    ):
+    if input_backend in [TensorBackend.ov, TensorBackend.numpy]:
         if is_openvino_available():
-            return True
+            from nncf.openvino.cpu_info import is_arm_cpu
+
+            # Due to a bug in CPU plugin compression models can fail at compilation on ARM CPUs. Ticket: 164135.
+            return not is_arm_cpu() or is_openvino_at_least("2025.2")
         else:
             nncf_logger.info_once(
                 "OpenVINO optimizations are disabled. Install OpenVINO to enable them and improve the performance."

--- a/nncf/quantization/algorithms/weight_compression/weight_lowering.py
+++ b/nncf/quantization/algorithms/weight_compression/weight_lowering.py
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
@@ -544,7 +544,10 @@ def quantize_dequantize_weight(
 
 
 def _can_run_optimized(input_backend: TensorBackend) -> bool:
-    if input_backend in [TensorBackend.ov, TensorBackend.numpy]:
+    if (
+        input_backend in [TensorBackend.ov, TensorBackend.numpy]
+        and os.environ.get("NNCF_DISABLE_OPTIMIZED_COMPRESSION") is None
+    ):
         if is_openvino_available():
             from nncf.openvino.cpu_info import is_arm_cpu
 

--- a/nncf/quantization/algorithms/weight_compression/weight_lowering.py
+++ b/nncf/quantization/algorithms/weight_compression/weight_lowering.py
@@ -16,7 +16,9 @@ import numpy as np
 
 import nncf
 from nncf.common.logging.logger import nncf_logger
+from nncf.common.utils.backend import is_openvino_at_least
 from nncf.common.utils.backend import is_openvino_available
+from nncf.openvino.cpu_info import is_arm_cpu
 from nncf.parameters import CompressWeightsMode
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionConfig
 from nncf.quantization.fake_quantize import calculate_scale_zero_point
@@ -543,7 +545,10 @@ def quantize_dequantize_weight(
 
 
 def _can_run_optimized(input_backend: TensorBackend) -> bool:
-    if input_backend in [TensorBackend.ov, TensorBackend.numpy]:
+    # Due to a bug in CPU plugin compression models can fail at compilation on ARM CPUs. Ticket: 164135.
+    if input_backend in [TensorBackend.ov, TensorBackend.numpy] and (
+        not is_arm_cpu() or is_openvino_at_least("2025.2")
+    ):
         if is_openvino_available():
             return True
         else:


### PR DESCRIPTION
### Changes

- Disabled optimized compression on ARM CPUs until the next OV 2025.2 release. The fix https://github.com/openvinotoolkit/openvino/pull/29577 won't be merged in time.
- Added `NNCF_DISABLE_OPTIMIZED_COMPRESSION` environment variable flag to disable optimized compression if needed.

### Reason for changes

Enable weights compression on ARM CPUs.

### Related tickets

164135
