### PR TITLE
[ONNX] Add support for ONNX models larger than 2GB

### DIFF
--- a/nncf/common/factory.py
+++ b/nncf/common/factory.py
@@ -40,7 +40,7 @@ class NNCFGraphFactory:
 
             from nncf.onnx.graph.nncf_graph_builder import GraphConverter as ONNXGraphConverter
 
-            return ONNXGraphConverter.create_nncf_graph(cast(ModelProto, model))
+            return ONNXGraphConverter.create_nncf_graph(cast(ModelProto, model.model_proto))
         if model_backend == BackendType.OPENVINO:
             from openvino import Model  # type: ignore
 
@@ -79,11 +79,10 @@ class ModelTransformerFactory:
         """
         model_backend = get_backend(model)
         if model_backend == BackendType.ONNX:
-            from onnx import ModelProto
-
             from nncf.onnx.graph.model_transformer import ONNXModelTransformer
+            from nncf.onnx.graph.model_utils import OnnxModel
 
-            return ONNXModelTransformer(cast(ModelProto, model))
+            return ONNXModelTransformer(cast(OnnxModel, model))
         if model_backend == BackendType.OPENVINO:
             from openvino import Model
 
@@ -123,11 +122,10 @@ class EngineFactory:
         """
         model_backend = get_backend(model)
         if model_backend == BackendType.ONNX:
-            from onnx import ModelProto
-
             from nncf.onnx.engine import ONNXEngine
+            from nncf.onnx.graph.model_utils import OnnxModel
 
-            return ONNXEngine(cast(ModelProto, model))
+            return ONNXEngine(cast(OnnxModel, model))
         if model_backend == BackendType.OPENVINO:
             from openvino import Model
 

--- a/nncf/common/factory.py
+++ b/nncf/common/factory.py
@@ -80,9 +80,9 @@ class ModelTransformerFactory:
         model_backend = get_backend(model)
         if model_backend == BackendType.ONNX:
             from nncf.onnx.graph.model_transformer import ONNXModelTransformer
-            from nncf.onnx.graph.model_utils import OnnxModel
+            from nncf.onnx.graph.model_utils import ONNXModel
 
-            return ONNXModelTransformer(cast(OnnxModel, model))
+            return ONNXModelTransformer(cast(ONNXModel, model))
         if model_backend == BackendType.OPENVINO:
             from openvino import Model
 
@@ -123,9 +123,9 @@ class EngineFactory:
         model_backend = get_backend(model)
         if model_backend == BackendType.ONNX:
             from nncf.onnx.engine import ONNXEngine
-            from nncf.onnx.graph.model_utils import OnnxModel
+            from nncf.onnx.graph.model_utils import ONNXModel
 
-            return ONNXEngine(cast(OnnxModel, model))
+            return ONNXEngine(cast(ONNXModel, model))
         if model_backend == BackendType.OPENVINO:
             from openvino import Model
 

--- a/nncf/common/factory.py
+++ b/nncf/common/factory.py
@@ -80,7 +80,7 @@ class ModelTransformerFactory:
         model_backend = get_backend(model)
         if model_backend == BackendType.ONNX:
             from nncf.onnx.graph.model_transformer import ONNXModelTransformer
-            from nncf.onnx.graph.model_utils import ONNXModel
+            from nncf.onnx.model import ONNXModel
 
             return ONNXModelTransformer(cast(ONNXModel, model))
         if model_backend == BackendType.OPENVINO:
@@ -123,7 +123,7 @@ class EngineFactory:
         model_backend = get_backend(model)
         if model_backend == BackendType.ONNX:
             from nncf.onnx.engine import ONNXEngine
-            from nncf.onnx.graph.model_utils import ONNXModel
+            from nncf.onnx.model import ONNXModel
 
             return ONNXEngine(cast(ONNXModel, model))
         if model_backend == BackendType.OPENVINO:

--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -100,9 +100,9 @@ def is_onnx_model(model: Any) -> bool:
     """
     import onnx  # type: ignore
 
-    from nncf.onnx.graph.model_utils import OnnxModel  # type: ignore
+    from nncf.onnx.graph.model_utils import ONNXModel  # type: ignore
 
-    return isinstance(model, onnx.ModelProto) or isinstance(model, OnnxModel)
+    return isinstance(model, onnx.ModelProto) or isinstance(model, ONNXModel)
 
 
 @result_verifier

--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -100,7 +100,9 @@ def is_onnx_model(model: Any) -> bool:
     """
     import onnx  # type: ignore
 
-    return isinstance(model, onnx.ModelProto)
+    from nncf.onnx.graph.model_utils import OnnxModel  # type: ignore
+
+    return isinstance(model, onnx.ModelProto) or isinstance(model, OnnxModel)
 
 
 @result_verifier

--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -102,7 +102,7 @@ def is_onnx_model(model: Any) -> bool:
 
     from nncf.onnx.model import ONNXModel  # type: ignore
 
-    return isinstance(model, onnx.ModelProto) or isinstance(model, ONNXModel)
+    return isinstance(model, (onnx.ModelProto, ONNXModel))
 
 
 @result_verifier
@@ -178,6 +178,12 @@ def copy_model(model: TModel) -> TModel:
 
         model = TFModelTransformer(model).transform(TFTransformationLayout())
         return model
+    if model_backend == BackendType.ONNX:
+        from nncf.onnx.model import ONNXModel
+
+        onnx_model = cast(ONNXModel, model)
+        return cast(TModel, onnx_model.clone())
+
     return deepcopy(model)
 
 

--- a/nncf/common/utils/backend.py
+++ b/nncf/common/utils/backend.py
@@ -100,7 +100,7 @@ def is_onnx_model(model: Any) -> bool:
     """
     import onnx  # type: ignore
 
-    from nncf.onnx.graph.model_utils import ONNXModel  # type: ignore
+    from nncf.onnx.model import ONNXModel  # type: ignore
 
     return isinstance(model, onnx.ModelProto) or isinstance(model, ONNXModel)
 

--- a/nncf/onnx/engine.py
+++ b/nncf/onnx/engine.py
@@ -15,7 +15,7 @@ import numpy as np
 import onnxruntime as rt
 
 from nncf.common.engine import Engine
-from nncf.onnx.graph.model_utils import OnnxModel
+from nncf.onnx.graph.model_utils import ONNXModel
 
 
 class ONNXEngine(Engine):
@@ -23,7 +23,7 @@ class ONNXEngine(Engine):
     Engine for ONNX backend using ONNXRuntime to infer the model.
     """
 
