### PR TITLE
Remove xfail for test_mixed_precision_e2m1

### DIFF
--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -975,8 +975,6 @@ def test_call_gptq_with_dataset_scale_estimation_neg_group_size(mode):
     compress_weights(model, mode=mode, ratio=1.0, group_size=-1, dataset=dataset, gptq=True, scale_estimation=True)
 
 
-# TODO(andreyanufr) Waiting for the e2m1 in OV release
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     ("mode", "all_layers", "ratio", "ref_ids"),
     (

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -998,7 +998,7 @@ def test_call_gptq_with_dataset_scale_estimation_neg_group_size(mode):
 )
 def test_mixed_precision_e2m1(mode, all_layers, ratio, ref_ids):
     model = SequentialMatmulModel().ov_model
-    dataset = Dataset([np.ones([1, 4, 4]), np.arange(16).reshape(4, 4)])
+    dataset = Dataset([np.ones([1, 4, 4]), np.arange(16).reshape(1, 4, 4)])
     compressed_model = compress_weights(
         model,
         mode=CompressWeightsMode.E2M1,


### PR DESCRIPTION
### Changes

Remove xfail for tests/openvino/native/quantization/test_weights_compression.py::test_mixed_precision_e2m1

### Reason for changes

```
XPASS tests/openvino/native/quantization/test_weights_compression.py::test_mixed_precision_e2m1[weight_quantization_error-True-1-ref_ids0]
XPASS tests/openvino/native/quantization/test_weights_compression.py::test_mixed_precision_e2m1[weight_quantization_error-True-0.8-ref_ids1]
...
```
