### PR TITLE
Update onnxruntime to v1.21.0

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -7,7 +7,7 @@ torchvision==0.21.0
 
 # ONNX
 onnx==1.17.0
-onnxruntime==1.19.2
+onnxruntime==1.21.0
 
 # TensorFlow
 tensorflow==2.15.1

--- a/examples/post_training_quantization/onnx/mobilenet_v2/requirements.txt
+++ b/examples/post_training_quantization/onnx/mobilenet_v2/requirements.txt
@@ -3,6 +3,6 @@ tqdm
 scikit-learn
 fastdownload
 onnx==1.17.0
-onnxruntime==1.19.2
+onnxruntime==1.21.0
 openvino==2025.1
 numpy<2

--- a/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/requirements.txt
+++ b/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/requirements.txt
@@ -1,4 +1,4 @@
 ultralytics==8.3.22
 onnx==1.17.0
-onnxruntime==1.19.2
+onnxruntime==1.21.0
 openvino==2025.1


### PR DESCRIPTION
### Changes

- Update onnxruntime to v1.21.0

### Reason for changes

An update is required to use the `session.model_external_initializers_file_folder_path` config option.
