### PR TITLE
More helpful error message in case of invalid group size (#3391)

### DIFF
--- a/nncf/__init__.py
+++ b/nncf/__init__.py
@@ -22,6 +22,7 @@ from nncf.errors import BufferFullError as BufferFullError
 from nncf.errors import InstallationError as InstallationError
 from nncf.errors import InternalError as InternalError
 from nncf.errors import InvalidCollectorTypeError as InvalidCollectorTypeError
+from nncf.errors import InvalidGroupSizeError as InvalidGroupSizeError
 from nncf.errors import InvalidPathError as InvalidPathError
 from nncf.errors import InvalidQuantizerGroupError as InvalidQuantizerGroupError
 from nncf.errors import ModuleNotFoundError as ModuleNotFoundError

--- a/nncf/errors.py
+++ b/nncf/errors.py
@@ -79,6 +79,14 @@ class UnsupportedModelError(Exception):
     pass
 
 
+class InvalidGroupSizeError(Exception):
+    """
+    Raised in case of group-wise quantization, when number of channels are not divided by the given group size.
+    """
+
+    pass
+
+
 class UnsupportedVersionError(Exception):
     """
     Raised when an unsupported version is encountered.

--- a/nncf/quantization/algorithms/weight_compression/handle_errors.py
+++ b/nncf/quantization/algorithms/weight_compression/handle_errors.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+import nncf
+
+
+def handle_invalid_group_size_error(first_caught_exception: nncf.InvalidGroupSizeError, node_names: List[str]) -> None:
+    """
+    Handles the InvalidGroupSizeError by generating a detailed error message and re-raising the exception.
+
+    :param first_caught_exception: The first InvalidGroupSizeError instance that was caught.
+    :param node_names: The list of node names where the error occurred.
+        Used to suggest adding them to the ignored scope.
+    :raises nncf.InvalidGroupSizeError: Re-raises the exception with an enhanced message suggesting corrective actions.
+    """
+    names = ",".join(f'"{name}"' for name in node_names)
+    msg = (
+        f"Compression of the '{node_names[0]}' layer failed with the following error:\n{first_caught_exception}\n"
+        "Ensure that the group size is divisible by the channel size, "
+        "or include this node and others with similar issues in the ignored scope:\n"
+        f"nncf.compress_weight(\n\t..., \n\tignored_scope=IgnoredScope(names=[{names}]\n\t)\n)"
+    )
+    raise nncf.InvalidGroupSizeError(msg) from first_caught_exception

--- a/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -55,6 +55,7 @@ from nncf.quantization.algorithms.weight_compression.backend import MixedPrecisi
 from nncf.quantization.algorithms.weight_compression.backend import WeightCompressionAlgoBackend
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionConfig
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionParameters
+from nncf.quantization.algorithms.weight_compression.handle_errors import handle_invalid_group_size_error
 from nncf.quantization.algorithms.weight_compression.lora_correction import LoraCorrectionAlgorithm
 from nncf.quantization.algorithms.weight_compression.weight_lowering import compress_weight
 from nncf.tensor import Tensor
@@ -246,7 +247,6 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                 layer_scales,
                 layer_zero_points,
             )
-
         compressed_const = create_ov_const_from_tensor(
             compressed_weight.tensor, compression_dtype, name=const_node_name
         )
@@ -288,6 +288,8 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
         compression_format: CompressionFormat = CompressionFormat.DQ,
         advanced_parameters: AdvancedCompressionParameters = AdvancedCompressionParameters(),
     ) -> ov.Model:
+        invalid_node_names = []
+        first_caught_error = None
         for wc_params in weight_compression_parameters:
             const_attributes = wc_params.node_with_weight.layer_attributes.constant_attributes[wc_params.weight_port_id]
             const_node_name = const_attributes["name"]
@@ -310,17 +312,22 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
             layer_zero_points = (
                 None if precomputed_zero_points is None else precomputed_zero_points.get(wc_params.weight_name)
             )
-            mul, compressed_weight = self._create_compression_subgraph(
-                weight=weight,
-                compression_config=wc_params.compression_config,
-                reduction_axes=wc_params.reduction_axes,
-                const_node_name=const_node_name,
-                weight_port_id=wc_params.weight_port_id,
-                const_dtype=const_dtype,
-                should_add_convert_node=should_add_convert_node,
-                layer_scales=layer_scales,
-                layer_zero_points=layer_zero_points,
-            )
+            try:
+                mul, compressed_weight = self._create_compression_subgraph(
+                    weight=weight,
+                    compression_config=wc_params.compression_config,
+                    reduction_axes=wc_params.reduction_axes,
+                    const_node_name=const_node_name,
+                    weight_port_id=wc_params.weight_port_id,
+                    const_dtype=const_dtype,
+                    should_add_convert_node=should_add_convert_node,
+                    layer_scales=layer_scales,
+                    layer_zero_points=layer_zero_points,
+                )
+            except nncf.InvalidGroupSizeError as error:
+                first_caught_error = error
+                invalid_node_names.append(wc_params.node_with_weight.node_name)
+                continue
 
             mul_output = mul.output(0)
             for target_input in const_node.output(0).get_target_inputs():
@@ -334,6 +341,8 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                 adapters = lora_correction_algo.calculate_adapters(weight, compressed_weight, wc_params)
                 self.insert_adapters(wc_params, *adapters, int8_lora=lora_correction_algo.use_int8_adapters)
 
+        if first_caught_error:
+            handle_invalid_group_size_error(first_caught_error, invalid_node_names)
         # reset name_to_node_mapping
         self.name_to_node_mapping = None
 

--- a/nncf/quantization/algorithms/weight_compression/scale_estimation.py
+++ b/nncf/quantization/algorithms/weight_compression/scale_estimation.py
@@ -23,6 +23,7 @@ from nncf.quantization.algorithms.weight_compression.activation_stats import pro
 from nncf.quantization.algorithms.weight_compression.backend import WeightCompressionAlgoBackend
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionConfig
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionParameters
+from nncf.quantization.algorithms.weight_compression.handle_errors import handle_invalid_group_size_error
 from nncf.quantization.algorithms.weight_compression.weight_lowering import calculate_normalized_weight_and_fp4_scale
 from nncf.quantization.algorithms.weight_compression.weight_lowering import do_int_quantization
 from nncf.quantization.algorithms.weight_compression.weight_lowering import do_nf4_dequantization
@@ -116,6 +117,8 @@ class ScaleEstimation:
             self._set_backend_entity(model)
         scales, zero_points = dict(), dict()
 
+        invalid_node_names = []
+        first_caught_error = None
         for wp in track(all_weight_params, description="Applying Scale Estimation"):
             weight_name = wp.weight_name
             node_name = wp.node_with_weight.node_name
@@ -134,16 +137,23 @@ class ScaleEstimation:
 
             weight = self._backend_entity.get_weight(wp.node_with_weight, weight_port_id, model, graph)
 
-            scales[weight_name], zero_points[weight_name] = self.calculate_quantization_params(
-                stats,
-                weight,
-                wp.reduction_axes,
-                config,
-                self._subset_size,
-                self._initial_steps,
-                self._scale_steps,
-                self._weight_penalty,
-            )
+            try:
+                scales[weight_name], zero_points[weight_name] = self.calculate_quantization_params(
+                    stats,
+                    weight,
+                    wp.reduction_axes,
+                    config,
+                    self._subset_size,
+                    self._initial_steps,
+                    self._scale_steps,
+                    self._weight_penalty,
+                )
+            except nncf.InvalidGroupSizeError as error:
+                first_caught_error = error
+                invalid_node_names.append(wp.node_with_weight.node_name)
+
+        if first_caught_error:
+            handle_invalid_group_size_error(first_caught_error, invalid_node_names)
 
         return scales, zero_points
 

--- a/nncf/quantization/algorithms/weight_compression/torch_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/torch_backend.py
@@ -51,6 +51,7 @@ from nncf.quantization.algorithms.weight_compression.backend import AWQAlgoBacke
 from nncf.quantization.algorithms.weight_compression.backend import MixedPrecisionAlgoBackend
 from nncf.quantization.algorithms.weight_compression.backend import WeightCompressionAlgoBackend
 from nncf.quantization.algorithms.weight_compression.config import WeightCompressionParameters
+from nncf.quantization.algorithms.weight_compression.handle_errors import handle_invalid_group_size_error
 from nncf.quantization.algorithms.weight_compression.lora_correction import LoraCorrectionAlgorithm
 from nncf.quantization.algorithms.weight_compression.weight_lowering import CompressedWeight
 from nncf.quantization.algorithms.weight_compression.weight_lowering import compress_weight
@@ -476,6 +477,8 @@ class PTWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
         transformation_layout = TransformationLayout()
         is_all_8bit = all(wc_params.compression_config.num_bits == 8 for wc_params in weight_compression_parameters)
+        invalid_node_names = []
+        first_caught_error = None
         for wc_params in weight_compression_parameters:
             compression_config = wc_params.compression_config
             if compression_config.mode in [
@@ -492,14 +495,19 @@ class PTWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                 msg = f"Could not find a torch.nn.Parameter in the model by name {weight_name}."
                 raise nncf.InternalError(msg)
 
-            # calculates compressed weights and decompression parameters
-            compressed_weight = compress_weight(
-                Tensor(weight),
-                wc_params.reduction_axes,
-                compression_config,
-                None if precomputed_scales is None else precomputed_scales.get(wc_params.weight_name),
-                None if precomputed_zero_points is None else precomputed_zero_points.get(wc_params.weight_name),
-            )
+            try:
+                # calculates compressed weights and decompression parameters
+                compressed_weight = compress_weight(
+                    Tensor(weight),
+                    wc_params.reduction_axes,
+                    compression_config,
+                    None if precomputed_scales is None else precomputed_scales.get(wc_params.weight_name),
+                    None if precomputed_zero_points is None else precomputed_zero_points.get(wc_params.weight_name),
+                )
+            except nncf.InvalidGroupSizeError as error:
+                first_caught_error = error
+                invalid_node_names.append(wc_params.node_with_weight.node_name)
+                continue
 
             if compression_format == CompressionFormat.DQ:
                 command = self.get_dq_insertion_command(compressed_weight, wc_params, model, graph, weight_node)
@@ -510,6 +518,8 @@ class PTWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                 )
             transformation_layout.register(command)
 
+        if first_caught_error:
+            handle_invalid_group_size_error(first_caught_error, invalid_node_names)
         # To have FQ's with requires_grad=True only
         model.requires_grad_(False)
 

--- a/nncf/quantization/algorithms/weight_compression/weight_lowering.py
+++ b/nncf/quantization/algorithms/weight_compression/weight_lowering.py
@@ -90,8 +90,8 @@ def reshape_weight_for_grouped_quantization(
         raise nncf.UnsupportedModelError(msg)
     channel_size = weight.shape[reduction_axes]
     if channel_size % group_size != 0:
-        msg = f"Channel size {channel_size} should be divisible by size of group {group_size}"
-        raise nncf.UnsupportedModelError(msg)
+        msg = f"Channel size {channel_size} should be divisible by size of group {group_size}."
+        raise nncf.InvalidGroupSizeError(msg)
 
     num_groups_per_channel = channel_size // group_size
     shape = list(weight.shape)  # [a1, r, a2] - "r" refers to number of channels along reduction axis

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -638,11 +638,6 @@ def test_raise_error_for_many_axes():
         reshape_weight_for_grouped_quantization(WEIGHTS_2x4, reduction_axes=(0, 1), group_size=1)
 
 
-def test_raise_error_channel_size_is_not_divisible_by_group_size():
-    with pytest.raises(nncf.UnsupportedModelError):
-        reshape_weight_for_grouped_quantization(WEIGHTS_2x4, reduction_axes=(0,), group_size=3)
-
-
 @pytest.mark.parametrize("mode", INT8_MODES)
 @pytest.mark.parametrize(
     "params",
@@ -1547,6 +1542,10 @@ class TestOVTemplateWeightCompression(TemplateWeightCompression):
         names = {op.get_friendly_name() for op in model.get_ordered_ops() if op.get_element_type() == ov.Type.i4}
         low_precision_nodes = {f"weights_{i}" for i in ref_ids}
         assert low_precision_nodes == names
+
+    @staticmethod
+    def get_not_supported_algorithms() -> List[str]:
+        return []
 
     @staticmethod
     def get_scale_estimation_ref():

--- a/tests/torch/ptq/test_weights_compression.py
+++ b/tests/torch/ptq/test_weights_compression.py
@@ -490,6 +490,10 @@ class TestPTTemplateWeightCompression(TemplateWeightCompression):
                     assert isinstance(op, INT4SymmetricWeightsDecompressor)
 
     @staticmethod
+    def get_not_supported_algorithms() -> List[str]:
+        return ["lora_correction", "gptq"]
+
+    @staticmethod
     def get_scale_estimation_ref():
         return torch.tensor(
             [

--- a/tests/torch2/function_hook/quantization/test_weights_compression.py
+++ b/tests/torch2/function_hook/quantization/test_weights_compression.py
@@ -410,6 +410,10 @@ class TestPTTemplateWeightCompression(TemplateWeightCompression):
                     assert isinstance(op, INT4SymmetricWeightsDecompressor)
 
     @staticmethod
+    def get_not_supported_algorithms() -> List[str]:
+        return ["lora_correction", "gptq"]
+
+    @staticmethod
     def get_scale_estimation_ref():
         return torch.tensor(
             [
@@ -472,3 +476,7 @@ class TestPTTemplateWeightCompression(TemplateWeightCompression):
                 torch.tensor([[1.226455, 1.205499, 1.141340, 1.097436, 1.064355, 1.037971, 1.016118, 0.997526]])
             )
         }
+
+    def test_error_message_for_invalid_group_size(self):
+        # TODO (dokuchaev) fix wrapping.
+        pytest.xfail("Known issue with wrapping")


### PR DESCRIPTION
### Changes

Cherry-pick of #3391
If the number of weight channels is not dividable by group size, the compression will fail with the following message:

![image](https://github.com/user-attachments/assets/8119f07c-a24b-46a1-835c-2a4228dcfb4c)

### Reason for changes

previous message wasn't informative

### Related tickets

n/a

### Tests

- test_raise_error_with_unsupported_params_for_int8