-    def __init__(self, model: OnnxModel, **rt_session_options: Any):
+    def __init__(self, model: ONNXModel, **rt_session_options: Any):
         names = []
         tensors = []
         for name, tensor in model.tensors.items():

--- a/nncf/onnx/engine.py
+++ b/nncf/onnx/engine.py
@@ -15,7 +15,7 @@ import numpy as np
 import onnxruntime as rt
 
 from nncf.common.engine import Engine
-from nncf.onnx.graph.model_utils import ONNXModel
+from nncf.onnx.model import ONNXModel
 
 
 class ONNXEngine(Engine):

--- a/nncf/onnx/graph/metatypes/onnx_metatypes.py
+++ b/nncf/onnx/graph/metatypes/onnx_metatypes.py
@@ -791,15 +791,15 @@ def _is_depthwise_conv(model: onnx.ModelProto, node: onnx.NodeProto) -> bool:
     for attribute in node.attribute:
         if attribute.name == "group":
             conv_group = onnx.helper.get_attribute_value(attribute)
-    weight_tensor_value = None
+    shape = None
     initializer_name = get_tensor_edge_name(model, node, 1, get_parents_node_mapping(model))
     for init in model.graph.initializer:
         if init.name == initializer_name:
-            weight_tensor_value = onnx.numpy_helper.to_array(init)
-    if weight_tensor_value is None:
+            shape = [dim for dim in init.dims]
+    if shape is None:
         return False
-    conv_out_channels = weight_tensor_value.shape[0]
-    conv_in_channels = weight_tensor_value.shape[1] * conv_group
+    conv_out_channels = shape[0]
+    conv_in_channels = shape[1] * conv_group
     if (
         conv_out_channels % conv_in_channels == 0
         and conv_out_channels // conv_in_channels > 0

--- a/nncf/onnx/graph/model_transformer.py
+++ b/nncf/onnx/graph/model_transformer.py
@@ -19,7 +19,7 @@ import nncf
 from nncf.common.graph.model_transformer import ModelTransformer
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.transformations.layout import TransformationLayout
-from nncf.onnx.graph.model_utils import ONNXModel
+from nncf.onnx.model import ONNXModel
 from nncf.onnx.graph.node_utils import get_input_edge
 from nncf.onnx.graph.onnx_helper import get_children
 from nncf.onnx.graph.onnx_helper import get_children_node_mapping

--- a/nncf/onnx/graph/model_transformer.py
+++ b/nncf/onnx/graph/model_transformer.py
@@ -19,7 +19,7 @@ import nncf
 from nncf.common.graph.model_transformer import ModelTransformer
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.transformations.layout import TransformationLayout
-from nncf.onnx.graph.model_utils import OnnxModel
+from nncf.onnx.graph.model_utils import ONNXModel
 from nncf.onnx.graph.node_utils import get_input_edge
 from nncf.onnx.graph.onnx_helper import get_children
 from nncf.onnx.graph.onnx_helper import get_children_node_mapping
@@ -46,7 +46,7 @@ class ONNXModelTransformer(ModelTransformer):
     SCALE_TENSOR_NAME_PREFIX = "scale_"
     ZERO_POINT_NAME_PREFIX = "zero_point_"
 
-    def __init__(self, model: OnnxModel):
+    def __init__(self, model: ONNXModel):
         super().__init__(model)
         self.onnx_model_extractor = onnx.utils.Extractor(model.model_proto)
 
@@ -107,7 +107,7 @@ class ONNXModelTransformer(ModelTransformer):
                 initializer_update_transformations.append(transformation)
         # Inplace transformations, using deepcopy of model
         if quantizer_insert_transformations or initializer_update_transformations or qdq_node_removing_transformations:
-            model = OnnxModel(deepcopy(self._model.model_proto), self._model.tensors)
+            model = ONNXModel(deepcopy(self._model.model_proto), self._model.tensors)
 
             if quantizer_insert_transformations:
                 model = self._apply_quantizer_insertion_transformations(model, quantizer_insert_transformations)
@@ -122,7 +122,7 @@ class ONNXModelTransformer(ModelTransformer):
             model = self._apply_model_extraction_transformation(model_extraction_transformation)
         return model
 
-    def _apply_output_insertion_transformations(self, transformations: List[ONNXOutputInsertionCommand]) -> OnnxModel:
+    def _apply_output_insertion_transformations(self, transformations: List[ONNXOutputInsertionCommand]) -> ONNXModel:
         """
         Returns a new model with extra outputs provided by transformations.
 
@@ -142,7 +142,7 @@ class ONNXModelTransformer(ModelTransformer):
             model_outputs.add(target_edge_name)
 
         model_with_outputs = ONNXModelTransformer._insert_outputs(self._model.model_proto, outputs=model_outputs)
-        return OnnxModel(model_with_outputs, self._model.tensors)
+        return ONNXModel(model_with_outputs, self._model.tensors)
 
     @staticmethod
     def _insert_outputs(model: onnx.ModelProto, outputs: Union[List[str], Set[str]]) -> onnx.ModelProto:
@@ -189,7 +189,7 @@ class ONNXModelTransformer(ModelTransformer):
         return new_model
 
     def _apply_quantizer_insertion_transformations(
-        self, model: OnnxModel, transformations: List[ONNXQuantizerInsertionCommand]
+        self, model: ONNXModel, transformations: List[ONNXQuantizerInsertionCommand]
     ) -> onnx.ModelProto:
         """
         Creates a new model as a deepcopy of provided model and inserts QuantizeLinear-DequantizeLinear nodes pair.
@@ -303,11 +303,11 @@ class ONNXModelTransformer(ModelTransformer):
 
     def _insert_quantizer_dequantizer(
         self,
-        model: OnnxModel,
+        model: ONNXModel,
         transformation: ONNXQuantizerInsertionCommand,
         node_mapping: Dict[str, onnx.NodeProto],
         children_node_mapping: Dict[str, List[onnx.ValueInfoProto]],
-    ) -> OnnxModel:
+    ) -> ONNXModel:
         """
         Inserts QuantizeLinear-DequantizeLinear nodes pair.
 
@@ -357,7 +357,7 @@ class ONNXModelTransformer(ModelTransformer):
         return model
 
     def _apply_initializer_update_transformations(
-        self, model: OnnxModel, transformations: List[ONNXInitializerUpdateCommand]
+        self, model: ONNXModel, transformations: List[ONNXInitializerUpdateCommand]
     ) -> onnx.ModelProto:
         """
         Creates a copy of original model and applies bias correction transformations on the model.
