### PR TITLE
Fix disable_caching context manager

### DIFF
--- a/nncf/common/utils/caching.py
+++ b/nncf/common/utils/caching.py
@@ -95,9 +95,11 @@ def disable_results_caching(cache: ResultsCache) -> Iterator[None]:
 
     :param cache: A cache container where results are stored.
     """
-    if cache.enabled():
+    should_reenable = cache.enabled()
+    if should_reenable:
         cache.disable()
+    try:
         yield
-        cache.enable()
-    else:
-        yield
+    finally:
+        if should_reenable:
+            cache.enable()

--- a/tests/common/utils/test_cache_results_decorator.py
+++ b/tests/common/utils/test_cache_results_decorator.py
@@ -8,6 +8,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import threading
+
 from nncf.common.utils.caching import ResultsCache
 from nncf.common.utils.caching import cache_results
 from nncf.common.utils.caching import disable_results_caching
@@ -137,3 +139,18 @@ def test_caching_results():
                 check_fn()
         else:
             check_fn()
+
+
+def test_disable_caching_with_exception():
+    def thread_fn():
+        with disable_results_caching(TEST_CACHE_CONTAINER):
+            assert not TEST_CACHE_CONTAINER.enabled()
+            raise Exception
+
+    assert TEST_CACHE_CONTAINER.enabled()
+
+    thread = threading.Thread(target=thread_fn)
+    thread.start()
+    thread.join()
+
+    assert TEST_CACHE_CONTAINER.enabled()

--- a/tests/common/utils/test_cache_results_decorator.py
+++ b/tests/common/utils/test_cache_results_decorator.py
@@ -144,9 +144,9 @@ def test_caching_results():
 def test_disable_caching_with_exception():
     assert TEST_CACHE_CONTAINER.enabled()
 
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         with disable_results_caching(TEST_CACHE_CONTAINER):
             assert not TEST_CACHE_CONTAINER.enabled()
-            raise Exception
+            raise RuntimeError
 
     assert TEST_CACHE_CONTAINER.enabled()

--- a/tests/common/utils/test_cache_results_decorator.py
+++ b/tests/common/utils/test_cache_results_decorator.py
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import threading
+import pytest
 
 from nncf.common.utils.caching import ResultsCache
 from nncf.common.utils.caching import cache_results
@@ -142,15 +142,11 @@ def test_caching_results():
 
 
 def test_disable_caching_with_exception():
-    def thread_fn():
+    assert TEST_CACHE_CONTAINER.enabled()
+
+    with pytest.raises(Exception):
         with disable_results_caching(TEST_CACHE_CONTAINER):
             assert not TEST_CACHE_CONTAINER.enabled()
             raise Exception
-
-    assert TEST_CACHE_CONTAINER.enabled()
-
-    thread = threading.Thread(target=thread_fn)
-    thread.start()
-    thread.join()
 
     assert TEST_CACHE_CONTAINER.enabled()


### PR DESCRIPTION
### Changes

Enable caching back in case an exception is raised after disabling.

### Tests

Added a corresponding test (fails on develop).
