### PR TITLE
[ONNX] Add external_data_dir backend parameter

### DIFF
--- a/.ci/cspell_dict.txt
+++ b/.ci/cspell_dict.txt
@@ -154,6 +154,7 @@ gacts
 gelsy
 gelu
 genai
+getsizeof
 gflop
 gflops
 giga

--- a/nncf/onnx/engine.py
+++ b/nncf/onnx/engine.py
@@ -16,7 +16,7 @@ import onnxruntime as rt
 from onnx import ModelProto
 
 from nncf.common.engine import Engine
-from nncf.onnx.graph.model_utils import get_metadata_by_key
+from nncf.onnx.graph.onnx_helper import get_metadata_by_key
 
 
 class ONNXEngine(Engine):

--- a/nncf/onnx/engine.py
+++ b/nncf/onnx/engine.py
@@ -16,7 +16,8 @@ import onnxruntime as rt
 from onnx import ModelProto
 
 from nncf.common.engine import Engine
-from nncf.onnx.graph.onnx_helper import get_metadata_by_key
+from nncf.onnx.graph.model_metadata import MetadataKey
+from nncf.onnx.graph.model_metadata import get_metadata
 
 
 class ONNXEngine(Engine):
@@ -28,7 +29,7 @@ class ONNXEngine(Engine):
         self.input_names = set()
 
         sees_options = rt.SessionOptions()