@@ -402,10 +402,10 @@ class ONNXModelTransformer(ModelTransformer):
             if tensor is not None:
                 submodel_tensors[tensor_proto.name] = tensor
 
-        return OnnxModel(submodel_proto, submodel_tensors)
+        return ONNXModel(submodel_proto, submodel_tensors)
 
     def _apply_qdq_node_removing_transformations(
-        self, model: OnnxModel, transformations: List[ONNXQDQNodeRemovingCommand]
+        self, model: ONNXModel, transformations: List[ONNXQDQNodeRemovingCommand]
     ) -> onnx.ModelProto:
         # TODO(andrey-churkin): Update
         """

--- a/nncf/onnx/graph/model_utils.py
+++ b/nncf/onnx/graph/model_utils.py
@@ -10,8 +10,6 @@
 # limitations under the License.
 from collections import deque
 
-import onnx
-
 from nncf.common.factory import ModelTransformerFactory
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.transformations.commands import TargetType
@@ -20,9 +18,12 @@ from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXDequantizeLinearMetatyp
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXQuantizeLinearMetatype
 from nncf.onnx.graph.transformations.commands import ONNXQDQNodeRemovingCommand
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
+from nncf.onnx.model import ONNXModel
 
 
-def remove_fq_from_inputs(model: onnx.ModelProto, nncf_graph: NNCFGraph) -> onnx.ModelProto:
+# TODO(andrey-churkin): This can be optimized. The ONNXModel instance can contain
+# information about all FQs that were inserted.
+def remove_fq_from_inputs(model: ONNXModel, nncf_graph: NNCFGraph) -> ONNXModel:
     """
     This method removes the activation Quantizer nodes from the model.
     It's needed for the further bias shift calculation that relates on quantized weights.

