### PR TITLE
Fixed bug with FQ_LORA for shared weights

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/torch_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/torch_backend.py
@@ -356,11 +356,9 @@ class PTWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
             scale = scale.type(quantizer.scale.dtype)
             quantizer.scale = torch.nn.Parameter(scale * levels / 2)
 
-        target_node_name = wc_params.node_with_weight.node_name
-        target_point = PTTargetPoint(
-            TargetType.OPERATION_WITH_WEIGHTS, target_node_name=target_node_name, input_port_id=wc_params.weight_port_id
-        )
-        storage_key = "FQ_LORA_{}".format(wc_params.weight_name.replace(".", "_"))
+        target_node_name = wc_params.weight_name
+        target_point = PTTargetPoint(TargetType.OPERATOR_POST_HOOK, target_node_name=target_node_name)
+        storage_key = "FQ_LORA_{}".format(target_node_name.replace(".", "_"))
 
         return PTSharedFnInsertionCommand(
             target_points=[target_point],

--- a/nncf/torch/quantization/strip.py
+++ b/nncf/torch/quantization/strip.py
@@ -24,7 +24,6 @@ from nncf.torch.graph.transformations.commands import ExtraCompressionModuleType
 from nncf.torch.graph.transformations.commands import PTSharedFnInsertionCommand
 from nncf.torch.graph.transformations.commands import PTTargetPoint
 from nncf.torch.model_graph_manager import get_const_data
-from nncf.torch.model_graph_manager import get_const_node
 from nncf.torch.model_graph_manager import get_module_by_name
 from nncf.torch.model_graph_manager import split_const_name
 from nncf.torch.model_transformer import PTModelTransformer
@@ -339,8 +338,7 @@ def replace_with_decompressors(model: NNCFNetwork) -> NNCFNetwork:
             raise nncf.ValidationError(msg)
 
         tp = command.target_points[0]
-        node_with_weight = graph.get_node_by_name(tp.target_node_name)
-        weight_node = get_const_node(node_with_weight, tp.input_port_id, graph)
+        weight_node = graph.get_node_by_name(tp.target_node_name)
         if weight_node is None:
             msg = "FQ is not assigned to weight. Strip to DQ format is not supported for FQ on activation."
             raise nncf.UnsupportedModelError(msg)

--- a/tests/cross_fw/shared/nx_graph.py
+++ b/tests/cross_fw/shared/nx_graph.py
@@ -25,9 +25,11 @@ from nncf.common.utils.dot_file_rw import write_dot_graph
 def sort_dot(path):
     with open(path, encoding="utf8") as f:
         content = f.readlines()
-    start_line = "strict digraph  {\n"
+    start_line_flavors = ["strict digraph  {\n", "strict digraph {\n"]  # due to different versions of networkx
+    for start_line in start_line_flavors:
+        if start_line in content:
+            content.remove(start_line)
     end_line = "}\n"
-    content.remove(start_line)
     content.remove(end_line)
 
     @total_ordering

--- a/tests/torch/data/reference_graphs/compress_weights/fq_lora/ShortTransformer_all_layers_False.dot
+++ b/tests/torch/data/reference_graphs/compress_weights/fq_lora/ShortTransformer_all_layers_False.dot
@@ -1,0 +1,24 @@
+strict digraph {
+"0 /nncf_model_input_0" [id=0, type="nncf_model_input"];
+"1 wte.weight" [id=1, type="nncf_model_const"];
+"2 ShortTransformer/Embedding[wte]/AsymmetricQuantizer/asymmetric_quantize_0" [id=2, type="asymmetric_quantize"];
+"3 ShortTransformer/Embedding[wte]/embedding_0" [id=3, type=embedding];
+"4 linear.weight" [id=4, type="nncf_model_const"];
+"5 ShortTransformer/Linear[linear]/SymmetricLoraQuantizer/symmetric_quantize_lora_0" [id=5, type="symmetric_quantize_lora"];
+"6 linear.bias" [id=6, type="nncf_model_const"];
+"7 ShortTransformer/Linear[linear]/linear_0" [id=7, type=linear];
+"8 lm_head.bias" [id=8, type="nncf_model_const"];
+"9 ShortTransformer/Linear[lm_head]/linear_0" [id=9, type=linear];
+"10 /nncf_model_output_0" [id=10, type="nncf_model_output"];
+"0 /nncf_model_input_0" -> "3 ShortTransformer/Embedding[wte]/embedding_0" [style=dashed, label="(8,)"];
+"1 wte.weight" -> "2 ShortTransformer/Embedding[wte]/AsymmetricQuantizer/asymmetric_quantize_0" [style=solid, label="(16, 8)"];
+"2 ShortTransformer/Embedding[wte]/AsymmetricQuantizer/asymmetric_quantize_0" -> "3 ShortTransformer/Embedding[wte]/embedding_0" [style=solid, label="(16, 8)"];
+"2 ShortTransformer/Embedding[wte]/AsymmetricQuantizer/asymmetric_quantize_0" -> "9 ShortTransformer/Linear[lm_head]/linear_0" [style=solid, label="(16, 8)"];
+"3 ShortTransformer/Embedding[wte]/embedding_0" -> "7 ShortTransformer/Linear[linear]/linear_0" [style=solid, label="(8, 8)"];
+"4 linear.weight" -> "5 ShortTransformer/Linear[linear]/SymmetricLoraQuantizer/symmetric_quantize_lora_0" [style=solid, label="(8, 8)"];
+"5 ShortTransformer/Linear[linear]/SymmetricLoraQuantizer/symmetric_quantize_lora_0" -> "7 ShortTransformer/Linear[linear]/linear_0" [style=solid, label="(8, 8)"];
+"6 linear.bias" -> "7 ShortTransformer/Linear[linear]/linear_0" [style=solid, label="(8,)"];
+"7 ShortTransformer/Linear[linear]/linear_0" -> "9 ShortTransformer/Linear[lm_head]/linear_0" [style=solid, label="(8, 8)"];
+"8 lm_head.bias" -> "9 ShortTransformer/Linear[lm_head]/linear_0" [style=solid, label="(16,)"];
+"9 ShortTransformer/Linear[lm_head]/linear_0" -> "10 /nncf_model_output_0" [style=solid, label="(8, 16)"];
+}

--- a/tests/torch/data/reference_graphs/compress_weights/fq_lora/ShortTransformer_all_layers_True.dot
+++ b/tests/torch/data/reference_graphs/compress_weights/fq_lora/ShortTransformer_all_layers_True.dot
@@ -1,0 +1,24 @@
+strict digraph {
+"0 /nncf_model_input_0" [id=0, type="nncf_model_input"];
+"1 wte.weight" [id=1, type="nncf_model_const"];
+"2 ShortTransformer/Embedding[wte]/SymmetricLoraQuantizer/symmetric_quantize_lora_0" [id=2, type="symmetric_quantize_lora"];
+"3 ShortTransformer/Embedding[wte]/embedding_0" [id=3, type=embedding];
+"4 linear.weight" [id=4, type="nncf_model_const"];
+"5 ShortTransformer/Linear[linear]/SymmetricLoraQuantizer/symmetric_quantize_lora_0" [id=5, type="symmetric_quantize_lora"];
+"6 linear.bias" [id=6, type="nncf_model_const"];
+"7 ShortTransformer/Linear[linear]/linear_0" [id=7, type=linear];
+"8 lm_head.bias" [id=8, type="nncf_model_const"];
+"9 ShortTransformer/Linear[lm_head]/linear_0" [id=9, type=linear];
+"10 /nncf_model_output_0" [id=10, type="nncf_model_output"];
+"0 /nncf_model_input_0" -> "3 ShortTransformer/Embedding[wte]/embedding_0" [style=dashed, label="(8,)"];
+"1 wte.weight" -> "2 ShortTransformer/Embedding[wte]/SymmetricLoraQuantizer/symmetric_quantize_lora_0" [style=solid, label="(16, 8)"];
+"2 ShortTransformer/Embedding[wte]/SymmetricLoraQuantizer/symmetric_quantize_lora_0" -> "3 ShortTransformer/Embedding[wte]/embedding_0" [style=solid, label="(16, 8)"];
+"2 ShortTransformer/Embedding[wte]/SymmetricLoraQuantizer/symmetric_quantize_lora_0" -> "9 ShortTransformer/Linear[lm_head]/linear_0" [style=solid, label="(16, 8)"];
+"3 ShortTransformer/Embedding[wte]/embedding_0" -> "7 ShortTransformer/Linear[linear]/linear_0" [style=solid, label="(8, 8)"];
+"4 linear.weight" -> "5 ShortTransformer/Linear[linear]/SymmetricLoraQuantizer/symmetric_quantize_lora_0" [style=solid, label="(8, 8)"];
+"5 ShortTransformer/Linear[linear]/SymmetricLoraQuantizer/symmetric_quantize_lora_0" -> "7 ShortTransformer/Linear[linear]/linear_0" [style=solid, label="(8, 8)"];
+"6 linear.bias" -> "7 ShortTransformer/Linear[linear]/linear_0" [style=solid, label="(8,)"];
+"7 ShortTransformer/Linear[linear]/linear_0" -> "9 ShortTransformer/Linear[lm_head]/linear_0" [style=solid, label="(8, 8)"];
+"8 lm_head.bias" -> "9 ShortTransformer/Linear[lm_head]/linear_0" [style=solid, label="(16,)"];
+"9 ShortTransformer/Linear[lm_head]/linear_0" -> "10 /nncf_model_output_0" [style=solid, label="(8, 16)"];
+}

--- a/tests/torch/ptq/test_fq_lora.py
+++ b/tests/torch/ptq/test_fq_lora.py
@@ -28,10 +28,16 @@ from nncf.quantization.advanced_parameters import AdvancedCompressionParameters
 from nncf.quantization.quantize_model import compress_weights
 from nncf.scopes import IgnoredScope
 from nncf.torch import load_from_config
+from nncf.torch.model_creation import wrap_model
 from nncf.torch.quantization.layers import AsymmetricQuantizer as AQ
 from nncf.torch.quantization.layers import LoraMixin
 from nncf.torch.quantization.layers import SymmetricQuantizer as SQ
+from tests.cross_fw.shared.paths import TEST_ROOT
+from tests.torch.ptq.test_weights_compression import ShortTransformer
+from tests.torch.test_compressed_graph import check_graph
 from tests.torch.test_models.synthetic import LinearModel
+
+REFERENCE_GRAPH_DIR = TEST_ROOT / "torch" / "data" / "reference_graphs" / "compress_weights" / "fq_lora"
 
 
 class ValidationMock:
@@ -220,3 +226,32 @@ def test_invalid_lora_rank():
             compression_format=CompressionFormat.FQ_LORA,
             advanced_parameters=AdvancedCompressionParameters(lora_adapter_rank=too_big_rank),
         )
