### PR TITLE
Proper handling cuda/cpu tests for weight compression

### DIFF
--- a/tests/torch/fx/test_compress_weights.py
+++ b/tests/torch/fx/test_compress_weights.py
@@ -293,8 +293,6 @@ def test_get_dtype_attribute_of_parameter():
 
 @pytest.mark.parametrize("dtype", ("float16", "float32"))
 def test_model_devices_and_precisions(use_cuda, dtype):
-    if use_cuda and not torch.cuda.is_available():
-        pytest.skip("Skipping for CPU-only setups")
     device = torch.device("cuda" if use_cuda else "cpu")
     dtype = torch.float16 if dtype == "float16" else torch.float32
 

--- a/tests/torch/ptq/test_fq_lora.py
+++ b/tests/torch/ptq/test_fq_lora.py
@@ -72,6 +72,7 @@ def get_ov_model(model: AutoModelForCausalLM, tmp_path: str) -> OVModelForCausal
     )
 
 
+@pytest.mark.cuda
 @pytest.mark.parametrize(
     "compression_kwargs",
     (dict(scale_estimation=True, awq=True), dict(scale_estimation=False, awq=False)),
@@ -85,10 +86,8 @@ def get_ov_model(model: AutoModelForCausalLM, tmp_path: str) -> OVModelForCausal
     ),
     ids=["asym", "sym"],
 )
-def test_fq_lora_tuning(tmp_path, mode, backup_mode, compression_kwargs, ref_num_trainable, _seed, use_cuda):
+def test_fq_lora_tuning(tmp_path, mode, backup_mode, compression_kwargs, ref_num_trainable, _seed):
     model_id = "facebook/opt-125m"
-    if not use_cuda:
-        pytest.skip("Skipping for CPU-only setups")
     device = "cuda"
     model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.bfloat16, device_map=device)
     tokenizer = AutoTokenizer.from_pretrained(model_id)
@@ -159,9 +158,8 @@ def test_fq_lora_tuning(tmp_path, mode, backup_mode, compression_kwargs, ref_num
         assert torch.allclose(tuned_vs_stripped_ov, vm.validation_ref, atol=atol)
 
 
-def test_checkpoint_loading(tmp_path, use_cuda):
-    if not use_cuda:
-        pytest.skip("Skipping for CPU-only setups")
+@pytest.mark.cuda
+def test_checkpoint_loading(tmp_path):
     device = "cuda"
     device_map = "auto"
     model_id = "hf-internal-testing/tiny-random-GPTNeoXForCausalLM"

--- a/tests/torch/ptq/test_fq_lora.py
+++ b/tests/torch/ptq/test_fq_lora.py
@@ -85,9 +85,11 @@ def get_ov_model(model: AutoModelForCausalLM, tmp_path: str) -> OVModelForCausal
     ),
     ids=["asym", "sym"],
 )
-def test_fq_lora_tuning(tmp_path, mode, backup_mode, compression_kwargs, ref_num_trainable, _seed):
+def test_fq_lora_tuning(tmp_path, mode, backup_mode, compression_kwargs, ref_num_trainable, _seed, use_cuda):
     model_id = "facebook/opt-125m"
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if not use_cuda:
+        pytest.skip("Skipping for CPU-only setups")
+    device = "cuda"
     model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.bfloat16, device_map=device)
     tokenizer = AutoTokenizer.from_pretrained(model_id)
     inputs = tokenizer("overfit " * 10, return_tensors="pt").to(device)
@@ -157,12 +159,13 @@ def test_fq_lora_tuning(tmp_path, mode, backup_mode, compression_kwargs, ref_num
         assert torch.allclose(tuned_vs_stripped_ov, vm.validation_ref, atol=atol)
 
 
-def test_checkpoint_loading(tmp_path):
-    model_id = "hf-internal-testing/tiny-random-GPTNeoXForCausalLM"
-    if not torch.cuda.is_available():
-        pytest.skip("Skipping CUDA test case for CPU only setups.")
+def test_checkpoint_loading(tmp_path, use_cuda):
+    if not use_cuda:
+        pytest.skip("Skipping for CPU-only setups")
     device = "cuda"
-    model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.bfloat16, device_map="auto")
+    device_map = "auto"
+    model_id = "hf-internal-testing/tiny-random-GPTNeoXForCausalLM"
+    model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.bfloat16, device_map=device_map)
     tokenizer = AutoTokenizer.from_pretrained(model_id)
     example_input = tokenizer("dummy", return_tensors="pt").to(device)
     except_lm_head_and_5th_vproj = (
@@ -195,7 +198,7 @@ def test_checkpoint_loading(tmp_path):
 
     # load checkpoint
     nncf_ckpt = torch.load(ckpt_path, weights_only=False)
-    model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.bfloat16, device_map="auto")
+    model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.bfloat16, device_map=device_map)
     model = load_from_config(model, nncf_ckpt["nncf_config"], example_input=dict(example_input))
     model.nncf.load_state_dict(nncf_ckpt["nncf_state_dict"])
 

--- a/tests/torch/ptq/test_weights_compression.py
+++ b/tests/torch/ptq/test_weights_compression.py
@@ -397,8 +397,6 @@ def test_get_dtype_attribute_of_parameter():
 
 @pytest.mark.parametrize("dtype", ("float16", "float32"))
 def test_model_devices_and_precisions(use_cuda, dtype):
-    if use_cuda and not torch.cuda.is_available():
-        pytest.skip("Skipping for CPU-only setups")
     device = torch.device("cuda" if use_cuda else "cpu")
     dtype = torch.float16 if dtype == "float16" else torch.float32
 

--- a/tests/torch2/function_hook/quantization/test_weights_compression.py
+++ b/tests/torch2/function_hook/quantization/test_weights_compression.py
@@ -330,8 +330,6 @@ def test_get_dtype_attribute_of_parameter():
 
 @pytest.mark.parametrize("dtype", ("float16", "float32"))
 def test_model_devices_and_precisions(use_cuda, dtype):
-    if use_cuda and not torch.cuda.is_available():
-        pytest.skip("Skipping for CPU-only setups")
     device = torch.device("cuda" if use_cuda else "cpu")
     dtype = torch.float16 if dtype == "float16" else torch.float32
 


### PR DESCRIPTION
### Changes

as stated in the title

### Reason for changes

Currently, tests are launched on CUDA or CPU based on the marker `cuda`: https://github.com/openvinotoolkit/nncf/blob/develop/Makefile#L146-L150
Check `torch.cuda.is_available()` is not valid anymore. 

### Related tickets

n/a

### Tests

pre-commit