--- a/nncf/onnx/graph/model_utils.py
+++ b/nncf/onnx/graph/model_utils.py
@@ -107,7 +107,7 @@ def insert_raw_data_into_model(model: onnx.ModelProto, data: Dict[str, np.ndarra
             tensor.CopyFrom(tensor_proto)
 
 
-class OnnxModel:
+class ONNXModel:
     def __init__(self, model: onnx.ModelProto, data: Dict[str, np.ndarray]):
         """
         :param model: The ONNX model without raw data loaded into its initializer tensors.
@@ -126,12 +126,12 @@ class OnnxModel:
         return self._data
 
     @classmethod
-    def from_model(cls, model: onnx.ModelProto) -> "OnnxModel":
+    def from_model(cls, model: onnx.ModelProto) -> "ONNXModel":
         """
-        Creates an instance of OnnxModel from a given ONNX model.
+        Creates an instance of ONNXModel from a given ONNX model.
 
         :param model: The ONNX model.
-        :return: An OnnxModel instance containing the model and the extracted raw data from the
+        :return: An ONNXModel instance containing the model and the extracted raw data from the
             initializer tensors.
         """
         # The `extract_raw_data_from_model()` method modifies the model passed to it,
@@ -146,7 +146,7 @@ class OnnxModel:
 
     def export(self) -> onnx.ModelProto:
         """
-        Exports the OnnxModel instance to an ONNX model, inserting the raw data into
+        Exports the ONNXModel instance to an ONNX model, inserting the raw data into
         its initializer tensors.
 
         :return: The ONNX model with the raw data inserted into its initializer tensors.

--- a/nncf/onnx/graph/model_utils.py
+++ b/nncf/onnx/graph/model_utils.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import copy
 from collections import deque
 from typing import Dict
 
@@ -107,50 +106,3 @@ def insert_raw_data_into_model(model: onnx.ModelProto, data: Dict[str, np.ndarra
             tensor.CopyFrom(tensor_proto)
 
 
-class ONNXModel:
-    def __init__(self, model: onnx.ModelProto, data: Dict[str, np.ndarray]):
-        """
-        :param model: The ONNX model without raw data loaded into its initializer tensors.
-        :param data: A dictionary where the keys are the names of the initializer tensors and
-            the values are NumPy arrays representing the `raw_data` field for each corresponding tensor.
-        """
-        self._model = model
-        self._data = data
-
-    @property
-    def model_proto(self) -> onnx.ModelProto:
-        return self._model
-
-    @property
-    def tensors(self) -> Dict[str, np.ndarray]:
-        return self._data
-
-    @classmethod
-    def from_model(cls, model: onnx.ModelProto) -> "ONNXModel":
-        """
-        Creates an instance of ONNXModel from a given ONNX model.
-
-        :param model: The ONNX model.
-        :return: An ONNXModel instance containing the model and the extracted raw data from the
-            initializer tensors.
-        """
-        # The `extract_raw_data_from_model()` method modifies the model passed to it,
-        # so we should create a copy of the original model here.
-        copy_model = copy.deepcopy(model)
-        data = extract_raw_data_from_model(copy_model)
-
-        # TODO(andrey-churkin): Complete all preprocessing here
-        copy_model = onnx.shape_inference.infer_shapes(copy_model)
-
-        return cls(copy_model, data)
-
-    def export(self) -> onnx.ModelProto:
-        """
-        Exports the ONNXModel instance to an ONNX model, inserting the raw data into
-        its initializer tensors.
-
-        :return: The ONNX model with the raw data inserted into its initializer tensors.
-        """
-        copy_model = copy.deepcopy(self._model)
-        insert_raw_data_into_model(copy_model, self._data)
-        return copy_model

--- a/nncf/onnx/graph/model_utils.py
+++ b/nncf/onnx/graph/model_utils.py
@@ -9,12 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import deque
-from typing import Dict
 
-import numpy as np
 import onnx
-from onnx.external_data_helper import _get_initializer_tensors
-from onnx.external_data_helper import set_external_data
 
 from nncf.common.factory import ModelTransformerFactory
 from nncf.common.graph.graph import NNCFGraph
@@ -55,54 +51,3 @@ def remove_fq_from_inputs(model: onnx.ModelProto, nncf_graph: NNCFGraph) -> onnx
         nodes_queue.extend(nncf_graph.get_next_nodes(current_node))
 
     return model_transformer.transform(transformation_layout)
-
-
-def extract_raw_data_from_model(model: onnx.ModelProto) -> Dict[str, np.ndarray]:
-    """
-    Extracts raw data from the initializer tensors of an ONNX model.
-
-    This method iterates through all the initializer tensor protos in the given ONNX model,
-    converting the content of the `raw_data` field into NumPy array. It then clears the `raw_data`
-    field in each tensor.
-
-    :param model: The ONNX model to extract raw data from.
-    :return: A dictionary with tensor names as keys and NumPy arrays of raw data as values.
-    """
-    tensors = _get_initializer_tensors(model)
-    data = {}
-    for tensor in tensors:
-        if not tensor.HasField("raw_data"):
-            continue
-        # TODO(andrey-churkin): Handle the case when the model is loaded without data
-        # `onnx.load("model.onnx", load_external_data=False)`.
-
-        # TODO(andrey-churkin): Probably, we should convert the NumPy array into an `ort.OrtValue`
-        # here as follows: `OrtValue.ortvalue_from_numpy(numpy_tensor)`.
-        data[tensor.name] = onnx.numpy_helper.to_array(tensor)
-
-        # We should call the `set_external_data()`` method here; otherwise, we will get an error during
-        # session creation because we can't replace a non-external initializer with external data.
-        set_external_data(tensor, location="foo.bin")
-        tensor.ClearField("raw_data")
-
-    return data
-
-
-def insert_raw_data_into_model(model: onnx.ModelProto, data: Dict[str, np.ndarray]) -> None:
-    """
-    Updates the `raw_data` field of the initializer tensors in the given ONNX model using the
-    NumPy arrays from the provided dictionary.
-
-    :param model: The ONNX model to insert raw data into.
-    :param data: A dictionary where the keys are the names of the initializer tensors and the values
-        are NumPy arrays to be assigned to the `raw_data` field of the corresponding tensors.
-    """
-    tensors = _get_initializer_tensors(model)
-    for tensor in tensors:
-        numpy_array = data.get(tensor.name, None)
-        if numpy_array is not None:
-            # TODO(andrey-churkin): Should we preserve the external data options here?
-            tensor_proto = onnx.numpy_helper.from_array(numpy_array, tensor.name)
-            tensor.CopyFrom(tensor_proto)
-
-

--- a/nncf/onnx/graph/nncf_graph_builder.py
+++ b/nncf/onnx/graph/nncf_graph_builder.py
@@ -346,6 +346,7 @@ class GraphConverter:
         :param onnx_model: ONNX model.
         :return: NNCFGraph.
         """
+        # TODO(andrey-churkin): Move all preprocessing
         onnx_model = GraphConverter._replace_empty_node_name(onnx_model)
         onnx_model = onnx.shape_inference.infer_shapes(onnx_model)
         edge_info_mapping = get_edge_info_mapping(onnx_model)

--- a/nncf/onnx/graph/node_utils.py
+++ b/nncf/onnx/graph/node_utils.py
@@ -22,6 +22,7 @@ from nncf.onnx.graph.metatypes import onnx_metatypes as om
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXDequantizeLinearMetatype
 from nncf.onnx.graph.onnx_helper import get_tensor_value
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
+from nncf.onnx.model import ONNXModel
 
 
 def is_node_with_bias(node: NNCFNode) -> bool:
@@ -36,7 +37,7 @@ def is_node_with_bias(node: NNCFNode) -> bool:
     return node.layer_attributes.has_bias()
 
 
-def get_bias_value(node_with_bias: NNCFNode, model: onnx.ModelProto) -> np.ndarray:
+def get_bias_value(node_with_bias: NNCFNode, model: ONNXModel) -> np.ndarray:
     """
     Returns the bias tensor for the biased node.
 

--- a/nncf/onnx/graph/onnx_helper.py
+++ b/nncf/onnx/graph/onnx_helper.py
@@ -15,6 +15,7 @@ import numpy as np
 import onnx
 
 import nncf
+from nncf.onnx.model import ONNXModel
 
 
 def get_name_to_node_map(model: onnx.ModelProto) -> Dict[str, onnx.NodeProto]:
@@ -173,7 +174,7 @@ def get_tensor(model: onnx.ModelProto, tensor_name: str) -> onnx.TensorProto:
     raise nncf.ValidationError(msg)
 
 
-def get_tensor_value(model: onnx.ModelProto, tensor_name: str) -> np.ndarray:
+def get_tensor_value(model: ONNXModel, tensor_name: str) -> np.ndarray:
     """
     Returns tensor value of a tensor with the name 'tensor_name'.
 

--- a/nncf/onnx/graph/onnx_helper.py
+++ b/nncf/onnx/graph/onnx_helper.py
@@ -13,7 +13,6 @@ from typing import Dict, Iterator, List, Optional, Union
 
 import numpy as np
 import onnx
-from onnx import numpy_helper
 
 import nncf
 
@@ -182,7 +181,8 @@ def get_tensor_value(model: onnx.ModelProto, tensor_name: str) -> np.ndarray:
     :param tensor_name: Name of the tensor.
     :return: The value of the tensor.
     """
-    return numpy_helper.to_array(get_tensor(model, tensor_name))
+    # TODO(andrey-churkin): Consider adding a separate method: `OnnxModel.get_tensor_by_name(name: str) -> np.ndarray`
+    return model.tensors[tensor_name]
 
 
 def get_edge_shape(edge: Union[onnx.ValueInfoProto, onnx.TensorProto]) -> List[int]:

--- a/nncf/onnx/model.py
+++ b/nncf/onnx/model.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+from typing import Dict
+
+import numpy as np
+import onnx
+
+from nncf.onnx.graph.model_utils import extract_raw_data_from_model
+from nncf.onnx.graph.model_utils import insert_raw_data_into_model
+
+
+class ONNXModel:
+    def __init__(self, model: onnx.ModelProto, data: Dict[str, np.ndarray]):
+        """
+        :param model: The ONNX model without raw data loaded into its initializer tensors.
+        :param data: A dictionary where the keys are the names of the initializer tensors and
+            the values are NumPy arrays representing the `raw_data` field for each corresponding tensor.
+        """
+        self._model = model
+        self._data = data
+
+    @property
+    def model_proto(self) -> onnx.ModelProto:
+        return self._model
+
+    @property
+    def tensors(self) -> Dict[str, np.ndarray]:
+        return self._data
+
+    @classmethod
+    def from_model(cls, model: onnx.ModelProto) -> "ONNXModel":
+        """
+        Creates an instance of ONNXModel from a given ONNX model.
+
+        :param model: The ONNX model.
+        :return: An ONNXModel instance containing the model and the extracted raw data from the
+            initializer tensors.
+        """
+        # The `extract_raw_data_from_model()` method modifies the model passed to it,
+        # so we should create a copy of the original model here.
+        copy_model = copy.deepcopy(model)
+        data = extract_raw_data_from_model(copy_model)
+
+        # TODO(andrey-churkin): Complete all preprocessing here
+        copy_model = onnx.shape_inference.infer_shapes(copy_model)
+
+        return cls(copy_model, data)
+
+    def export(self) -> onnx.ModelProto:
+        """
+        Exports the ONNXModel instance to an ONNX model, inserting the raw data into
+        its initializer tensors.
+
+        :return: The ONNX model with the raw data inserted into its initializer tensors.
+        """
+        copy_model = copy.deepcopy(self._model)
+        insert_raw_data_into_model(copy_model, self._data)
+        return copy_model

--- a/nncf/onnx/model.py
+++ b/nncf/onnx/model.py
@@ -14,9 +14,57 @@ from typing import Dict
 
 import numpy as np
 import onnx
+from onnx.external_data_helper import _get_initializer_tensors
+from onnx.external_data_helper import set_external_data
 
-from nncf.onnx.graph.model_utils import extract_raw_data_from_model
-from nncf.onnx.graph.model_utils import insert_raw_data_into_model
+
+def extract_raw_data_from_model(model: onnx.ModelProto) -> Dict[str, np.ndarray]:
+    """
+    Extracts raw data from the initializer tensors of an ONNX model.
+
+    This method iterates through all the initializer tensor protos in the given ONNX model,
+    converting the content of the `raw_data` field into NumPy array. It then clears the `raw_data`
+    field in each tensor.
+
+    :param model: The ONNX model to extract raw data from.
+    :return: A dictionary with tensor names as keys and NumPy arrays of raw data as values.
+    """
+    tensors = _get_initializer_tensors(model)
+    data = {}
+    for tensor in tensors:
+        if not tensor.HasField("raw_data"):
+            continue
+        # TODO(andrey-churkin): Handle the case when the model is loaded without data
+        # `onnx.load("model.onnx", load_external_data=False)`.
+
+        # TODO(andrey-churkin): Probably, we should convert the NumPy array into an `ort.OrtValue`
+        # here as follows: `OrtValue.ortvalue_from_numpy(numpy_tensor)`.
+        data[tensor.name] = onnx.numpy_helper.to_array(tensor)
+
+        # We should call the `set_external_data()`` method here; otherwise, we will get an error during
+        # session creation because we can't replace a non-external initializer with external data.
+        set_external_data(tensor, location="foo.bin")
+        tensor.ClearField("raw_data")
+
+    return data
+
+
+def insert_raw_data_into_model(model: onnx.ModelProto, data: Dict[str, np.ndarray]) -> None:
+    """
+    Updates the `raw_data` field of the initializer tensors in the given ONNX model using the
+    NumPy arrays from the provided dictionary.
+
+    :param model: The ONNX model to insert raw data into.
+    :param data: A dictionary where the keys are the names of the initializer tensors and the values
+        are NumPy arrays to be assigned to the `raw_data` field of the corresponding tensors.
+    """
+    tensors = _get_initializer_tensors(model)
+    for tensor in tensors:
+        numpy_array = data.get(tensor.name, None)
+        if numpy_array is not None:
+            # TODO(andrey-churkin): Should we preserve the external data options here?
+            tensor_proto = onnx.numpy_helper.from_array(numpy_array, tensor.name)
+            tensor.CopyFrom(tensor_proto)
 
 
 class ONNXModel:

--- a/nncf/onnx/quantization/quantize_model.py
+++ b/nncf/onnx/quantization/quantize_model.py
@@ -18,7 +18,7 @@ from nncf.common.logging.logger import nncf_logger
 from nncf.common.quantization.structs import QuantizationPreset
 from nncf.data import Dataset
 from nncf.onnx.graph.metatypes.groups import OPERATIONS_OUTPUT_HAS_NO_BATCH_AXIS
-from nncf.onnx.graph.model_utils import ONNXModel
+from nncf.onnx.model import ONNXModel
 from nncf.onnx.graph.nncf_graph_builder import GraphConverter
 from nncf.parameters import DropType
 from nncf.parameters import ModelType

--- a/nncf/onnx/quantization/quantize_model.py
+++ b/nncf/onnx/quantization/quantize_model.py
@@ -18,6 +18,7 @@ from nncf.common.logging.logger import nncf_logger
 from nncf.common.quantization.structs import QuantizationPreset
 from nncf.data import Dataset
 from nncf.onnx.graph.metatypes.groups import OPERATIONS_OUTPUT_HAS_NO_BATCH_AXIS
+from nncf.onnx.graph.model_utils import OnnxModel
 from nncf.onnx.graph.nncf_graph_builder import GraphConverter
 from nncf.parameters import DropType
 from nncf.parameters import ModelType
@@ -80,10 +81,11 @@ def quantize_impl(
         model_type=model_type,
         advanced_parameters=advanced_parameters,
     )
-
-    graph = GraphConverter.create_nncf_graph(model)
+    onnx_model = OnnxModel.from_model(model)
+    graph = GraphConverter.create_nncf_graph(onnx_model.model_proto)
     warning_model_no_batchwise_support(graph, advanced_parameters, model_type, OPERATIONS_OUTPUT_HAS_NO_BATCH_AXIS)
-    quantized_model = quantization_algorithm.apply(model, graph, dataset=calibration_dataset)
+    quantized_onnx_model = quantization_algorithm.apply(onnx_model, graph, dataset=calibration_dataset)
+    quantized_model = quantized_onnx_model.export()
 
     return quantized_model
 

--- a/nncf/onnx/quantization/quantize_model.py
+++ b/nncf/onnx/quantization/quantize_model.py
@@ -18,7 +18,7 @@ from nncf.common.logging.logger import nncf_logger
 from nncf.common.quantization.structs import QuantizationPreset
 from nncf.data import Dataset
 from nncf.onnx.graph.metatypes.groups import OPERATIONS_OUTPUT_HAS_NO_BATCH_AXIS
-from nncf.onnx.graph.model_utils import OnnxModel
+from nncf.onnx.graph.model_utils import ONNXModel
 from nncf.onnx.graph.nncf_graph_builder import GraphConverter
 from nncf.parameters import DropType
 from nncf.parameters import ModelType
@@ -81,7 +81,7 @@ def quantize_impl(
         model_type=model_type,
         advanced_parameters=advanced_parameters,
     )
-    onnx_model = OnnxModel.from_model(model)
+    onnx_model = ONNXModel.from_model(model)
     graph = GraphConverter.create_nncf_graph(onnx_model.model_proto)
     warning_model_no_batchwise_support(graph, advanced_parameters, model_type, OPERATIONS_OUTPUT_HAS_NO_BATCH_AXIS)
     quantized_onnx_model = quantization_algorithm.apply(onnx_model, graph, dataset=calibration_dataset)

--- a/nncf/onnx/statistics/aggregator.py
+++ b/nncf/onnx/statistics/aggregator.py
@@ -12,9 +12,7 @@
 from typing import Dict
 
 import numpy as np
-import onnx
 
-from nncf.common.factory import TModel
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.transformations.layout import TransformationLayout
@@ -23,6 +21,7 @@ from nncf.common.tensor_statistics.statistic_point import StatisticPointsContain
 from nncf.common.utils.backend import BackendType
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
 from nncf.experimental.common.tensor_statistics.statistics import TensorStatistic
+from nncf.onnx.graph.model_utils import OnnxModel
 from nncf.onnx.graph.node_utils import get_input_edge
 from nncf.onnx.graph.node_utils import get_input_edges_mapping
 from nncf.onnx.graph.onnx_helper import get_name_to_node_map
@@ -34,9 +33,9 @@ from nncf.tensor import Tensor
 class ONNXStatisticsAggregator(StatisticsAggregator):
     BACKEND: BackendType = BackendType.ONNX
 
-    def collect_statistics(self, model: onnx.ModelProto, graph: NNCFGraph) -> None:
+    def collect_statistics(self, model: OnnxModel, graph: NNCFGraph) -> None:
         self.input_edges_mapping = get_input_edges_mapping(graph)
-        self.node_mapping = get_name_to_node_map(model)
+        self.node_mapping = get_name_to_node_map(model.model_proto)
         self._registered_weights = set()
         super().collect_statistics(model, graph)
 
@@ -84,7 +83,7 @@ class ONNXStatisticsAggregator(StatisticsAggregator):
 
     @staticmethod
     def _get_merged_statistic_points(
-        statistic_points: StatisticPointsContainer, model: TModel, graph: NNCFGraph
+        statistic_points: StatisticPointsContainer, model: OnnxModel, graph: NNCFGraph
     ) -> StatisticPointsContainer:
         # TODO: migrate to experimental statistic collector and use common merging algorithm
         return statistic_points

--- a/nncf/onnx/statistics/aggregator.py
+++ b/nncf/onnx/statistics/aggregator.py
@@ -21,7 +21,7 @@ from nncf.common.tensor_statistics.statistic_point import StatisticPointsContain
 from nncf.common.utils.backend import BackendType
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
 from nncf.experimental.common.tensor_statistics.statistics import TensorStatistic
-from nncf.onnx.graph.model_utils import ONNXModel
+from nncf.onnx.model import ONNXModel
 from nncf.onnx.graph.node_utils import get_input_edge
 from nncf.onnx.graph.node_utils import get_input_edges_mapping
 from nncf.onnx.graph.onnx_helper import get_name_to_node_map

--- a/nncf/onnx/statistics/aggregator.py
+++ b/nncf/onnx/statistics/aggregator.py
@@ -21,7 +21,7 @@ from nncf.common.tensor_statistics.statistic_point import StatisticPointsContain
 from nncf.common.utils.backend import BackendType
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
 from nncf.experimental.common.tensor_statistics.statistics import TensorStatistic
-from nncf.onnx.graph.model_utils import OnnxModel
+from nncf.onnx.graph.model_utils import ONNXModel
 from nncf.onnx.graph.node_utils import get_input_edge
 from nncf.onnx.graph.node_utils import get_input_edges_mapping
 from nncf.onnx.graph.onnx_helper import get_name_to_node_map
@@ -33,7 +33,7 @@ from nncf.tensor import Tensor
 class ONNXStatisticsAggregator(StatisticsAggregator):
     BACKEND: BackendType = BackendType.ONNX
 
-    def collect_statistics(self, model: OnnxModel, graph: NNCFGraph) -> None:
+    def collect_statistics(self, model: ONNXModel, graph: NNCFGraph) -> None:
         self.input_edges_mapping = get_input_edges_mapping(graph)
         self.node_mapping = get_name_to_node_map(model.model_proto)
         self._registered_weights = set()
@@ -83,7 +83,7 @@ class ONNXStatisticsAggregator(StatisticsAggregator):
 
     @staticmethod
     def _get_merged_statistic_points(
-        statistic_points: StatisticPointsContainer, model: OnnxModel, graph: NNCFGraph
+        statistic_points: StatisticPointsContainer, model: ONNXModel, graph: NNCFGraph
     ) -> StatisticPointsContainer:
         # TODO: migrate to experimental statistic collector and use common merging algorithm
         return statistic_points

--- a/nncf/quantization/algorithms/bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/onnx_backend.py
@@ -11,8 +11,6 @@
 
 from typing import Dict, Optional, Set, Tuple
 
-import onnx
-
 from nncf.common.graph import NNCFGraph
 from nncf.common.graph import NNCFNode
 from nncf.common.graph.transformations.commands import TargetType
@@ -27,6 +25,7 @@ from nncf.onnx.graph.transformations.commands import ONNXInitializerUpdateComman
 from nncf.onnx.graph.transformations.commands import ONNXModelExtractionCommand
 from nncf.onnx.graph.transformations.commands import ONNXOutputInsertionCommand
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
+from nncf.onnx.model import ONNXModel
 from nncf.onnx.statistics.collectors import get_mean_statistic_collector
 from nncf.onnx.statistics.collectors import get_raw_stat_collector
 from nncf.quantization.algorithms.bias_correction.backend import BiasCorrectionAlgoBackend
@@ -80,17 +79,17 @@ class ONNXBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
         return 0
 
     @staticmethod
-    def get_bias_value(node: NNCFNode, model: onnx.ModelProto, nncf_graph: NNCFGraph) -> Tensor:
+    def get_bias_value(node: NNCFNode, model: ONNXModel, nncf_graph: NNCFGraph) -> Tensor:
         return Tensor(get_bias_value(node, model))
 
     @staticmethod
-    def get_input_name(model: onnx.ModelProto, node_name: str, input_port_id: int) -> str:
-        node_mapping = get_name_to_node_map(model)
+    def get_input_name(model: ONNXModel, node_name: str, input_port_id: int) -> str:
+        node_mapping = get_name_to_node_map(model.model_proto)
         return node_mapping[node_name].input[input_port_id]
 
     @staticmethod
-    def get_output_name(model: onnx.ModelProto, node_name: str, output_port_id: int) -> str:
-        node_mapping = get_name_to_node_map(model)
+    def get_output_name(model: ONNXModel, node_name: str, output_port_id: int) -> str:
+        node_mapping = get_name_to_node_map(model.model_proto)
         return node_mapping[node_name].output[output_port_id]
 
     @staticmethod
@@ -102,7 +101,7 @@ class ONNXBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
         return is_node_with_bias(node)
 
     @staticmethod
-    def remove_fq_from_inputs(model: onnx.ModelProto, nncf_graph: NNCFGraph) -> onnx.ModelProto:
+    def remove_fq_from_inputs(model: ONNXModel, nncf_graph: NNCFGraph) -> ONNXModel:
         return remove_fq_from_inputs(model, nncf_graph)
 
     @staticmethod

--- a/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
@@ -61,7 +61,7 @@ class ONNXFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
 
     @staticmethod
     def get_sub_input_output_names(subgraph: onnx.ModelProto) -> Tuple[str, str]:
-        return subgraph.graph.input[0].name, subgraph.graph.output[0].name
+        return subgraph.model_proto.graph.input[0].name, subgraph.model_proto.graph.output[0].name
 
     @staticmethod
     def create_input_data(

--- a/tests/onnx/quantization/test_bias_correction.py
+++ b/tests/onnx/quantization/test_bias_correction.py
@@ -30,13 +30,6 @@ from tests.cross_fw.test_templates.test_bias_correction import TemplateTestBCAlg
 from tests.onnx.quantization.common import compare_nncf_graph
 
 
-def get_data_from_node(model: onnx.ModelProto, node_name: str):
-    data = [t for t in model.graph.initializer if t.name == node_name]
-    if data:
-        return onnx.numpy_helper.to_array(data[0])
-    return None
-
-
 class TestONNXBCAlgorithm(TemplateTestBCAlgorithm):
     @staticmethod
     def list_to_backend_type(data: List) -> np.ndarray:

--- a/tests/onnx/quantization/test_fast_bias_correction.py
+++ b/tests/onnx/quantization/test_fast_bias_correction.py
@@ -22,13 +22,6 @@ from nncf.quantization.algorithms.fast_bias_correction.onnx_backend import ONNXF
 from tests.cross_fw.test_templates.test_fast_bias_correction import TemplateTestFBCAlgorithm
 
 
-def get_data_from_node(model: onnx.ModelProto, node_name: str):
-    data = [t for t in model.graph.initializer if t.name == node_name]
-    if data:
-        return onnx.numpy_helper.to_array(data[0])
-    return None
-
-
 class TestONNXFBCAlgorithm(TemplateTestFBCAlgorithm):
     @staticmethod
     def list_to_backend_type(data: List) -> np.ndarray:

--- a/tests/onnx/quantization/test_fast_bias_correction.py
+++ b/tests/onnx/quantization/test_fast_bias_correction.py
@@ -18,6 +18,7 @@ import torch
 from nncf.common.factory import NNCFGraphFactory
 from nncf.onnx.graph.node_utils import get_bias_value
 from nncf.onnx.graph.node_utils import is_node_with_bias
+from nncf.onnx.model import ONNXModel
 from nncf.quantization.algorithms.fast_bias_correction.onnx_backend import ONNXFastBiasCorrectionAlgoBackend
 from tests.cross_fw.test_templates.test_fast_bias_correction import TemplateTestFBCAlgorithm
 
@@ -36,7 +37,7 @@ class TestONNXFBCAlgorithm(TemplateTestFBCAlgorithm):
         onnx_path = f"{tmp_dir}/model.onnx"
         torch.onnx.export(model, torch.rand(model.INPUT_SIZE), onnx_path, opset_version=13, input_names=["input.1"])
         onnx_model = onnx.load(onnx_path)
-        return onnx_model
+        return ONNXModel.from_model(onnx_model)
 
     @staticmethod
     def fn_to_type(tensor):
@@ -51,7 +52,7 @@ class TestONNXFBCAlgorithm(TemplateTestFBCAlgorithm):
         return transform_fn
 
     @staticmethod
-    def check_bias(model: onnx.ModelProto, ref_bias: list):
+    def check_bias(model: ONNXModel, ref_bias: list):
         ref_bias = np.array(ref_bias)
         nncf_graph = NNCFGraphFactory.create(model)
         for node in nncf_graph.get_all_nodes():

--- a/tests/onnx/quantization/test_qdq_params_calculation.py
+++ b/tests/onnx/quantization/test_qdq_params_calculation.py
@@ -15,7 +15,7 @@ import onnx
 import pytest
 
 from nncf.common.quantization.structs import QuantizationPreset
-from nncf.onnx.graph.onnx_helper import get_tensor_value
+from nncf.onnx.graph.onnx_helper import get_tensor
 from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
 from nncf.quantization.advanced_parameters import OverflowFix
 from tests.cross_fw.shared.comparator import compare_stats
@@ -38,8 +38,8 @@ def get_q_nodes_params(model: onnx.ModelProto) -> Dict[str, np.ndarray]:
     output = {}
     for node in model.graph.node:
         if node.op_type == "QuantizeLinear":
-            scale = get_tensor_value(model, node.input[1])
-            zero_point = get_tensor_value(model, node.input[2])
+            scale = onnx.numpy_helper.to_array(get_tensor(model, node.input[1]))
+            zero_point = onnx.numpy_helper.to_array(get_tensor(model, node.input[2]))
             output[node.name] = {"scale": scale, "zero_point": zero_point}
     return output
 

--- a/tests/onnx/test_engine.py
+++ b/tests/onnx/test_engine.py
@@ -22,6 +22,7 @@ from nncf.onnx.graph.model_transformer import ONNXModelTransformer
 from nncf.onnx.graph.nncf_graph_builder import GraphConverter
 from nncf.onnx.graph.transformations.commands import ONNXOutputInsertionCommand
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
+from nncf.onnx.model import ONNXModel
 from tests.onnx.models import NonShapeModel
 
 
@@ -39,7 +40,9 @@ TARGET_LAYERS_OUTPUT = [["Y", "conv"], ["Y", "conv", "relu_1"], ["Y", "conv", "r
 @pytest.mark.parametrize("target_layers, target_layers_output", zip(TARGET_LAYERS, TARGET_LAYERS_OUTPUT))
 def test_output_insertion(target_layers, target_layers_output):
     model = NonShapeModel().onnx_model
-    nncf_graph = GraphConverter.create_nncf_graph(model)
+    model = ONNXModel.from_model(model)
+
+    nncf_graph = GraphConverter.create_nncf_graph(model.model_proto)
     nncf_input_node_next_onnx_nodes = {}
     for input_node in nncf_graph.get_input_nodes():
         next_nodes = nncf_graph.get_next_nodes(input_node)

--- a/tests/onnx/test_node_utils.py
+++ b/tests/onnx/test_node_utils.py
@@ -18,6 +18,7 @@ from nncf.onnx.graph.nncf_graph_builder import GraphConverter
 from nncf.onnx.graph.nncf_graph_builder import ONNXLayerAttributes
 from nncf.onnx.graph.node_utils import get_act_quantization_axis
 from nncf.onnx.graph.node_utils import get_bias_value
+from nncf.onnx.model import ONNXModel
 from tests.onnx.models import OneConvolutionalIdentityBiasModel
 from tests.onnx.models import OneConvolutionalModel
 
@@ -28,8 +29,8 @@ def create_nncf_node(**layer_atrributes) -> NNCFNode:
 
 @pytest.mark.parametrize("model", [OneConvolutionalModel(), OneConvolutionalIdentityBiasModel()])
 def test_get_bias_value(model):
-    onnx_model = model.onnx_model
-    nncf_graph = GraphConverter.create_nncf_graph(onnx_model)
+    onnx_model = ONNXModel.from_model(model.onnx_model)
+    nncf_graph = GraphConverter.create_nncf_graph(onnx_model.model_proto)
     # Only one Convolution in test models
     conv_node = nncf_graph.get_nodes_by_metatypes([ONNXConvolutionMetatype])[0]
     bias_value = get_bias_value(conv_node, onnx_model)

--- a/tests/onnx/test_statistics_aggregator.py
+++ b/tests/onnx/test_statistics_aggregator.py
@@ -18,6 +18,7 @@ from nncf import Dataset
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.experimental.common.tensor_statistics.collectors import TensorReducerBase
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
+from nncf.onnx.model import ONNXModel
 from nncf.onnx.statistics.aggregator import ONNXStatisticsAggregator
 from nncf.quantization.algorithms.bias_correction.onnx_backend import ONNXBiasCorrectionAlgoBackend
 from nncf.quantization.algorithms.fast_bias_correction.onnx_backend import ONNXFastBiasCorrectionAlgoBackend
@@ -45,9 +46,11 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
     def get_backend_model(self, dataset_samples):
         sample = dataset_samples[0].reshape(INPUT_SHAPE[1:])
         conv_w = self.dataset_samples_to_conv_w(sample)
-        return IdentityConvolutionalModel(
-            input_shape=INPUT_SHAPE, inp_ch=3, out_ch=3, kernel_size=3, conv_w=conv_w
-        ).onnx_model
+        return ONNXModel.from_model(
+            IdentityConvolutionalModel(
+                input_shape=INPUT_SHAPE, inp_ch=3, out_ch=3, kernel_size=3, conv_w=conv_w
+            ).onnx_model
+        )
 
     def get_statistics_aggregator(self, dataset):
         return ONNXStatisticsAggregator(dataset)


### PR DESCRIPTION
### Changes

The main objective of this PR is to extract tensors (`raw_data` attribute for initializer tensors) from the `onnx.ModelProto`  and store them within the `OnnxModel` wrapper. After the extraction, the `onnx.ModelProto` model will no longer contain the weights, resulting in a serialized form with a size of less than 2GB.

Extracted tensors can be explicitly passed into the inference session.

```python
sees_options = ort.SessionOptions()
sees_options.add_external_initializers(names, tensors)  # names: List[str], tensors: List[ort.OrtValue]
sess = ort.InferenceSession(serialized_model, sees_options, providers=["CPUExecutionProvider"])
```

### Reason for changes

Any proto in serialized form must be <2GB ([Total Size of the Message](https://protobuf.dev/programming-guides/proto-limits/))

To use `ort.InferenceSession()`, we call `model.SerializeToString()` to pass the model as bytes. However, for large models (greater than 2GB), the serialized form also exceeds 2GB, which is not supported. As a result, passing such a model to `ort.InferenceSession()` causes an error during inference.

### Related tickets

Ref: 164211

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