+
+
+@pytest.mark.parametrize("all_layers", [True, False])
+def test_compress_shared_weights(mocker, all_layers):
+    model = ShortTransformer(8, 16, share_weights=True)
+
+    input_ids = torch.randint(0, 10, (8,))
+    wrapped_model = wrap_model(model, example_input=input_ids, trace_parameters=True)
+
+    compressed_model = compress_weights(
+        wrapped_model,
+        mode=CompressWeightsMode.INT4_SYM,
+        all_layers=all_layers,
+        group_size=4,
+        compression_format=CompressionFormat.FQ_LORA,
+        advanced_parameters=AdvancedCompressionParameters(lora_adapter_rank=4),
+    )
+    nncf_graph = compressed_model.nncf.get_graph()
+    filename = f"{model.__class__.__name__}_all_layers_{str(all_layers)}.dot"
+    check_graph(nncf_graph, filename, REFERENCE_GRAPH_DIR, extended=True)
+
+    assert len(compressed_model.nncf.external_quantizers) == 2
+    # check that the weight decompressors are called only once
+    # for val in compressed_model.nncf.external_quantizers.values():
+    for val in compressed_model.nncf.external_quantizers.values():
+        mocker.spy(val, "forward")
+    compressed_model(input_ids)
+    for val in compressed_model.nncf.external_quantizers.values():
+        assert val.forward.call_count == 1

--- a/tests/torch/ptq/test_fq_lora.py
+++ b/tests/torch/ptq/test_fq_lora.py
@@ -140,7 +140,7 @@ def test_fq_lora_tuning(tmp_path, mode, backup_mode, compression_kwargs, ref_num
     assert first_loss > 8
     assert float(loss) < 1
 
-    if "awq" in compression_kwargs:
+    if compression_kwargs["awq"]:
         return  # Skip test for strip for awq + se initialization. Cases with data-free methods are enough.
 
     with torch.no_grad():


### PR DESCRIPTION
### Changes

Insert FQ_LORA as post_hook, instead of pre_hook. 

### Reason for changes

Models with shared weights had incorrect quantizer setup.

| before fix | after fix |
|--------|-------|
| ![Screenshot 2025-03-31 191411](https://github.com/user-attachments/assets/b104c542-df96-4a6a-a65f-c458246b00b2)|  ![Screenshot 2025-03-31 191313](https://github.com/user-attachments/assets/edb94470-5637-49f9-9380-84bcde38a443)|

### Related tickets

n/a

### Tests

- test_compress_shared_weights
