### PR TITLE
fix len() of unsized object

### DIFF
--- a/nncf/quantization/algorithms/bias_correction/algorithm.py
+++ b/nncf/quantization/algorithms/bias_correction/algorithm.py
@@ -550,7 +550,10 @@ class BiasCorrection(Algorithm):
         for tensor_collector in statistic_points.get_algo_statistics_for_node(
             node_name, output_filter_func, self._algorithm_key
         ):
-            output_fp.extend(tensor_collector.get_statistics().mean_values)
+            if not hasattr(tensor_collector.get_statistics().mean_values, "__len__"):
+                output_fp.append(tensor_collector.get_statistics().mean_values)
+            else:
+                output_fp.extend(tensor_collector.get_statistics().mean_values)
         return output_fp
 
     def get_statistic_points(self, model: TModel, graph: NNCFGraph) -> StatisticPointsContainer:


### PR DESCRIPTION
### Changes

<!--- What was changed (briefly), how to reproduce (if applicable), what the reviewers should focus on -->

Added new logic when `hasattr(tensor_collector.get_statistics().mean_values, "__len__") == False`.

### Reason for changes

<!--- Why should the change be applied -->

if `tensor_collector.get_statistics().mean_values` is a `nncf.tensor` with shape `()` of dim `0`, `extend` function call will fail.

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
`tests/onnx/quantization/test_bias_correction.py` is tested.
I am not sure how to test it as I encountered this bug during quantization of a network from one of my robotics projects. I guess the bug will only be triggled by certain networks and certain calibration datasets, therefor no new tests are added to varify the fix.