-        external_data_dir = get_metadata_by_key(model, "nncf.external_data_dir")
+        external_data_dir = get_metadata(model, MetadataKey.EXTERNAL_DATA_DIR)
         if external_data_dir:
             sees_options.add_session_config_entry(
                 "session.model_external_initializers_file_folder_path", external_data_dir

--- a/nncf/onnx/graph/metatypes/onnx_metatypes.py
+++ b/nncf/onnx/graph/metatypes/onnx_metatypes.py
@@ -17,6 +17,7 @@ import onnx
 from nncf.common.graph.operator_metatypes import OperatorMetatype
 from nncf.common.graph.operator_metatypes import OperatorMetatypeRegistry
 from nncf.common.hardware.opset import HWConfigOpName
+from nncf.onnx.graph.onnx_helper import get_array_from_tensor
 from nncf.onnx.graph.onnx_helper import get_parent
 from nncf.onnx.graph.onnx_helper import get_parents_node_mapping
 from nncf.onnx.graph.onnx_helper import get_tensor
@@ -801,7 +802,7 @@ def _is_depthwise_conv(model: onnx.ModelProto, node: onnx.NodeProto) -> bool:
     initializer_name = get_tensor_edge_name(model, node, 1, get_parents_node_mapping(model))
     for init in model.graph.initializer:
         if init.name == initializer_name:
-            weight_tensor_value = onnx.numpy_helper.to_array(init)
+            weight_tensor_value = get_array_from_tensor(model, init)
     if weight_tensor_value is None:
         return False
     conv_out_channels = weight_tensor_value.shape[0]

--- a/nncf/onnx/graph/model_metadata.py
+++ b/nncf/onnx/graph/model_metadata.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+from typing import Optional
+
+import onnx
+
+
+class MetadataKey(Enum):
+    EXTERNAL_DATA_DIR = "nncf.metadata.external_data_dir"
+
+
+def set_metadata(model: onnx.ModelProto, key: MetadataKey, value: str) -> None:
+    """
+    Sets a metadata property on an ONNX model.
+
+    :param model: The ONNX model to which the metadata will be added.
+    :param key: The metadata key.
+    :param value: The string value to associate with the given metadata key.
+    """
+    entry = model.metadata_props.add()
+    entry.key = key.value
+    entry.value = value
+
+
+def get_metadata(model: onnx.ModelProto, key: MetadataKey) -> Optional[str]:
+    """
+    Returns the metadata value associated with the given key from the ONNX model.
+
+    :param model: The ONNX model.
+    :param key: The key of the metadata value to retrieve.
+    :return: The metadata value associated with the provided key, or None if the key is not found.
+    """
+    for prop in model.metadata_props:
+        if prop.key == key.value:
+            return prop.value
+    return None
+
+
+def remove_metadata(model: onnx.ModelProto, key: MetadataKey) -> None:
+    """
+    Removes a metadata property from an ONNX model.
+
+    :param model: The ONNX model from which the metadata will be removed.
+    :param key: The metadata key to be removed.
+    """
+    for prop in model.metadata_props:
+        if prop.key == key.value:
+            model.metadata_props.remove(prop)
+            break

--- a/nncf/onnx/graph/model_transformer.py
+++ b/nncf/onnx/graph/model_transformer.py
@@ -394,7 +394,12 @@ class ONNXModelTransformer(ModelTransformer):
         if not output_tensor_names:
             output_tensor_names = [n.name for n in self._model.graph.output]
 
-        return self.onnx_model_extractor.extract_model(input_tensor_names, output_tensor_names)
+        extracted_model = self.onnx_model_extractor.extract_model(input_tensor_names, output_tensor_names)
+        if self.model.metadata_props:
+            values = {p.key: p.value for p in self.model.metadata_props}
+            onnx.helper.set_model_props(extracted_model, values)
+
+        return extracted_model
 
     def _apply_qdq_node_removing_transformations(
         self, model: onnx.ModelProto, transformations: list[ONNXQDQNodeRemovingCommand]

--- a/nncf/onnx/graph/model_transformer.py
+++ b/nncf/onnx/graph/model_transformer.py
@@ -395,8 +395,8 @@ class ONNXModelTransformer(ModelTransformer):
             output_tensor_names = [n.name for n in self._model.graph.output]
 
         extracted_model = self.onnx_model_extractor.extract_model(input_tensor_names, output_tensor_names)
-        if self.model.metadata_props:
-            values = {p.key: p.value for p in self.model.metadata_props}
+        if self._model.metadata_props:
+            values = {p.key: p.value for p in self._model.metadata_props}
             onnx.helper.set_model_props(extracted_model, values)
 
         return extracted_model

--- a/nncf/onnx/graph/model_utils.py
+++ b/nncf/onnx/graph/model_utils.py
@@ -53,17 +53,3 @@ def remove_fq_from_inputs(model: onnx.ModelProto, nncf_graph: NNCFGraph) -> onnx
         nodes_queue.extend(nncf_graph.get_next_nodes(current_node))
 
     return model_transformer.transform(transformation_layout)
-
-
-def get_metadata_by_key(model: onnx.ModelProto, key: str) -> Optional[str]:
-    """
-    Returns the metadata value associated with the given key from the ONNX model.
-
-    :param model: The ONNX model.
-    :param key: The key of the metadata value to retrieve.
-    :return: The metadata value associated with the provided key, or None if the key is not found.
-    """
-    for metadata in model.metadata_props:
-        if metadata.key == key:
-            return metadata.value
-    return None

--- a/nncf/onnx/graph/model_utils.py
+++ b/nncf/onnx/graph/model_utils.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 from collections import deque
-from typing import Optional
 
 import onnx
 

--- a/nncf/onnx/graph/model_utils.py
+++ b/nncf/onnx/graph/model_utils.py
@@ -8,7 +8,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from collections import deque
+from typing import Optional
 
 import onnx
 
@@ -51,3 +53,17 @@ def remove_fq_from_inputs(model: onnx.ModelProto, nncf_graph: NNCFGraph) -> onnx
         nodes_queue.extend(nncf_graph.get_next_nodes(current_node))
 
     return model_transformer.transform(transformation_layout)
+
+
+def get_metadata_by_key(model: onnx.ModelProto, key: str) -> Optional[str]:
+    """
+    Returns the metadata value associated with the given key from the ONNX model.
+
+    :param model: The ONNX model.
+    :param key: The key of the metadata value to retrieve.
+    :return: The metadata value associated with the provided key, or None if the key is not found.
+    """
+    for metadata in model.metadata_props:
+        if metadata.key == key:
+            return metadata.value
+    return None

--- a/nncf/onnx/graph/onnx_helper.py
+++ b/nncf/onnx/graph/onnx_helper.py
@@ -16,7 +16,6 @@ import onnx
 from onnx import numpy_helper
 
 import nncf
-from nncf.onnx.graph.model_utils import get_metadata_by_key
 from nncf.tensor.definitions import TensorDataType
 
 NNCF_DTYPE_TO_ONNX_DTYPE = {
@@ -33,6 +32,20 @@ NNCF_DTYPE_TO_ONNX_DTYPE = {
 }
 
 ONNX_DTYPE_TO_NNCF_DTYPE = {v: k for k, v in NNCF_DTYPE_TO_ONNX_DTYPE.items()}
+
+
+def get_metadata_by_key(model: onnx.ModelProto, key: str) -> Optional[str]:
+    """
+    Returns the metadata value associated with the given key from the ONNX model.
+
+    :param model: The ONNX model.
+    :param key: The key of the metadata value to retrieve.
+    :return: The metadata value associated with the provided key, or None if the key is not found.
+    """
+    for metadata in model.metadata_props:
+        if metadata.key == key:
+            return metadata.value
+    return None
 
 
 def get_name_to_node_map(model: onnx.ModelProto) -> dict[str, onnx.NodeProto]:

--- a/nncf/onnx/graph/onnx_helper.py
+++ b/nncf/onnx/graph/onnx_helper.py
@@ -218,9 +218,11 @@ def get_tensor_value(model: onnx.ModelProto, tensor_name: str) -> np.ndarray:
 
 def get_array_from_tensor(model: onnx.ModelProto, tensor: onnx.TensorProto) -> np.ndarray:
     """
-    :param model:
-    :param tensor:
-    :return:
+    Returns the data from an ONNX tensor as NumPy array.
+
+    :param model: The ONNX model containing the tensor.
+    :param tensor: The specific tensor whose data is to be extracted.
+    :return: A NumPy array containing the tensor's data.
     """
     external_data_dir = get_metadata_by_key(model, "nncf.external_data_dir")
     base_dir = external_data_dir if external_data_dir else ""

--- a/nncf/onnx/graph/onnx_helper.py
+++ b/nncf/onnx/graph/onnx_helper.py
@@ -16,6 +16,7 @@ import onnx
 from onnx import numpy_helper
 
 import nncf
+from nncf.onnx.graph.model_utils import get_metadata_by_key
 from nncf.tensor.definitions import TensorDataType
 
 NNCF_DTYPE_TO_ONNX_DTYPE = {
@@ -198,7 +199,19 @@ def get_tensor_value(model: onnx.ModelProto, tensor_name: str) -> np.ndarray:
     :param tensor_name: Name of the tensor.
     :return: The value of the tensor.
     """
-    return numpy_helper.to_array(get_tensor(model, tensor_name))
+    tensor = get_tensor(model, tensor_name)
+    return get_array_from_tensor(model, tensor)
+
+
+def get_array_from_tensor(model: onnx.ModelProto, tensor: onnx.TensorProto) -> np.ndarray:
+    """
+    :param model:
+    :param tensor:
+    :return:
+    """
+    external_data_dir = get_metadata_by_key(model, "nncf.external_data_dir")
+    base_dir = external_data_dir if external_data_dir else ""
+    return numpy_helper.to_array(tensor, base_dir)
 
 
 def get_edge_shape(edge: Union[onnx.ValueInfoProto, onnx.TensorProto]) -> list[int]:

--- a/nncf/onnx/graph/onnx_helper.py
+++ b/nncf/onnx/graph/onnx_helper.py
@@ -16,6 +16,8 @@ import onnx
 from onnx import numpy_helper
 
 import nncf
+from nncf.onnx.graph.model_metadata import MetadataKey
+from nncf.onnx.graph.model_metadata import get_metadata
 from nncf.tensor.definitions import TensorDataType
 
 NNCF_DTYPE_TO_ONNX_DTYPE = {
@@ -32,20 +34,6 @@ NNCF_DTYPE_TO_ONNX_DTYPE = {
 }
 
 ONNX_DTYPE_TO_NNCF_DTYPE = {v: k for k, v in NNCF_DTYPE_TO_ONNX_DTYPE.items()}
-
-
-def get_metadata_by_key(model: onnx.ModelProto, key: str) -> Optional[str]:
-    """
-    Returns the metadata value associated with the given key from the ONNX model.
-
-    :param model: The ONNX model.
-    :param key: The key of the metadata value to retrieve.
-    :return: The metadata value associated with the provided key, or None if the key is not found.
-    """
-    for metadata in model.metadata_props:
-        if metadata.key == key:
-            return metadata.value
-    return None
 
 
 def get_name_to_node_map(model: onnx.ModelProto) -> dict[str, onnx.NodeProto]:
@@ -224,7 +212,7 @@ def get_array_from_tensor(model: onnx.ModelProto, tensor: onnx.TensorProto) -> n
     :param tensor: The specific tensor whose data is to be extracted.
     :return: A NumPy array containing the tensor's data.
     """
-    external_data_dir = get_metadata_by_key(model, "nncf.external_data_dir")
+    external_data_dir = get_metadata(model, MetadataKey.EXTERNAL_DATA_DIR)
     base_dir = external_data_dir if external_data_dir else ""
     return numpy_helper.to_array(tensor, base_dir)
 

--- a/nncf/onnx/quantization/backend_parameters.py
+++ b/nncf/onnx/quantization/backend_parameters.py
@@ -17,7 +17,8 @@ from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
 
 class BackendParameters:
     """
-    :param EXTERNAL_DATA_DIR:
+    :param EXTERNAL_DATA_DIR: An absolute path to the directory where the external data
+        files are stored. All external data files must be located in the same folder.
     """
 
     EXTERNAL_DATA_DIR = "external_data_dir"

--- a/nncf/onnx/quantization/backend_parameters.py
+++ b/nncf/onnx/quantization/backend_parameters.py
@@ -26,8 +26,12 @@ class BackendParameters:
 def get_external_data_dir(
     advanced_parameters: Optional[Union[AdvancedQuantizationParameters, AdvancedCompressionParameters]],
 ) -> Optional[str]:
-    """ """
+    """
+    Returns the value associated with the `BackendParameters.EXTERNAL_DATA_DIR` key from the backend parameters.
 
+    :param advanced_parameters: Advanced parameters that may contain backend parameters.
+    :return: A string representing the external data directory if found; otherwise, `None`.
+    """
     if advanced_parameters is not None and advanced_parameters.backend_params is not None:
         return advanced_parameters.backend_params.get(BackendParameters.EXTERNAL_DATA_DIR, None)
     return None

--- a/nncf/onnx/quantization/backend_parameters.py
+++ b/nncf/onnx/quantization/backend_parameters.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Union
+
+from nncf.quantization.advanced_parameters import AdvancedCompressionParameters
+from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
+
+
+class BackendParameters:
+    """
+    :param EXTERNAL_DATA_DIR:
+    """
+
+    EXTERNAL_DATA_DIR = "external_data_dir"
+
+
+def get_external_data_dir(
+    advanced_parameters: Optional[Union[AdvancedQuantizationParameters, AdvancedCompressionParameters]],
+) -> Optional[str]:
+    """ """
+
+    if advanced_parameters is not None and advanced_parameters.backend_params is not None:
+        return advanced_parameters.backend_params.get(BackendParameters.EXTERNAL_DATA_DIR, None)
+    return None

--- a/nncf/onnx/quantization/quantize_model.py
+++ b/nncf/onnx/quantization/quantize_model.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Iterable, Optional, TypeVar, Union
 import onnx
 from onnx.external_data_helper import ExternalDataInfo
 from onnx.external_data_helper import _get_all_tensors
+from onnx.external_data_helper import load_external_data_for_model
 from onnx.external_data_helper import uses_external_data
 
 import nncf
@@ -164,6 +165,7 @@ def quantize_impl(
     if external_data_dir:
         remove_metadata(model, MetadataKey.EXTERNAL_DATA_DIR)
         remove_metadata(quantized_model, MetadataKey.EXTERNAL_DATA_DIR)
+        load_external_data_for_model(quantized_model, external_data_dir)
 
     return quantized_model
 
@@ -335,5 +337,6 @@ def compress_weights_impl(
 
     if external_data_dir:
         remove_metadata(compressed_model, MetadataKey.EXTERNAL_DATA_DIR)
+        load_external_data_for_model(compressed_model, external_data_dir)
 
     return compressed_model

--- a/nncf/onnx/quantization/quantize_model.py
+++ b/nncf/onnx/quantization/quantize_model.py
@@ -60,9 +60,11 @@ def check_model_protobuf_size(model: onnx.ModelProto) -> None:
     MAXIMUM_PROTOBUF = 2000000000  # Limitation of single protobuf file is 2GB
     protobuf_string = model.SerializeToString()
     if sys.getsizeof(protobuf_string) > MAXIMUM_PROTOBUF:
-        msg = "The protobuf of onnx model is too large (>2GB). \
-               Please load the model with the `load_external_data` flag set to `False`. \
-               For more details, please visit: https://onnx.ai/onnx/repo-docs/ExternalData.html "
+        msg = (
+            "The protobuf of onnx model is too large (>2GB). "
+            "Please load the model with the `load_external_data` flag set to `False`. "
+            "For more details, please visit: https://onnx.ai/onnx/repo-docs/ExternalData.html"
+        )
         raise nncf.ValidationError(msg)
 
 
@@ -79,8 +81,10 @@ def check_external_data_location(model: onnx.ModelProto, external_data_dir: Opti
     external_data_dir = Path.cwd() if external_data_dir is None else Path(external_data_dir)
 
     if not external_data_dir.is_absolute():
-        msg = f"BackendParameters.EXTERNAL_DATA_DIR should be an absolute path, but {str(external_data_dir)} \
-                was provided instead."
+        msg = (
+            f"BackendParameters.EXTERNAL_DATA_DIR should be an absolute path, but {str(external_data_dir)} "
+            "was provided instead."
+        )
         raise nncf.ValidationError(msg)
 
     for tensor in _get_all_tensors(model):
@@ -93,8 +97,10 @@ def check_external_data_location(model: onnx.ModelProto, external_data_dir: Opti
             external_data_file_name = Path(info.location).name  # Extract only the filename
             data_path = external_data_dir / external_data_file_name
             if not data_path.exist() or not data_path.is_file() or data_path.is_symlink():
-                msg = f"Data of TensorProto (tensor name: {tensor.name}) should be stored in {str(data_path)}, \
-                        but it doesn't exist or is not accessible."
+                msg = (
+                    f"Data of TensorProto (tensor name: {tensor.name}) should be stored in {str(data_path)}, "
+                    "but it doesn't exist or is not accessible."
+                )
                 raise nncf.ValidationError(msg)
 
 

--- a/nncf/onnx/quantization/quantize_model.py
+++ b/nncf/onnx/quantization/quantize_model.py
@@ -308,7 +308,6 @@ def compress_weights_impl(
         msg = "ONNX models with opset version < 21 do not support block-wise quantization."
         raise nncf.ValidationError(msg)
 
-    check_model_protobuf_size(model)
     external_data_dir = get_external_data_dir(advanced_parameters)
     check_external_data_location(model, external_data_dir)
     if external_data_dir:

--- a/nncf/onnx/quantization/quantize_model.py
+++ b/nncf/onnx/quantization/quantize_model.py
@@ -78,6 +78,11 @@ def check_external_data_location(model: onnx.ModelProto, external_data_dir: Opti
     # If external_data_dir is not provided, we should test against the current working directory.
     external_data_dir = Path.cwd() if external_data_dir is None else Path(external_data_dir)
 
+    if not external_data_dir.is_absolute():
+        msg = f"BackendParameters.EXTERNAL_DATA_DIR should be an absolute path, but {str(external_data_dir)} \
+                was provided instead."
+        raise nncf.ValidationError(msg)
+
     for tensor in _get_all_tensors(model):
         if uses_external_data(tensor):
             info = ExternalDataInfo(tensor)

--- a/nncf/onnx/quantization/quantize_model.py
+++ b/nncf/onnx/quantization/quantize_model.py
@@ -61,7 +61,7 @@ def check_model_protobuf_size(model: onnx.ModelProto) -> None:
 
     :param model: The ONNX model to be checked.
     """
-    MAXIMUM_PROTOBUF = 2000000000  # Limitation of single protobuf file is 2GB
+    MAXIMUM_PROTOBUF = 2147483648  # Limitation of single protobuf file is 2GB
     protobuf_string = model.SerializeToString()
     if sys.getsizeof(protobuf_string) > MAXIMUM_PROTOBUF:
         msg = (
@@ -344,6 +344,7 @@ def compress_weights_impl(
     compressed_model = compression_algorithm.apply(model, graph, dataset=dataset)
 
     if external_data_dir:
+        remove_metadata(model, MetadataKey.EXTERNAL_DATA_DIR)
         remove_metadata(compressed_model, MetadataKey.EXTERNAL_DATA_DIR)
         load_external_data_for_model(compressed_model, external_data_dir)
 

--- a/nncf/onnx/quantization/quantize_model.py
+++ b/nncf/onnx/quantization/quantize_model.py
@@ -12,7 +12,6 @@
 from typing import Any, Callable, Iterable, Optional, TypeVar, Union
 
 import onnx
-from onnx.quantization.backend_parameters import get_external_data_dir
 
 import nncf
 from nncf.common.factory import NNCFGraphFactory
@@ -21,6 +20,7 @@ from nncf.common.quantization.structs import QuantizationPreset
 from nncf.data import Dataset
 from nncf.onnx.graph.metatypes.groups import OPERATIONS_OUTPUT_HAS_NO_BATCH_AXIS
 from nncf.onnx.graph.nncf_graph_builder import GraphConverter
+from nncf.onnx.quantization.backend_parameters import get_external_data_dir
 from nncf.parameters import BackupMode
 from nncf.parameters import CompressionFormat
 from nncf.parameters import CompressWeightsMode

--- a/nncf/onnx/quantization/quantize_model.py
+++ b/nncf/onnx/quantization/quantize_model.py
@@ -61,9 +61,9 @@ def check_model_protobuf_size(model: onnx.ModelProto) -> None:
 
     :param model: The ONNX model to be checked.
     """
-    MAXIMUM_PROTOBUF = 2147483648  # Limitation of single protobuf file is 2GB
+    maximum_protobuf = 2147483648  # Limitation of single protobuf file is 2GB
     protobuf_string = model.SerializeToString()
-    if sys.getsizeof(protobuf_string) > MAXIMUM_PROTOBUF:
+    if sys.getsizeof(protobuf_string) > maximum_protobuf:
         msg = (
             "The protobuf of onnx model is too large (>2GB). "
             "Please load the model with the `load_external_data` flag set to `False`. "

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -373,6 +373,8 @@ class AdvancedCompressionParameters:
     :type lora_correction_params: AdvancedLoraCorrectionParameters
     :param lora_adapter_rank: Rank of lora adapters for FQ_LORA format. Defaults to 256.
     :type lora_adapter_rank: int
+    :param backend_params: Backend-specific parameters.
+    :type backend_params: Dict[str, Any]
     """
 
     statistics_path: Optional[str] = None
@@ -383,6 +385,7 @@ class AdvancedCompressionParameters:
     gptq_params: AdvancedGPTQParameters = field(default_factory=AdvancedGPTQParameters)
     lora_correction_params: AdvancedLoraCorrectionParameters = field(default_factory=AdvancedLoraCorrectionParameters)
     lora_adapter_rank: int = 256
+    backend_params: Dict[str, Any] = field(default_factory=dict)
 
 
 @api()

--- a/nncf/quantization/advanced_parameters.py
+++ b/nncf/quantization/advanced_parameters.py
@@ -228,7 +228,7 @@ class AdvancedQuantizationParameters:
     :param smooth_quant_alpha: Deprecated SmoothQuant-related parameter.
     :type smooth_quant_alpha: float
     :param backend_params: Backend-specific parameters.
-    :type backend_params: Dict[str, Any]
+    :type backend_params: dict[str, Any]
     """
 
     # General parameters
@@ -374,7 +374,7 @@ class AdvancedCompressionParameters:
     :param lora_adapter_rank: Rank of lora adapters for FQ_LORA format. Defaults to 256.
     :type lora_adapter_rank: int
     :param backend_params: Backend-specific parameters.
-    :type backend_params: Dict[str, Any]
+    :type backend_params: dict[str, Any]
     """
 
     statistics_path: Optional[str] = None
@@ -385,7 +385,7 @@ class AdvancedCompressionParameters:
     gptq_params: AdvancedGPTQParameters = field(default_factory=AdvancedGPTQParameters)
     lora_correction_params: AdvancedLoraCorrectionParameters = field(default_factory=AdvancedLoraCorrectionParameters)
     lora_adapter_rank: int = 256
-    backend_params: Dict[str, Any] = field(default_factory=dict)
+    backend_params: dict[str, Any] = field(default_factory=dict)
 
 
 @api()

--- a/nncf/quantization/algorithms/accuracy_control/onnx_backend.py
+++ b/nncf/quantization/algorithms/accuracy_control/onnx_backend.py
@@ -25,6 +25,7 @@ from nncf.onnx.graph.metatypes.groups import QUANTIZE_DEQUANTIZE_OPERATIONS
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXOpMetatype
 from nncf.onnx.graph.node_utils import get_bias_value
 from nncf.onnx.graph.node_utils import is_node_with_bias
+from nncf.onnx.graph.onnx_helper import get_array_from_tensor
 from nncf.onnx.graph.onnx_helper import get_tensor_value
 from nncf.quantization.algorithms.accuracy_control.backend import AccuracyControlAlgoBackend
 from nncf.quantization.algorithms.accuracy_control.backend import PreparedModel
@@ -113,11 +114,11 @@ class ONNXAccuracyControlAlgoBackend(AccuracyControlAlgoBackend):
     def get_model_size(model: onnx.ModelProto) -> int:
         model_size = 0
         for initializer in model.graph.initializer:
-            model_size += onnx.numpy_helper.to_array(initializer).nbytes
+            model_size += get_array_from_tensor(model, initializer).nbytes
         for node in model.graph.node:
             for attr in node.attribute:
                 if attr.HasField("t"):
-                    model_size += onnx.numpy_helper.to_array(attr.t).nbytes
+                    model_size += get_array_from_tensor(model, attr.t).nbytes
                 for t in attr.tensors:
-                    model_size += onnx.numpy_helper.to_array(t).nbytes
+                    model_size += get_array_from_tensor(model, t).nbytes
         return model_size

--- a/nncf/quantization/algorithms/weight_compression/onnx_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/onnx_backend.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import dataclasses
 from typing import Callable, Iterable, Optional
 
 import numpy as np
@@ -186,12 +185,6 @@ class ONNXWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
         if compression_format != CompressionFormat.DQ:
             msg = "Compression format is not supported for the ONNX backend"
             raise nncf.ValidationError(msg)
-        default = AdvancedCompressionParameters()
-        for field in dataclasses.fields(advanced_parameters):
-            name = field.name
-            if name != "backend_params" and getattr(default, name) != getattr(advanced_parameters, name):
-                msg = "Advanced parameters are not supported for the ONNX backend"
-                raise nncf.ValidationError(msg)
 
     def transform_model(
         self,

--- a/nncf/quantization/algorithms/weight_compression/onnx_backend.py
+++ b/nncf/quantization/algorithms/weight_compression/onnx_backend.py
@@ -8,6 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import dataclasses
 from typing import Callable, Iterable, Optional
 
 import numpy as np
@@ -185,9 +186,12 @@ class ONNXWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
         if compression_format != CompressionFormat.DQ:
             msg = "Compression format is not supported for the ONNX backend"
             raise nncf.ValidationError(msg)
-        if advanced_parameters != AdvancedCompressionParameters():
-            msg = "Advanced parameters are not supported for the ONNX backend"
-            raise nncf.ValidationError(msg)
+        default = AdvancedCompressionParameters()
+        for field in dataclasses.fields(advanced_parameters):
+            name = field.name
+            if name != "backend_params" and getattr(default, name) != getattr(advanced_parameters, name):
+                msg = "Advanced parameters are not supported for the ONNX backend"
+                raise nncf.ValidationError(msg)
 
     def transform_model(
         self,

--- a/tests/onnx/models.py
+++ b/tests/onnx/models.py
@@ -1879,3 +1879,21 @@ class RoPEModel(ONNXReferenceModel):
         model = onnx.helper.make_model(graph_def, opset_imports=[op])
         onnx.checker.check_model(model)
         super().__init__(model, [input_shape], "rope_model.dot")
+
+
+def build_matmul_model() -> onnx.ModelProto:
+    """
+    Builds an ONNX model that contains only a MatMul operation.
+    """
+    X = onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [2, 3])
+    A = onnx.helper.make_tensor_value_info("A", onnx.TensorProto.FLOAT, [2, 2])
+    matmul = onnx.helper.make_node("MatMul", inputs=["X", "W"], outputs=["A"])
+
+    W_values = np.random.rand(3, 2).astype(np.float32)
+    W_initializer = onnx.helper.make_tensor(
+        name="W", data_type=onnx.TensorProto.FLOAT, dims=[3, 2], vals=W_values.tobytes(), raw=True
+    )
+
+    graph = onnx.helper.make_graph([matmul], "matmul-model", [X], [A], [W_initializer])
+    model = onnx.helper.make_model(graph)
+    return model

--- a/tests/onnx/quantization/test_backend_parameters.py
+++ b/tests/onnx/quantization/test_backend_parameters.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nncf.onnx.quantization.backend_parameters import BackendParameters
+from nncf.onnx.quantization.backend_parameters import get_external_data_dir
+from nncf.quantization.advanced_parameters import AdvancedCompressionParameters
+from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
+
+
+def test_get_external_data_dir():
+    assert get_external_data_dir(None) is None
+    assert get_external_data_dir(AdvancedQuantizationParameters()) is None
+    assert get_external_data_dir(AdvancedCompressionParameters()) is None
+    assert get_external_data_dir(AdvancedQuantizationParameters(backend_params={})) is None
+    assert get_external_data_dir(AdvancedCompressionParameters(backend_params={})) is None
+    assert (
+        get_external_data_dir(
+            AdvancedQuantizationParameters(backend_params={BackendParameters.EXTERNAL_DATA_DIR: "path"})
+        )
+        == "path"
+    )
+    assert (
+        get_external_data_dir(
+            AdvancedCompressionParameters(backend_params={BackendParameters.EXTERNAL_DATA_DIR: "path"})
+        )
+        == "path"
+    )

--- a/tests/onnx/test_engine.py
+++ b/tests/onnx/test_engine.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import tempfile
 
 import numpy as np
 import onnx
@@ -17,11 +18,14 @@ import pytest
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.transformations.layout import TransformationLayout
 from nncf.onnx.engine import ONNXEngine
+from nncf.onnx.graph.model_metadata import MetadataKey
+from nncf.onnx.graph.model_metadata import set_metadata
 from nncf.onnx.graph.model_transformer import ONNXModelTransformer
 from nncf.onnx.graph.nncf_graph_builder import GraphConverter
 from nncf.onnx.graph.transformations.commands import ONNXOutputInsertionCommand
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
 from tests.onnx.models import NonShapeModel
+from tests.onnx.models import build_matmul_model
 
 
 def check_engine_creation_and_inference(model: onnx.ModelProto, input_data: np.ndarray, reference_outputs: list[str]):
@@ -56,3 +60,21 @@ def test_output_insertion(target_layers, target_layers_output):
 
     input_data = {"X": np.ones([1, 3, 32, 32]).astype(np.float32)}
     check_engine_creation_and_inference(transformed_model, input_data, target_layers_output)
+
+
+def test_infer_for_model_with_external_data():
+    with tempfile.TemporaryDirectory(dir=tempfile.gettempdir()) as temp_dir:
+        model = build_matmul_model()
+        model_path = f"{temp_dir}/model.onnx"
+        onnx.save_model(
+            model,
+            model_path,
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location="model.data",
+            size_threshold=0,
+            convert_attribute=False,
+        )
+        model = onnx.load_model(model_path, load_external_data=False)
+        set_metadata(model, MetadataKey.EXTERNAL_DATA_DIR, temp_dir)
+        check_engine_creation_and_inference(model, {"X": np.ones([2, 3], dtype=np.float32)}, ["A"])

--- a/tests/onnx/test_external_data.py
+++ b/tests/onnx/test_external_data.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import tempfile
+
+import onnx
+import pytest
+
+import nncf
+from nncf.onnx.quantization.quantize_model import check_external_data_location
+from tests.onnx.models import build_matmul_model
+
+
+def _build_model_with_external_data(temp_dir: str):
+    model = build_matmul_model()
+    model_path = f"{temp_dir}/model.onnx"
+    onnx.save_model(
+        model,
+        model_path,
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location="model.data",
+        size_threshold=0,
+        convert_attribute=False,
+    )
+    model = onnx.load_model(model_path, load_external_data=False)
+    return model
+
+
+def test_no_external_data():
+    model = build_matmul_model()
+    assert check_external_data_location(model, None) is None
+
+
+def test_should_be_absolute():
+    with tempfile.TemporaryDirectory(dir=tempfile.gettempdir()) as temp_dir:
+        model = _build_model_with_external_data(temp_dir)
+
+        invalid_path = "data_dir"
+        msg = (
+            f"BackendParameters.EXTERNAL_DATA_DIR should be an absolute path, but {invalid_path} was provided instead."
+        )
+
+        with pytest.raises(nncf.ValidationError, match=msg):
+            check_external_data_location(model, invalid_path)
+
+
+def test_not_accessible():
+    with tempfile.TemporaryDirectory(dir=tempfile.gettempdir()) as temp_dir:
+        model = _build_model_with_external_data(temp_dir)
+
+        invalid_path = f"{temp_dir}_invalid"
+        msg = re.escape(
+            f"Data of TensorProto (tensor name: W) should be stored in {invalid_path}/model.data, "
+            "but it doesn't exist or is not accessible."
+        )
+
+        with pytest.raises(nncf.ValidationError, match=msg):
+            check_external_data_location(model, invalid_path)
+
+
+def test_valid_external_data_dir():
+    with tempfile.TemporaryDirectory(dir=tempfile.gettempdir()) as temp_dir:
+        model = _build_model_with_external_data(temp_dir)
+        assert check_external_data_location(model, temp_dir) == temp_dir

--- a/tests/onnx/test_model_metadata.py
+++ b/tests/onnx/test_model_metadata.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nncf.onnx.graph.model_metadata import MetadataKey
+from nncf.onnx.graph.model_metadata import get_metadata
+from nncf.onnx.graph.model_metadata import remove_metadata
+from nncf.onnx.graph.model_metadata import set_metadata
+from tests.onnx.models import build_matmul_model
+
+
+def test_set_and_get_metadata():
+    model = build_matmul_model()
+    path = "path/to/data/dir"
+    set_metadata(model, MetadataKey.EXTERNAL_DATA_DIR, path)
+    value = get_metadata(model, MetadataKey.EXTERNAL_DATA_DIR)
+    assert value == path
+
+
+def test_get_metadata_key_not_found():
+    model = build_matmul_model()
+    value = get_metadata(model, MetadataKey.EXTERNAL_DATA_DIR)
+    assert value is None
+
+
+def test_remove_metadata():
+    model = build_matmul_model()
+    path = "path/to/data/dir"
+    set_metadata(model, MetadataKey.EXTERNAL_DATA_DIR, path)
+    assert get_metadata(model, MetadataKey.EXTERNAL_DATA_DIR) == path
+    remove_metadata(model, MetadataKey.EXTERNAL_DATA_DIR)
+    assert get_metadata(model, MetadataKey.EXTERNAL_DATA_DIR) is None
+
+
+def test_remove_metadata_key_not_found():
+    model = build_matmul_model()
+    remove_metadata(model, MetadataKey.EXTERNAL_DATA_DIR)
+    assert get_metadata(model, MetadataKey.EXTERNAL_DATA_DIR) is None

--- a/tests/onnx/test_onnx_helper.py
+++ b/tests/onnx/test_onnx_helper.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+
+import onnx
+
+from nncf.onnx.graph.model_metadata import MetadataKey
+from nncf.onnx.graph.model_metadata import set_metadata
+from nncf.onnx.graph.onnx_helper import get_array_from_tensor
+from tests.onnx.models import build_matmul_model
+
+
+def test_get_array_from_tensor():
+    model = build_matmul_model()
+    tensor = None
+    for x in model.graph.initializer:
+        if x.name == "W":
+            tensor = x
+
+    assert get_array_from_tensor(model, tensor).shape == (3, 2)
+
+
+def test_get_array_from_tensor_external_data():
+    with tempfile.TemporaryDirectory(dir=tempfile.gettempdir()) as temp_dir:
+        model = build_matmul_model()
+        model_path = f"{temp_dir}/model.onnx"
+        onnx.save_model(
+            model,
+            model_path,
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location="model.data",
+            size_threshold=0,
+            convert_attribute=False,
+        )
+        model = onnx.load_model(model_path, load_external_data=False)
+        set_metadata(model, MetadataKey.EXTERNAL_DATA_DIR, temp_dir)
+
+        tensor = None
+        for x in model.graph.initializer:
+            if x.name == "W":
+                tensor = x
+        assert get_array_from_tensor(model, tensor).shape == (3, 2)


### PR DESCRIPTION
### Changes

- Added the `BackendParameters.EXTERNAL_DATA_DIR` parameter for the ONNX backend. This parameter specifies the absolute path to the directory where the model’s external data files are stored. All external data files must be located in the same directory. It should be used when the model is loaded without external data using `onnx.load("model.onnx", load_external_data=False)`, and the external data files are not in the current working directory of the process. This parameter can be omitted if the external data files are located in the current working directory of the process.

- Added `check_model_protobuf_size()` and `check_external_data_location()` validation checks. After this PR, calling `nncf.quantize()` on an ONNX model with a protobuf size exceeding 2GB will raise an `nncf.ValidationError`. The `check_external_data_location()` method ensures that the external data files can be successfully located.

### Reason for changes

Any proto in serialized form must be <2GB ([Total Size of the Message](https://protobuf.dev/programming-guides/proto-limits/))

To use `ort.InferenceSession()`, we call `model.SerializeToString()` to pass the model as bytes. However, for large models (greater than 2GB), the serialized form also exceeds 2GB, which is not supported. As a result, passing such a model to `ort.InferenceSession()` causes an error during inference.

### Related tickets

Ref: 164211

### Tests

tests/onnx/models.py
tests/onnx/quantization/test_backend_parameters.py
tests/onnx/test_engine.py
tests/onnx/test_external_data.py
tests/onnx/test_model_metadata.py
tests/onnx/test_onnx_helper.py
