### PR TITLE
[gha] skip cuda examples on windows

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -187,6 +187,7 @@ jobs:
           export LIB="${LIB};$(python -c "import sys; print(sys.prefix + '/libs')")"
           export INCLUDE="${INCLUDE};$(python -c "import sysconfig; print(sysconfig.get_path('include'))")"
           python -m pytest -s -ra tests/cross_fw/examples \
+            -m 'not cuda' \
             --junit-xml=pytest-results.xml \
             --durations-path=tests/cross_fw/examples/.test_durations \
             --splitting-algorithm=least_duration \


### PR DESCRIPTION
### Changes

Set mark 'not cuda' for windows runner

https://github.com/openvinotoolkit/nncf/pull/3386

### Reason for changes

No gpu on windows hosts
https://github.com/openvinotoolkit/nncf/actions/runs/14298014723/job/40067736711

