### PR TITLE
Add xfail to activation sparsity OV export test

### DIFF
--- a/tests/torch/experimental/sparsify_activations/test_algo.py
+++ b/tests/torch/experimental/sparsify_activations/test_algo.py
@@ -179,6 +179,8 @@ class TestSparsifyActivationsAlgorithm:
         compare_nx_graph_with_reference(graph, ref_dot_path)
 
     def test_export_openvino(self):
+        if self.desc.name == "dummy_llama" and self.compress_weights:
+            pytest.xfail("Disabled until ticket 165186 is resolved.")
         model: NNCFNetwork = self.model
         example_input = next(iter(self.dataset.get_inference_data()))
         with torch.no_grad():


### PR DESCRIPTION
### Changes

As in the title.

### Reason for changes

A bug in OV CPU plugin prevents a model from being compiled. Reproduces on OV 2025.1 RC.

### Related tickets

165186

### Tests

- NNCF/job/precommit/job/ubuntu20_precommit_pytorch/6687/
- NNCF/job/nightly/job/windows/job/precommit_torch_cpu/621/
