### PR TITLE
[gha] set timeout

### DIFF
--- a/.github/workflows/api_set_label.yml
+++ b/.github/workflows/api_set_label.yml
@@ -11,6 +11,7 @@ jobs:
   update_labels:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'openvinotoolkit' }}
     permissions:
       pull-requests: write
 

--- a/.github/workflows/api_set_label.yml
+++ b/.github/workflows/api_set_label.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   update_labels:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 5
     permissions:
       pull-requests: write
 

--- a/.github/workflows/build_and_publish_doc.yml
+++ b/.github/workflows/build_and_publish_doc.yml
@@ -23,6 +23,7 @@ jobs:
   publish:
     needs: [call-build-html-doc, call-build-schema-page]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout main repo  # the github-pages-deploy-action seems to require this step
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/build_schema_page.yml
+++ b/.github/workflows/build_schema_page.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build-config-schema-html:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -24,6 +24,7 @@ jobs:
   examples-cpu:
     name: Test examples CPU [${{ matrix.group }}/4]
     runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 80
     strategy:
       fail-fast: false
       matrix:
@@ -72,6 +73,7 @@ jobs:
           python .github/scripts/pytest_md_summary.py pytest-results.xml >> $GITHUB_STEP_SUMMARY
 
   examples-win-cpu:
+    timeout-minutes: 80
     name: Test examples CPU Windows [${{ matrix.group }}/4]
     runs-on: windows-2019-16-core
     if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_windows == 'false' }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -13,6 +13,7 @@ jobs:
   install-cpu:
     name: Test install [${{ matrix.backend }} - ${{ matrix.runner }}]
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +49,7 @@ jobs:
       run:
         shell: bash
     runs-on: aks-linux-4-cores-28gb-gpu-tesla-t4
+    timeout-minutes: 20
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:

--- a/.github/workflows/model_hub.yml
+++ b/.github/workflows/model_hub.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   torch:
     runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   mypy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0

--- a/.github/workflows/pre-commit-linters.yml
+++ b/.github/workflows/pre-commit-linters.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
@@ -22,6 +23,7 @@ jobs:
         run: make pre-commit
   md-dead-link-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: AlexanderDokuchaev/md-dead-link-check@d5a37e0b14e5918605d22b34562532762ccb2e47 # v1.2.0

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,32 +22,31 @@ on:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
-
+    timeout-minutes: 60
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Set up Python
-      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
-      with:
-        python-version: 3.10.14
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel build twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        NNCF_RELEASE_BUILD: "1"
-      run: |
-        python -m build
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: 3.10.14
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel build twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          NNCF_RELEASE_BUILD: "1"
+        run: |
+          python -m build
 
-        # Disallow uploading dev packages
-        for file in dist/*; do
-          if [[ $file == *"dev"* ]]; then
-             exit 42
-          fi
-        done
+          # Disallow uploading dev packages
+          for file in dist/*; do
+            if [[ $file == *"dev"* ]]; then
+              exit 42
+            fi
+          done
 
-        twine upload dist/*
+          twine upload dist/*


### PR DESCRIPTION
### Changes

Set a timeout for all jobs to prevent slow or stacked jobs from running indefinitely.
Add a condition for the update_labels job to avoid failure when the API changes check job is canceled or fails.

### Reason for changes

1. To catch slow or stacked jobs
2. To prevent the `update_labels` job from failing with `Error: no artifacts found` when the `API changes check` job is canceled (e.g., due to a new commit push or PR closure).
