### PR TITLE
Enable ruff UP006 rule 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,6 @@ ignore = [
     "SIM117", # multiple-with-statements
     "SIM103", # needless-bool
     "NPY002", # numpy-legacy-random
-    "UP006", # non-pep585-annotation
     "UP007", # non-pep604-annotation-union
     "UP035", # deprecated-import
     "UP038", # non-pep604-isinstance

--- a/tests/common/accuracy_control/backend.py
+++ b/tests/common/accuracy_control/backend.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
@@ -26,31 +26,31 @@ from tests.common.quantization.metatypes import ShapeOfTestMetatype
 
 class AABackendForTests(AccuracyControlAlgoBackend):
     @staticmethod
-    def get_op_with_weights_metatypes() -> List[OperatorMetatype]:
+    def get_op_with_weights_metatypes() -> list[OperatorMetatype]:
         return WEIGHT_LAYER_METATYPES
 
     @staticmethod
-    def get_quantizer_metatypes() -> List[OperatorMetatype]:
+    def get_quantizer_metatypes() -> list[OperatorMetatype]:
         return QUANTIZER_METATYPES
 
     @staticmethod
-    def get_const_metatypes() -> List[OperatorMetatype]:
+    def get_const_metatypes() -> list[OperatorMetatype]:
         return CONSTANT_METATYPES
 
     @staticmethod
-    def get_quantizable_metatypes() -> List[OperatorMetatype]:
+    def get_quantizable_metatypes() -> list[OperatorMetatype]:
         return QUANTIZABLE_METATYPES
 
     @staticmethod
-    def get_start_nodes_for_activation_path_tracing(nncf_graph: NNCFGraph) -> List[NNCFNode]:
+    def get_start_nodes_for_activation_path_tracing(nncf_graph: NNCFGraph) -> list[NNCFNode]:
         return nncf_graph.get_input_nodes()
 
     @staticmethod
-    def get_quantize_agnostic_metatypes() -> List[OperatorMetatype]:
+    def get_quantize_agnostic_metatypes() -> list[OperatorMetatype]:
         return QUANTIZE_AGNOSTIC_METATYPES
 
     @staticmethod
-    def get_shapeof_metatypes() -> List[OperatorMetatype]:
+    def get_shapeof_metatypes() -> list[OperatorMetatype]:
         return [ShapeOfTestMetatype]
 
     @staticmethod
@@ -70,7 +70,7 @@ class AABackendForTests(AccuracyControlAlgoBackend):
         return None
 
     @staticmethod
-    def get_weight_tensor_port_ids(node: NNCFNode) -> List[Optional[int]]:
+    def get_weight_tensor_port_ids(node: NNCFNode) -> list[Optional[int]]:
         return None
 
     @staticmethod

--- a/tests/common/accuracy_control/test_evaluator.py
+++ b/tests/common/accuracy_control/test_evaluator.py
@@ -11,7 +11,7 @@
 
 import logging
 from dataclasses import dataclass
-from typing import List, TypeVar, Union
+from typing import TypeVar, Union
 from unittest.mock import MagicMock
 from unittest.mock import Mock
 
@@ -29,7 +29,7 @@ TModel = TypeVar("TModel")
 @dataclass
 class ModeTestStruct:
     metric_value: float
-    values_for_each_item: Union[None, List[float], List[List[np.ndarray]]]
+    values_for_each_item: Union[None, list[float], list[list[np.ndarray]]]
     expected_is_metric_mode: bool
     raise_exception: bool = False
 
@@ -209,7 +209,7 @@ def test_validate_metric_mode_none_or_false(
 
     metric, values_for_each_item = evaluator_returns_tensor.validate(model, dataset)
     assert evaluator_returns_tensor.num_passed_iterations == expected_iterations
-    assert all(isinstance(item, List) for item in values_for_each_item)
+    assert all(isinstance(item, list) for item in values_for_each_item)
     assert all(isinstance(item, np.ndarray) for item in values_for_each_item[0])
     assert isinstance(metric, float)
 

--- a/tests/common/accuracy_control/test_ranking.py
+++ b/tests/common/accuracy_control/test_ranking.py
@@ -11,7 +11,6 @@
 
 
 import operator
-from typing import List
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -100,7 +99,7 @@ def test_normalized_mse(x_ref: np.ndarray, x_approx: np.ndarray, expected_nmse: 
         "subset_size_greater_than_num_errors",
     ],
 )
-def test_get_subset_indices(errors: List[float], subset_size: int, expected_indices: List[int]):
+def test_get_subset_indices(errors: list[float], subset_size: int, expected_indices: list[int]):
     actual_indices = get_subset_indices(errors, subset_size)
     assert expected_indices == actual_indices
 
@@ -136,7 +135,7 @@ def test_get_subset_indices(errors: List[float], subset_size: int, expected_indi
         "subset_size_greater_than_num_errors",
     ],
 )
-def test_get_subset_indices_pot_version(errors: List[float], subset_size: int, expected_indices: List[int]):
+def test_get_subset_indices_pot_version(errors: list[float], subset_size: int, expected_indices: list[int]):
     actual_indices = get_subset_indices_pot_version(errors, subset_size)
     assert expected_indices == actual_indices
 
@@ -165,7 +164,7 @@ def test_get_subset_indices_pot_version(errors: List[float], subset_size: int, e
         ),
     ],
 )
-def test_find_groups_of_quantizers_to_rank(nncf_graph_name: NNCFGraph, ref_groups: List[GroupToRank]):
+def test_find_groups_of_quantizers_to_rank(nncf_graph_name: NNCFGraph, ref_groups: list[GroupToRank]):
     ranker = Ranker(1, tuple(), AABackendForTests, None)
     nncf_graph = aa_create_nncf_graph(AA_GRAPHS_DESCR[nncf_graph_name])
     ret_val = ranker.find_groups_of_quantizers_to_rank(nncf_graph)
@@ -276,7 +275,7 @@ def test_sequential_calculation_ranking_score(
     ranker._ranking_fn = ranker._create_ranking_fn(BackendType.OPENVINO)
 
     groups_to_rank = ranker.find_groups_of_quantizers_to_rank(quantized_model_graph)
-    scores: List[float] = ranker._sequential_calculation_ranking_score(
+    scores: list[float] = ranker._sequential_calculation_ranking_score(
         quantized_model,
         quantized_model_graph,
         groups_to_rank,

--- a/tests/common/experimental/test_reducers_and_aggregators.py
+++ b/tests/common/experimental/test_reducers_and_aggregators.py
@@ -13,7 +13,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from functools import partial
 from itertools import product
-from typing import Any, Iterator, List, Optional, Tuple
+from typing import Any, Iterator, Optional
 
 import numpy as np
 import pytest
@@ -169,7 +169,7 @@ class TemplateTestReducersAggregators:
         pass
 
     @abstractmethod
-    def squeeze_tensor(self, ref_tensor: List[Any], axes: Optional[Tuple[int]] = None):
+    def squeeze_tensor(self, ref_tensor: list[Any], axes: Optional[tuple[int]] = None):
         pass
 
     @abstractmethod
@@ -378,7 +378,7 @@ class TemplateTestReducersAggregators:
     def _get_inputs_for_mean_median_aggregators(
         self,
         dims: int,
-        aggregation_axes: Tuple[int, ...],
+        aggregation_axes: tuple[int, ...],
         is_median: bool,
         different_sizes: bool = False,
     ) -> Iterator[NNCFTensor]:

--- a/tests/common/experimental/test_statistic_collector.py
+++ b/tests/common/experimental/test_statistic_collector.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from abc import abstractmethod
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 import pytest
@@ -42,7 +42,7 @@ class DummyTensorReducer(TensorReducerBase):
         self.output_name = output_name
         self._inplace_mock = inplace_mock
 
-    def _reduce_out_of_place(self, x: List[TensorType]):
+    def _reduce_out_of_place(self, x: list[TensorType]):
         return x
 
     def get_inplace_fn(self):
@@ -67,7 +67,7 @@ class DummyTensorAggregator(AggregatorBase):
         return self._container[0]
 
 
-def get_output_info(reducers: List[DummyTensorReducer]) -> List[Tuple[int, List[str]]]:
+def get_output_info(reducers: list[DummyTensorReducer]) -> list[tuple[int, list[str]]]:
     retval = []
     for reducer in reducers:
         retval.append((hash(reducer), [reducer.output_name]))
@@ -250,7 +250,7 @@ class DummyMultipleInpOutTensorReducer(DummyTensorReducer):
     NUM_INPUTS = 3
     NUM_OUTPUTS = 2
 
-    def _reduce_out_of_place(self, x: List[TensorType]):
+    def _reduce_out_of_place(self, x: list[TensorType]):
         return x[: self.NUM_OUTPUTS]
 
 

--- a/tests/common/experimental/test_tensor_collector_batch_size.py
+++ b/tests/common/experimental/test_tensor_collector_batch_size.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 from abc import ABC
 from abc import abstractmethod
-from typing import List
 
 import numpy as np
 import pytest
@@ -43,14 +42,14 @@ class TemplateTestTensorCollectorBatchSize(ABC):
     def to_backend_tensor(self, tensor: np.ndarray):
         pass
 
-    def create_dataitems_without_batch_dim(self, input_shape: List[int], length: int = 100) -> List[np.ndarray]:
+    def create_dataitems_without_batch_dim(self, input_shape: list[int], length: int = 100) -> list[np.ndarray]:
         rng = np.random.default_rng(seed=0)
         data_items = []
         for _ in range(length):
             data_items.append(rng.uniform(0, 1, input_shape))
         return data_items
 
-    def add_batch_dim_to_dataitems(self, data_items: List[np.ndarray], batch_size: int) -> List[np.ndarray]:
+    def add_batch_dim_to_dataitems(self, data_items: list[np.ndarray], batch_size: int) -> list[np.ndarray]:
         assert batch_size >= 1
         dataset = []
         item = []

--- a/tests/common/hyperparameter_tuner/test_hyperparameter_tuner.py
+++ b/tests/common/hyperparameter_tuner/test_hyperparameter_tuner.py
@@ -12,7 +12,7 @@
 import copy
 from dataclasses import dataclass
 from dataclasses import field
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import pytest
 
@@ -20,8 +20,8 @@ from nncf.quantization.algorithms.hyperparameter_tuner.algorithm import apply_co
 from nncf.quantization.algorithms.hyperparameter_tuner.algorithm import create_combinations
 from nncf.quantization.algorithms.hyperparameter_tuner.algorithm import find_best_combination
 
-CombinationKey = Tuple[int, ...]
-Combination = Dict[str, Any]
+CombinationKey = tuple[int, ...]
+Combination = dict[str, Any]
 
 
 # =========================================================
@@ -107,7 +107,7 @@ Combination = Dict[str, Any]
     ],
 )
 def test_create_combinations(
-    param_settings: Dict[str, List[Any]], expected_combinations: Dict[CombinationKey, Combination]
+    param_settings: dict[str, list[Any]], expected_combinations: dict[CombinationKey, Combination]
 ):
     actual_combinations = create_combinations(param_settings)
     assert expected_combinations == actual_combinations
@@ -233,7 +233,7 @@ class ParamsC:
         "change_one_parameter_and_one_subparameter_depth_3",
     ],
 )
-def test_apply_combination(init_params: Dict[str, Any], combination: Combination, expected_params: Dict[str, Any]):
+def test_apply_combination(init_params: dict[str, Any], combination: Combination, expected_params: dict[str, Any]):
     init_params_copy = copy.deepcopy(init_params)
     actual_params = apply_combination(init_params, combination)
 
@@ -422,9 +422,9 @@ def test_apply_combination(init_params: Dict[str, Any], combination: Combination
     ],
 )
 def test_find_best_combination(
-    combinations: Dict[CombinationKey, Combination],
-    scores: Dict[CombinationKey, float],
-    param_settings: Dict[str, List[Any]],
+    combinations: dict[CombinationKey, Combination],
+    scores: dict[CombinationKey, float],
+    param_settings: dict[str, list[Any]],
     expected_combination_key: CombinationKey,
 ):
     combination_score_func = lambda x: scores[x]

--- a/tests/common/pruning/dummy_types.py
+++ b/tests/common/pruning/dummy_types.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 
 from nncf.common.graph.operator_metatypes import OperatorMetatype
 from nncf.common.pruning.operations import BatchNormPruningOp
@@ -33,7 +32,7 @@ class DummyDefaultMetatype(OperatorMetatype):
     name = None
 
     @classmethod
-    def get_all_aliases(cls) -> List[str]:
+    def get_all_aliases(cls) -> list[str]:
         return [cls.name]
 
 

--- a/tests/common/pruning/tensor.py
+++ b/tests/common/pruning/tensor.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -19,7 +19,7 @@ from nncf.common.tensor import NNCFTensor
 
 class NPNNCFTensorProcessor(NNCFPruningBaseTensorProcessor):
     @classmethod
-    def concatenate(cls, tensors: List[NNCFTensor], axis: int) -> NNCFTensor:
+    def concatenate(cls, tensors: list[NNCFTensor], axis: int) -> NNCFTensor:
         for tensor in tensors[1:]:
             assert tensors[0].device == tensor.device
 
@@ -27,11 +27,11 @@ class NPNNCFTensorProcessor(NNCFPruningBaseTensorProcessor):
         return NPNNCFTensor(ret_tensor, tensors[0].device)
 
     @classmethod
-    def ones(cls, shape: Union[int, List[int]], device: Optional[str]) -> NNCFTensor:
+    def ones(cls, shape: Union[int, list[int]], device: Optional[str]) -> NNCFTensor:
         return NPNNCFTensor(np.ones(shape), device)
 
     @classmethod
-    def assert_allclose(cls, tensors: List[NNCFTensor]) -> None:
+    def assert_allclose(cls, tensors: list[NNCFTensor]) -> None:
         for input_mask in tensors[1:]:
             np.testing.assert_allclose(tensors[0].tensor, input_mask.tensor)
 
@@ -41,12 +41,12 @@ class NPNNCFTensorProcessor(NNCFPruningBaseTensorProcessor):
         return NPNNCFTensor(ret_tensor)
 
     @classmethod
-    def elementwise_mask_propagation(cls, input_masks: List[NNCFTensor]) -> NNCFTensor:
+    def elementwise_mask_propagation(cls, input_masks: list[NNCFTensor]) -> NNCFTensor:
         cls.assert_allclose(input_masks)
         return input_masks[0]
 
     @classmethod
-    def split(cls, tensor: NNCFTensor, output_shapes: List[int]) -> List[NNCFTensor]:
+    def split(cls, tensor: NNCFTensor, output_shapes: list[int]) -> list[NNCFTensor]:
         chunks = len(output_shapes)
         ret_tensors = np.split(tensor.tensor, chunks)
         return [NPNNCFTensor(ret_tensor) for ret_tensor in ret_tensors]

--- a/tests/common/quantization/data_generators.py
+++ b/tests/common/quantization/data_generators.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict, Tuple
 
 import numpy as np
 
@@ -79,7 +78,7 @@ def generate_random_scale(min_scale: float = 0.1, max_scale: float = 1.0) -> flo
     return min_scale + np.random.random() * (max_scale - min_scale)
 
 
-def generate_random_scale_by_input_size(input_size: Tuple, is_per_channel: bool, is_weights: bool) -> np.array:
+def generate_random_scale_by_input_size(input_size: tuple, is_per_channel: bool, is_weights: bool) -> np.array:
     """
     Generate random scales for each channels.
 
@@ -110,7 +109,7 @@ def generate_random_scale_by_input_size(input_size: Tuple, is_per_channel: bool,
     return scales
 
 
-def generate_random_low_and_range(min_range: float = 0.1, max_range: float = 3.0) -> Tuple[float, float]:
+def generate_random_low_and_range(min_range: float = 0.1, max_range: float = 3.0) -> tuple[float, float]:
     """
     Generate random input_low and input_range.
 
@@ -125,8 +124,8 @@ def generate_random_low_and_range(min_range: float = 0.1, max_range: float = 3.0
 
 
 def generate_random_low_and_range_by_input_size(
-    input_size: Tuple, is_per_channel: bool, is_weights: bool
-) -> Tuple[np.array, np.array]:
+    input_size: tuple, is_per_channel: bool, is_weights: bool
+) -> tuple[np.array, np.array]:
     """
     Generate random input_low and input_range for each channels.
 
@@ -185,7 +184,7 @@ def get_points_near_of_mid_points(input_data: np.array, mid_points: np.array, at
     return is_near_mid_point
 
 
-def generate_lazy_sweep_data(shape: Tuple[int], min_val: float = -1.0, max_val: float = 1.0):
+def generate_lazy_sweep_data(shape: tuple[int], min_val: float = -1.0, max_val: float = 1.0):
     """
     Generate tensor that contains sweep values from -1.0 to 1.0.
 
@@ -203,7 +202,7 @@ def generate_lazy_sweep_data(shape: Tuple[int], min_val: float = -1.0, max_val: 
 
 def generate_sweep_for_one_channel(
     input_low, input_range, input_size, levels, rtol_for_mid_point
-) -> Tuple[np.array, np.array, np.array]:
+) -> tuple[np.array, np.array, np.array]:
     """
     Generate sorted array that include:
         - values from `input_low - input_range * 0.5` to `input_low + input_range * 1.05`
@@ -261,7 +260,7 @@ def generate_sweep_for_one_channel(
 
 
 def generate_sweep_data(
-    input_size: Tuple,
+    input_size: tuple,
     input_low: np.array,
     input_range: np.array,
     levels: int,
@@ -364,7 +363,7 @@ def check_outputs(arr_a: np.array, arr_b: np.array, is_near_mid_point: np.array,
 
 
 def scatter_plot(
-    data: Dict[str, np.array], x_column: str = None, vertical_lines: np.array = None, save_to_file: str = None
+    data: dict[str, np.array], x_column: str = None, vertical_lines: np.array = None, save_to_file: str = None
 ) -> None:
     """
     Function to render test data on scatter plot.

--- a/tests/common/quantization/metatypes.py
+++ b/tests/common/quantization/metatypes.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 
 from nncf.common.graph.operator_metatypes import INPUT_NOOP_METATYPES
 from nncf.common.graph.operator_metatypes import OperatorMetatype
@@ -23,7 +22,7 @@ class TestMetatype(OperatorMetatype):
     name = None
 
     @classmethod
-    def get_all_aliases(cls) -> List[str]:
+    def get_all_aliases(cls) -> list[str]:
         assert cls.name is not None
         return [cls.name]
 

--- a/tests/common/quantization/mock_graphs.py
+++ b/tests/common/quantization/mock_graphs.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import random
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Optional
 from unittest.mock import MagicMock
 
 import networkx as nx
@@ -58,7 +58,7 @@ class NodeWithType:
 
 
 def create_mock_graph(
-    nodes: List[NodeWithType], node_edges: List[Tuple[str, str]], edges_attrs: Optional[Tuple[Any]] = None
+    nodes: list[NodeWithType], node_edges: list[tuple[str, str]], edges_attrs: Optional[tuple[Any]] = None
 ) -> nx.DiGraph:
     mock_graph = nx.DiGraph()
     for node in nodes:
@@ -89,7 +89,7 @@ def mark_input_ports_lexicographically_based_on_input_node_key(graph: nx.DiGraph
 def get_nncf_graph_from_mock_nx_graph(nx_graph: nx.DiGraph, nncf_graph_cls=NNCFGraph) -> NNCFGraph:
     mock_graph = nncf_graph_cls()
     key_vs_id = {}
-    edge_vs_output_idx_and_creator_id: Dict[Tuple[str, str], Tuple[int, int]] = {}
+    edge_vs_output_idx_and_creator_id: dict[tuple[str, str], tuple[int, int]] = {}
     from networkx.algorithms.dag import lexicographical_topological_sort
 
     for idx, curr_node_key in enumerate(lexicographical_topological_sort(nx_graph)):
@@ -189,9 +189,9 @@ def get_mock_nncf_node_attrs(op_name=None, scope_str=None, metatype=None, type_=
 
 def _add_nodes_with_layer_attrs(
     nx_graph: nx.DiGraph,
-    node_keys: List[str],
-    layer_attrs: Dict[str, BaseLayerAttributes],
-    metatypes: Dict[str, OperatorMetatype] = None,
+    node_keys: list[str],
+    layer_attrs: dict[str, BaseLayerAttributes],
+    metatypes: dict[str, OperatorMetatype] = None,
 ) -> nx.DiGraph:
     for node_key in node_keys:
         metatype = None
@@ -385,7 +385,7 @@ def get_node_name(op_name: str, call_order: int = 0) -> str:
     return f"/{op_name}_{call_order}"
 
 
-def get_randomly_connected_model_graph(op_name_keys: Set[str]) -> nx.DiGraph:
+def get_randomly_connected_model_graph(op_name_keys: set[str]) -> nx.DiGraph:
     graph_len = len(op_name_keys)
     mock_graph = nx.generators.gnc_graph(graph_len, None, 0)
 
@@ -400,7 +400,7 @@ def get_randomly_connected_model_graph(op_name_keys: Set[str]) -> nx.DiGraph:
     return mock_graph
 
 
-def get_sequentially_connected_model_graph(op_name_keys: List[str]) -> nx.DiGraph:
+def get_sequentially_connected_model_graph(op_name_keys: list[str]) -> nx.DiGraph:
     graph = nx.DiGraph()
     node_key_appearances = {k: 0 for k in op_name_keys}
 

--- a/tests/common/quantization/test_quantizer_propagation_graph.py
+++ b/tests/common/quantization/test_quantizer_propagation_graph.py
@@ -13,7 +13,7 @@ from abc import abstractmethod
 from collections import Counter
 from collections import namedtuple
 from copy import deepcopy
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Optional
 
 import networkx as nx
 import pytest
@@ -47,7 +47,7 @@ from tests.common.quantization.mock_graphs import get_two_branch_mock_model_grap
 from tests.common.quantization.mock_graphs import mark_input_ports_lexicographically_based_on_input_node_key
 
 
-def get_edge_paths(graph, start_node_key, finish_node_key) -> List[List[Tuple]]:
+def get_edge_paths(graph, start_node_key, finish_node_key) -> list[list[tuple]]:
     node_paths = list(nx.all_simple_paths(graph, start_node_key, finish_node_key))
     edge_paths = []
     for path in node_paths:
@@ -55,7 +55,7 @@ def get_edge_paths(graph, start_node_key, finish_node_key) -> List[List[Tuple]]:
     return edge_paths
 
 
-def get_edge_paths_for_propagation(graph, start_node_key, finish_node_key) -> List[List[Tuple]]:
+def get_edge_paths_for_propagation(graph, start_node_key, finish_node_key) -> list[list[tuple]]:
     paths = get_edge_paths(graph, start_node_key, finish_node_key)
     return [list(reversed(path)) for path in paths]
 
@@ -208,7 +208,7 @@ class TestQuantizerPropagationStateGraph:
         ref_paths = start_ip_node_and_path_to_dominating_node[1]
         test_paths = mock_qp_graph.get_paths_to_immediately_dominating_insertion_points(start_node)
 
-        def get_cat_path_list(path_list: List[List[Tuple[str, str]]]):
+        def get_cat_path_list(path_list: list[list[tuple[str, str]]]):
             str_paths = [[str(edge[0]) + " -> " + str(edge[1]) for edge in path] for path in path_list]
             cat_paths = [";".join(path) for path in str_paths]
             return cat_paths
@@ -216,7 +216,7 @@ class TestQuantizerPropagationStateGraph:
         assert Counter(get_cat_path_list(ref_paths)) == Counter(get_cat_path_list(test_paths))
 
     class DomIPGroupedByUnifiedScalesTestStruct:
-        def __init__(self, start_ip_node_key: str, ref_groups_vs_paths: Dict[Optional[int], List[PropagationPath]]):
+        def __init__(self, start_ip_node_key: str, ref_groups_vs_paths: dict[Optional[int], list[PropagationPath]]):
             self.start_ip_node_key = start_ip_node_key
             self.ref_groups_vs_paths = ref_groups_vs_paths
 
@@ -291,7 +291,7 @@ class TestQuantizerPropagationStateGraph:
             )
         )
 
-        def get_cat_path_list(path_list: List[List[Tuple[str, str]]]):
+        def get_cat_path_list(path_list: list[list[tuple[str, str]]]):
             str_paths = [[str(edge[0]) + " -> " + str(edge[1]) for edge in path] for path in path_list]
             cat_paths = [";".join(path) for path in str_paths]
             return cat_paths
@@ -558,7 +558,7 @@ class TestQuantizerPropagationStateGraph:
         return request.param
 
     @staticmethod
-    def mark_nodes_with_traits(qpsg: QPSG, node_keys_vs_traits_dict: Dict[str, QuantizationTrait]) -> QPSG:
+    def mark_nodes_with_traits(qpsg: QPSG, node_keys_vs_traits_dict: dict[str, QuantizationTrait]) -> QPSG:
         for node_key, node in qpsg.nodes.items():
             if node_key in node_keys_vs_traits_dict:
                 node[QPSG.QUANTIZATION_TRAIT_NODE_ATTR] = node_keys_vs_traits_dict[node_key]
@@ -756,7 +756,7 @@ class TestQuantizerPropagationStateGraph:
             target_node = quantizers_test_struct.target_node_for_quantizer
             is_merged = quantizers_test_struct.is_merged
             prop_path = quantizers_test_struct.prop_path
-            node_key_vs_trait_dict: Dict[str, QuantizationTrait] = {}
+            node_key_vs_trait_dict: dict[str, QuantizationTrait] = {}
             for node_key in quant_prop_graph.nodes:
                 node_key_vs_trait_dict[node_key] = QuantizationTrait.QUANTIZATION_AGNOSTIC
             primary_prop_quant = None
@@ -823,8 +823,8 @@ class TestQuantizerPropagationStateGraph:
 
 class TestRedundantQuantizerMerge:
     class RedundantQuantizerMergeTestStruct(ABC):
-        ref_remaining_pq_positions: Set[str]
-        operator_node_key_vs_trait_dict: Dict[str, QuantizationTrait]
+        ref_remaining_pq_positions: set[str]
+        operator_node_key_vs_trait_dict: dict[str, QuantizationTrait]
 
         def prepare_qpsg_state(self, qpsg: QPSG) -> QPSG:
             qpsg = TestQuantizerPropagationStateGraph.mark_nodes_with_traits(qpsg, self.operator_node_key_vs_trait_dict)
@@ -1317,8 +1317,8 @@ MODEL_GRAPH: NNCFGraph = create_graph_for_output_quant_as_weights()
 
 
 class OutputQuantAsWeightsSetupTestStruct(ABC):
-    operator_node_key_vs_trait_dict: Dict[str, QuantizationTrait]
-    quantizable_module_node_names_vs_qconfigs: Dict[NNCFNodeName, List[QuantizerConfig]]
+    operator_node_key_vs_trait_dict: dict[str, QuantizationTrait]
+    quantizable_module_node_names_vs_qconfigs: dict[NNCFNodeName, list[QuantizerConfig]]
 
     def prepare_qpsg_state(self, qpsg: QPSG) -> QPSG:
         qpsg = TestQuantizerPropagationStateGraph.mark_nodes_with_traits(qpsg, self.operator_node_key_vs_trait_dict)

--- a/tests/common/quantization/test_quantizer_propagation_solver.py
+++ b/tests/common/quantization/test_quantizer_propagation_solver.py
@@ -14,7 +14,7 @@ from collections import Counter
 from collections import namedtuple
 from dataclasses import dataclass
 from itertools import permutations
-from typing import Callable, Dict, List, Optional, Set, Tuple
+from typing import Callable, Optional
 
 import networkx as nx
 import pytest
@@ -177,9 +177,9 @@ class MultiQPSerializedDataForTest:
         self,
         target_type: TargetType,
         node_name: NNCFNodeName,
-        qconfigs: List[QuantizerConfig],
+        qconfigs: list[QuantizerConfig],
         input_port_id: int = None,
-        directly_quantized_op_node_names: List[NNCFNodeName] = None,
+        directly_quantized_op_node_names: list[NNCFNodeName] = None,
     ):
         self.target_type = target_type
         self.node_name = node_name
@@ -195,12 +195,12 @@ class RunOnIpGraphTestStruct:
     def __init__(
         self,
         base_nx_graph: nx.DiGraph,
-        retval_qp_data: Dict[QuantizationPointId, MultiQPSerializedDataForTest],
-        retval_unified_scale_qp_groups: List[Set[QuantizationPointId]],
-        retval_shared_input_operation_set_groups: List[Set[QuantizationPointId]],
+        retval_qp_data: dict[QuantizationPointId, MultiQPSerializedDataForTest],
+        retval_unified_scale_qp_groups: list[set[QuantizationPointId]],
+        retval_shared_input_operation_set_groups: list[set[QuantizationPointId]],
         expected_count_finished_quant: int,
         expected_count_active_quant: int,
-        ignored_scopes: Optional[List[str]],
+        ignored_scopes: Optional[list[str]],
     ):
         self.base_graph = get_nncf_graph_from_mock_nx_graph(base_nx_graph)
         self.retval_unified_scale_qp_groups = retval_unified_scale_qp_groups
@@ -208,7 +208,7 @@ class RunOnIpGraphTestStruct:
         self.expected_count_finished_quant = expected_count_finished_quant
         self.expected_count_active_quant = expected_count_active_quant
         self.ignored_scopes = ignored_scopes
-        self.retval_qps: Dict[QuantizationPointId, MultiConfigQuantizationPoint] = {}
+        self.retval_qps: dict[QuantizationPointId, MultiConfigQuantizationPoint] = {}
         for id_, qp_data in retval_qp_data.items():
             if qp_data.target_type is TargetType.OPERATION_WITH_WEIGHTS:
                 qip = WeightQuantizationInsertionPoint(qp_data.node_name)
@@ -926,7 +926,7 @@ class TestQuantizerPropagationSolver:
     @dataclass
     class BranchTransitionTestStruct:
         # Unspecified nodes are marked as quantization agnostic
-        init_node_to_trait_and_configs_dict: Dict[str, "TestQuantizerPropagationSolver.InitNodeTestStruct"]
+        init_node_to_trait_and_configs_dict: dict[str, "TestQuantizerPropagationSolver.InitNodeTestStruct"]
         starting_primary_quantizer_ip_node: str
         target_branching_node_for_primary_quantizer: str
         expected_status: TransitionStatus
@@ -1289,8 +1289,8 @@ class TestQuantizerPropagationSolver:
 
     @staticmethod
     def prepare_propagation_graph_state(
-        ip_graph: InsertionPointGraph, init_node_to_trait_configs_and_target_node_dict: Dict[str, Tuple]
-    ) -> Tuple[List[PropagatingQuantizer], QPSG]:
+        ip_graph: InsertionPointGraph, init_node_to_trait_configs_and_target_node_dict: dict[str, tuple]
+    ) -> tuple[list[PropagatingQuantizer], QPSG]:
         quant_prop_graph = QPSG(ip_graph)
         prop_quantizers = []
         for node in quant_prop_graph.nodes.values():

--- a/tests/common/quantization/test_quantizer_removal.py
+++ b/tests/common/quantization/test_quantizer_removal.py
@@ -11,7 +11,6 @@
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import List
 
 import pytest
 
@@ -43,8 +42,8 @@ class Edge:
 
 @dataclass
 class Graph:
-    nodes: List[Node]
-    edges: List[Edge]
+    nodes: list[Node]
+    edges: list[Edge]
 
 
 GRAPHS = {
@@ -206,8 +205,8 @@ class ParameterTestCase:
     """
 
     node_name: str
-    nodes: List[str]
-    ops: List[str]
+    nodes: list[str]
+    ops: list[str]
 
 
 TEST_CASES = {

--- a/tests/common/sdl/test_config_schema.py
+++ b/tests/common/sdl/test_config_schema.py
@@ -11,7 +11,6 @@
 
 from collections import namedtuple
 from pathlib import Path
-from typing import List
 
 import jsonschema
 import pytest
@@ -39,7 +38,7 @@ ConfigPathVsPassesSchemaVal = namedtuple("ConfigPathVsPassesSchemaVal", ("path",
 TEST_STRUCTS = []
 
 
-def get_all_jsons_from_sources(source_directories_list: List[Path]) -> List[Path]:
+def get_all_jsons_from_sources(source_directories_list: list[Path]) -> list[Path]:
     retval = []
     for source_dir in source_directories_list:
         files = source_dir.glob("**/*.json")

--- a/tests/common/tensor/test_disaptcher.py
+++ b/tests/common/tensor/test_disaptcher.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import deque
-from typing import Dict, List, Tuple, Union
+from typing import Union
 
 import pytest
 
@@ -42,9 +42,9 @@ def test_unwrap_tensors(data, ref):
     (
         (1, int, 1),
         (1, Tensor, Tensor(1)),
-        ([1, 1], List[int], [1, 1]),
-        ([1, 1], List[Tensor], [Tensor(1), Tensor(1)]),
-        ((1, 1), Tuple[Tensor, int], (Tensor(1), 1)),
+        ([1, 1], list[int], [1, 1]),
+        ([1, 1], list[Tensor], [Tensor(1), Tensor(1)]),
+        ((1, 1), tuple[Tensor, int], (Tensor(1), 1)),
     ),
 )
 def test_wrap_output(data, ret_ann, ref):
@@ -74,10 +74,10 @@ def test_get_arg_type(data, ref):
     (
         (float, [float]),
         (Union[float, str], [float, str]),
-        (List[float], [float]),
-        (List[Union[float, str]], [float, str]),
-        (Dict[str, int], [int]),
-        (Dict[str, Union[float, int]], [float, int]),
+        (list[float], [float]),
+        (list[Union[float, str]], [float, str]),
+        (dict[str, int], [int]),
+        (dict[str, Union[float, int]], [float, int]),
     ),
 )
 def test_get_register_types(data, ref):

--- a/tests/common/test_builder_state.py
+++ b/tests/common/test_builder_state.py
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from nncf import NNCFConfig
 from nncf.api.compression import CompressionAlgorithmController
@@ -28,10 +28,10 @@ class A(BaseCompressionAlgorithmBuilder):
         super().__init__(config, should_init)
         self.state_value = state_value
 
-    def _load_state_without_name(self, state_without_name: Dict[str, Any]):
+    def _load_state_without_name(self, state_without_name: dict[str, Any]):
         self.state_value = state_without_name.get(STATE_ATTR)
 
-    def _get_state_without_name(self) -> Dict[str, Any]:
+    def _get_state_without_name(self) -> dict[str, Any]:
         return {STATE_ATTR: self.state_value}
 
     def apply_to(self, model: TModel) -> TModel:
@@ -68,7 +68,7 @@ class CA(CompositeCompressionAlgorithmBuilder):
         pass
 
 
-def _get_mock_config(algo_name: Union[List[str], str]) -> NNCFConfig:
+def _get_mock_config(algo_name: Union[list[str], str]) -> NNCFConfig:
     config = NNCFConfig()
     config["input_info"] = {"sample_size": [1, 1]}
     if isinstance(algo_name, list):

--- a/tests/common/test_ctrl_state.py
+++ b/tests/common/test_ctrl_state.py
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from nncf.api.compression import CompressionLoss
 from nncf.api.compression import CompressionScheduler
@@ -29,18 +29,18 @@ class ALoss(CompressionLoss):
     def calculate(self, *args, **kwargs) -> Any:
         pass
 
-    def load_state(self, state: Dict[str, Any]) -> None:
+    def load_state(self, state: dict[str, Any]) -> None:
         self.state = state.get(STATE_ATTR)
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {STATE_ATTR: self.state}
 
 
 class BLoss(ALoss):
-    def load_state(self, state: Dict[str, Any]) -> None:
+    def load_state(self, state: dict[str, Any]) -> None:
         self.state = state.get(DIFF_STATE_ATTR)
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {DIFF_STATE_ATTR: self.state}
 
 
@@ -54,18 +54,18 @@ class AScheduler(CompressionScheduler):
     def epoch_step(self, next_epoch: Optional[int] = None) -> None:
         pass
 
-    def load_state(self, state: Dict[str, Any]) -> None:
+    def load_state(self, state: dict[str, Any]) -> None:
         self.state = state.get(STATE_ATTR)
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {STATE_ATTR: self.state}
 
 
 class BScheduler(AScheduler):
-    def load_state(self, state: Dict[str, Any]) -> None:
+    def load_state(self, state: dict[str, Any]) -> None:
         self.state = state.get(DIFF_STATE_ATTR)
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {DIFF_STATE_ATTR: self.state}
 
 
@@ -85,7 +85,7 @@ class A(BaseCompressionAlgorithmController):
     def scheduler(self) -> CompressionScheduler:
         return self._scheduler
 
-    def get_compression_state(self) -> Dict[str, Any]:
+    def get_compression_state(self) -> dict[str, Any]:
         pass
 
     def statistics(self, quickly_collected_only: bool = False) -> Statistics:
@@ -114,16 +114,16 @@ class CA(CompositeCompressionAlgorithmController):
     def name(self) -> str:
         pass
 
-    def get_compression_state(self) -> Dict[str, Any]:
+    def get_compression_state(self) -> dict[str, Any]:
         pass
 
     def export_model(
         self,
         save_path: str,
         save_format: Optional[str] = None,
-        input_names: Optional[List[str]] = None,
-        output_names: Optional[List[str]] = None,
-        model_args: Optional[Tuple[Any, ...]] = None,
+        input_names: Optional[list[str]] = None,
+        output_names: Optional[list[str]] = None,
+        model_args: Optional[tuple[Any, ...]] = None,
     ) -> None:
         pass
 

--- a/tests/common/test_hardware_config.py
+++ b/tests/common/test_hardware_config.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict
 
 import pytest
 
@@ -32,7 +31,7 @@ def load_config_for_device(target_device: TargetDevice) -> HWConfig:
     return HWConfig.from_json(hw_config_path)
 
 
-def get_quantization_config(hw_config: HWConfig) -> Dict:
+def get_quantization_config(hw_config: HWConfig) -> dict:
     """
     Returns quantization config aggregated by types.
 

--- a/tests/common/test_statistics_aggregator.py
+++ b/tests/common/test_statistics_aggregator.py
@@ -13,7 +13,7 @@ from collections import Counter
 from dataclasses import dataclass
 from enum import Enum
 from itertools import product
-from typing import Any, List, Type, Union
+from typing import Any, Union
 
 import numpy as np
 import pytest
@@ -63,15 +63,15 @@ class BCStatsCollectors(Enum):
 class TemplateTestStatisticsAggregator:
     @staticmethod
     @abstractmethod
-    def get_min_max_algo_backend_cls() -> Type[MinMaxAlgoBackend]:
+    def get_min_max_algo_backend_cls() -> type[MinMaxAlgoBackend]:
         pass
 
     @abstractmethod
-    def get_bias_correction_algo_backend_cls(self) -> Type[BiasCorrectionAlgoBackend]:
+    def get_bias_correction_algo_backend_cls(self) -> type[BiasCorrectionAlgoBackend]:
         pass
 
     @abstractmethod
-    def get_fast_bias_correction_algo_backend_cls(self) -> Type[FastBiasCorrectionAlgoBackend]:
+    def get_fast_bias_correction_algo_backend_cls(self) -> type[FastBiasCorrectionAlgoBackend]:
         pass
 
     @abstractmethod
@@ -122,7 +122,7 @@ class TemplateTestStatisticsAggregator:
         """
 
     @abstractmethod
-    def reducers_map(self) -> List[TensorReducerBase]:
+    def reducers_map(self) -> list[TensorReducerBase]:
         pass
 
     @pytest.fixture
@@ -130,7 +130,7 @@ class TemplateTestStatisticsAggregator:
         return [{"max": 1, "min": -10}, {"max": 0.1, "min": -1}, {"max": 128, "min": -128}]
 
     @staticmethod
-    def get_min_max_algo_cls() -> Type[MinMaxQuantization]:
+    def get_min_max_algo_cls() -> type[MinMaxQuantization]:
         return MinMaxQuantization
 
     @dataclass

--- a/tests/common/test_statistics_serializer.py
+++ b/tests/common/test_statistics_serializer.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 import json
 from collections import defaultdict
-from typing import Dict
 
 import numpy as np
 import pytest
@@ -28,7 +27,7 @@ from tests.cross_fw.test_templates.test_statistics_serializer import TemplateTes
 
 
 class TestNPStatisticsSerializer(TemplateTestStatisticsSerializer):
-    def _get_backend_statistics(self) -> Dict[str, Dict[str, np.ndarray]]:
+    def _get_backend_statistics(self) -> dict[str, dict[str, np.ndarray]]:
         return {
             "layer/1/activation": {"mean": Tensor(np.array([0.1, 0.2, 0.3]))},
             "layer/2/activation": {"variance": Tensor(np.array([0.05, 0.06, 0.07]))},
@@ -38,7 +37,7 @@ class TestNPStatisticsSerializer(TemplateTestStatisticsSerializer):
         # any backend for numpy tensor, e.g. OpenVINO
         return BackendType.OPENVINO
 
-    def is_equal(self, a1: Dict[str, Tensor], a2: Dict[str, Tensor]) -> bool:
+    def is_equal(self, a1: dict[str, Tensor], a2: dict[str, Tensor]) -> bool:
         for key in a1:
             if key not in a2:
                 return False

--- a/tests/common/test_telemetry.py
+++ b/tests/common/test_telemetry.py
@@ -11,7 +11,6 @@
 import importlib
 import os
 import sys
-from typing import Tuple
 from unittest import mock
 from unittest.mock import MagicMock
 from unittest.mock import call
@@ -77,7 +76,7 @@ def test_telemetry_is_mocked_if_env_vars_defined(env_var_to_define, hide_pytest)
 
 
 @pytest.fixture(name="spies")
-def spies_(request, mocker) -> Tuple[MagicMock, MagicMock, MagicMock]:
+def spies_(request, mocker) -> tuple[MagicMock, MagicMock, MagicMock]:
     from nncf.telemetry import telemetry
 
     send_event_spy = mocker.spy(telemetry, "send_event")

--- a/tests/common/utils/test_decorators.py
+++ b/tests/common/utils/test_decorators.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import List, Optional, Type
+from typing import Optional
 from unittest.mock import patch
 
 import pytest
@@ -21,8 +21,8 @@ from nncf.common.utils.decorators import skip_if_dependency_unavailable
 
 @dataclass
 class StructForTest:
-    dependencies: List[str]
-    side_effect: Optional[Type[Exception]]
+    dependencies: list[str]
+    side_effect: Optional[type[Exception]]
     result_is_none: bool
     final_imported_dependencies: bool
 

--- a/tests/cross_fw/examples/run_example.py
+++ b/tests/cross_fw/examples/run_example.py
@@ -15,12 +15,12 @@ import sys
 import tarfile
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Dict, Tuple, Union
+from typing import Union
 
 from tests.cross_fw.shared.paths import PROJECT_ROOT
 
 
-def post_training_quantization_mobilenet_v2(example_root_dir: str) -> Dict[str, float]:
+def post_training_quantization_mobilenet_v2(example_root_dir: str) -> dict[str, float]:
     sys.path.append(example_root_dir)
     import main as mobilenet_v2
 
@@ -41,17 +41,17 @@ def post_training_quantization_mobilenet_v2(example_root_dir: str) -> Dict[str, 
     return metrics
 
 
-def post_training_quantization_onnx_mobilenet_v2() -> Dict[str, float]:
+def post_training_quantization_onnx_mobilenet_v2() -> dict[str, float]:
     example_root = str(PROJECT_ROOT / "examples" / "post_training_quantization" / "onnx" / "mobilenet_v2")
     return post_training_quantization_mobilenet_v2(example_root)
 
 
-def post_training_quantization_openvino_mobilenet_v2_quantize() -> Dict[str, float]:
+def post_training_quantization_openvino_mobilenet_v2_quantize() -> dict[str, float]:
     example_root = str(PROJECT_ROOT / "examples" / "post_training_quantization" / "openvino" / "mobilenet_v2")
     return post_training_quantization_mobilenet_v2(example_root)
 
 
-def post_training_quantization_tensorflow_mobilenet_v2() -> Dict[str, float]:
+def post_training_quantization_tensorflow_mobilenet_v2() -> dict[str, float]:
     import tensorflow_datasets as tfds
 
     tfds.display_progress_bar(enable=False)
@@ -60,12 +60,12 @@ def post_training_quantization_tensorflow_mobilenet_v2() -> Dict[str, float]:
     return post_training_quantization_mobilenet_v2(example_root)
 
 
-def post_training_quantization_torch_mobilenet_v2() -> Dict[str, float]:
+def post_training_quantization_torch_mobilenet_v2() -> dict[str, float]:
     example_root = str(PROJECT_ROOT / "examples" / "post_training_quantization" / "torch" / "mobilenet_v2")
     return post_training_quantization_mobilenet_v2(example_root)
 
 
-def format_results(results: Tuple[float]) -> Dict[str, float]:
+def format_results(results: tuple[float]) -> dict[str, float]:
     return {
         "fp32_mAP": results[0],
         "int8_mAP": results[1],
@@ -76,7 +76,7 @@ def format_results(results: Tuple[float]) -> Dict[str, float]:
     }
 
 
-def post_training_quantization_openvino_yolo8_quantize() -> Dict[str, float]:
+def post_training_quantization_openvino_yolo8_quantize() -> dict[str, float]:
     from examples.post_training_quantization.openvino.yolov8.main import main as yolo8_main
 
     results = yolo8_main()
@@ -84,7 +84,7 @@ def post_training_quantization_openvino_yolo8_quantize() -> Dict[str, float]:
     return format_results(results)
 
 
-def post_training_quantization_openvino_yolo8_quantize_with_accuracy_control() -> Dict[str, float]:
+def post_training_quantization_openvino_yolo8_quantize_with_accuracy_control() -> dict[str, float]:
     from examples.post_training_quantization.openvino.yolov8_quantize_with_accuracy_control.main import (
         main as yolo8_main,
     )
@@ -94,7 +94,7 @@ def post_training_quantization_openvino_yolo8_quantize_with_accuracy_control() -
     return format_results(results)
 
 
-def post_training_quantization_onnx_yolo8_quantize_with_accuracy_control() -> Dict[str, float]:
+def post_training_quantization_onnx_yolo8_quantize_with_accuracy_control() -> dict[str, float]:
     from examples.post_training_quantization.onnx.yolov8_quantize_with_accuracy_control.main import (
         run_example as yolo8_main,
     )
@@ -122,7 +122,7 @@ def post_training_quantization_onnx_yolo8_quantize_with_accuracy_control() -> Di
     }
 
 
-def post_training_quantization_openvino_anomaly_stfpm_quantize_with_accuracy_control() -> Dict[str, float]:
+def post_training_quantization_openvino_anomaly_stfpm_quantize_with_accuracy_control() -> dict[str, float]:
     from examples.post_training_quantization.openvino.anomaly_stfpm_quantize_with_accuracy_control.main import (
         run_example as anomaly_stfpm_main,
     )
@@ -142,7 +142,7 @@ def post_training_quantization_openvino_anomaly_stfpm_quantize_with_accuracy_con
     }
 
 
-def post_training_quantization_torch_ssd300_vgg16() -> Dict[str, float]:
+def post_training_quantization_torch_ssd300_vgg16() -> dict[str, float]:
     from examples.post_training_quantization.torch.ssd300_vgg16.main import main as ssd300_vgg16_main
 
     results = ssd300_vgg16_main()
@@ -160,7 +160,7 @@ def post_training_quantization_torch_ssd300_vgg16() -> Dict[str, float]:
     }
 
 
-def llm_compression() -> Dict[str, float]:
+def llm_compression() -> dict[str, float]:
     from examples.llm_compression.openvino.tiny_llama.main import main as llm_compression_main
 
     result = llm_compression_main()
@@ -168,7 +168,7 @@ def llm_compression() -> Dict[str, float]:
     return {"word_count": len(result.split())}
 
 
-def llm_tune_params() -> Dict[str, float]:
+def llm_tune_params() -> dict[str, float]:
     from examples.llm_compression.openvino.tiny_llama_find_hyperparams.main import main as llm_tune_params_main
 
     awq, ratio, group_size = llm_tune_params_main()
@@ -176,7 +176,7 @@ def llm_tune_params() -> Dict[str, float]:
     return {"awq": bool(awq), "ratio": ratio, "group_size": group_size}
 
 
-def llm_compression_synthetic() -> Dict[str, float]:
+def llm_compression_synthetic() -> dict[str, float]:
     from examples.llm_compression.openvino.tiny_llama_synthetic_data.main import main as llm_compression_synthetic_main
 
     result = llm_compression_synthetic_main()
@@ -184,7 +184,7 @@ def llm_compression_synthetic() -> Dict[str, float]:
     return {"word_count": len(result.split())}
 
 
-def fp8_llm_quantization() -> Dict[str, float]:
+def fp8_llm_quantization() -> dict[str, float]:
     from examples.llm_compression.openvino.smollm2_360m_fp8.main import main as fp8_llm_quantization_main
 
     result = fp8_llm_quantization_main()
@@ -298,7 +298,7 @@ def quantization_aware_training_torch_anomalib(data: Union[str, None]):
     }
 
 
-def quantization_aware_training_tensorflow_mobilenet_v2() -> Dict[str, float]:
+def quantization_aware_training_tensorflow_mobilenet_v2() -> dict[str, float]:
     import tensorflow_datasets as tfds
 
     tfds.display_progress_bar(enable=False)

--- a/tests/cross_fw/examples/test_examples.py
+++ b/tests/cross_fw/examples/test_examples.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 import pytest
 
@@ -68,8 +68,8 @@ def _is_connection_error(txt: str) -> bool:
 def test_examples(
     tmp_path: Path,
     example_name: str,
-    example_params: Dict[str, Any],
-    backends_list: List[str],
+    example_params: dict[str, Any],
+    backends_list: list[str],
     is_check_performance: bool,
     ov_version_override: str,
     data: str,

--- a/tests/cross_fw/install/test_install.py
+++ b/tests/cross_fw/install/test_install.py
@@ -13,7 +13,6 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import List
 
 import pytest
 
@@ -63,7 +62,7 @@ def removable_tmp_path(tmp_path: Path):
 
 
 @pytest.fixture(name="backend_to_test")
-def backend_to_test_(request, backend_clopt: List[str]):
+def backend_to_test_(request, backend_clopt: list[str]):
     backends_to_test = set()
     for be in backend_clopt:
         if be == "all":
@@ -80,7 +79,7 @@ class TestInstall:
         removable_tmp_path: Path,
         backend: str,
         package_type: str,
-        backend_clopt: List[str],
+        backend_clopt: list[str],
         host_configuration_clopt: str,
         ov_version_override: str,
     ):

--- a/tests/cross_fw/shared/case_collection.py
+++ b/tests/cross_fw/shared/case_collection.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List
 
 import pytest
 
@@ -19,7 +18,7 @@ COMMON_SCOPE_MARKS_VS_OPTIONS = {
 }
 
 
-def skip_marked_cases_if_options_not_specified(config, items, marks_vs_options: Dict[str, str]) -> None:
+def skip_marked_cases_if_options_not_specified(config, items, marks_vs_options: dict[str, str]) -> None:
     options_not_given = {mark: option for mark, option in marks_vs_options.items() if config.getoption(option) is None}
     for item in items:
         for mark, option in options_not_given.items():
@@ -29,6 +28,6 @@ def skip_marked_cases_if_options_not_specified(config, items, marks_vs_options: 
                 )
 
 
-def skip_if_backend_not_selected(backend: str, backends_list: List[str]):
+def skip_if_backend_not_selected(backend: str, backends_list: list[str]):
     if "all" not in backends_list and backend not in backends_list:
         pytest.skip("not selected for testing")

--- a/tests/cross_fw/shared/command.py
+++ b/tests/cross_fw/shared/command.py
@@ -15,7 +15,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 
 def is_windows() -> bool:
@@ -23,7 +23,7 @@ def is_windows() -> bool:
 
 
 class Command:
-    def __init__(self, cmd: str, cwd: Path = None, env: Dict = None):
+    def __init__(self, cmd: str, cwd: Path = None, env: dict = None):
         self.cmd = cmd
         self.process = None
         self.exec_time = -1
@@ -114,7 +114,7 @@ class Command:
         return self.exec_time
 
 
-def arg_list_from_arg_dict(dct: Dict[str, Any]) -> List[str]:
+def arg_list_from_arg_dict(dct: dict[str, Any]) -> list[str]:
     retval = []
     for key, val in dct.items():
         retval.append(key)

--- a/tests/cross_fw/shared/comparator.py
+++ b/tests/cross_fw/shared/comparator.py
@@ -11,7 +11,7 @@
 
 from abc import ABC
 from abc import abstractmethod
-from typing import Callable, Dict, List, TypeVar, Union
+from typing import Callable, TypeVar, Union
 
 import numpy as np
 
@@ -27,8 +27,8 @@ class BaseTensorListComparator(ABC):
     @classmethod
     def _check_assertion(
         cls,
-        test: Union[TensorType, List[TensorType]],
-        reference: Union[TensorType, List[TensorType]],
+        test: Union[TensorType, list[TensorType]],
+        reference: Union[TensorType, list[TensorType]],
         assert_fn: Callable[[np.ndarray, np.ndarray], bool],
     ):
         if not isinstance(test, list):
@@ -45,8 +45,8 @@ class BaseTensorListComparator(ABC):
     @classmethod
     def check_equal(
         cls,
-        test: Union[TensorType, List[TensorType]],
-        reference: Union[TensorType, List[TensorType]],
+        test: Union[TensorType, list[TensorType]],
+        reference: Union[TensorType, list[TensorType]],
         rtol: float = 1e-1,
         atol=0,
     ):
@@ -55,8 +55,8 @@ class BaseTensorListComparator(ABC):
     @classmethod
     def check_not_equal(
         cls,
-        test: Union[TensorType, List[TensorType]],
-        reference: Union[TensorType, List[TensorType]],
+        test: Union[TensorType, list[TensorType]],
+        reference: Union[TensorType, list[TensorType]],
         rtol: float = 1e-4,
     ):
         cls._check_assertion(
@@ -67,14 +67,14 @@ class BaseTensorListComparator(ABC):
 
     @classmethod
     def check_less(
-        cls, test: Union[TensorType, List[TensorType]], reference: Union[TensorType, List[TensorType]], rtol=1e-4
+        cls, test: Union[TensorType, list[TensorType]], reference: Union[TensorType, list[TensorType]], rtol=1e-4
     ):
         cls.check_not_equal(test, reference, rtol=rtol)
         cls._check_assertion(test, reference, np.testing.assert_array_less)
 
     @classmethod
     def check_greater(
-        cls, test: Union[TensorType, List[TensorType]], reference: Union[TensorType, List[TensorType]], rtol=1e-4
+        cls, test: Union[TensorType, list[TensorType]], reference: Union[TensorType, list[TensorType]], rtol=1e-4
     ):
         cls.check_not_equal(test, reference, rtol=rtol)
         cls._check_assertion(
@@ -82,7 +82,7 @@ class BaseTensorListComparator(ABC):
         )
 
 
-def compare_stats(expected: Dict[str, np.ndarray], actual: Dict[str, np.ndarray]):
+def compare_stats(expected: dict[str, np.ndarray], actual: dict[str, np.ndarray]):
     assert len(expected) == len(actual)
     for ref_node_name, ref_stats in expected.items():
         actual_stats = actual[ref_node_name]

--- a/tests/cross_fw/shared/datasets.py
+++ b/tests/cross_fw/shared/datasets.py
@@ -9,13 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from copy import deepcopy
-from typing import List
 
 import numpy as np
 
 
 class MockDataset:
-    def __init__(self, shape: List[int]):
+    def __init__(self, shape: list[int]):
         self.n = 0
         self.shape = deepcopy(shape)
 

--- a/tests/cross_fw/shared/helpers.py
+++ b/tests/cross_fw/shared/helpers.py
@@ -11,7 +11,7 @@
 import subprocess
 import sys
 from pathlib import Path
-from typing import Callable, Set
+from typing import Callable
 
 from tests.cross_fw.shared.paths import GITHUB_REPO_URL
 from tests.cross_fw.shared.paths import PROJECT_ROOT
@@ -52,7 +52,7 @@ def find_file_by_extension(directory: Path, extension: str) -> str:
     raise FileNotFoundError(msg)
 
 
-def create_venv_with_nncf(tmp_path: Path, package_type: str, venv_type: str, backends: Set[str] = None):
+def create_venv_with_nncf(tmp_path: Path, package_type: str, venv_type: str, backends: set[str] = None):
     venv_path = tmp_path / "venv"
     venv_path.mkdir(exist_ok=True)
 

--- a/tests/cross_fw/shared/install_fixtures.py
+++ b/tests/cross_fw/shared/install_fixtures.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Set
 
 import pytest
 
@@ -16,6 +15,6 @@ from tests.cross_fw.shared.helpers import create_venv_with_nncf
 
 
 @pytest.fixture(scope="function")
-def tmp_venv_with_nncf(tmp_path, package_type: str, venv_type: str, extras: Set[str]):
+def tmp_venv_with_nncf(tmp_path, package_type: str, venv_type: str, extras: set[str]):
     venv_path = create_venv_with_nncf(tmp_path, package_type, venv_type, backends=extras)
     return venv_path

--- a/tests/cross_fw/shared/isolation_runner.py
+++ b/tests/cross_fw/shared/isolation_runner.py
@@ -12,14 +12,14 @@
 import inspect
 import os
 import subprocess
-from typing import Callable, Tuple
+from typing import Callable
 
 import pytest
 
 ISOLATION_RUN_ENV_VAR = "ISOLATION_RUN"
 
 
-def run_pytest_case_function_in_separate_process(fn: Callable) -> Tuple[int, str, str]:
+def run_pytest_case_function_in_separate_process(fn: Callable) -> tuple[int, str, str]:
     """
     Use this function for launching test cases that rely on global object behaviour such as module import
     order that cannot be reliably reset and/or isolated using regular pytest functionality. This will

--- a/tests/cross_fw/shared/json.py
+++ b/tests/cross_fw/shared/json.py
@@ -11,7 +11,6 @@
 import json
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict
 
 import numpy as np
 
@@ -34,6 +33,6 @@ class NumpyEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
-def dump_to_json(local_path: Path, data: Dict[str, np.ndarray]):
+def dump_to_json(local_path: Path, data: dict[str, np.ndarray]):
     with open(local_path, "w", encoding="utf8") as file:
         json.dump(deepcopy(data), file, indent=4, cls=NumpyEncoder)

--- a/tests/cross_fw/shared/nx_graph.py
+++ b/tests/cross_fw/shared/nx_graph.py
@@ -13,7 +13,7 @@ import os
 import re
 from functools import total_ordering
 from pathlib import Path
-from typing import Dict, Optional, Tuple, Union
+from typing import Optional, Union
 
 import networkx as nx
 
@@ -100,8 +100,8 @@ def sort_dot(path):
 
 def _build_node_id_vs_attrs_dict(
     nx_graph: nx.DiGraph, id_from_attr: bool = False
-) -> Dict[Union[int, str], Dict[str, str]]:
-    retval: Dict[Union[int, str], Dict[str, str]] = {}
+) -> dict[Union[int, str], dict[str, str]]:
+    retval: dict[Union[int, str], dict[str, str]] = {}
     for node_name, node_attrs in nx_graph.nodes.items():
         # When read a dot graph dumped by pydot the extra '\n' symbol appears as a graph node.
         # https://github.com/networkx/networkx/issues/5686
@@ -117,7 +117,7 @@ def _build_node_id_vs_attrs_dict(
 
 def _build_edge_vs_attrs_dict(
     nx_graph: nx.DiGraph, id_from_attr: bool = False
-) -> Dict[Tuple[Union[int, str], Union[int, str]], Dict[str, str]]:
+) -> dict[tuple[Union[int, str], Union[int, str]], dict[str, str]]:
     retval = {}
     for edge_tuple, edge_attrs in nx_graph.edges.items():
         from_node_name, to_node_name = edge_tuple

--- a/tests/cross_fw/shared/openvino_version.py
+++ b/tests/cross_fw/shared/openvino_version.py
@@ -9,13 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
 
 import openvino as ov
 from packaging import version
 
 
-def get_openvino_major_minor_version() -> Tuple[int]:
+def get_openvino_major_minor_version() -> tuple[int]:
     ov_version = ov.__version__
     pos = ov_version.find("-")
     if pos != -1:

--- a/tests/cross_fw/shared/patterns.py
+++ b/tests/cross_fw/shared/patterns.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict
 
 from nncf.common.graph.patterns import HWFusedPatternNames
 from nncf.common.graph.patterns import IgnoredPatternNames
@@ -16,7 +15,7 @@ from nncf.common.graph.patterns.manager import PatternsManager
 from nncf.common.utils.backend import BackendType
 
 
-def check_hw_patterns(backend: BackendType, reasons: Dict[HWFusedPatternNames, str]):
+def check_hw_patterns(backend: BackendType, reasons: dict[HWFusedPatternNames, str]):
     backend_patterns = PatternsManager._get_backend_hw_patterns_map(backend)
 
     all_base_patterns = HWFusedPatternNames
@@ -30,7 +29,7 @@ def check_hw_patterns(backend: BackendType, reasons: Dict[HWFusedPatternNames, s
         assert base_pattern in backend_patterns, f"Pattern {pattern_name} not found in {backend.name}"
 
 
-def check_ignored_patterns(backend: BackendType, reasons: Dict[IgnoredPatternNames, str]):
+def check_ignored_patterns(backend: BackendType, reasons: dict[IgnoredPatternNames, str]):
     backend_patterns = PatternsManager._get_backend_ignored_patterns_map(backend)
 
     all_base_patterns = IgnoredPatternNames

--- a/tests/cross_fw/test_templates/helpers.py
+++ b/tests/cross_fw/test_templates/helpers.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Optional, Tuple, TypeVar
+from typing import Callable, Optional, TypeVar
 
 import numpy as np
 import torch
@@ -34,7 +34,7 @@ class StaticDatasetMock:
 
     def __init__(
         self,
-        input_size: Tuple,
+        input_size: tuple,
         fn_to_type: Callable = None,
         length: int = 1,
     ):
@@ -43,7 +43,7 @@ class StaticDatasetMock:
         self._input_size = input_size
         self._fn_to_type = fn_to_type
 
-    def __getitem__(self, _) -> Tuple[TTensor, int]:
+    def __getitem__(self, _) -> tuple[TTensor, int]:
         np.random.seed(0)
         data = np.random.rand(*tuple(self._input_size)).astype(np.float32)
         if self._fn_to_type:
@@ -55,7 +55,7 @@ class StaticDatasetMock:
 
 
 def get_static_dataset(
-    input_size: Tuple, transform_fn: Callable, fn_to_type: Optional[Callable] = None, length: int = 1
+    input_size: tuple, transform_fn: Callable, fn_to_type: Optional[Callable] = None, length: int = 1
 ) -> Dataset:
     """
     Create nncf.Dataset for StaticDatasetMock.

--- a/tests/cross_fw/test_templates/template_test_weights_compression.py
+++ b/tests/cross_fw/test_templates/template_test_weights_compression.py
@@ -12,7 +12,7 @@ import math
 import re
 from abc import ABC
 from abc import abstractmethod
-from typing import Dict, List, TypeVar
+from typing import TypeVar
 
 import numpy as np
 import pytest
@@ -114,12 +114,12 @@ class TemplateWeightCompression(ABC):
         """Returns a backend tensor."""
 
     @abstractmethod
-    def check_weights(model: TModel, ref_ids: List[int]) -> None:
+    def check_weights(model: TModel, ref_ids: list[int]) -> None:
         """Checks that only weights with specified ids are compressed in int4 format."""
 
     @staticmethod
     @abstractmethod
-    def get_not_supported_algorithms() -> List[str]:
+    def get_not_supported_algorithms() -> list[str]:
         """
         Returns a list of not supported weight compression algorithms.
         """
@@ -303,7 +303,7 @@ class TemplateWeightCompression(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_reference_for_test_awq_scale_reference() -> Dict[str, Tensor]:
+    def get_reference_for_test_awq_scale_reference() -> dict[str, Tensor]:
         "Returns reference for test_awq_scale_reference."
 
     def test_awq_scale_reference(self, monkeypatch):

--- a/tests/cross_fw/test_templates/test_bias_correction.py
+++ b/tests/cross_fw/test_templates/test_bias_correction.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from abc import abstractmethod
-from typing import Any, Dict, List, Tuple, TypeVar
+from typing import Any, TypeVar
 
 import pytest
 
@@ -35,7 +35,7 @@ TTensor = TypeVar("TTensor")
 class TemplateTestBCAlgorithm:
     @staticmethod
     @abstractmethod
-    def list_to_backend_type(data: List) -> TTensor:
+    def list_to_backend_type(data: list) -> TTensor:
         """
         Convert list to backend specific type
 
@@ -64,7 +64,7 @@ class TemplateTestBCAlgorithm:
         Get transformation function for dataset.
         """
 
-    def get_dataset(self, input_size: Tuple) -> StaticDatasetMock:
+    def get_dataset(self, input_size: tuple) -> StaticDatasetMock:
         """
         Return backend specific random dataset.
 
@@ -81,13 +81,13 @@ class TemplateTestBCAlgorithm:
 
     @staticmethod
     @abstractmethod
-    def check_bias(model: TModel, ref_biases: Dict) -> None:
+    def check_bias(model: TModel, ref_biases: dict) -> None:
         """
         Checks biases values.
         """
 
     @staticmethod
-    def map_references(ref_biases: Dict, model_cls: Any) -> Dict[str, List]:
+    def map_references(ref_biases: dict, model_cls: Any) -> dict[str, list]:
         """
         Returns backend-specific reference.
         """

--- a/tests/cross_fw/test_templates/test_channel_alignment.py
+++ b/tests/cross_fw/test_templates/test_channel_alignment.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 from abc import abstractmethod
-from typing import Type
 
 import numpy as np
 import pytest
@@ -149,7 +148,7 @@ INVALID_CONV_LAYER_ATTR = ConvolutionLayerAttributes(
 
 class TemplateTestChannelAlignment:
     @abstractmethod
-    def get_backend_cls(self) -> Type[ChannelAlignmentAlgoBackend]:
+    def get_backend_cls(self) -> type[ChannelAlignmentAlgoBackend]:
         pass
 
     @abstractmethod

--- a/tests/cross_fw/test_templates/test_fast_bias_correction.py
+++ b/tests/cross_fw/test_templates/test_fast_bias_correction.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from abc import abstractmethod
-from typing import List, TypeVar
+from typing import TypeVar
 
 import pytest
 
@@ -31,7 +31,7 @@ TTensor = TypeVar("TTensor")
 class TemplateTestFBCAlgorithm:
     @staticmethod
     @abstractmethod
-    def list_to_backend_type(data: List) -> TTensor:
+    def list_to_backend_type(data: list) -> TTensor:
         """
         Convert list to backend specific type
 

--- a/tests/cross_fw/test_templates/test_min_max.py
+++ b/tests/cross_fw/test_templates/test_min_max.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import abstractmethod
-from typing import Tuple
 
 import pytest
 
@@ -59,7 +58,7 @@ class TemplateTestMinMaxAlgorithm:
 
 class TemplateTestGetTargetPointShape(TemplateTestMinMaxAlgorithm):
     @abstractmethod
-    def get_nncf_graph(self, weight_port_id: int, weight_shape: Tuple[int]) -> NNCFGraph:
+    def get_nncf_graph(self, weight_port_id: int, weight_shape: tuple[int]) -> NNCFGraph:
         "Returns backend specific NNCFGraph having a single Convolution."
 
     @pytest.mark.parametrize(
@@ -71,7 +70,7 @@ class TemplateTestGetTargetPointShape(TemplateTestMinMaxAlgorithm):
         ),
     )
     def test_get_target_point_shape(
-        self, target_point_type: TargetType, input_port_id: int, reference_shape: Tuple[int]
+        self, target_point_type: TargetType, input_port_id: int, reference_shape: tuple[int]
     ):
         nncf_graph = self.get_nncf_graph(input_port_id, CONV_WEIGHT_SHAPE)
         nodes = nncf_graph.get_nodes_by_metatypes((self.conv_metatype,))
@@ -94,18 +93,18 @@ class TemplateTestGetChannelAxes(TemplateTestMinMaxAlgorithm):
 
     @staticmethod
     @abstractmethod
-    def get_conv_node_attrs(weight_port_id: int, weight_shape: Tuple[int]) -> BaseLayerAttributes:
+    def get_conv_node_attrs(weight_port_id: int, weight_shape: tuple[int]) -> BaseLayerAttributes:
         "Returns backend specific layer attributes for Convolution."
 
     @staticmethod
     @abstractmethod
-    def get_depthwiseconv_node_attrs(weight_port_id: int, weight_shape: Tuple[int]) -> BaseLayerAttributes:
+    def get_depthwiseconv_node_attrs(weight_port_id: int, weight_shape: tuple[int]) -> BaseLayerAttributes:
         "Returns backend specific layer attributes for Convolution."
 
     @staticmethod
     @abstractmethod
     def get_matmul_node_attrs(
-        weight_port_id: int, transpose_weight: Tuple[int], weight_shape: Tuple[int]
+        weight_port_id: int, transpose_weight: tuple[int], weight_shape: tuple[int]
     ) -> BaseLayerAttributes:
         "Returns backend specific layer attributes for MatMul."
 

--- a/tests/cross_fw/test_templates/test_ptq_params.py
+++ b/tests/cross_fw/test_templates/test_ptq_params.py
@@ -11,7 +11,6 @@
 from abc import abstractmethod
 from collections import Counter
 from copy import deepcopy
-from typing import Dict
 
 import pytest
 
@@ -64,7 +63,7 @@ class ModelToTestOverflowFix:
     #          |
     #       Output_1
 
-    def __init__(self, metatypes: Dict[TestMetatype, OperatorMetatype]):
+    def __init__(self, metatypes: dict[TestMetatype, OperatorMetatype]):
         nodes = [
             NodeWithType("Input_1", InputNoopMetatype),
             NodeWithType("Input_2", InputNoopMetatype),
@@ -103,7 +102,7 @@ class ModelWithUnifiedScales:
     #           |
     #        Output_1
 
-    def __init__(self, metatypes: Dict[TestMetatype, OperatorMetatype], nncf_graph_cls=NNCFGraph):
+    def __init__(self, metatypes: dict[TestMetatype, OperatorMetatype], nncf_graph_cls=NNCFGraph):
         nodes = [
             NodeWithType("Input_1", InputNoopMetatype),
             NodeWithType("Conv_1", metatypes[Conv2dTestMetatype]),

--- a/tests/cross_fw/test_templates/test_quantizer_config.py
+++ b/tests/cross_fw/test_templates/test_quantizer_config.py
@@ -12,7 +12,6 @@
 from abc import abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import List
 
 import pytest
 
@@ -121,8 +120,8 @@ class TemplateTestQuantizerConfig:
         target_type: TargetType
         target_node_name: str
         batchwise_statistics: bool
-        ref_per_ch_reduction_axes: List[int]
-        ref_per_tensor_reduction_axes: List[int]
+        ref_per_ch_reduction_axes: list[int]
+        ref_per_tensor_reduction_axes: list[int]
 
     @pytest.fixture(
         params=[

--- a/tests/cross_fw/test_templates/test_smooth_quant.py
+++ b/tests/cross_fw/test_templates/test_smooth_quant.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from abc import abstractmethod
-from typing import Any, Callable, Dict, Type, TypeVar
+from typing import Any, Callable, TypeVar
 
 import pytest
 
@@ -57,7 +57,7 @@ class TemplateTestSQAlgorithm:
         """
 
     @abstractmethod
-    def get_node_name_map(self, model_cls) -> Dict[str, str]:
+    def get_node_name_map(self, model_cls) -> dict[str, str]:
         """
         Return backend specific map from the given model class labels
         to nncf_grpah nodes names.
@@ -79,14 +79,14 @@ class TemplateTestSQAlgorithm:
 
     @staticmethod
     @abstractmethod
-    def check_scales(model: TModel, reference_values: Dict[str, TTensor], model_cls) -> None:
+    def check_scales(model: TModel, reference_values: dict[str, TTensor], model_cls) -> None:
         """
         Checking scales from model with references.
         """
 
     @staticmethod
     @abstractmethod
-    def get_backend() -> Type[SmoothQuantAlgoBackend]:
+    def get_backend() -> type[SmoothQuantAlgoBackend]:
         """
         Returns backend-specific SmoothQuantAlgoBackend.
         """

--- a/tests/cross_fw/test_templates/test_statistics_serializer.py
+++ b/tests/cross_fw/test_templates/test_statistics_serializer.py
@@ -11,7 +11,6 @@
 import json
 from abc import abstractmethod
 from pathlib import Path
-from typing import Dict
 
 import pytest
 
@@ -25,7 +24,7 @@ from nncf.tensor.tensor import Tensor
 
 class TemplateTestStatisticsSerializer:
     @abstractmethod
-    def _get_backend_statistics(self) -> Dict[str, Dict[str, Tensor]]:
+    def _get_backend_statistics(self) -> dict[str, dict[str, Tensor]]:
         """Returns a dictionary of statistics for testing purposes."""
 
     @abstractmethod
@@ -33,7 +32,7 @@ class TemplateTestStatisticsSerializer:
         """Returns the backend used for testing."""
 
     @abstractmethod
-    def is_equal(self, a1: Dict[str, Tensor], a2: Dict[str, Tensor]) -> bool:
+    def is_equal(self, a1: dict[str, Tensor], a2: dict[str, Tensor]) -> bool:
         """Determine if two statistics are equal."""
 
     def test_load_no_statistics_file(self, tmp_path):

--- a/tests/cross_fw/test_templates/test_unified_scales.py
+++ b/tests/cross_fw/test_templates/test_unified_scales.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from abc import abstractmethod
-from typing import List, TypeVar
+from typing import TypeVar
 
 import pytest
 import torch
@@ -38,7 +38,7 @@ class TemplateTestUnifiedScales:
         ((ConcatSDPABlock, [["x", "y"]], [["/nncf_model_input_0", "/nncf_model_input_1"]]),),
     )
     def test_unified_groups(
-        self, model_cls: TModel, unified_group: List[List[str]], unified_group_nncf_network: List[List[str]]
+        self, model_cls: TModel, unified_group: list[list[str]], unified_group_nncf_network: list[list[str]]
     ):
         backend_model = self.get_backend_specific_model(model_cls())
         if isinstance(backend_model, torch.nn.Module) and not isinstance(backend_model, torch.fx.GraphModule):

--- a/tests/onnx/benchmarking/run_ptq.py
+++ b/tests/onnx/benchmarking/run_ptq.py
@@ -11,7 +11,7 @@
 
 import os
 from functools import partial
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 import onnx
@@ -49,8 +49,8 @@ def run(
     output_model_path: str,
     dataset: nncf.Dataset,
     num_init_samples: int,
-    ignored_scopes: Optional[List[str]] = None,
-    disallowed_op_types: Optional[List[str]] = None,
+    ignored_scopes: Optional[list[str]] = None,
+    disallowed_op_types: Optional[list[str]] = None,
     convert_model_opset: bool = True,
 ):
     print("Post-Training Quantization Parameters:")

--- a/tests/onnx/models.py
+++ b/tests/onnx/models.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 
 import numpy as np
 import onnx
@@ -31,7 +30,7 @@ def create_initializer_tensor(
 
 
 class ONNXReferenceModel:
-    def __init__(self, onnx_model, input_shape: List[List[int]], graph_path):
+    def __init__(self, onnx_model, input_shape: list[list[int]], graph_path):
         self.onnx_model = onnx_model
         self.onnx_model.ir_version = 9
         self.input_shape = input_shape

--- a/tests/onnx/quantization/common.py
+++ b/tests/onnx/quantization/common.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import numpy as np
 import onnx
@@ -85,7 +85,7 @@ def get_random_dataset_for_test(model: onnx.ModelProto, has_batch_dim: bool, len
     return Dataset(list(range(length)), transform_fn)
 
 
-def get_dataset_for_test(samples: List[Tuple[np.ndarray, int]], input_name: str):
+def get_dataset_for_test(samples: list[tuple[np.ndarray, int]], input_name: str):
     def transform_fn(data_item):
         inputs = data_item
         return {input_name: [inputs]}
@@ -94,7 +94,7 @@ def get_dataset_for_test(samples: List[Tuple[np.ndarray, int]], input_name: str)
 
 
 class ModelToTest:
-    def __init__(self, model_name: str, input_shape: Optional[List[int]] = None):
+    def __init__(self, model_name: str, input_shape: Optional[list[int]] = None):
         self.model_name = model_name
         self.path_ref_graph = self.model_name + ".dot"
         self.input_shape = input_shape
@@ -104,7 +104,7 @@ def min_max_quantize_model(
     original_model: onnx.ModelProto,
     convert_model_opset: bool = True,
     dataset_has_batch_size: bool = False,
-    quantization_params: Dict[str, Any] = None,
+    quantization_params: dict[str, Any] = None,
 ) -> onnx.ModelProto:
     if convert_model_opset:
         original_model = convert_opset_version(original_model)
@@ -131,7 +131,7 @@ def ptq_quantize_model(
     original_model: onnx.ModelProto,
     convert_model_opset: bool = True,
     dataset_has_batch_size: bool = False,
-    quantization_params: Dict[str, Any] = None,
+    quantization_params: dict[str, Any] = None,
 ) -> onnx.ModelProto:
     if convert_model_opset:
         original_model = convert_opset_version(original_model)
@@ -163,6 +163,6 @@ def compare_nncf_graph_onnx_models(quantized_model: onnx.ModelProto, _quantized_
     check_nx_graph(nx_graph, _nx_graph, check_edge_attrs=True)
 
 
-def find_ignored_scopes(disallowed_op_types: List[str], model: onnx.ModelProto) -> List[str]:
+def find_ignored_scopes(disallowed_op_types: list[str], model: onnx.ModelProto) -> list[str]:
     disallowed_op_types = set(disallowed_op_types)
     return [node.name for node in model.graph.node if node.op_type in disallowed_op_types]

--- a/tests/onnx/quantization/test_bias_correction.py
+++ b/tests/onnx/quantization/test_bias_correction.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List
 
 import numpy as np
 import onnx
@@ -39,7 +38,7 @@ def get_data_from_node(model: onnx.ModelProto, node_name: str):
 
 class TestONNXBCAlgorithm(TemplateTestBCAlgorithm):
     @staticmethod
-    def list_to_backend_type(data: List) -> np.ndarray:
+    def list_to_backend_type(data: list) -> np.ndarray:
         return np.array(data)
 
     @staticmethod
@@ -75,7 +74,7 @@ class TestONNXBCAlgorithm(TemplateTestBCAlgorithm):
         return compare_nncf_graph(model, ref_path)
 
     @staticmethod
-    def check_bias(model: onnx.ModelProto, ref_biases: Dict) -> None:
+    def check_bias(model: onnx.ModelProto, ref_biases: dict) -> None:
         nncf_graph = NNCFGraphFactory.create(model)
         for ref_name, ref_value in ref_biases.items():
             node = nncf_graph.get_node_by_name(ref_name)

--- a/tests/onnx/quantization/test_fast_bias_correction.py
+++ b/tests/onnx/quantization/test_fast_bias_correction.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 
 import numpy as np
 import onnx
@@ -31,7 +30,7 @@ def get_data_from_node(model: onnx.ModelProto, node_name: str):
 
 class TestONNXFBCAlgorithm(TemplateTestFBCAlgorithm):
     @staticmethod
-    def list_to_backend_type(data: List) -> np.ndarray:
+    def list_to_backend_type(data: list) -> np.ndarray:
         return np.array(data)
 
     @staticmethod

--- a/tests/onnx/quantization/test_min_max.py
+++ b/tests/onnx/quantization/test_min_max.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Tuple
 
 import pytest
 
@@ -42,7 +41,7 @@ class TestONNXMinMaxAlgorithm(TemplateTestMinMaxAlgorithm):
 
 
 class TestONNXGetTargetPointShape(TemplateTestGetTargetPointShape, TestONNXMinMaxAlgorithm):
-    def get_nncf_graph(self, weight_port_id: int, weight_shape: Tuple[int]) -> NNCFGraph:
+    def get_nncf_graph(self, weight_port_id: int, weight_shape: tuple[int]) -> NNCFGraph:
         conv_layer_attrs = ONNXLayerAttributes(weight_attrs={weight_port_id: {"shape": weight_shape}}, bias_attrs={})
         return NNCFGraphToTest(ONNXConvolutionMetatype, conv_layer_attrs).nncf_graph
 
@@ -57,16 +56,16 @@ class TestONNXGetChannelAxesMinMaxAlgorithm(TemplateTestGetChannelAxes, TestONNX
         return ONNXGemmMetatype
 
     @staticmethod
-    def get_conv_node_attrs(weight_port_id: int, weight_shape: Tuple[int]) -> ONNXLayerAttributes:
+    def get_conv_node_attrs(weight_port_id: int, weight_shape: tuple[int]) -> ONNXLayerAttributes:
         return ONNXLayerAttributes(weight_attrs={weight_port_id: {"shape": weight_shape}}, bias_attrs={})
 
     @staticmethod
-    def get_depthwiseconv_node_attrs(weight_port_id: int, weight_shape: Tuple[int]) -> ONNXLayerAttributes:
+    def get_depthwiseconv_node_attrs(weight_port_id: int, weight_shape: tuple[int]) -> ONNXLayerAttributes:
         return TestONNXGetChannelAxesMinMaxAlgorithm.get_conv_node_attrs(weight_port_id, weight_shape)
 
     @staticmethod
     def get_matmul_node_attrs(
-        weight_port_id: int, transpose_weight: Tuple[int], weight_shape: Tuple[int]
+        weight_port_id: int, transpose_weight: tuple[int], weight_shape: tuple[int]
     ) -> ONNXLayerAttributes:
         weight_attrs = {weight_port_id: {"name": "dummy", "shape": weight_shape}}
         if weight_port_id == 0:

--- a/tests/onnx/quantization/test_qdq_params_calculation.py
+++ b/tests/onnx/quantization/test_qdq_params_calculation.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict
 
 import numpy as np
 import onnx
@@ -34,7 +33,7 @@ from tests.onnx.quantization.common import min_max_quantize_model
 REFERENCE_SCALES_DIR = ONNX_TEST_ROOT / "data" / "reference_scales"
 
 
-def get_q_nodes_params(model: onnx.ModelProto) -> Dict[str, np.ndarray]:
+def get_q_nodes_params(model: onnx.ModelProto) -> dict[str, np.ndarray]:
     output = {}
     for node in model.graph.node:
         if node.op_type == "QuantizeLinear":

--- a/tests/onnx/quantization/test_reducers_and_aggregators.py
+++ b/tests/onnx/quantization/test_reducers_and_aggregators.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional
 
 import numpy as np
 import pytest
@@ -53,7 +53,7 @@ class TestReducersAggregators(TemplateTestReducersAggregators):
         ref_ = np.array(ref)
         return np.allclose(val_, ref_) and val_.shape == ref_.shape
 
-    def squeeze_tensor(self, ref_tensor: List[Any], axes: Optional[Tuple[int]] = None):
+    def squeeze_tensor(self, ref_tensor: list[Any], axes: Optional[tuple[int]] = None):
         return np.squeeze(np.array(ref_tensor), axes)
 
     def cast_tensor(self, tensor, dtype: Dtype):

--- a/tests/onnx/test_e2e_ptq.py
+++ b/tests/onnx/test_e2e_ptq.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Dict, List, Optional
+from typing import Optional
 
 import pandas as pd
 import pytest
@@ -67,7 +67,7 @@ XFAIL_MODELS = {
 }
 
 
-def check_skip_model(model_name: str, model_names_to_test: Optional[List[str]]):
+def check_skip_model(model_name: str, model_names_to_test: Optional[list[str]]):
     if model_names_to_test is not None and model_name not in model_names_to_test:
         pytest.skip(f"The model {model_name} is skipped, because it was not included in --model-names.")
     if model_name in XFAIL_MODELS:
@@ -80,7 +80,7 @@ def remove_prefix_if_exist(line: str, prefix: str) -> str:
     return line
 
 
-def run_command(command: List[str]):
+def run_command(command: list[str]):
     com_str = " ".join(command)
     print(f"Run command: {com_str}")
     with subprocess.Popen(
@@ -278,7 +278,7 @@ class TestPTQ:
         self,
         task_type: str,
         model_name: str,
-        model_names_to_test: Optional[List[str]],
+        model_names_to_test: Optional[list[str]],
         model_dir: Path,
         data_dir: Path,
         anno_dir: Path,
@@ -324,7 +324,7 @@ class TestBenchmark:
         anno_dir: Path,
         out_file_name: Path,
         eval_size: Optional[int],
-    ) -> List[str]:
+    ) -> list[str]:
         com_line = [
             sys.executable, str(program_path),
             "-c", str(config_path),
@@ -351,7 +351,7 @@ class TestBenchmark:
         is_quantized: bool,
         is_ov_ep: bool,
         is_cpu_ep: bool,
-    ) -> List[str]:
+    ) -> list[str]:
         program_path, config_path, model_path, output_dir, data_dir, anno_dir = configure_paths(
             task_type, model_name, model_dir, data_dir, anno_dir, output_dir, eval_size, program, False, is_quantized
         )
@@ -377,7 +377,7 @@ class TestBenchmark:
         eval_size: int,
         program: str,
         is_quantized: bool,
-    ) -> List[str]:
+    ) -> list[str]:
         program_path, config_path, model_path, output_dir, data_dir, anno_dir = configure_paths(
             task_type, model_name, model_dir, data_dir, anno_dir, output_dir, eval_size, program, True, is_quantized
         )
@@ -507,7 +507,7 @@ class TestBenchmarkResult:
 
     def get_row_colors(
         self, df: pd.DataFrame, reference_model_accuracy: pd.DataFrame, int8_col_name: str
-    ) -> Dict[int, str]:
+    ) -> dict[int, str]:
         row_colors = {}
         for idx, row in df.iterrows():
             for i, model_name in enumerate(reference_model_accuracy.index):
@@ -582,9 +582,9 @@ class TestBenchmarkResult:
     def generate_html(
         self,
         df: pd.DataFrame,
-        cpu_ep_row_colors: Dict[int, str],
-        ov_ep_row_colors: Dict[int, str],
-        ov_row_colors: Dict[int, str],
+        cpu_ep_row_colors: dict[int, str],
+        ov_ep_row_colors: dict[int, str],
+        ov_row_colors: dict[int, str],
         output_fp: str,
     ) -> None:
         doc, tag, text = Doc().tagtext()

--- a/tests/onnx/test_engine.py
+++ b/tests/onnx/test_engine.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 
 import numpy as np
 import onnx
@@ -25,7 +24,7 @@ from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
 from tests.onnx.models import NonShapeModel
 
 
-def check_engine_creation_and_inference(model: onnx.ModelProto, input_data: np.ndarray, reference_outputs: List[str]):
+def check_engine_creation_and_inference(model: onnx.ModelProto, input_data: np.ndarray, reference_outputs: list[str]):
     engine = ONNXEngine(model)
     outputs = engine.infer(input_data)
     for result_name in outputs:

--- a/tests/onnx/test_statistics_aggregator.py
+++ b/tests/onnx/test_statistics_aggregator.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Type
 
 import numpy as np
 import pytest
@@ -33,13 +32,13 @@ INPUT_SHAPE = [1, 3, 3, 3]
 
 class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
     @staticmethod
-    def get_min_max_algo_backend_cls() -> Type[ONNXMinMaxAlgoBackend]:
+    def get_min_max_algo_backend_cls() -> type[ONNXMinMaxAlgoBackend]:
         return ONNXMinMaxAlgoBackend
 
-    def get_bias_correction_algo_backend_cls(self) -> Type[ONNXBiasCorrectionAlgoBackend]:
+    def get_bias_correction_algo_backend_cls(self) -> type[ONNXBiasCorrectionAlgoBackend]:
         return ONNXBiasCorrectionAlgoBackend
 
-    def get_fast_bias_correction_algo_backend_cls(self) -> Type[ONNXFastBiasCorrectionAlgoBackend]:
+    def get_fast_bias_correction_algo_backend_cls(self) -> type[ONNXFastBiasCorrectionAlgoBackend]:
         return ONNXFastBiasCorrectionAlgoBackend
 
     def get_backend_model(self, dataset_samples):
@@ -79,7 +78,7 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
     def get_target_point_cls(self):
         return ONNXTargetPoint
 
-    def reducers_map(self) -> List[TensorReducerBase]:
+    def reducers_map(self) -> list[TensorReducerBase]:
         return None
 
     @pytest.fixture

--- a/tests/openvino/native/common.py
+++ b/tests/openvino/native/common.py
@@ -11,7 +11,6 @@
 import json
 from copy import deepcopy
 from pathlib import Path
-from typing import Tuple
 
 import numpy as np
 import openvino as ov
@@ -25,7 +24,7 @@ from tests.cross_fw.shared.openvino_version import get_openvino_version
 from tests.openvino.conftest import OPENVINO_NATIVE_TEST_ROOT
 
 
-def convert_torch_model(model: torch.nn.Module, input_shape: Tuple[int], tmp_path: Path) -> ov.Model:
+def convert_torch_model(model: torch.nn.Module, input_shape: tuple[int], tmp_path: Path) -> ov.Model:
     model_tmp_path = tmp_path / ("model.onnx")
     with torch.no_grad():
         torch.onnx.export(model, torch.ones(input_shape), model_tmp_path)

--- a/tests/openvino/native/models.py
+++ b/tests/openvino/native/models.py
@@ -12,7 +12,7 @@
 from abc import ABC
 from abc import abstractmethod
 from functools import partial
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional
 
 import numpy as np
 import openvino as ov
@@ -30,7 +30,7 @@ from tests.torch.test_models.swin import SwinTransformerBlock
 SYNTHETIC_MODELS = Registry("OV_SYNTHETIC_MODELS")
 
 
-def get_torch_model_info(model_name: str) -> Tuple[Callable, Tuple[int]]:
+def get_torch_model_info(model_name: str) -> tuple[Callable, tuple[int]]:
     models = {
         "mobilenet-v2": (mobilenet_v2, (1, 3, 224, 224)),
         "mobilenet-v3-small": (mobilenet_v3_small, (1, 3, 224, 224)),

--- a/tests/openvino/native/quantization/test_channel_alignment.py
+++ b/tests/openvino/native/quantization/test_channel_alignment.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import Type
 
 import pytest
 
@@ -33,7 +32,7 @@ from tests.cross_fw.test_templates.test_channel_alignment import TemplateTestCha
 
 
 class TestOVChannelAlignment(TemplateTestChannelAlignment):
-    def get_backend_cls(self) -> Type[OVChannelAlignmentAlgoBackend]:
+    def get_backend_cls(self) -> type[OVChannelAlignmentAlgoBackend]:
         return OVChannelAlignmentAlgoBackend
 
     def target_point(self, target_type: TargetType, target_node_name: str, port_id: int) -> OVTargetPoint:

--- a/tests/openvino/native/quantization/test_graphs.py
+++ b/tests/openvino/native/quantization/test_graphs.py
@@ -11,7 +11,6 @@
 
 
 from pathlib import Path
-from typing import Dict
 
 import numpy as np
 import openvino as ov
@@ -131,7 +130,7 @@ def test_real_models_sq_placement(model_name_params, tmp_path):
     compare_nncf_graphs(quantized_model, path_ref_graph)
 
 
-def smooth_quant_model(ov_model: ov.Model, q_params: Dict, quantize=True):
+def smooth_quant_model(ov_model: ov.Model, q_params: dict, quantize=True):
     dataset = get_dataset_for_test(ov_model)
     graph = GraphConverter.create_nncf_graph(ov_model)
 

--- a/tests/openvino/native/quantization/test_min_max.py
+++ b/tests/openvino/native/quantization/test_min_max.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
 
 import pytest
 
@@ -42,7 +41,7 @@ class TestOVMinMaxAlgorithm(TemplateTestMinMaxAlgorithm):
 
 
 class TestOVGetTargetPointShape(TemplateTestGetTargetPointShape, TestOVMinMaxAlgorithm):
-    def get_nncf_graph(self, weight_port_id: int, weight_shape: Tuple[int]) -> NNCFGraph:
+    def get_nncf_graph(self, weight_port_id: int, weight_shape: tuple[int]) -> NNCFGraph:
         conv_layer_attrs = OVLayerAttributes({weight_port_id: {"name": "dummy", "shape": weight_shape, "dtype": "f32"}})
         return NNCFGraphToTest(OVConvolutionMetatype, conv_layer_attrs).nncf_graph
 
@@ -57,17 +56,17 @@ class TestOVGetChannelAxes(TemplateTestGetChannelAxes, TestOVMinMaxAlgorithm):
         return OVMatMulMetatype
 
     @staticmethod
-    def get_conv_node_attrs(weight_port_id: int, weight_shape: Tuple[int]) -> OVLayerAttributes:
+    def get_conv_node_attrs(weight_port_id: int, weight_shape: tuple[int]) -> OVLayerAttributes:
         constant_attributes = {weight_port_id: {"name": "dummy", "shape": weight_shape, "dtype": "f32"}}
         return OVLayerAttributes(constant_attributes, {}, {})
 
     @staticmethod
-    def get_depthwiseconv_node_attrs(weight_port_id: int, weight_shape: Tuple[int]) -> OVLayerAttributes:
+    def get_depthwiseconv_node_attrs(weight_port_id: int, weight_shape: tuple[int]) -> OVLayerAttributes:
         return TestOVGetChannelAxes.get_conv_node_attrs(weight_port_id, weight_shape)
 
     @staticmethod
     def get_matmul_node_attrs(
-        weight_port_id: int, transpose_weight: Tuple[int], weight_shape: Tuple[int]
+        weight_port_id: int, transpose_weight: tuple[int], weight_shape: tuple[int]
     ) -> OVLayerAttributes:
         constant_attributes = {weight_port_id: {"name": "dummy", "shape": weight_shape, "dtype": "f32"}}
         constant_attributes[weight_port_id]["transpose"] = transpose_weight

--- a/tests/openvino/native/quantization/test_quantizer_removal.py
+++ b/tests/openvino/native/quantization/test_quantizer_removal.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import List
 
 import openvino as ov
 import pytest
@@ -37,10 +36,10 @@ class InputTestData:
     """
 
     quantized_model: ov.Model
-    operations: List[str]
-    quantizers: List[str]
+    operations: list[str]
+    quantizers: list[str]
     restore_mode: RestoreMode
-    expected_remaining_quantizers: List[str]
+    expected_remaining_quantizers: list[str]
 
 
 TEST_CASES = [

--- a/tests/openvino/native/quantization/test_reducers_and_aggregators.py
+++ b/tests/openvino/native/quantization/test_reducers_and_aggregators.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional
 
 import numpy as np
 import openvino as ov
@@ -69,7 +69,7 @@ class TestReducersAggregators(TemplateTestReducersAggregators):
         ref_ = np.array(ref)
         return np.allclose(val_, ref_) and val_.shape == ref_.shape
 
-    def squeeze_tensor(self, ref_tensor: List[Any], axes: Optional[Tuple[int]] = None):
+    def squeeze_tensor(self, ref_tensor: list[Any], axes: Optional[tuple[int]] = None):
         return np.squeeze(np.array(ref_tensor), axes)
 
     def cast_tensor(self, tensor, dtype: Dtype):

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -11,7 +11,7 @@
 
 import inspect
 import os
-from typing import Callable, Dict, List
+from typing import Callable
 from unittest.mock import patch
 
 import numpy as np
@@ -123,7 +123,7 @@ def get_next_node(node):
     return next_node
 
 
-def get_shape_for_second_input(op_with_weights: ov.Node) -> List[int]:
+def get_shape_for_second_input(op_with_weights: ov.Node) -> list[int]:
     return list(op_with_weights.inputs()[1].get_shape())
 
 
@@ -240,7 +240,7 @@ def check_int8_sym(op: ov.Node):
     return check_int8_node(op, mode=CompressWeightsMode.INT8_SYM)
 
 
-def get_mixed_mapping(primary_fn: Callable, list_layers: List[str]):
+def get_mixed_mapping(primary_fn: Callable, list_layers: list[str]):
     mapping = {node_name: check_int8_node for node_name in list_layers}
     primary_node_name = TEST_MODELS[IntegerModel][0]
     mapping[primary_node_name] = primary_fn
@@ -457,7 +457,7 @@ def test_shared_gather_all_layers(all_layers):
 
 @dataclass
 class QuantErrorDesc:
-    weight: List[float]
+    weight: list[float]
     ref_error: int = 0
     axis = (1,)
     name: str = ""
@@ -1559,13 +1559,13 @@ class TestOVTemplateWeightCompression(TemplateWeightCompression):
         raise NotImplementedError
 
     @staticmethod
-    def check_weights(model: ov.Model, ref_ids: List[int]) -> None:
+    def check_weights(model: ov.Model, ref_ids: list[int]) -> None:
         names = {op.get_friendly_name() for op in model.get_ordered_ops() if op.get_element_type() == ov.Type.i4}
         low_precision_nodes = {f"weights_{i}" for i in ref_ids}
         assert low_precision_nodes == names
 
     @staticmethod
-    def get_not_supported_algorithms() -> List[str]:
+    def get_not_supported_algorithms() -> list[str]:
         return []
 
     @staticmethod
@@ -1634,7 +1634,7 @@ class TestOVTemplateWeightCompression(TemplateWeightCompression):
         return awq_num
 
     @staticmethod
-    def get_reference_for_test_awq_scale_reference() -> Dict[str, Tensor]:
+    def get_reference_for_test_awq_scale_reference() -> dict[str, Tensor]:
         return {
             "MatMul_3": Tensor(
                 np.array(

--- a/tests/openvino/native/quantization/test_weights_compression_statistics_caching.py
+++ b/tests/openvino/native/quantization/test_weights_compression_statistics_caching.py
@@ -11,7 +11,6 @@
 from copy import deepcopy
 from functools import partial
 from itertools import product
-from typing import Tuple
 
 import datasets
 import numpy as np
@@ -56,7 +55,7 @@ def create_transform_fn(model: OVModelForCausalLM, tokenizer: AutoTokenizer):
     return transform_fn
 
 
-def _setup_model_and_dataset(model_id: str) -> Tuple[OVModelForCausalLM, nncf.Dataset]:
+def _setup_model_and_dataset(model_id: str) -> tuple[OVModelForCausalLM, nncf.Dataset]:
     dataset = datasets.load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
     tokenizer = AutoTokenizer.from_pretrained(model_id)
     model = OVModelForCausalLM.from_pretrained(model_id, export=True, load_in_8bit=False, compile=False, stateful=False)

--- a/tests/openvino/native/test_bias_correction.py
+++ b/tests/openvino/native/test_bias_correction.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 import openvino as ov
@@ -34,7 +34,7 @@ class TestOVBCAlgorithm(TemplateTestBCAlgorithm):
     TRANSPOSE_CONV_NAME = "/conv/ConvTranspose/WithoutBiases"
 
     @staticmethod
-    def list_to_backend_type(data: List) -> np.ndarray:
+    def list_to_backend_type(data: list) -> np.ndarray:
         return np.array(data)
 
     @staticmethod
@@ -65,7 +65,7 @@ class TestOVBCAlgorithm(TemplateTestBCAlgorithm):
         return transform_fn
 
     @staticmethod
-    def map_references(ref_biases: Dict, model_cls: Any) -> Dict[str, List]:
+    def map_references(ref_biases: dict, model_cls: Any) -> dict[str, list]:
         mapping = {f"{name}/WithoutBiases": val for name, val in ref_biases.items()}
         return mapping
 
@@ -79,7 +79,7 @@ class TestOVBCAlgorithm(TemplateTestBCAlgorithm):
         return compare_nncf_graphs(model, ref_path)
 
     @staticmethod
-    def check_bias(model: ov.Model, ref_biases: Dict) -> None:
+    def check_bias(model: ov.Model, ref_biases: dict) -> None:
         nncf_graph = NNCFGraphFactory.create(model)
         for ref_name, ref_value in ref_biases.items():
             node = nncf_graph.get_node_by_name(ref_name)

--- a/tests/openvino/native/test_fast_bias_correction.py
+++ b/tests/openvino/native/test_fast_bias_correction.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 
 import numpy as np
 import openvino as ov
@@ -25,7 +24,7 @@ from tests.cross_fw.test_templates.test_fast_bias_correction import TemplateTest
 
 class TestOVFBCAlgorithm(TemplateTestFBCAlgorithm):
     @staticmethod
-    def list_to_backend_type(data: List) -> np.ndarray:
+    def list_to_backend_type(data: list) -> np.ndarray:
         return np.array(data)
 
     @staticmethod

--- a/tests/openvino/native/test_layer_attributes.py
+++ b/tests/openvino/native/test_layer_attributes.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Callable, Tuple
+from typing import Callable
 
 import numpy as np
 import openvino as ov
@@ -153,11 +153,11 @@ def get_one_layer_model(op_name: str, node_creator, input_shape):
 @dataclass
 class LayerAttributesTestCase:
     node_creator: Callable
-    input_shape: Tuple[int, ...]
+    input_shape: tuple[int, ...]
     act_port_id: int
     ref_layer_attrs: OVLayerAttributes
-    ref_weights_layout: Tuple[OVLayoutElem]
-    ref_acts_layout: Tuple[OVLayoutElem]
+    ref_weights_layout: tuple[OVLayoutElem]
+    ref_acts_layout: tuple[OVLayoutElem]
 
 
 TEST_CASES_CONV = [

--- a/tests/openvino/native/test_model_transformer.py
+++ b/tests/openvino/native/test_model_transformer.py
@@ -11,7 +11,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, List, Tuple
+from typing import Callable
 
 import numpy as np
 import openvino as ov
@@ -100,7 +100,7 @@ def get_extra_outputs(original_model, transformed_model, as_nodes=False):
     return nodes_set if as_nodes else names_set
 
 
-def get_nodes_by_type(model: ov.Model, type_name: str) -> List[ov.Node]:
+def get_nodes_by_type(model: ov.Model, type_name: str) -> list[ov.Node]:
     fq_nodes = []
     for op in model.get_ops():
         if op.get_type_name() == type_name:
@@ -130,10 +130,10 @@ def verify_inputs_equality(node: ov.Node) -> None:
 @dataclass
 class InplaceOpTestCase:
     name: str
-    reduce_shape: Tuple[int, ...]
+    reduce_shape: tuple[int, ...]
     op_builder: Callable
-    ref_types: List[str]
-    ref_values: List[np.array]
+    ref_types: list[str]
+    ref_values: list[np.array]
     dims: str = "DEFAULT"
 
     def __str__(self) -> str:

--- a/tests/openvino/native/test_smooth_quant.py
+++ b/tests/openvino/native/test_smooth_quant.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Dict
+from typing import Callable
 
 import numpy as np
 import openvino as ov
@@ -79,7 +79,7 @@ class TestOVSQAlgorithm(TemplateTestSQAlgorithm):
     def inplace_statistics(self, request) -> bool:
         return request.param
 
-    def get_node_name_map(self, model_cls) -> Dict[str, str]:
+    def get_node_name_map(self, model_cls) -> dict[str, str]:
         if model_cls is LinearMultiShapeModel:
             return OV_LINEAR_MODEL_MM_OP_MAP
         if model_cls is ConvTestModel:
@@ -105,7 +105,7 @@ class TestOVSQAlgorithm(TemplateTestSQAlgorithm):
         return ov.convert_model(model, example_input=torch.rand(model.INPUT_SIZE), input=model.INPUT_SIZE)
 
     @staticmethod
-    def check_scales(model: ov.Model, reference_values: Dict[str, np.ndarray], model_cls) -> None:
+    def check_scales(model: ov.Model, reference_values: dict[str, np.ndarray], model_cls) -> None:
         names_map = OV_LINEAR_MODEL_SQ_OP_MAP if model_cls is LinearMultiShapeModel else OV_CONV_MODEL_SQ_OP_MAP
         ops_list = {op.get_friendly_name(): op for op in model.get_ops()}
         for ref_names, ref_value in reference_values.items():

--- a/tests/openvino/native/test_statistics_aggregator.py
+++ b/tests/openvino/native/test_statistics_aggregator.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Type
 
 import numpy as np
 import openvino as ov
@@ -51,13 +50,13 @@ def get_StatisticAggregatorTestModel(input_shape, kernel):
 
 class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
     @staticmethod
-    def get_min_max_algo_backend_cls() -> Type[OVMinMaxAlgoBackend]:
+    def get_min_max_algo_backend_cls() -> type[OVMinMaxAlgoBackend]:
         return OVMinMaxAlgoBackend
 
-    def get_bias_correction_algo_backend_cls(self) -> Type[OVBiasCorrectionAlgoBackend]:
+    def get_bias_correction_algo_backend_cls(self) -> type[OVBiasCorrectionAlgoBackend]:
         return OVBiasCorrectionAlgoBackend
 
-    def get_fast_bias_correction_algo_backend_cls(self) -> Type[OVFastBiasCorrectionAlgoBackend]:
+    def get_fast_bias_correction_algo_backend_cls(self) -> type[OVFastBiasCorrectionAlgoBackend]:
         return OVFastBiasCorrectionAlgoBackend
 
     def get_backend_model(self, dataset_samples):
@@ -120,7 +119,7 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
         conv_w = self.dataset_samples_to_conv_w(sample)
         return SharedConvModel(input_name=INPUT_NAME, input_shape=INPUT_SHAPE, kernel=conv_w).ov_model
 
-    def reducers_map(self) -> List[TensorReducerBase]:
+    def reducers_map(self) -> list[TensorReducerBase]:
         map_ = OV_REDUCERS_MAP.copy()
         map_.update({"batch_mean": OVBatchMeanReducer, "mean_per_ch": OVMeanPerChanelReducer})
         return map_

--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from dataclasses import replace
 from enum import Enum
 from itertools import islice
-from typing import Any, Dict, Iterable, List, Optional, TypeVar
+from typing import Any, Iterable, Optional, TypeVar
 
 import numpy as np
 import openvino as ov
@@ -988,10 +988,10 @@ class ACDataset:
         self._indices = list(range(model_evaluator.dataset.full_size))
         self._transform_func = transform_func
 
-    def get_data(self, indices: Optional[List[int]] = None):
+    def get_data(self, indices: Optional[list[int]] = None):
         return DataProvider(self._indices, None, indices)
 
-    def get_inference_data(self, indices: Optional[List[int]] = None):
+    def get_inference_data(self, indices: Optional[list[int]] = None):
         return DataProvider(ACDattasetWrapper(self._model_evaluator), self._transform_func, indices)
 
 
@@ -1085,7 +1085,7 @@ def update_accuracy_checker_config(accuracy_checker_config: Config, batch_size: 
             print(f"Updated batch size value to {batch_size}")
 
 
-def update_nncf_algorithms_config(nncf_algorithms_config: Dict[str, Dict[str, Any]], batch_size: int) -> None:
+def update_nncf_algorithms_config(nncf_algorithms_config: dict[str, dict[str, Any]], batch_size: int) -> None:
     """
     Updates subset_size parameter depending on batch_size and subset_size from an algorithm config.
 

--- a/tests/post_training/experimental/sparsify_activations/pipelines.py
+++ b/tests/post_training/experimental/sparsify_activations/pipelines.py
@@ -12,7 +12,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Optional
 
 import numpy as np
 import openvino as ov
@@ -144,7 +144,7 @@ class SAPipelineMixin(BaseTestPipeline):
         self.run_info.num_compress_nodes.num_int4 = num_int4
         self.run_info.num_compress_nodes.num_sparse_activations = num_sparse_activations
 
-    def collect_errors(self) -> List[ErrorReport]:
+    def collect_errors(self) -> list[ErrorReport]:
         errors = super().collect_errors()
         run_info = self.run_info
         reference_data = self.reference_data
@@ -214,7 +214,7 @@ class LMSparsifyActivations(SAPipelineMixin, LMWeightCompression):
     def get_transform_calibration_fn(self):
         process_one = super().get_transform_calibration_fn()
 
-        def transform_fn(chunk: List[Dict]):
+        def transform_fn(chunk: list[dict]):
             samples = [process_one(data, max_tokens=128, filter_bad_tokens=False) for data in chunk]
             inputs = {}
             for input_name, sample_value in samples[0].items():

--- a/tests/post_training/experimental/sparsify_activations/test_sparsify_activations_conformance.py
+++ b/tests/post_training/experimental/sparsify_activations/test_sparsify_activations_conformance.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 import pytest
 import yaml
@@ -37,7 +37,7 @@ def test_sparsify_activations(
     test_case_name: str,
     data_dir: Path,
     output_dir: Path,
-    result_data: Dict[str, RunInfo],
+    result_data: dict[str, RunInfo],
     no_eval: bool,
     batch_size: int,
     run_fp32_backend: bool,

--- a/tests/post_training/model_scope.py
+++ b/tests/post_training/model_scope.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 import copy
-from typing import Dict, List
 
 import nncf
 from nncf import ModelType
@@ -555,7 +554,7 @@ WEIGHT_COMPRESSION_MODELS = [
 ]
 
 
-def generate_tests_scope(models_list: List[Dict]) -> Dict[str, dict]:
+def generate_tests_scope(models_list: list[dict]) -> dict[str, dict]:
     """
     Generate tests by names "{reported_name}_backend_{backend}"
     """

--- a/tests/post_training/pipelines/base.py
+++ b/tests/post_training/pipelines/base.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 import onnx
@@ -76,7 +76,7 @@ class StatsFromOutput:
     Contains statistics that are parsed from the stdout.
     """
 
-    def get_stats(self) -> Dict[str, str]:
+    def get_stats(self) -> dict[str, str]:
         """
         Returns statistics collected from the stdout. Usually it parses execution time from the log of the progress bar.
         """
@@ -190,7 +190,7 @@ class RunInfo:
             return None
         return int(memory)
 
-    def get_result_dict(self) -> Dict[str, str]:
+    def get_result_dict(self) -> dict[str, str]:
         """Returns a dictionary with the results of the run."""
         ram_data = {}
         if self.compression_memory_usage_system is None:
@@ -342,7 +342,7 @@ class BaseTestPipeline(ABC):
         self.validate()
         self.run_bench()
 
-    def collect_errors(self) -> List[ErrorReport]:
+    def collect_errors(self) -> list[ErrorReport]:
         """
         Collects errors based on the pipeline's run information.
 
@@ -373,7 +373,7 @@ class BaseTestPipeline(ABC):
 
         return errors
 
-    def update_status(self, error_reports: List[ErrorReport]) -> List[str]:
+    def update_status(self, error_reports: list[ErrorReport]) -> list[str]:
         """
         Updates status of the pipeline based on the errors encountered during the run.
 
@@ -561,7 +561,7 @@ class PTQTestPipeline(BaseTestPipeline):
         self.run_info.num_compress_nodes.num_fq_nodes = num_fq
 
 
-def get_num_fq_int4_int8(model: ov.Model) -> Tuple[int, int, int]:
+def get_num_fq_int4_int8(model: ov.Model) -> tuple[int, int, int]:
     num_fq = 0
     num_int8 = 0
     num_int4 = 0
@@ -579,14 +579,14 @@ def get_num_fq_int4_int8(model: ov.Model) -> Tuple[int, int, int]:
     return num_fq, num_int4, num_int8
 
 
-def _are_exceptions_matched(report: ErrorReport, reference_exception: Dict[str, str]) -> bool:
+def _are_exceptions_matched(report: ErrorReport, reference_exception: dict[str, str]) -> bool:
     return (
         reference_exception["error_message"] == report.msg.split(" | ")[1]
         and reference_exception["type"] == report.msg.split(" | ")[0]
     )
 
 
-def _is_error_xfailed(report: ErrorReport, xfail_reason: str, reference_data: Dict[str, Dict[str, str]]) -> bool:
+def _is_error_xfailed(report: ErrorReport, xfail_reason: str, reference_data: dict[str, dict[str, str]]) -> bool:
     if xfail_reason not in reference_data:
         return False
 
@@ -595,7 +595,7 @@ def _is_error_xfailed(report: ErrorReport, xfail_reason: str, reference_data: Di
     return True
 
 
-def _get_xfail_message(report: ErrorReport, xfail_reason: str, reference_data: Dict[str, Dict[str, str]]) -> str:
+def _get_xfail_message(report: ErrorReport, xfail_reason: str, reference_data: dict[str, dict[str, str]]) -> str:
     if report.reason == ErrorReason.EXCEPTION:
         return f"XFAIL: {reference_data[xfail_reason]['message']} - {report.msg}"
     return f"XFAIL: {xfail_reason} - {report.msg}"

--- a/tests/post_training/pipelines/image_classification_torchvision.py
+++ b/tests/post_training/pipelines/image_classification_torchvision.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Any, Callable, Tuple
+from typing import Any, Callable
 
 import numpy as np
 import onnx
@@ -24,18 +24,18 @@ from tests.post_training.pipelines.base import BackendType
 from tests.post_training.pipelines.image_classification_base import ImageClassificationBase
 
 
-def _torch_export_for_training(model: torch.nn.Module, args: Tuple[Any, ...]) -> torch.fx.GraphModule:
+def _torch_export_for_training(model: torch.nn.Module, args: tuple[Any, ...]) -> torch.fx.GraphModule:
     return torch.export.export_for_training(model, args).module()
 
 
-def _torch_export(model: torch.nn.Module, args: Tuple[Any, ...]) -> torch.fx.GraphModule:
+def _torch_export(model: torch.nn.Module, args: tuple[Any, ...]) -> torch.fx.GraphModule:
     return torch.export.export(model, args).module()
 
 
 @dataclass
 class VisionModelParams:
     weights: models.WeightsEnum
-    export_fn: Callable[[torch.nn.Module, Tuple[Any, ...]], torch.fx.GraphModule]
+    export_fn: Callable[[torch.nn.Module, tuple[Any, ...]], torch.fx.GraphModule]
     export_torch_before_ov_convert: bool = False
 
 

--- a/tests/post_training/pipelines/lm_weight_compression.py
+++ b/tests/post_training/pipelines/lm_weight_compression.py
@@ -15,7 +15,7 @@ import shutil
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Optional
 
 import numpy as np
 import openvino as ov
@@ -72,7 +72,7 @@ class WCTimeStats(StatsFromOutput):
                     setattr(self, attr_name, match.group(1))
                 continue
 
-    def get_stats(self) -> Dict[str, str]:
+    def get_stats(self) -> dict[str, str]:
         VARS = [getattr(self, name) for name in self.VAR_NAMES]
         return dict(zip(self.STAT_NAMES, VARS))
 
@@ -355,13 +355,13 @@ class LMWeightCompression(BaseTestPipeline):
         self.run_info.num_compress_nodes.num_int8 = num_int8
         self.run_info.num_compress_nodes.num_int4 = num_int4
 
-    def collect_errors(self) -> List[ErrorReport]:
+    def collect_errors(self) -> list[ErrorReport]:
         errors = super().collect_errors()
         errors.extend(collect_int4_int8_num_errors(self.run_info, self.reference_data))
         return errors
 
 
-def collect_int4_int8_num_errors(run_info: RunInfo, reference_data: dict) -> List[ErrorReport]:
+def collect_int4_int8_num_errors(run_info: RunInfo, reference_data: dict) -> list[ErrorReport]:
     errors = []
     num_int4_reference = reference_data.get("num_int4")
     num_int8_reference = reference_data.get("num_int8")

--- a/tests/post_training/test_quantize_conformance.py
+++ b/tests/post_training/test_quantize_conformance.py
@@ -16,7 +16,7 @@ import traceback
 from collections import OrderedDict
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 import pandas as pd
 import pytest
@@ -54,7 +54,7 @@ def _parse_version(s: Path):
     return version.parse(version_str)
 
 
-def ref_data_correction(data: Dict, file_name: str):
+def ref_data_correction(data: dict, file_name: str):
     """
     Apply corrections from reference YAML files according current of OV version to the provided data dictionary.
 
@@ -108,7 +108,7 @@ def fixture_wc_reference_data():
 
 @pytest.fixture(scope="session", name="result_data")
 def fixture_report_data(output_dir, run_benchmark_app, forked):
-    data: Dict[str, RunInfo] = {}
+    data: dict[str, RunInfo] = {}
     yield data
     if data:
         columns_to_drop = ["FPS"] if not run_benchmark_app else []
@@ -195,7 +195,7 @@ def run_pipeline(
     test_case_name: str,
     reference_data: dict,
     test_cases: dict,
-    result_data: Dict[str, RunInfo],
+    result_data: dict[str, RunInfo],
     output_dir: Path,
     data_dir: Optional[Path],
     no_eval: bool,
@@ -269,7 +269,7 @@ def test_ptq_quantization(
     test_case_name: str,
     data_dir: Path,
     output_dir: Path,
-    result_data: Dict[str, RunInfo],
+    result_data: dict[str, RunInfo],
     no_eval: bool,
     batch_size: Optional[int],
     run_fp32_backend: bool,
@@ -306,7 +306,7 @@ def test_weight_compression(
     wc_reference_data: dict,
     test_case_name: str,
     output_dir: Path,
-    result_data: Dict[str, RunInfo],
+    result_data: dict[str, RunInfo],
     no_eval: bool,
     batch_size: int,
     run_fp32_backend: bool,

--- a/tests/tensorflow/accuracy_aware_training/test_keras_api.py
+++ b/tests/tensorflow/accuracy_aware_training/test_keras_api.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 import random
-from typing import Dict
 
 import numpy as np
 import pytest
@@ -85,7 +84,7 @@ class MockResultFunctor:
         self._call_count = 0
         self._mock_retval = mock_retval
 
-    def __call__(self, results_dict: Dict) -> float:
+    def __call__(self, results_dict: dict) -> float:
         if self._call_count == 0:
             retval = self._mock_retval
         else:

--- a/tests/tensorflow/quantization/test_statistics.py
+++ b/tests/tensorflow/quantization/test_statistics.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import Optional
 
 import pytest
 
@@ -20,7 +20,7 @@ from tests.tensorflow.helpers import create_compressed_model_and_algo_for_test
 from tests.tensorflow.helpers import get_empty_config
 
 
-def _get_basic_quantization_config(mode: str, granularity: str, input_sample_sizes: Optional[List[int]] = None):
+def _get_basic_quantization_config(mode: str, granularity: str, input_sample_sizes: Optional[list[int]] = None):
     config = get_empty_config(input_sample_sizes)
     per_channel = granularity == "per_channel"
 
@@ -46,7 +46,7 @@ class Case:
         self,
         model_name: str,
         model_builder,
-        input_sample_sizes: List[int],
+        input_sample_sizes: list[int],
         mode: str,
         granularity: str,
         expected: QuantizationStatistics,

--- a/tests/tensorflow/sparsity/test_common.py
+++ b/tests/tensorflow/sparsity/test_common.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import Optional
 
 import pytest
 
@@ -139,7 +139,7 @@ class TestPolynomialSparsityScheduler:
         steps_per_epoch: int,
         scheduler: PolynomialSparsityScheduler,
         set_sparsity_mock,
-        ref_vals: List[Optional[float]],
+        ref_vals: list[Optional[float]],
         explicit,
         epoch,
     ):

--- a/tests/tensorflow/tensor_statistics/test_tensor_statistics.py
+++ b/tests/tensorflow/tensor_statistics/test_tensor_statistics.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 from functools import partial
-from typing import Dict, Tuple, Type
 
 import pytest
 import tensorflow as tf
@@ -98,8 +97,8 @@ class TestCollectedStatistics:
     )
     def test_collected_statistics_with_shape_convert(
         self,
-        collector: Type[TensorStatisticCollectorBase],
-        reduction_shapes_vs_ref_statistic: Dict[Tuple[ReductionAxes, ReductionAxes], TensorStatistic],
+        collector: type[TensorStatisticCollectorBase],
+        reduction_shapes_vs_ref_statistic: dict[tuple[ReductionAxes, ReductionAxes], TensorStatistic],
     ):
         for reduction_shape in reduction_shapes_vs_ref_statistic:
             collector_obj = collector(use_abs_max=True, reduction_shape=reduction_shape)
@@ -176,8 +175,8 @@ class TestCollectedStatistics:
     )
     def test_collected_statistics(
         self,
-        collector: Type[TensorStatisticCollectorBase],
-        reduction_shapes_vs_ref_statistic: Dict[ReductionAxes, TensorStatistic],
+        collector: type[TensorStatisticCollectorBase],
+        reduction_shapes_vs_ref_statistic: dict[ReductionAxes, TensorStatistic],
     ):
         for reduction_shape in reduction_shapes_vs_ref_statistic:
             collector_obj = collector(reduction_shape=reduction_shape)

--- a/tests/tensorflow/test_compressed_graph.py
+++ b/tests/tensorflow/test_compressed_graph.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 import os
-from typing import List
 
 import networkx as nx
 import pytest
@@ -181,7 +180,7 @@ class ModelDesc:
         model_builder,
         input_sample_sizes,
         rename_resource_nodes=False,
-        ignored_scopes: List[str] = None,
+        ignored_scopes: list[str] = None,
         unstable_node_names: bool = False,
     ):
         self.model_name, _ = os.path.splitext(ref_graph_filename)

--- a/tests/tensorflow/test_sota_checkpoints.py
+++ b/tests/tensorflow/test_sota_checkpoints.py
@@ -16,7 +16,7 @@ import sys
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import openvino as ov
 import pandas as pd
@@ -74,7 +74,7 @@ class EvalRunParamsStruct:
     target_ov: float
     metric_type: str
     dataset_name: str
-    dataset_types: List[str]
+    dataset_types: list[str]
     sample_type: str
     resume_file: Optional[Path]
     weights: Optional[str]
@@ -121,7 +121,7 @@ class ResultInfo:
         }
 
 
-def read_reference_file(ref_path: Path) -> List[EvalRunParamsStruct]:
+def read_reference_file(ref_path: Path) -> list[EvalRunParamsStruct]:
     """
     Reads the reference file to get a list of `EvalRunParamsStruct` objects.
 
@@ -261,7 +261,7 @@ class TestSotaCheckpoints:
         Fixture to collect information about tests in `ResultInfo` struct
         and dump it to `metrics_dump_dir / results.csv`.
         """
-        data: List[ResultInfo] = []
+        data: list[ResultInfo] = []
         yield data
         if metrics_dump_dir and data:
             path = metrics_dump_dir / "results.csv"
@@ -305,7 +305,7 @@ class TestSotaCheckpoints:
 
     def get_reference_fp32_metric(
         self, metrics_dump_path: Path, reference_name: str, dataset_type: Optional[str] = None
-    ) -> Tuple[Optional[float], bool]:
+    ) -> tuple[Optional[float], bool]:
         """
         Get reference metric to not compressed model.
         In case of exists reference data will get reference metric from it others reference data gets
@@ -353,7 +353,7 @@ class TestSotaCheckpoints:
     @staticmethod
     def get_weight_params(
         eval_test_struct: EvalRunParamsStruct, sota_checkpoints_dir: Path
-    ) -> Dict[str, Union[Path, bool]]:
+    ) -> dict[str, Union[Path, bool]]:
         if eval_test_struct.resume_file is not None:
             return {"resume_file_path": sota_checkpoints_dir / eval_test_struct.resume_file}
         elif eval_test_struct.weights:
@@ -386,7 +386,7 @@ class TestSotaCheckpoints:
         eval_test_struct: EvalRunParamsStruct,
         dataset_type: str,
         metrics_dump_dir: Path,
-        collected_data: List[ResultInfo],
+        collected_data: list[ResultInfo],
     ):
         if sota_data_dir is None:
             pytest.skip("Path to datasets is not set")
@@ -487,7 +487,7 @@ class TestSotaCheckpoints:
         sota_checkpoints_dir: Path,
         ov_data_dir: Path,
         openvino: bool,
-        collected_data: List[ResultInfo],
+        collected_data: list[ResultInfo],
     ):
         if not openvino:
             pytest.skip()

--- a/tests/torch/accuracy_aware_training/test_runner.py
+++ b/tests/torch/accuracy_aware_training/test_runner.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
 
 import pytest
 import torch
@@ -30,7 +29,7 @@ from tests.torch.sparsity.magnitude.test_helpers import get_basic_magnitude_spar
 
 def create_initialized_lenet_model_and_dataloader(
     config: NNCFConfig,
-) -> Tuple[nn.Module, DataLoader, CompressionAlgorithmController]:
+) -> tuple[nn.Module, DataLoader, CompressionAlgorithmController]:
     with set_torch_seed():
         train_loader = create_random_mock_dataloader(config, num_samples=10)
         model = LeNet()

--- a/tests/torch/experimental/search_building_blocks/test_search_building_blocks.py
+++ b/tests/torch/experimental/search_building_blocks/test_search_building_blocks.py
@@ -12,7 +12,7 @@
 import json
 import os
 from functools import partial
-from typing import Callable, List, Optional, Type, Union
+from typing import Callable, Optional, Union
 
 import pytest
 import torch
@@ -62,8 +62,8 @@ def check_blocks_and_groups(name, actual_blocks: BuildingBlocks, actual_group_de
 class BuildingBlockParamsCase:
     def __init__(
         self,
-        model_creator: Union[Type[torch.nn.Module], Callable[[], torch.nn.Module]],
-        input_sizes: List[int],
+        model_creator: Union[type[torch.nn.Module], Callable[[], torch.nn.Module]],
+        input_sizes: list[int],
         min_block_size: int = 5,
         max_block_size: int = 50,
         name: Optional[str] = None,

--- a/tests/torch/experimental/search_building_blocks/test_transformer_blocks.py
+++ b/tests/torch/experimental/search_building_blocks/test_transformer_blocks.py
@@ -12,7 +12,7 @@
 import json
 import os
 from functools import partial
-from typing import Callable, Dict, List, Optional, Set, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import pytest
@@ -59,7 +59,7 @@ def check_extended_blocks(name, actual_blocks: ExtendedBuildingBlocks):
 
 
 class TransformerSearchBBlockParamsCase:
-    def __init__(self, name: str, input_info: Union[List, Dict], model_creator: Callable[[], nn.Module]):
+    def __init__(self, name: str, input_info: Union[list, dict], model_creator: Callable[[], nn.Module]):
         self.input_info = input_info
         self.model_creator = model_creator
         self.name = name.lower().replace(" ", "_")
@@ -142,11 +142,11 @@ def test_transformer_building_blocks(desc: TransformerSearchBBlockParamsCase):
 class FilterBlockTestDesc:
     def __init__(
         self,
-        start_ids: List[int],
-        end_ids: List[int],
-        overlapping_blocks_ids_min: Optional[Set[int]] = None,
-        overlapping_blocks_ids_seq: Optional[Set[int]] = None,
-        num_ops_in_block: Optional[List[int]] = None,
+        start_ids: list[int],
+        end_ids: list[int],
+        overlapping_blocks_ids_min: Optional[set[int]] = None,
+        overlapping_blocks_ids_seq: Optional[set[int]] = None,
+        num_ops_in_block: Optional[list[int]] = None,
         name: Optional[str] = None,
     ):
         self.start_ids = start_ids

--- a/tests/torch/fx/helpers.py
+++ b/tests/torch/fx/helpers.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Tuple, Union
+from typing import Union
 
 import torch.fx
 import torch.nn.parallel
@@ -124,7 +124,7 @@ def visualize_fx_model(model: torch.fx.GraphModule, output_svg_path: str):
 
 
 def get_torch_fx_model(
-    model: torch.nn.Module, ex_input: Union[torch.Tensor, Tuple[torch.Tensor, ...]], dynamic_shapes=None
+    model: torch.nn.Module, ex_input: Union[torch.Tensor, tuple[torch.Tensor, ...]], dynamic_shapes=None
 ) -> torch.fx.GraphModule:
     """
     Converts given module to GraphModule.

--- a/tests/torch/fx/test_bias_correction.py
+++ b/tests/torch/fx/test_bias_correction.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import re
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 import openvino as ov
@@ -33,7 +33,7 @@ from tests.torch.fx.helpers import get_torch_fx_model_q_transformed
 
 class TestFXBCAlgorithm(TemplateTestBCAlgorithm):
     @staticmethod
-    def list_to_backend_type(data: List) -> torch.Tensor:
+    def list_to_backend_type(data: list) -> torch.Tensor:
         return torch.tensor(data)
 
     @staticmethod
@@ -56,7 +56,7 @@ class TestFXBCAlgorithm(TemplateTestBCAlgorithm):
         return transform_fn
 
     @staticmethod
-    def map_references(ref_biases: Dict, model_cls: Any) -> Dict[str, List]:
+    def map_references(ref_biases: dict, model_cls: Any) -> dict[str, list]:
         if model_cls is ConvTestModel or model_cls is DepthwiseConvTestModel:
             return {"conv2d": ref_biases["/conv/Conv"]}
         if model_cls is TransposeConvTestModel:
@@ -76,7 +76,7 @@ class TestFXBCAlgorithm(TemplateTestBCAlgorithm):
         return remove_fq_from_inputs(model, graph)
 
     @staticmethod
-    def check_bias(model: ov.Model, ref_biases: Dict) -> None:
+    def check_bias(model: ov.Model, ref_biases: dict) -> None:
         nncf_graph = NNCFGraphFactory.create(model)
         for ref_name, ref_value in ref_biases.items():
             node = nncf_graph.get_node_by_name(ref_name)

--- a/tests/torch/fx/test_compress_weights.py
+++ b/tests/torch/fx/test_compress_weights.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict
 
 import pytest
 import torch
@@ -60,7 +59,7 @@ def get_model_size(model):
 
 
 def get_compressed_modules_weights(
-    compressed_model: torch.fx.GraphModule, dtype: torch.dtype, compressed_node_weight_port: Dict[str, int]
+    compressed_model: torch.fx.GraphModule, dtype: torch.dtype, compressed_node_weight_port: dict[str, int]
 ):
     n_target_modules = 0
     n_compressed_weights = 0

--- a/tests/torch/fx/test_fast_bias_correction.py
+++ b/tests/torch/fx/test_fast_bias_correction.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 
 import pytest
 import torch
@@ -24,7 +23,7 @@ from tests.torch.fx.helpers import get_torch_fx_model_q_transformed
 
 class TestTorchFXFBCAlgorithm(TemplateTestFBCAlgorithm):
     @staticmethod
-    def list_to_backend_type(data: List) -> torch.Tensor:
+    def list_to_backend_type(data: list) -> torch.Tensor:
         return torch.Tensor(data)
 
     @staticmethod
@@ -68,7 +67,7 @@ class TestTorchFXFBCAlgorithm(TemplateTestFBCAlgorithm):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skipping for CPU-only setups")
 class TestTorchFXCudaFBCAlgorithm(TestTorchFXFBCAlgorithm):
     @staticmethod
-    def list_to_backend_type(data: List) -> torch.Tensor:
+    def list_to_backend_type(data: list) -> torch.Tensor:
         return torch.Tensor(data).cuda()
 
     @staticmethod

--- a/tests/torch/fx/test_min_max.py
+++ b/tests/torch/fx/test_min_max.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
 
 import pytest
 
@@ -46,7 +45,7 @@ class TestTorchFXMinMaxAlgorithm(TemplateTestMinMaxAlgorithm):
 
 
 class TestTorchFXGetTargetPointShape(TemplateTestGetTargetPointShape, TestTorchFXMinMaxAlgorithm):
-    def get_nncf_graph(self, weight_port_id: int, weight_shape: Tuple[int]) -> NNCFGraph:
+    def get_nncf_graph(self, weight_port_id: int, weight_shape: tuple[int]) -> NNCFGraph:
         return NNCFGraphToTest(
             conv_metatype=PTConv2dMetatype, nncf_graph_cls=PTNNCFGraph, const_metatype=PTConstNoopMetatype
         ).nncf_graph
@@ -62,18 +61,18 @@ class TestTorchFXGetChannelAxes(TemplateTestGetChannelAxes, TestTorchFXMinMaxAlg
         return PTLinearMetatype
 
     @staticmethod
-    def get_conv_node_attrs(weight_port_id: int, weight_shape: Tuple[int]) -> BaseLayerAttributes:
+    def get_conv_node_attrs(weight_port_id: int, weight_shape: tuple[int]) -> BaseLayerAttributes:
         # This method isn't needed for Torch FX backend
         return None
 
     @staticmethod
-    def get_depthwiseconv_node_attrs(weight_port_id: int, weight_shape: Tuple[int]) -> BaseLayerAttributes:
+    def get_depthwiseconv_node_attrs(weight_port_id: int, weight_shape: tuple[int]) -> BaseLayerAttributes:
         # This method isn't needed for Torch FX backend
         return None
 
     @staticmethod
     def get_matmul_node_attrs(
-        weight_port_id: int, transpose_weight: Tuple[int], weight_shape: Tuple[int]
+        weight_port_id: int, transpose_weight: tuple[int], weight_shape: tuple[int]
     ) -> BaseLayerAttributes:
         # This method isn't needed for Torch FX backend
         return None

--- a/tests/torch/fx/test_model_transformer.py
+++ b/tests/torch/fx/test_model_transformer.py
@@ -12,7 +12,7 @@
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any
 
 import pytest
 import torch
@@ -62,7 +62,7 @@ from tests.torch.test_models.synthetic import ScalarCloneTestModel
 @dataclass
 class ModelExtractionTestCase:
     model: torch.nn.Module
-    input_shape: Tuple[int, ...]
+    input_shape: tuple[int, ...]
     command: PTModelExtractionCommand
 
 

--- a/tests/torch/fx/test_models.py
+++ b/tests/torch/fx/test_models.py
@@ -14,7 +14,7 @@ import os
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import Callable, Dict, List, Tuple, Type, Union
+from typing import Callable, Union
 
 import openvino.torch  # noqa
 import pytest
@@ -59,10 +59,10 @@ FX_DYNAMIC_QUANTIZED_COMPRESSED_DIR_NAME = FX_DYNAMIC_DIR / "post_quantization_c
 class ModelCase:
     model_builder: Callable[[], torch.nn.Module]
     model_id: str
-    input_shape: Tuple[int]
+    input_shape: tuple[int]
 
 
-def torchvision_model_case(model_id: str, input_shape: Tuple[int,]):
+def torchvision_model_case(model_id: str, input_shape: tuple[int,]):
     model = getattr(models, model_id)
     return ModelCase(partial(model, weights=None), model_id, input_shape)
 
@@ -94,8 +94,8 @@ def get_full_path_to_json(model_json_name: str, attributes: bool = False) -> str
 
 
 def get_ref_from_json(
-    model_name: str, model_metatypes: Dict[NNCFNodeName, Union[Type[OperatorMetatype], bool]], attributes=False
-) -> Dict[NNCFNodeName, Union[Type[OperatorMetatype], bool]]:
+    model_name: str, model_metatypes: dict[NNCFNodeName, Union[type[OperatorMetatype], bool]], attributes=False
+) -> dict[NNCFNodeName, Union[type[OperatorMetatype], bool]]:
     model_json_name = get_json_filename(model_name)
     complete_path = get_full_path_to_json(model_json_name, attributes)
 
@@ -195,7 +195,7 @@ def test_quantized_model(
     compress_weights: bool,
     compress_n_qdq: int,
     enable_dynamic_shapes: bool,
-    dynamic_shape_config: List[bool],
+    dynamic_shape_config: list[bool],
 ):
     model = model_case.model_builder()
     dtype = torch.int32 if model_case.model_id == "synthetic_transformer" else torch.float32

--- a/tests/torch/fx/test_quantizer.py
+++ b/tests/torch/fx/test_quantizer.py
@@ -12,7 +12,7 @@
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, Tuple
+from typing import Any, Callable
 
 import pytest
 import torch
@@ -49,10 +49,10 @@ FX_QUANTIZED_DIR_NAME = Path("fx") / "experimental"
 class ModelCase:
     model_builder: Callable[[], torch.nn.Module]
     model_id: str
-    input_shape: Tuple[int]
+    input_shape: tuple[int]
 
 
-def torchvision_model_case(model_id: str, input_shape: Tuple[int,]):
+def torchvision_model_case(model_id: str, input_shape: tuple[int,]):
     model = getattr(models, model_id)
     return ModelCase(partial(model, weights=None), model_id, input_shape)
 
@@ -98,7 +98,7 @@ TEST_MODELS_QUANIZED = (
 )
 
 
-def _build_torch_fx_model(model_case: ModelCase) -> Tuple[torch.fx.GraphModule, torch.Tensor]:
+def _build_torch_fx_model(model_case: ModelCase) -> tuple[torch.fx.GraphModule, torch.Tensor]:
     model = model_case.model_builder()
     dtype = torch.int32 if model_case.model_id == "synthetic_transformer" else torch.float32
     example_input = torch.ones(model_case.input_shape, dtype=dtype)
@@ -122,7 +122,7 @@ def _get_calibration_dataset(example_input: torch.Tensor) -> nncf.Dataset:
     "quantizer_builder", [get_x86_quantizer, get_openvino_quantizer], ids=["X86InductorQuantizer", "OpenVINOQuantizer"]
 )
 def test_quantized_model(
-    quantizer_builder: Callable[[Tuple[Any, ...]], Quantizer],
+    quantizer_builder: Callable[[tuple[Any, ...]], Quantizer],
     model_case: ModelCase,
     quantizer_params,
     pt2e_params,
@@ -201,8 +201,8 @@ TorchAOSharedQuantizationSpecTestCases = (
 )
 def test_OVQuantizer_TorchAOSharedQuantizationSpec_handling(
     model_case: ModelCase,
-    unified_scale_node_names: Tuple[str, str],
-    ref_fq_params: Tuple[float, int, int, int, torch.dtype],
+    unified_scale_node_names: tuple[str, str],
+    ref_fq_params: tuple[float, int, int, int, torch.dtype],
 ):
     model_case.model_builder()(torch.ones(model_case.input_shape))
     fx_model, example_input = _build_torch_fx_model(model_case)

--- a/tests/torch/fx/test_sanity.py
+++ b/tests/torch/fx/test_sanity.py
@@ -11,7 +11,6 @@
 
 
 from dataclasses import dataclass
-from typing import Tuple
 
 import numpy as np
 import openvino.torch  # noqa
@@ -88,7 +87,7 @@ def validate(val_loader: torch.utils.data.DataLoader, model: torch.nn.Module, de
     return top1_avg
 
 
-def accuracy(output: torch.Tensor, target: torch.tensor, topk: Tuple[int, ...] = (1,)):
+def accuracy(output: torch.Tensor, target: torch.tensor, topk: tuple[int, ...] = (1,)):
     with torch.no_grad():
         maxk = max(topk)
         batch_size = target.size(0)

--- a/tests/torch/fx/test_smooth_quant.py
+++ b/tests/torch/fx/test_smooth_quant.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, Type
+from typing import Any, Callable
 
 import numpy as np
 import openvino as ov
@@ -50,7 +50,7 @@ class TestTorchSQAlgorithm(TemplateTestSQAlgorithm):
     def inplace_statistics(self, request) -> bool:
         return request.param
 
-    def get_node_name_map(self, model_cls) -> Dict[str, str]:
+    def get_node_name_map(self, model_cls) -> dict[str, str]:
         if model_cls is LinearMultiShapeModel:
             return PT_LINEAR_MODEL_MM_MAP
         if model_cls is ConvTestModel:
@@ -90,7 +90,7 @@ class TestTorchSQAlgorithm(TemplateTestSQAlgorithm):
         return transform_fn
 
     @staticmethod
-    def get_backend() -> Type[FXSmoothQuantAlgoBackend]:
+    def get_backend() -> type[FXSmoothQuantAlgoBackend]:
         return FXSmoothQuantAlgoBackend()
 
     @staticmethod
@@ -98,7 +98,7 @@ class TestTorchSQAlgorithm(TemplateTestSQAlgorithm):
         return get_torch_fx_model_q_transformed(model, torch.ones(model.INPUT_SIZE))
 
     @staticmethod
-    def check_scales(model: torch.nn.Module, reference_values: Dict[str, np.ndarray], model_cls) -> None:
+    def check_scales(model: torch.nn.Module, reference_values: dict[str, np.ndarray], model_cls) -> None:
         names_map = PT_LINEAR_MODEL_MM_MAP if model_cls is LinearMultiShapeModel else PT_CONV_MODEL_MM_MAP
         ops_list = {node.name: node for node in model.graph.nodes}
         for ref_names, ref_value in reference_values.items():

--- a/tests/torch/fx/test_statistics_aggregator.py
+++ b/tests/torch/fx/test_statistics_aggregator.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Type
 
 import numpy as np
 import pytest
@@ -47,13 +46,13 @@ class IdentityConv(nn.Module):
 
 class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
     @staticmethod
-    def get_min_max_algo_backend_cls() -> Type[FXMinMaxAlgoBackend]:
+    def get_min_max_algo_backend_cls() -> type[FXMinMaxAlgoBackend]:
         return FXMinMaxAlgoBackend
 
     def get_bias_correction_algo_backend_cls(self) -> None:
         pytest.skip("FXBiasCorrectionAlgoBackend is not implemented")
 
-    def get_fast_bias_correction_algo_backend_cls(self) -> Type[FXFastBiasCorrectionAlgoBackend]:
+    def get_fast_bias_correction_algo_backend_cls(self) -> type[FXFastBiasCorrectionAlgoBackend]:
         return FXFastBiasCorrectionAlgoBackend
 
     def get_backend_model(self, dataset_samples):
@@ -104,7 +103,7 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
     def is_backend_support_custom_estimators(self) -> bool:
         return True
 
-    def reducers_map(self) -> List[TensorReducerBase]:
+    def reducers_map(self) -> list[TensorReducerBase]:
         return None
 
     @pytest.mark.skip("Merging is not implemented yet")

--- a/tests/torch/helpers.py
+++ b/tests/torch/helpers.py
@@ -16,7 +16,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Tuple, TypeVar, Union
+from typing import Any, Callable, TypeVar, Union
 
 import numpy as np
 import onnx
@@ -365,7 +365,7 @@ class SharedCustomConv(nn.Module):
 
 
 def get_empty_config(
-    model_size=4, input_sample_sizes: Union[Tuple[List[int]], List[int]] = None, input_info: Dict = None
+    model_size=4, input_sample_sizes: Union[tuple[list[int]], list[int]] = None, input_info: dict = None
 ) -> NNCFConfig:
     if input_sample_sizes is None:
         input_sample_sizes = [1, 1, 4, 4]
@@ -386,7 +386,7 @@ def get_empty_config(
     return config
 
 
-def get_grads(variables: List[nn.Parameter]) -> List[torch.Tensor]:
+def get_grads(variables: list[nn.Parameter]) -> list[torch.Tensor]:
     return [var.grad.clone() for var in variables]
 
 
@@ -405,9 +405,9 @@ def create_compressed_model_and_algo_for_test(
     model: Module,
     config: NNCFConfig = None,
     dummy_forward_fn: Callable[[Module], Any] = None,
-    wrap_inputs_fn: Callable[[Tuple, Dict], Tuple[Tuple, Dict]] = None,
-    compression_state: Dict[str, Any] = None,
-) -> Tuple[NNCFNetwork, PTCompressionAlgorithmController]:
+    wrap_inputs_fn: Callable[[tuple, dict], tuple[tuple, dict]] = None,
+    compression_state: dict[str, Any] = None,
+) -> tuple[NNCFNetwork, PTCompressionAlgorithmController]:
     if config is not None:
         assert isinstance(config, NNCFConfig)
         NNCFConfig.validate(config)
@@ -426,8 +426,8 @@ def create_nncf_model_and_single_algo_builder(
     model: Module,
     config: NNCFConfig,
     dummy_forward_fn: Callable[[Module], Any] = None,
-    wrap_inputs_fn: Callable[[Tuple, Dict], Tuple[Tuple, Dict]] = None,
-) -> Tuple[NNCFNetwork, PTCompressionAlgorithmController]:
+    wrap_inputs_fn: Callable[[tuple, dict], tuple[tuple, dict]] = None,
+) -> tuple[NNCFNetwork, PTCompressionAlgorithmController]:
     assert isinstance(config, NNCFConfig)
     NNCFConfig.validate(config)
     input_info = FillerInputInfo.from_nncf_config(config)
@@ -496,7 +496,7 @@ class ModelWithReloadedForward(nn.Module):
 
 def check_correct_nncf_modules_replacement(
     model: torch.nn.Module, compressed_model: NNCFNetwork
-) -> Tuple[Dict[Scope, Module], Dict[Scope, Module]]:
+) -> tuple[dict[Scope, Module], dict[Scope, Module]]:
     """
     Checks that all extendable modules in model were replaced by NNCF-extended counterparts.
     :param model: original model
@@ -514,13 +514,13 @@ def check_correct_nncf_modules_replacement(
 
 
 class BaseDatasetMock(Dataset, ABC):
-    def __init__(self, input_size: Tuple, num_samples: int = 10):
+    def __init__(self, input_size: tuple, num_samples: int = 10):
         super().__init__()
         self._input_size = input_size
         self._len = num_samples
 
     @abstractmethod
-    def __getitem__(self, index: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    def __getitem__(self, index: int) -> tuple[torch.Tensor, torch.Tensor]:
         pass
 
     def __len__(self) -> int:
@@ -528,7 +528,7 @@ class BaseDatasetMock(Dataset, ABC):
 
 
 class OnesDatasetMock(BaseDatasetMock):
-    def __getitem__(self, index: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    def __getitem__(self, index: int) -> tuple[torch.Tensor, torch.Tensor]:
         return torch.ones(self._input_size), torch.ones(1)
 
 
@@ -561,7 +561,7 @@ def create_random_mock_dataloader(config: NNCFConfig, num_samples: int = 1, batc
 
 
 # ONNX graph helpers
-def get_nodes_by_type(onnx_model: onnx.ModelProto, node_type: str) -> List[onnx.NodeProto]:
+def get_nodes_by_type(onnx_model: onnx.ModelProto, node_type: str) -> list[onnx.NodeProto]:
     retval = []
     for node in onnx_model.graph.node:
         if str(node.op_type) == node_type:
@@ -569,7 +569,7 @@ def get_nodes_by_type(onnx_model: onnx.ModelProto, node_type: str) -> List[onnx.
     return retval
 
 
-def get_all_inputs_for_graph_node(node: onnx.NodeProto, graph: onnx.GraphProto) -> Dict[str, onnx.AttributeProto]:
+def get_all_inputs_for_graph_node(node: onnx.NodeProto, graph: onnx.GraphProto) -> dict[str, onnx.AttributeProto]:
     retval = {}
     for input_ in node.input:
         constant_input_nodes = [x for x in graph.node if input_ in x.output and x.op_type == "Constant"]
@@ -590,7 +590,7 @@ def get_all_inputs_for_graph_node(node: onnx.NodeProto, graph: onnx.GraphProto) 
 
 def resolve_constant_node_inputs_to_values(
     node: onnx.NodeProto, graph: onnx.GraphProto
-) -> Dict[str, onnx.AttributeProto]:
+) -> dict[str, onnx.AttributeProto]:
     retval = {}
     for input_ in node.input:
         constant_input_nodes = [x for x in graph.node if input_ in x.output and x.op_type == "Constant"]
@@ -687,7 +687,7 @@ class HookChecker:
 
     def add_ref(
         self,
-        ref_hooks: List[callable],
+        ref_hooks: list[callable],
         target_type: TargetType,
         target_node_name: str,
         input_port_id: int,
@@ -750,7 +750,7 @@ class HookChecker:
         self._ref_hooks.clear()
 
     @staticmethod
-    def _check_weight_update_hooks(ref_hooks: Dict[torch.nn.Module, List[HookType]]):
+    def _check_weight_update_hooks(ref_hooks: dict[torch.nn.Module, list[HookType]]):
         for target_module, ref_hooks_per_module in ref_hooks.items():
             assert len(target_module.pre_ops) == len(ref_hooks_per_module)
             for actual_op, ref_op in zip(target_module.pre_ops.values(), ref_hooks_per_module):
@@ -758,14 +758,14 @@ class HookChecker:
                 assert actual_op.op is ref_op
 
     @staticmethod
-    def _check_pre_post_op_hooks(hooks: List[torch.ModuleDict], ref_hooks: List[HookType]):
+    def _check_pre_post_op_hooks(hooks: list[torch.ModuleDict], ref_hooks: list[HookType]):
         assert len(hooks) == len(ref_hooks)
         for actual_hook, ref_hook in zip(hooks.values(), ref_hooks):
             assert actual_hook is ref_hook
 
     @staticmethod
     def _check_pre_post_hooks(
-        hooks: Dict[OperationAddress, Dict[Any, HookType]], ref_hooks: Dict[OperationAddress, List[HookType]]
+        hooks: dict[OperationAddress, dict[Any, HookType]], ref_hooks: dict[OperationAddress, list[HookType]]
     ):
         assert len(hooks) == len(ref_hooks)
         for op_address, ref_hooks in ref_hooks.items():
@@ -776,7 +776,7 @@ class HookChecker:
 
 
 class LinearModel(nn.Module):
-    def __init__(self, input_shape=List[int]):
+    def __init__(self, input_shape=list[int]):
         super().__init__()
         with set_torch_seed():
             self.linear = nn.Linear(input_shape[1], input_shape[0], bias=False)

--- a/tests/torch/models_hub_test/common.py
+++ b/tests/torch/models_hub_test/common.py
@@ -13,7 +13,7 @@ from abc import ABC
 from abc import abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import networkx as nx
 import pytest
@@ -25,13 +25,13 @@ import nncf
 from nncf.common.graph import NNCFGraph
 from nncf.torch.model_creation import wrap_model
 
-ExampleType = Union[Tuple[torch.Tensor, ...], List[torch.Tensor], Dict[str, torch.Tensor]]
+ExampleType = Union[tuple[torch.Tensor, ...], list[torch.Tensor], dict[str, torch.Tensor]]
 
 
 @pytest.mark.models_hub
 class BaseTestModel(ABC):
     @abstractmethod
-    def load_model(self, model_name: str) -> Tuple[nn.Module, ExampleType]:
+    def load_model(self, model_name: str) -> tuple[nn.Module, ExampleType]:
         """
         Load model by name and create example of input.
 
@@ -89,7 +89,7 @@ def idfn(val):
     return None
 
 
-def get_models_list(path: Path) -> List[ModelInfo]:
+def get_models_list(path: Path) -> list[ModelInfo]:
     """
     Get list of test model from file.
 
@@ -125,7 +125,7 @@ def get_models_list(path: Path) -> List[ModelInfo]:
     return models
 
 
-def get_model_params(path: Path) -> List[Union[ModelInfo, ParameterSet]]:
+def get_model_params(path: Path) -> list[Union[ModelInfo, ParameterSet]]:
     """
     Get test cases from the file.
 

--- a/tests/torch/models_hub_test/test_hf_transformers.py
+++ b/tests/torch/models_hub_test/test_hf_transformers.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Tuple
 
 import pytest
 import torch
@@ -27,7 +26,7 @@ from tests.torch.models_hub_test.common import idfn
 MODEL_LIST_FILE = Path(__file__).parent / "hf_transformers_models.txt"
 
 
-def filter_example(model: nn.Module, example: ExampleType) -> Tuple[nn.Module, ExampleType]:
+def filter_example(model: nn.Module, example: ExampleType) -> tuple[nn.Module, ExampleType]:
     """
     Filter example of input by signature of the model.
 
@@ -60,7 +59,7 @@ def fixture_image(request):
 
 
 class TestTransformersModel(BaseTestModel):
-    def load_model(self, name: str) -> Tuple[nn.Module, ExampleType]:
+    def load_model(self, name: str) -> tuple[nn.Module, ExampleType]:
         torch.manual_seed(0)
 
         mi = model_info(name)

--- a/tests/torch/models_hub_test/test_timm.py
+++ b/tests/torch/models_hub_test/test_timm.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Tuple
 
 import pytest
 import timm
@@ -27,7 +26,7 @@ MODEL_LIST_FILE = Path(__file__).parent / "timm_models.txt"
 
 
 class TestTimmModel(BaseTestModel):
-    def load_model(self, model_name: str) -> Tuple[nn.Module, ExampleType]:
+    def load_model(self, model_name: str) -> tuple[nn.Module, ExampleType]:
         m = timm.create_model(model_name, pretrained=False)
         cfg = timm.get_pretrained_cfg(model_name)
         shape = [1] + list(cfg.input_size)

--- a/tests/torch/models_hub_test/test_torchvision_models.py
+++ b/tests/torch/models_hub_test/test_torchvision_models.py
@@ -11,7 +11,6 @@
 
 import tempfile
 from pathlib import Path
-from typing import Tuple
 
 import pytest
 import torch
@@ -58,7 +57,7 @@ def prepare_frames_for_raft(name, frames1, frames2):
 
 
 class TestTorchHubModel(BaseTestModel):
-    def load_model(self, model_name: str) -> Tuple[nn.Module, ExampleType]:
+    def load_model(self, model_name: str) -> tuple[nn.Module, ExampleType]:
         torch.manual_seed(0)
         m = torch.hub.load("pytorch/vision", model_name, weights=None, skip_validation=True)
         m.eval()

--- a/tests/torch/modules/test_rnn.py
+++ b/tests/torch/modules/test_rnn.py
@@ -14,7 +14,6 @@ import os
 import sys
 from collections import namedtuple
 from functools import partial
-from typing import List, Tuple
 
 import onnx
 import pytest
@@ -56,7 +55,7 @@ def replace_lstm(model):
             bias=module_.bias,
         )
 
-        def get_param_names(bias: bool) -> List[str]:
+        def get_param_names(bias: bool) -> list[str]:
             suffixes = ["ih", "hh"]
             names = ["weight_" + suffix for suffix in suffixes]
             if bias:
@@ -85,7 +84,7 @@ def replace_lstm(model):
     return model
 
 
-def clone_test_data(data_list) -> List[torch.Tensor]:
+def clone_test_data(data_list) -> list[torch.Tensor]:
     results = []
     x = data_list[0]
     result = x if isinstance(x, PackedSequence) else x.clone()
@@ -385,11 +384,11 @@ class TestLSTM:
             torch.testing.assert_close(test, ref, rtol=1e-1, atol=1e-1)
 
     @classmethod
-    def flatten_nested_lists(cls, nested_list: List) -> List[torch.Tensor]:
+    def flatten_nested_lists(cls, nested_list: list) -> list[torch.Tensor]:
         return [tensor for tensor_tuple in nested_list for tensor in tensor_tuple]
 
     @classmethod
-    def get_test_lstm_hidden(cls, data: LSTMTestData) -> List[Tuple[torch.Tensor, ...]]:
+    def get_test_lstm_hidden(cls, data: LSTMTestData) -> list[tuple[torch.Tensor, ...]]:
         result = []
         hidden_names = ["h0", "c0"]
         for name in hidden_names:
@@ -402,7 +401,7 @@ class TestLSTM:
         return result
 
     @classmethod
-    def get_ref_lstm_hidden(cls, data: LSTMTestData) -> Tuple[torch.Tensor, torch.Tensor]:
+    def get_ref_lstm_hidden(cls, data: LSTMTestData) -> tuple[torch.Tensor, torch.Tensor]:
         hidden = cls.get_test_lstm_hidden(data)
         hidden_states = [torch.unsqueeze(tensor, dim=0) for tensor in hidden[0]]
         cell_states = [torch.unsqueeze(tensor, dim=0) for tensor in hidden[1]]
@@ -422,7 +421,7 @@ class TestLSTM:
                     getattr(nn_lstm, param_name).data.copy_(param[i].data)
 
     @classmethod
-    def get_param_names(cls, bias: bool) -> List[str]:
+    def get_param_names(cls, bias: bool) -> list[str]:
         suffixes = ["ih", "hh"]
         names = ["weight_" + suffix for suffix in suffixes]
         if bias:

--- a/tests/torch/nas/creators.py
+++ b/tests/torch/nas/creators.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Optional
 
 import torch
 
@@ -47,7 +47,7 @@ from tests.torch.test_models import mobilenet_v3_small
 # TODO(nlyalyus) reduce number of creators and descriptors. create wrapper of TrainingAlgorithm  (ticket 81015)
 def create_bootstrap_training_model_and_ctrl(
     model, nncf_config: NNCFConfig, register_bn_adapt: bool = True
-) -> Tuple[NNCFNetwork, BNASTrainingController]:
+) -> tuple[NNCFNetwork, BNASTrainingController]:
     algo_name = nncf_config.get("bootstrapNAS", {}).get("training", {}).get("algorithm", "progressive_shrinking")
     nncf_network = create_nncf_network(model, nncf_config)
     if register_bn_adapt:
@@ -110,7 +110,7 @@ NAS_MODEL_DESCS = {
 }
 
 
-def create_bootstrap_nas_training_algo(model_name) -> Tuple[NNCFNetwork, ProgressiveShrinkingController, Callable]:
+def create_bootstrap_nas_training_algo(model_name) -> tuple[NNCFNetwork, ProgressiveShrinkingController, Callable]:
     model = NAS_MODEL_DESCS[model_name][0]()
     nncf_config = get_empty_config(input_sample_sizes=NAS_MODEL_DESCS[model_name][1])
     nncf_config["bootstrapNAS"] = {"training": {"algorithm": "progressive_shrinking"}}
@@ -123,8 +123,8 @@ def create_bootstrap_nas_training_algo(model_name) -> Tuple[NNCFNetwork, Progres
 
 
 def create_supernet(
-    model_creator: Callable, input_sample_sizes: List[int], elasticity_params: Optional[Dict[str, Any]] = None
-) -> Tuple[MultiElasticityHandler, NNCFNetwork]:
+    model_creator: Callable, input_sample_sizes: list[int], elasticity_params: Optional[dict[str, Any]] = None
+) -> tuple[MultiElasticityHandler, NNCFNetwork]:
     params = {} if elasticity_params is None else elasticity_params
     config = get_empty_config(input_sample_sizes=input_sample_sizes)
     config["bootstrapNAS"] = {"training": {"elasticity": params}}
@@ -135,7 +135,7 @@ def create_supernet(
 
 def create_single_conv_kernel_supernet(
     kernel_size=5, out_channels=1, padding=2
-) -> Tuple[ElasticKernelHandler, NNCFNetwork]:
+) -> tuple[ElasticKernelHandler, NNCFNetwork]:
     params = {"available_elasticity_dims": [ElasticityDim.KERNEL.value]}
     model_creator = partial(BasicConvTestModel, 1, out_channels=out_channels, kernel_size=kernel_size, padding=padding)
     input_sample_sizes = [1, 1, kernel_size, kernel_size]

--- a/tests/torch/nas/descriptors.py
+++ b/tests/torch/nas/descriptors.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple
+from typing import Any, Callable, NamedTuple, Optional
 
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.base_handler import SingleElasticityBuilder
 from nncf.experimental.torch.nas.bootstrapNAS.elasticity.base_handler import create_elasticity_builder_from_config
@@ -25,10 +25,10 @@ class ElasticityDesc:
         self,
         elasticity_dim: ElasticityDim,
         model_cls: Optional[Callable] = None,
-        ref_state: Optional[Dict[str, Any]] = None,
+        ref_state: Optional[dict[str, Any]] = None,
         name: Optional[str] = None,
-        params: Dict[str, Any] = None,
-        input_size: Optional[List[int]] = None,
+        params: dict[str, Any] = None,
+        input_size: Optional[list[int]] = None,
         ref_search_space: Optional[Any] = None,
         ref_output_fn: Optional[Callable] = None,
     ):
@@ -64,7 +64,7 @@ class ElasticityDesc:
     def create_builder(self) -> SingleElasticityBuilder:
         return create_elasticity_builder_from_config(self.params, self.elasticity_dim)
 
-    def create_builder_with_config(self, config: Dict[str, Any]) -> SingleElasticityBuilder:
+    def create_builder_with_config(self, config: dict[str, Any]) -> SingleElasticityBuilder:
         return create_elasticity_builder_from_config(config, self.elasticity_dim)
 
 
@@ -90,7 +90,7 @@ class ModelStats(NamedTuple):
     flops: int
     num_weights: int
 
-    def __eq__(self, other: Tuple[int, int]):
+    def __eq__(self, other: tuple[int, int]):
         return other[0] == self.flops and other[1] == self.num_weights
 
 
@@ -104,9 +104,9 @@ class RefModelStats(NamedTuple):
 class MultiElasticityTestDesc(NamedTuple):
     model_creator: Any
     ref_model_stats: RefModelStats = None
-    blocks_to_skip: List[List[str]] = None
-    input_sizes: List[int] = [1, 3, 32, 32]
-    algo_params: Dict = {}
+    blocks_to_skip: list[list[str]] = None
+    input_sizes: list[int] = [1, 3, 32, 32]
+    algo_params: dict = {}
     name: str = None
 
     def __str__(self):

--- a/tests/torch/nas/test_elastic_depth.py
+++ b/tests/torch/nas/test_elastic_depth.py
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 import onnx
@@ -79,7 +79,7 @@ class DepthBasicConvTestModel(nn.Module):
         output = self.last_conv(output)
         return output
 
-    def set_skipped_layers(self, skipped_layers: Optional[List] = None):
+    def set_skipped_layers(self, skipped_layers: Optional[list] = None):
         if skipped_layers is None:
             skipped_layers = []
         self._skipped_layers = skipped_layers

--- a/tests/torch/nas/test_ps_controller.py
+++ b/tests/torch/nas/test_ps_controller.py
@@ -11,7 +11,7 @@
 from copy import deepcopy
 from functools import partial
 from functools import reduce
-from typing import Any, Dict, List, NamedTuple
+from typing import Any, NamedTuple
 
 import pytest
 import torch
@@ -31,9 +31,9 @@ from tests.torch.nas.test_scheduler import fixture_schedule_params  # noqa: F401
 
 class PSControllerTestDesc(NamedTuple):
     model_creator: Any
-    blocks_to_skip: List[List[str]] = None
-    input_sizes: List[int] = [1, 3, 32, 32]
-    algo_params: Dict = {}
+    blocks_to_skip: list[list[str]] = None
+    input_sizes: list[int] = [1, 3, 32, 32]
+    algo_params: dict = {}
     name: str = None
     mode: str = "auto"
 

--- a/tests/torch/nas/test_sanity_sample.py
+++ b/tests/torch/nas/test_sanity_sample.py
@@ -11,7 +11,6 @@
 
 import importlib
 from pathlib import Path
-from typing import Dict
 
 import pytest
 
@@ -52,7 +51,7 @@ class NASSampleTestDescriptor(SanityTestCaseDescriptor):
     def get_compression_section(self):
         pass
 
-    def get_config_update(self) -> Dict:
+    def get_config_update(self) -> dict:
         sample_params = self.get_sample_params()
         sample_params["num_mock_images"] = 2
         sample_params["epochs"] = 5

--- a/tests/torch/nas/test_scheduler.py
+++ b/tests/torch/nas/test_scheduler.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 from collections import OrderedDict
 from functools import partial
-from typing import List
 
 import pytest
 
@@ -200,9 +199,9 @@ class TestScheduler:
 class SchedulerTestDesc:
     def __init__(
         self,
-        list_stage_dims: List[List[ElasticityDim]],
-        progressivity_of_elasticity: List[ElasticityDim],
-        available_elasticity_dims: List[ElasticityDim],
+        list_stage_dims: list[list[ElasticityDim]],
+        progressivity_of_elasticity: list[ElasticityDim],
+        available_elasticity_dims: list[ElasticityDim],
         name: str = "",
         error_in_scheduler: bool = False,
         error_in_builder: bool = False,

--- a/tests/torch/nas/test_search.py
+++ b/tests/torch/nas/test_search.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, NamedTuple
+from typing import Any, NamedTuple
 
 import pytest
 import torch
@@ -39,9 +39,9 @@ def fixture_search_algo_name(request):
 class SearchTestDesc(NamedTuple):
     model_creator: Any
     # ref_model_stats: RefModelStats = None
-    blocks_to_skip: List[List[str]] = None
-    input_sizes: List[int] = [1, 3, 32, 32]
-    algo_params: Dict = {}
+    blocks_to_skip: list[list[str]] = None
+    input_sizes: list[int] = [1, 3, 32, 32]
+    algo_params: dict = {}
     name: str = None
     mode: str = "auto"
 
@@ -199,10 +199,10 @@ class TestSearchAlgorithm:
 class SearchTestResultDesc(NamedTuple):
     model_creator: Any
     expected_accuracy: float
-    subnet_expected_accuracy: Dict
-    input_sizes: List[int]
-    search_spaces: Dict
-    eval_datasets: List
+    subnet_expected_accuracy: dict
+    input_sizes: list[int]
+    search_spaces: dict
+    eval_datasets: list
 
 
 SEARCH_RESULT_DESCRIPTORS = [

--- a/tests/torch/nas/test_search_space.py
+++ b/tests/torch/nas/test_search_space.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from functools import partial
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, NamedTuple, Optional
 
 import pytest
 
@@ -41,8 +41,8 @@ LIST_KERNEL_SS_DESCS = [
 
 class WidthSearchSpaceParams(NamedTuple):
     max_out_channels: int
-    params: Optional[Dict[str, Any]]
-    list_output_channels: List[int]
+    params: Optional[dict[str, Any]]
+    list_output_channels: list[int]
     width_indicator: int = -1
 
     def __str__(self):

--- a/tests/torch/nncf_network/helpers.py
+++ b/tests/torch/nncf_network/helpers.py
@@ -11,7 +11,7 @@
 
 import functools
 import itertools
-from typing import Optional, Type
+from typing import Optional
 
 import torch
 
@@ -61,7 +61,7 @@ class InsertionCommandBuilder:
 
     AVAILABLE_MODELS = (TwoConvTestModel, TwoSharedConvTestModel)
 
-    def __init__(self, model_cls: Type[torch.nn.Module]):
+    def __init__(self, model_cls: type[torch.nn.Module]):
         self.model_cls = model_cls
 
     TRACE_VS_NODE_NAMES = {True: "CONV_NODES_NAMES", False: "NNCF_CONV_NODES_NAMES"}

--- a/tests/torch/nncf_network/test_hook_handlers.py
+++ b/tests/torch/nncf_network/test_hook_handlers.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, List, Tuple
+from typing import Callable
 
 import pytest
 import torch
@@ -44,7 +44,7 @@ class TestHookHandles:
     @staticmethod
     def _prepare_hook_handles_test(
         target_type: TargetType, target_node_name: str, input_port_id: int
-    ) -> Tuple[NNCFNetwork, PTInsertionPoint, Callable[[List[HookHandle]], None]]:
+    ) -> tuple[NNCFNetwork, PTInsertionPoint, Callable[[list[HookHandle]], None]]:
         model = SimplestModel()
         example_input = torch.ones(SimplestModel.INPUT_SIZE)
         input_info = ExampleInputInfo.from_example_input(example_input)

--- a/tests/torch/nncf_network/test_nncf_network.py
+++ b/tests/torch/nncf_network/test_nncf_network.py
@@ -14,7 +14,7 @@ import inspect
 from abc import ABCMeta
 from abc import abstractmethod
 from copy import deepcopy
-from typing import Callable, Type
+from typing import Callable
 
 import pytest
 import torch
@@ -455,7 +455,7 @@ class EvilSelfForwardProvider(ReplacementForwardProvider):
 @pytest.mark.parametrize(
     "replacement_forward_provider_cls", [ArgDecoratorForward, ArgAndKwargWrapsForward, EvilSelfForwardProvider]
 )
-def test_replacing_forward_of_original_model(replacement_forward_provider_cls: Type[ReplacementForwardProvider]):
+def test_replacing_forward_of_original_model(replacement_forward_provider_cls: type[ReplacementForwardProvider]):
     model = BasicConvTestModel()
     provider = replacement_forward_provider_cls()
     replacement_forward = provider.get_replacement_forward(model)

--- a/tests/torch/nncf_network/test_transformation_layout.py
+++ b/tests/torch/nncf_network/test_transformation_layout.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import itertools
-from typing import Tuple, Type, Union
+from typing import Union
 
 import pytest
 import torch
@@ -41,8 +41,8 @@ def trace_parameters_fixture(request) -> bool:
     return request.param
 
 
-def _get_trace_params_target_types_command_builders_and_models_cls() -> Tuple[
-    bool, Type[torch.nn.Module], TargetType, callable
+def _get_trace_params_target_types_command_builders_and_models_cls() -> tuple[
+    bool, type[torch.nn.Module], TargetType, callable
 ]:
     """
     Returns list of all avaliable command builders
@@ -89,7 +89,7 @@ def _translate_target_types(trace_parameters: bool, command: Union[PTInsertionCo
     _get_trace_params_target_types_command_builders_and_models_cls(),
 )
 def test_get_applied_modification_commands(
-    model_cls: Type[torch.nn.Module], command_builder: callable, target_type: TargetType, trace_parameters: bool
+    model_cls: type[torch.nn.Module], command_builder: callable, target_type: TargetType, trace_parameters: bool
 ):
     model = model_cls()
     nncf_model = wrap_model(model, torch.zeros(model_cls.INPUT_SHAPE), trace_parameters=trace_parameters)
@@ -113,7 +113,7 @@ def test_get_applied_modification_commands(
     _get_trace_params_target_types_command_builders_and_models_cls(),
 )
 def test_priority_of_get_applied_modification_commands(
-    command_builder: callable, model_cls: Type[torch.nn.Module], target_type: TargetType, trace_parameters: bool
+    command_builder: callable, model_cls: type[torch.nn.Module], target_type: TargetType, trace_parameters: bool
 ):
     layout = PTTransformationLayout()
     commands = dict()
@@ -140,7 +140,7 @@ def test_priority_of_get_applied_modification_commands(
 
 @pytest.mark.parametrize("model_cls", InsertionCommandBuilder.AVAILABLE_MODELS)
 def test_all_possible_combinations_of_commands_for_get_applied_commands(
-    model_cls: Type[torch.nn.Module], trace_parameters: bool
+    model_cls: type[torch.nn.Module], trace_parameters: bool
 ):
     dummy_state = "DummyState"
     commands = InsertionCommandBuilder(model_cls).get_all_available_commands(
@@ -169,7 +169,7 @@ def test_all_possible_combinations_of_commands_for_get_applied_commands(
 @pytest.mark.parametrize("target_type", (TargetType.OPERATION_WITH_WEIGHTS, TargetType.OPERATOR_PRE_HOOK))
 @pytest.mark.parametrize("model_cls", InsertionCommandBuilder.AVAILABLE_MODELS)
 def test_get_applied_modification_commands_broken_call_hook(
-    model_cls: Type[torch.nn.Module], target_type: TargetType, trace_parameters: bool
+    model_cls: type[torch.nn.Module], target_type: TargetType, trace_parameters: bool
 ):
     model = model_cls()
     nncf_model = wrap_model(model, torch.zeros(model_cls.INPUT_SHAPE), trace_parameters=trace_parameters)

--- a/tests/torch/pruning/experimental/test_nodes_grouping.py
+++ b/tests/torch/pruning/experimental/test_nodes_grouping.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 from dataclasses import dataclass
 from functools import partial
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 import pytest
@@ -137,7 +137,7 @@ def get_mobile_bert_big_model():
 @dataclass
 class GroupTestDesc:
     model_desc: IModelDesc
-    ref_groups: Optional[List[PruningGroup]] = None
+    ref_groups: Optional[list[PruningGroup]] = None
 
     def __str__(self) -> str:
         return self.model_desc.model_name

--- a/tests/torch/pruning/experimental/test_propagation.py
+++ b/tests/torch/pruning/experimental/test_propagation.py
@@ -11,7 +11,7 @@
 
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Optional
 
 import pytest
 
@@ -22,8 +22,8 @@ from nncf.experimental.common.pruning.operations import ReshapePruningOp
 
 @dataclass
 class ReshapeParsingDesc:
-    input_shape: List[int]
-    output_shape: List[int]
+    input_shape: list[int]
+    output_shape: list[int]
     mode: ReshapeMode = ReshapeMode.DEFAULT
     in_map: Optional[ReshapePruningOp.DIMENSION_MAP] = None
     out_map: Optional[ReshapePruningOp.DIMENSION_MAP] = None

--- a/tests/torch/pruning/test_model_pruning_analysis.py
+++ b/tests/torch/pruning/test_model_pruning_analysis.py
@@ -12,7 +12,7 @@
 
 from collections import Counter
 from functools import partial
-from typing import Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Callable, Optional, Union
 
 import pytest
 import torch
@@ -72,8 +72,8 @@ from tests.torch.pruning.helpers import get_basic_pruning_config
 
 
 def create_nncf_model_and_pruning_builder(
-    model: torch.nn.Module, config_params: Dict
-) -> Tuple[NNCFNetwork, FilterPruningBuilder]:
+    model: torch.nn.Module, config_params: dict
+) -> tuple[NNCFNetwork, FilterPruningBuilder]:
     nncf_config = get_basic_pruning_config(input_sample_size=[1, 1, 8, 8])
     nncf_config["compression"]["algorithm"] = "filter_pruning"
     for key, value in config_params.items():
@@ -85,13 +85,13 @@ def create_nncf_model_and_pruning_builder(
 class GroupPruningModulesTestStruct:
     def __init__(
         self,
-        model: Union[Type[torch.nn.Module], Callable[[], torch.nn.Module]],
-        non_pruned_module_nodes: List[NNCFNodeName],
-        pruned_groups: List[List[NNCFNodeName]],
-        pruned_groups_by_node_id: List[List[int]],
-        can_prune_after_analysis: Dict[int, bool],
-        final_can_prune: Dict[int, PruningAnalysisDecision],
-        prune_params: Tuple[bool, bool],
+        model: Union[type[torch.nn.Module], Callable[[], torch.nn.Module]],
+        non_pruned_module_nodes: list[NNCFNodeName],
+        pruned_groups: list[list[NNCFNodeName]],
+        pruned_groups_by_node_id: list[list[int]],
+        can_prune_after_analysis: dict[int, bool],
+        final_can_prune: dict[int, PruningAnalysisDecision],
+        prune_params: tuple[bool, bool],
         name: Optional[str] = None,
     ):
         self.model = model
@@ -839,7 +839,7 @@ def test_model_analyzer(test_struct: GroupSpecialModulesTestStruct):
 
 
 class ModulePrunableTestStruct:
-    def __init__(self, model: NNCFNetwork, config_params: dict, is_module_prunable: Dict[NNCFNodeName, bool]):
+    def __init__(self, model: NNCFNetwork, config_params: dict, is_module_prunable: dict[NNCFNodeName, bool]):
         self.model = model
         self.config_params = config_params
         self.is_module_prunable = is_module_prunable

--- a/tests/torch/qat/helpers.py
+++ b/tests/torch/qat/helpers.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import gc
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 from unittest.mock import MagicMock
 
 import torch
@@ -40,7 +40,7 @@ def convert_quantization_mode(mode: Optional[str]) -> QuantizationScheme:
     raise RuntimeError(msg)
 
 
-def convert_quantization_params(conf: Optional[Dict[str, Any]]) -> QuantizationParameters:
+def convert_quantization_params(conf: Optional[dict[str, Any]]) -> QuantizationParameters:
     if conf is None:
         return QuantizationParameters()
 
@@ -77,7 +77,7 @@ def convert_quantization_preset(preset: str) -> QuantizationPreset:
     raise RuntimeError(msg)
 
 
-def get_range_init_type(config_quantization_params: Dict[str, Any]) -> RangeEstimatorParameters:
+def get_range_init_type(config_quantization_params: dict[str, Any]) -> RangeEstimatorParameters:
     if (
         "initializer" in config_quantization_params
         and "range" in config_quantization_params["initializer"]
@@ -90,13 +90,13 @@ def get_range_init_type(config_quantization_params: Dict[str, Any]) -> RangeEsti
     return RangeEstimatorParametersSet.MINMAX
 
 
-def get_quantization_preset(config_quantization_params: Dict[str, Any]) -> Optional[QuantizationPreset]:
+def get_quantization_preset(config_quantization_params: dict[str, Any]) -> Optional[QuantizationPreset]:
     if "preset" not in config_quantization_params:
         return None
     return convert_quantization_preset(config_quantization_params["preset"])
 
 
-def get_advanced_ptq_parameters(config_quantization_params: Dict[str, Any]) -> AdvancedQuantizationParameters:
+def get_advanced_ptq_parameters(config_quantization_params: dict[str, Any]) -> AdvancedQuantizationParameters:
     range_estimator_params = get_range_init_type(config_quantization_params)
     return AdvancedQuantizationParameters(
         overflow_fix=convert_overflow_fix_param(config_quantization_params.get("overflow_fix")),
@@ -107,7 +107,7 @@ def get_advanced_ptq_parameters(config_quantization_params: Dict[str, Any]) -> A
     )
 
 
-def get_num_samples(config_quantization_params: Dict[str, Any]) -> int:
+def get_num_samples(config_quantization_params: dict[str, Any]) -> int:
     if (
         "initializer" in config_quantization_params
         and "range" in config_quantization_params["initializer"]

--- a/tests/torch/qat/test_qat_classification.py
+++ b/tests/torch/qat/test_qat_classification.py
@@ -11,7 +11,6 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
 
 import pytest
 import torch
@@ -53,7 +52,7 @@ from tests.cross_fw.shared.paths import PROJECT_ROOT
 CONFIGS = list((PROJECT_ROOT / Path("examples/torch/classification/configs/quantization")).glob("*"))
 
 
-def _get_filtered_quantization_configs() -> List[Path]:
+def _get_filtered_quantization_configs() -> list[Path]:
     configs = []
     for quantization_config_path in CONFIGS:
         if "imagenet" not in quantization_config_path.stem:

--- a/tests/torch/qat/test_qat_object_detection.py
+++ b/tests/torch/qat/test_qat_object_detection.py
@@ -11,7 +11,6 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
 
 import pytest
 import torch
@@ -51,7 +50,7 @@ from tests.cross_fw.shared.paths import PROJECT_ROOT
 CONFIGS = list((PROJECT_ROOT / Path("examples/torch/object_detection/configs")).glob("*"))
 
 
-def _get_filtered_quantization_configs() -> List[Path]:
+def _get_filtered_quantization_configs() -> list[Path]:
     configs = []
     for quantization_config_path in CONFIGS:
         nncf_config = NNCFConfig.from_json(quantization_config_path)

--- a/tests/torch/qat/test_qat_segmentation.py
+++ b/tests/torch/qat/test_qat_segmentation.py
@@ -11,7 +11,6 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
 
 import pytest
 import torch
@@ -55,7 +54,7 @@ from tests.cross_fw.shared.paths import PROJECT_ROOT
 CONFIGS = list((PROJECT_ROOT / Path("examples/torch/semantic_segmentation/configs")).glob("*"))
 
 
-def _get_filtered_quantization_configs() -> List[Path]:
+def _get_filtered_quantization_configs() -> list[Path]:
     configs = []
     for quantization_config_path in CONFIGS:
         nncf_config = NNCFConfig.from_json(quantization_config_path)

--- a/tests/torch/quantization/test_adjust_padding.py
+++ b/tests/torch/quantization/test_adjust_padding.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 import os
-from typing import List
 
 import pytest
 import torch
@@ -115,7 +114,7 @@ class MultiBranchesModelDesc(GeneralModelDesc):
         del self._config_update["compression"]["scope_overrides"]
         return self
 
-    def manual_precision(self, num_bits_for_weights: List[int], num_bits_for_activations: List[int]):
+    def manual_precision(self, num_bits_for_weights: list[int], num_bits_for_activations: list[int]):
         scopes_factory = self._get_scopes
         w_scopes, a_scopes = scopes_factory()
         bitwidth_per_scope = list(map(list, zip(num_bits_for_weights, w_scopes)))

--- a/tests/torch/quantization/test_algo_quantization.py
+++ b/tests/torch/quantization/test_algo_quantization.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 from collections import Counter
 from copy import deepcopy
-from typing import List, Tuple
 
 import pytest
 import torch
@@ -155,7 +154,7 @@ def test_quantization_configs__custom():
 
 
 def compare_weights_activation_quantizers_pairs(
-    actual_pairs: List[Tuple[List[WeightQuantizerId], NonWeightQuantizerId]], algo, ref_pair_names, model_name
+    actual_pairs: list[tuple[list[WeightQuantizerId], NonWeightQuantizerId]], algo, ref_pair_names, model_name
 ):
     def get_wq_name(name):
         return "/".join([model_name, name])

--- a/tests/torch/quantization/test_functions.py
+++ b/tests/torch/quantization/test_functions.py
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Callable, List, Optional
+from typing import Callable, Optional
 
 import numpy as np
 import pytest
@@ -46,8 +46,8 @@ RQ = ReferenceQuantize(backend_type=ReferenceBackendType.NUMPY)
 def generate_one_channel_input(
     input_low: np.ndarray,
     input_range: np.ndarray,
-    ch_idx: Optional[List[int]],
-    input_size: List[int],
+    ch_idx: Optional[list[int]],
+    input_size: list[int],
     bits: int,
     get_deviation: Callable[[], int],
     min_deviation: float,
@@ -75,7 +75,7 @@ def generate_one_channel_input(
 
 
 def generate_input(
-    input_size: List[int],
+    input_size: list[int],
     input_low: np.ndarray,
     input_range: np.ndarray,
     bits: int,

--- a/tests/torch/quantization/test_hawq_precision_init.py
+++ b/tests/torch/quantization/test_hawq_precision_init.py
@@ -16,7 +16,7 @@ from collections import OrderedDict
 from collections import namedtuple
 from functools import partial
 from pathlib import Path
-from typing import Callable, Dict, List, NamedTuple
+from typing import Callable, NamedTuple
 
 import pytest
 import torch
@@ -124,7 +124,7 @@ class BaseConfigBuilder:
     def __init__(self, config_creator_fn: Callable = None):
         if config_creator_fn:
             self._config = config_creator_fn()
-        self._options: Dict[str, str] = OrderedDict()
+        self._options: dict[str, str] = OrderedDict()
         self._extra_params: str = ""
 
     def with_ratio(self, ratio: float):
@@ -132,7 +132,7 @@ class BaseConfigBuilder:
         self._options["ratio"] = str(ratio)
         return self
 
-    def with_sample_size(self, sample_size: List[int]):
+    def with_sample_size(self, sample_size: list[int]):
         self._config["input_info"]["sample_size"] = sample_size
         return self
 
@@ -158,7 +158,7 @@ class BaseConfigBuilder:
     def build(self):
         return self._config
 
-    def with_ignored_scope(self, ignored_scopes=List[str], target_group: QuantizerGroup = None):
+    def with_ignored_scope(self, ignored_scopes=list[str], target_group: QuantizerGroup = None):
         if target_group is None:
             self._config["compression"]["ignored_scopes"] = ignored_scopes
         else:
@@ -168,7 +168,7 @@ class BaseConfigBuilder:
         self._options["with"] = "ignored_scopes"
         return self
 
-    def with_target_scope(self, target_scopes=List[str]):
+    def with_target_scope(self, target_scopes=list[str]):
         self._config["target_scopes"] = target_scopes
         self._config["compression"]["target_scopes"] = target_scopes
         self._options["with"] = "target_scopes"
@@ -544,7 +544,7 @@ def get_requires_grad_per_param(model):
     return OrderedDict(sorted(not_sorted.items()))
 
 
-def get_skipped_quantized_weight_node_names() -> List[NNCFNodeName]:
+def get_skipped_quantized_weight_node_names() -> list[NNCFNodeName]:
     scopes_list = [
         "MobileNetV2/Sequential[features]/Conv2dNormActivation[18]/NNCFConv2d[0]/conv2d_0",
         "MobileNetV2/Sequential[features]/InvertedResidual[17]/Sequential[conv]/NNCFConv2d[2]/conv2d_0",
@@ -728,7 +728,7 @@ class RatioCalculatorTestDesc:
         self._ignored_scopes = []
         self.ref_ratio = ref_ratio
 
-    def bitwidths(self, bitwidth_sequence=List[int]):
+    def bitwidths(self, bitwidth_sequence=list[int]):
         self._bitwidth_sequence = bitwidth_sequence
         return self
 

--- a/tests/torch/quantization/test_manual_precision_init.py
+++ b/tests/torch/quantization/test_manual_precision_init.py
@@ -11,7 +11,6 @@
 import os
 from copy import deepcopy
 from pathlib import Path
-from typing import List
 
 import pytest
 
@@ -33,7 +32,7 @@ from tests.torch.test_models.synthetic import AddTwoConv
 
 
 class ManualConfigTestParamsBase:
-    def __init__(self, name: str, bit_stats: List[List[str]]):
+    def __init__(self, name: str, bit_stats: list[list[str]]):
         self.name = name
         self.bit_stats = bit_stats
 

--- a/tests/torch/quantization/test_onnx_export.py
+++ b/tests/torch/quantization/test_onnx_export.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict, List, Tuple
 
 import numpy as np
 import onnx
@@ -160,7 +159,7 @@ def get_weight_fq_for_conv_node(node: onnx.NodeProto, graph: onnx.GraphProto):
 
 def get_input_low_input_high_for_wfq_node(
     wfq_node: onnx.NodeProto, graph: onnx.GraphProto
-) -> Tuple[onnx.AttributeProto, onnx.AttributeProto]:
+) -> tuple[onnx.AttributeProto, onnx.AttributeProto]:
     assert wfq_node.op_type == "FakeQuantize"
     conv_wfq_inputs = list(resolve_constant_node_inputs_to_values(wfq_node, graph).values())
     return conv_wfq_inputs[1], conv_wfq_inputs[2]
@@ -203,7 +202,7 @@ class ModelWithBranches(torch.nn.Module):
         return x1, x2, x3, x4
 
 
-def get_successors(node: onnx.NodeProto, graph: onnx.GraphProto) -> List[onnx.NodeProto]:
+def get_successors(node: onnx.NodeProto, graph: onnx.GraphProto) -> list[onnx.NodeProto]:
     retval = []
     for output_name in node.output:
         for target_node in graph.node:
@@ -245,8 +244,8 @@ def test_branching_fqs_are_not_chained(tmp_path, export_mode):
 
 
 def set_parameters_to_quantizer_and_get_attrs(
-    quantizer: BaseQuantizer, paramaters_to_set: Dict
-) -> Tuple[np.ndarray, np.ndarray, int]:
+    quantizer: BaseQuantizer, paramaters_to_set: dict
+) -> tuple[np.ndarray, np.ndarray, int]:
     if isinstance(quantizer, SymmetricQuantizer):
         return set_scale_to_sym_quantizer_and_get_attrs(quantizer, **paramaters_to_set)
     return set_input_low_and_input_range_to_asym_quantizer_and_get_attrs(quantizer, **paramaters_to_set)
@@ -254,7 +253,7 @@ def set_parameters_to_quantizer_and_get_attrs(
 
 def set_scale_to_sym_quantizer_and_get_attrs(
     quantizer: SymmetricQuantizer, scale: float
-) -> Tuple[np.ndarray, np.ndarray, int]:
+) -> tuple[np.ndarray, np.ndarray, int]:
     scale = np.full(quantizer.scale.size(), scale)
     levels = quantizer.levels
     level_low = quantizer.level_low
@@ -268,7 +267,7 @@ def set_scale_to_sym_quantizer_and_get_attrs(
 
 def set_input_low_and_input_range_to_asym_quantizer_and_get_attrs(
     quantizer: AsymmetricQuantizer, input_low: float, input_range: float
-) -> Tuple[np.ndarray, np.ndarray, int]:
+) -> tuple[np.ndarray, np.ndarray, int]:
     input_low = np.full(quantizer.input_low.size(), input_low)
     input_range = np.full(quantizer.input_low.size(), input_range)
     levels = quantizer.levels
@@ -279,7 +278,7 @@ def set_input_low_and_input_range_to_asym_quantizer_and_get_attrs(
 
 
 def generate_middle_quants(
-    size: List[int], input_low: np.ndarray, quant_len: np.ndarray, levels: np.ndarray
+    size: list[int], input_low: np.ndarray, quant_len: np.ndarray, levels: np.ndarray
 ) -> torch.Tensor:
     ref_weights = [input_low + (i + 0.5) * quant_len for i in range(levels)]
     elems = np.prod(size)

--- a/tests/torch/quantization/test_range_init.py
+++ b/tests/torch/quantization/test_range_init.py
@@ -13,7 +13,7 @@ import re
 from collections import namedtuple
 from dataclasses import dataclass
 from functools import partial
-from typing import List, Tuple, Union
+from typing import Union
 
 import pytest
 import torch
@@ -528,13 +528,13 @@ def init_idfn(val):
 
 @dataclass
 class SymQuantizerScaleRef:
-    scale: Tuple[float, ...]
+    scale: tuple[float, ...]
 
 
 @dataclass
 class AsymQuantizerScaleRef:
-    input_low: Tuple[float, ...]
-    input_range: Tuple[float, ...]
+    input_low: tuple[float, ...]
+    input_range: tuple[float, ...]
 
 
 @dataclass
@@ -950,7 +950,7 @@ QUANTIZER_RANGE_INITIALIZERS = [
 
 
 class QuantizeRangeInitScaleShapeTestStruct:
-    def __init__(self, per_channel: bool, is_weights: bool, input_shape: List[int], ref_scale_shape: Tuple[int, ...]):
+    def __init__(self, per_channel: bool, is_weights: bool, input_shape: list[int], ref_scale_shape: tuple[int, ...]):
         self.per_channel = per_channel
         self.is_weights = is_weights
         self.input_shape = input_shape
@@ -990,7 +990,7 @@ def quantizer_range_init_test_struct(request):
     return request.param
 
 
-def test_quantize_range_init_sets_correct_scale_shapes(quantizer_range_init_test_struct: Tuple[QRISSTS, str]):
+def test_quantize_range_init_sets_correct_scale_shapes(quantizer_range_init_test_struct: tuple[QRISSTS, str]):
     test_struct = quantizer_range_init_test_struct[0]
     initializer_type = quantizer_range_init_test_struct[1]
     for quantization_mode in [QuantizationMode.SYMMETRIC, QuantizationMode.ASYMMETRIC]:

--- a/tests/torch/quantization/test_sanity_sample.py
+++ b/tests/torch/quantization/test_sanity_sample.py
@@ -11,7 +11,6 @@
 
 from abc import ABC
 from pathlib import Path
-from typing import Dict
 
 import pytest
 import torch
@@ -36,7 +35,7 @@ class PrecisionTestCaseDescriptor(SanityTestCaseDescriptor, ABC):
     def config_directory(self) -> Path:
         return TEST_ROOT / "torch" / "data" / "configs" / "hawq"
 
-    def get_precision_section(self) -> Dict:
+    def get_precision_section(self) -> dict:
         raise NotImplementedError
 
     def get_compression_section(self):
@@ -91,7 +90,7 @@ class HAWQTestCaseDescriptor(PrecisionTestCaseDescriptor):
         result.update({"batch_size_init": self.batch_size_init_} if self.batch_size_init_ else {})
         return result
 
-    def get_precision_section(self) -> Dict:
+    def get_precision_section(self) -> dict:
         return {"type": "hawq", "num_data_points": 3, "iter_number": 1}
 
     def __str__(self):
@@ -146,7 +145,7 @@ class AutoQTestCaseDescriptor(PrecisionTestCaseDescriptor):
         self.debug_dump = debug_dump
         return self
 
-    def get_precision_section(self) -> Dict:
+    def get_precision_section(self) -> dict:
         return {
             "type": "autoq",
             "bits": self.BITS,
@@ -280,7 +279,7 @@ class ExportTestCaseDescriptor(PrecisionTestCaseDescriptor):
     def get_validator(self):
         return ExportSampleValidator(self)
 
-    def get_precision_section(self) -> Dict:
+    def get_precision_section(self) -> dict:
         return {}
 
     def get_sample_params(self):

--- a/tests/torch/quantization/test_solver_quantization_traits.py
+++ b/tests/torch/quantization/test_solver_quantization_traits.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict, List, Type
 
 from nncf.common.graph.operator_metatypes import INPUT_NOOP_METATYPES
 from nncf.common.graph.operator_metatypes import OUTPUT_NOOP_METATYPES
@@ -27,7 +26,7 @@ from tests.common.quantization.mock_graphs import get_randomly_connected_model_g
 def test_set_quantization_traits_for_quant_prop_graph_nodes():
     # Test all patchable metatypes. If a patchable metatype is not registered
     # in quantization trait-to-metatype dict, the test will fail.
-    tested_op_metatypes: List[Type[OperatorMetatype]] = get_operator_metatypes()
+    tested_op_metatypes: list[type[OperatorMetatype]] = get_operator_metatypes()
     tested_op_names = set()
     for op_meta in tested_op_metatypes:
         if op_meta not in INPUT_NOOP_METATYPES and op_meta not in OUTPUT_NOOP_METATYPES:
@@ -61,7 +60,7 @@ def test_set_quantization_traits_for_quant_prop_graph_nodes():
 
 
 def test_quantization_traits_are_unambiguous_for_op_names():
-    op_name_to_trait_dict: Dict[str, QuantizationTrait] = {}
+    op_name_to_trait_dict: dict[str, QuantizationTrait] = {}
     for trait, arches in DEFAULT_PT_QUANT_TRAIT_TO_OP_DICT.items():
         for op_meta in arches:
             aliases = op_meta.get_all_aliases()

--- a/tests/torch/quantization/test_strip.py
+++ b/tests/torch/quantization/test_strip.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Tuple
+from typing import Any
 
 import numpy as np
 import pytest
@@ -103,7 +103,7 @@ INPUT_TEST_SCALES = (
 )
 
 
-def range_mode_to_args(range_mode: str) -> Tuple[bool, bool]:
+def range_mode_to_args(range_mode: str) -> tuple[bool, bool]:
     """
     Get overflow_fix and narrow_range parameters by range_mode.
 

--- a/tests/torch/quantization/test_unified_scales.py
+++ b/tests/torch/quantization/test_unified_scales.py
@@ -12,7 +12,6 @@
 import itertools
 from collections import Counter
 from functools import partial
-from typing import Dict, List
 
 import onnx
 import pytest
@@ -287,9 +286,9 @@ def make_insertion_point_for_coalescing_test(node_name: NNCFNodeName, input_port
     ],
 )
 def test_insertion_point_coalescing(
-    input_insertion_points: List[PTTargetPoint],
-    linked_scopes_groups_list: List[List[str]],
-    ref_coalesced_ip_lists: List[List[PTTargetPoint]],
+    input_insertion_points: list[PTTargetPoint],
+    linked_scopes_groups_list: list[list[str]],
+    ref_coalesced_ip_lists: list[list[PTTargetPoint]],
 ):
     if ref_coalesced_ip_lists is None:
         with pytest.raises((nncf.InternalError, nncf.ValidationError)):
@@ -525,7 +524,7 @@ class TwoEmbeddingAddModel(torch.nn.Module):
 
 class TestsWithONNXInspection:
     @staticmethod
-    def get_fq_nodes(onnx_model: onnx.ModelProto) -> List[onnx.NodeProto]:
+    def get_fq_nodes(onnx_model: onnx.ModelProto) -> list[onnx.NodeProto]:
         return get_nodes_by_type(onnx_model, "FakeQuantize")
 
     @staticmethod
@@ -562,8 +561,8 @@ class TestsWithONNXInspection:
         return False
 
     @staticmethod
-    def group_nodes_by_output_target(nodes: List[onnx.NodeProto], graph: onnx.GraphProto) -> List[List[onnx.NodeProto]]:
-        output_nodes: Dict[str, List[onnx.NodeProto]] = {}
+    def group_nodes_by_output_target(nodes: list[onnx.NodeProto], graph: onnx.GraphProto) -> list[list[onnx.NodeProto]]:
+        output_nodes: dict[str, list[onnx.NodeProto]] = {}
         for node in nodes:
             succs = get_successors(node, graph)
             assert len(succs) == 1

--- a/tests/torch/sample_test_validator.py
+++ b/tests/torch/sample_test_validator.py
@@ -17,7 +17,7 @@ from abc import ABC
 from abc import abstractmethod
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Optional, Type
+from typing import Any, Optional
 
 import torch
 
@@ -30,7 +30,7 @@ from tests.cross_fw.shared.paths import EXAMPLES_DIR
 from tests.cross_fw.shared.paths import TEST_ROOT
 
 
-def create_command_line(args: Dict[str, Any], sample_type: str, main_filename: str = "main.py") -> str:
+def create_command_line(args: dict[str, Any], sample_type: str, main_filename: str = "main.py") -> str:
     executable = EXAMPLES_DIR.joinpath("torch", sample_type, main_filename).as_posix()
     cli_args = " ".join(key if (val is None or val is True) else f"{key} {val}" for key, val in args.items())
     return f"{sys.executable} {executable} {cli_args}"
@@ -221,7 +221,7 @@ class BaseSampleTestCaseDescriptor(ABC):
 
     def sample_type(self, sample_type: SampleType):
         self.sample_type_ = sample_type
-        sample_handler_cls: Type[BaseSampleHandler] = SAMPLE_HANDLERS.get(self.sample_type_)
+        sample_handler_cls: type[BaseSampleHandler] = SAMPLE_HANDLERS.get(self.sample_type_)
         self.sample_handler = sample_handler_cls()
         return self
 
@@ -241,17 +241,17 @@ class BaseSampleTestCaseDescriptor(ABC):
 class SanityTestCaseDescriptor(BaseSampleTestCaseDescriptor, ABC):
     def __init__(self):
         super().__init__()
-        self.config_dict: Dict = {}
+        self.config_dict: dict = {}
 
     @abstractmethod
     def get_compression_section(self):
         pass
 
-    def get_config_update(self) -> Dict:
+    def get_config_update(self) -> dict:
         sample_params = self.get_sample_params()
         return {**sample_params, "target_device": "NPU", "compression": self.get_compression_section()}
 
-    def get_sample_params(self) -> Dict:
+    def get_sample_params(self) -> dict:
         return {"dataset": self.dataset_name} if self.dataset_name else {}
 
     def finalize(self, dataset_dir=None) -> "SanityTestCaseDescriptor":
@@ -271,7 +271,7 @@ class SanitySampleValidator(BaseSampleValidator, ABC):
         self._desc = desc
         self._sample_handler = desc.sample_handler
 
-    def validate_sample(self, args: Dict[str, Any], mocker):
+    def validate_sample(self, args: dict[str, Any], mocker):
         arg_list = arg_list_from_arg_dict(args)
         command_line = " ".join(arg_list)
         print(f"Command line arguments: {command_line}")

--- a/tests/torch/sparsity/magnitude/test_algo.py
+++ b/tests/torch/sparsity/magnitude/test_algo.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 from copy import deepcopy
-from typing import List
 
 import pytest
 import torch
@@ -137,7 +136,7 @@ def test_magnitude_algo_binary_masks_are_applied():
     config = get_empty_config()
     config["compression"] = {"algorithm": "magnitude_sparsity"}
     compressed_model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
-    minfo_list: List[SparseModuleInfo] = compression_ctrl.sparsified_module_info
+    minfo_list: list[SparseModuleInfo] = compression_ctrl.sparsified_module_info
     minfo: SparseModuleInfo = minfo_list[0]
 
     minfo.operand.binary_mask = torch.ones_like(minfo.module.weight)  # 1x1x2x2

--- a/tests/torch/sparsity/movement/helpers/config.py
+++ b/tests/torch/sparsity/movement/helpers/config.py
@@ -9,12 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from copy import deepcopy
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from nncf.experimental.torch.sparsity.movement.scheduler import MovementSchedulerParams
 
 
-def convert_scheduler_params_to_dict(params: MovementSchedulerParams) -> Dict[str, Any]:
+def convert_scheduler_params_to_dict(params: MovementSchedulerParams) -> dict[str, Any]:
     result = {}
     for key, value in params.__dict__.items():
         if value is not None:
@@ -34,8 +34,8 @@ class MovementAlgoConfig:
     def __init__(
         self,
         scheduler_params: Optional[MovementSchedulerParams] = None,
-        sparse_structure_by_scopes: Optional[List[Dict]] = None,
-        ignored_scopes: Optional[List[str]] = None,
+        sparse_structure_by_scopes: Optional[list[dict]] = None,
+        ignored_scopes: Optional[list[str]] = None,
         compression_lr_multiplier: Optional[float] = None,
     ):
         self.scheduler_params = scheduler_params or deepcopy(MovementAlgoConfig.default_scheduler_params)
@@ -43,7 +43,7 @@ class MovementAlgoConfig:
         self.ignored_scopes = ignored_scopes or []
         self.compression_lr_multiplier = compression_lr_multiplier
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         result = {
             "algorithm": "movement_sparsity",
             "params": convert_scheduler_params_to_dict(self.scheduler_params),

--- a/tests/torch/sparsity/movement/helpers/run_recipe.py
+++ b/tests/torch/sparsity/movement/helpers/run_recipe.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import torch
 import torch.nn
@@ -88,7 +88,7 @@ class BaseMockRunRecipe(ABC):
 
     @property
     @abstractmethod
-    def transformer_block_info(self) -> List[TransformerBlockInfo]:
+    def transformer_block_info(self) -> list[TransformerBlockInfo]:
         pass
 
     @property
@@ -97,8 +97,8 @@ class BaseMockRunRecipe(ABC):
 
     def algo_config_(
         self,
-        sparse_structure_by_scopes: Union[List[Dict[str, Any]], _MISSING_TYPE] = MISSING,
-        ignored_scopes: Union[List[str], _MISSING_TYPE] = MISSING,
+        sparse_structure_by_scopes: Union[list[dict[str, Any]], _MISSING_TYPE] = MISSING,
+        ignored_scopes: Union[list[str], _MISSING_TYPE] = MISSING,
         compression_lr_multiplier: Union[float, None, _MISSING_TYPE] = MISSING,
     ):
         if sparse_structure_by_scopes is not MISSING:
@@ -196,7 +196,7 @@ class BaseMockRunRecipe(ABC):
         )[:num_samples]
         return Dataset.from_dict(input_dict)
 
-    def dumps_model_input_info(self, model_input_info: Optional[FillerInputInfo] = None) -> List[Dict[str, Any]]:
+    def dumps_model_input_info(self, model_input_info: Optional[FillerInputInfo] = None) -> list[dict[str, Any]]:
         if model_input_info is None:
             model_input_info = self.model_input_info
         result = []
@@ -211,7 +211,7 @@ class BaseMockRunRecipe(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> List[DictInTransformerBlockOrder]:
+    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> list[DictInTransformerBlockOrder]:
         pass
 
     @abstractmethod
@@ -250,7 +250,7 @@ class Wav2Vec2RunRecipe(BaseMockRunRecipe):
         return FillerInputInfo([FillerInputElement(shape=[1, 32], keyword="input_values")])
 
     @property
-    def transformer_block_info(self) -> List[TransformerBlockInfo]:
+    def transformer_block_info(self) -> list[TransformerBlockInfo]:
         model_config = self.model_config
         return [
             TransformerBlockInfo(
@@ -262,7 +262,7 @@ class Wav2Vec2RunRecipe(BaseMockRunRecipe):
         ]
 
     @staticmethod
-    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> List[DictInTransformerBlockOrder]:
+    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> list[DictInTransformerBlockOrder]:
         modules = []
         for block in compressed_model.wav2vec2.encoder.layers:
             modules.append(
@@ -318,7 +318,7 @@ class BertRunRecipe(BaseMockRunRecipe):
         )
 
     @property
-    def transformer_block_info(self) -> List[TransformerBlockInfo]:
+    def transformer_block_info(self) -> list[TransformerBlockInfo]:
         model_config = self.model_config
         return [
             TransformerBlockInfo(
@@ -330,7 +330,7 @@ class BertRunRecipe(BaseMockRunRecipe):
         ]
 
     @staticmethod
-    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> List[DictInTransformerBlockOrder]:
+    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> list[DictInTransformerBlockOrder]:
         modules = []
         for block in compressed_model.bert.encoder.layer:
             modules.append(
@@ -379,14 +379,14 @@ class DistilBertRunRecipe(BaseMockRunRecipe):
         return FillerInputInfo([FillerInputElement(shape=[1, dim], type_str="long")] * 2)
 
     @staticmethod
-    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> List[DictInTransformerBlockOrder]:
+    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> list[DictInTransformerBlockOrder]:
         pass
 
     def _create_model(self) -> torch.nn.Module:
         return AutoModelForSequenceClassification.from_config(self.model_config)
 
     @property
-    def transformer_block_info(self) -> List[TransformerBlockInfo]:
+    def transformer_block_info(self) -> list[TransformerBlockInfo]:
         pass
 
 
@@ -412,14 +412,14 @@ class MobileBertRunRecipe(BaseMockRunRecipe):
         return FillerInputInfo([FillerInputElement(shape=[1, dim], type_str="long")] * 4)
 
     @staticmethod
-    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> List[DictInTransformerBlockOrder]:
+    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> list[DictInTransformerBlockOrder]:
         pass
 
     def _create_model(self) -> torch.nn.Module:
         return AutoModelForSequenceClassification.from_config(self.model_config)
 
     @property
-    def transformer_block_info(self) -> List[TransformerBlockInfo]:
+    def transformer_block_info(self) -> list[TransformerBlockInfo]:
         pass
 
 
@@ -445,14 +445,14 @@ class ClipVisionRunRecipe(BaseMockRunRecipe):
         return FillerInputInfo([FillerInputElement(shape=[1, num_channels, image_size, image_size], type_str="float")])
 
     @staticmethod
-    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> List[DictInTransformerBlockOrder]:
+    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> list[DictInTransformerBlockOrder]:
         pass
 
     def _create_model(self) -> torch.nn.Module:
         return CLIPVisionModel(self.model_config)
 
     @property
-    def transformer_block_info(self) -> List[TransformerBlockInfo]:
+    def transformer_block_info(self) -> list[TransformerBlockInfo]:
         pass
 
 
@@ -488,7 +488,7 @@ class SwinRunRecipe(BaseMockRunRecipe):
         )
 
     @property
-    def transformer_block_info(self) -> List[TransformerBlockInfo]:
+    def transformer_block_info(self) -> list[TransformerBlockInfo]:
         model_config = self.model_config
         info_list = []
         for i, (depth, num_head) in enumerate(zip(model_config.depths, model_config.num_heads)):
@@ -506,7 +506,7 @@ class SwinRunRecipe(BaseMockRunRecipe):
         return info_list
 
     @staticmethod
-    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> List[DictInTransformerBlockOrder]:
+    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> list[DictInTransformerBlockOrder]:
         modules = []
         for layer in compressed_model.swin.encoder.layers:
             for block in layer.blocks:
@@ -586,11 +586,11 @@ class LinearRunRecipe(BaseMockRunRecipe):
         return FillerInputInfo([FillerInputElement(shape=[1, self.model_config.input_size], keyword="tensor")])
 
     @property
-    def transformer_block_info(self) -> List[TransformerBlockInfo]:
+    def transformer_block_info(self) -> list[TransformerBlockInfo]:
         return []
 
     @staticmethod
-    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> List[DictInTransformerBlockOrder]:
+    def get_nncf_modules_in_transformer_block_order(compressed_model: NNCFNetwork) -> list[DictInTransformerBlockOrder]:
         return []
 
 

--- a/tests/torch/sparsity/movement/helpers/trainer.py
+++ b/tests/torch/sparsity/movement/helpers/trainer.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 from collections import OrderedDict
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 import torch
@@ -36,7 +36,7 @@ class CompressionTrainer(Trainer):
         self,
         compression_ctrl: Optional[CompressionAlgorithmController],
         *args,
-        callbacks: Optional[List[TrainerCallback]] = None,
+        callbacks: Optional[list[TrainerCallback]] = None,
         **kwargs,
     ):
         self.compression_ctrl = compression_ctrl

--- a/tests/torch/sparsity/movement/test_components.py
+++ b/tests/torch/sparsity/movement/test_components.py
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Tuple
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -45,7 +45,7 @@ class TestSparseConfigByScope:
             {"mode": "per_dim", "axis": 1, "target_scopes": ["prune_column", "{re}another_block"]},
         ],
     )
-    def test_create_sparse_config_by_scope(self, config: Dict[str, Any]):
+    def test_create_sparse_config_by_scope(self, config: dict[str, Any]):
         sparse_config_by_scope = SparseConfigByScope.from_config(config)
         assert isinstance(sparse_config_by_scope, SparseConfigByScope)
         ref_target_scopes = config.pop("target_scopes")
@@ -291,7 +291,7 @@ class TestSparsifier:
         ],
     )
     def test_get_importance_shape(
-        self, sparse_cfg: SparseConfig, bias: bool, ref_weight_importance_shape: Tuple[int, int]
+        self, sparse_cfg: SparseConfig, bias: bool, ref_weight_importance_shape: tuple[int, int]
     ):
         weight_shape = (4, 6)
         operand = MovementSparsifier(

--- a/tests/torch/sparsity/movement/test_scheduler.py
+++ b/tests/torch/sparsity/movement/test_scheduler.py
@@ -12,7 +12,7 @@ import logging
 import math
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 from unittest.mock import MagicMock
 from unittest.mock import Mock
 
@@ -268,7 +268,7 @@ class TestSchedulerStatus:
             )
 
         ref_threshold, ref_factor = [], []
-        ref_state: Dict[str, Any] = {}
+        ref_state: dict[str, Any] = {}
         for _ in range(5):
             ref_scheduler.epoch_step()
             for _ in range(actual_steps_per_epoch):

--- a/tests/torch/sparsity/movement/test_structured_mask.py
+++ b/tests/torch/sparsity/movement/test_structured_mask.py
@@ -11,7 +11,6 @@
 import logging
 import re
 from pathlib import Path
-from typing import List, Tuple
 from unittest.mock import Mock
 
 import pandas as pd
@@ -424,7 +423,7 @@ class TestStructuredMaskHandler:
                 assert re.fullmatch(r"\[[0-9]+ items\]", item) is not None
         assert Path(tmp_path, f"{file_name}.csv").is_file()
 
-    def _get_handler_from_ctrl(self, compression_ctrl) -> Tuple[StructuredMaskHandler, List[StructuredMaskContext]]:
+    def _get_handler_from_ctrl(self, compression_ctrl) -> tuple[StructuredMaskHandler, list[StructuredMaskContext]]:
         handler = compression_ctrl._structured_mask_handler
         all_ctxes = []
         for group in handler._structured_mask_ctx_groups:

--- a/tests/torch/sparsity/movement/test_training.py
+++ b/tests/torch/sparsity/movement/test_training.py
@@ -13,7 +13,7 @@ import os
 import sys
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict, Union
+from typing import Union
 
 import pytest
 import torch.cuda
@@ -43,7 +43,7 @@ class MovementGlueHandler:
     def _get_main_filename(self) -> str:
         return "run_glue"
 
-    def get_metric_value_from_checkpoint(self, checkpoint_save_dir: str) -> Dict[str, Union[float, int]]:
+    def get_metric_value_from_checkpoint(self, checkpoint_save_dir: str) -> dict[str, Union[float, int]]:
         checkpoint_path = self.get_checkpoint_path(checkpoint_save_dir)
         result_path = checkpoint_path / "all_results.json"
         with open(result_path, encoding="utf-8") as f:
@@ -148,7 +148,7 @@ class MovementTrainingTestDescriptor(BaseSampleTestCaseDescriptor):
     def get_validator(self):
         return MovementTrainingValidator(self)
 
-    def get_metric(self) -> Dict[str, float]:
+    def get_metric(self) -> dict[str, float]:
         return self.sample_handler.get_metric_value_from_checkpoint(self.output_dir)
 
     def __str__(self):

--- a/tests/torch/sparsity/movement/training_scripts/run_glue.py
+++ b/tests/torch/sparsity/movement/training_scripts/run_glue.py
@@ -11,7 +11,7 @@
 import argparse
 import json
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 import datasets
 import evaluate
@@ -45,7 +45,7 @@ task_to_sample_keys = {
 dataset_columns = ["labels", "input_ids", "token_type_ids", "attention_mask", "position_ids"]
 
 
-def parse_args() -> Tuple[argparse.Namespace, TrainingArguments]:
+def parse_args() -> tuple[argparse.Namespace, TrainingArguments]:
     parser = argparse.ArgumentParser("GLUE")
     parser.add_argument(
         "--task_name",
@@ -100,7 +100,7 @@ class CompressionCallback(TrainerCallback):
         stats = self._gather_compression_stats(state.global_step, state.epoch)
         self.compression_logs.append(stats)
 
-    def _gather_compression_stats(self, step: int, epoch: Optional[float]) -> Dict[str, float]:
+    def _gather_compression_stats(self, step: int, epoch: Optional[float]) -> dict[str, float]:
         status = {"step": step}
         if epoch is not None:
             status["epoch"] = round(epoch, 2)
@@ -114,7 +114,7 @@ class CompressionTrainer(Trainer):
         self,
         compression_ctrl: Optional[CompressionAlgorithmController],
         *args,
-        callbacks: Optional[List[TrainerCallback]] = None,
+        callbacks: Optional[list[TrainerCallback]] = None,
         **kwargs,
     ):
         self.compression_ctrl = compression_ctrl
@@ -137,7 +137,7 @@ class CompressionTrainer(Trainer):
             loss = loss + loss_compress
         return (loss, outputs) if return_outputs else loss
 
-    def get_compression_logs(self) -> Optional[List[Dict[str, float]]]:
+    def get_compression_logs(self) -> Optional[list[dict[str, float]]]:
         if self._compression_callback is None:
             return None
         return self._compression_callback.compression_logs

--- a/tests/torch/sparsity/test_common.py
+++ b/tests/torch/sparsity/test_common.py
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Optional
+from typing import Optional
 
 import pytest
 import torch
@@ -163,7 +163,7 @@ class TestPolynomialSparsityScheduler:
 
     @staticmethod
     def run_epoch_with_per_step_sparsity_check(
-        steps_per_epoch: int, scheduler: PolynomialSparsityScheduler, set_sparsity_mock, ref_vals: List[Optional[float]]
+        steps_per_epoch: int, scheduler: PolynomialSparsityScheduler, set_sparsity_mock, ref_vals: list[Optional[float]]
     ):
         assert len(ref_vals) == steps_per_epoch + 1
         scheduler.epoch_step()

--- a/tests/torch/tensor_statistics/test_tensor_statistics.py
+++ b/tests/torch/tensor_statistics/test_tensor_statistics.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 from functools import partial
-from typing import Dict, Tuple, Type
 
 import pytest
 import torch
@@ -112,8 +111,8 @@ class TestCollectedStatistics:
     )
     def test_collected_statistics_with_shape_convert(
         self,
-        collector: Type[TensorStatisticCollectorBase],
-        reduction_axes_vs_ref_statistic: Dict[Tuple[ReductionAxes, ReductionAxes], TensorStatistic],
+        collector: type[TensorStatisticCollectorBase],
+        reduction_axes_vs_ref_statistic: dict[tuple[ReductionAxes, ReductionAxes], TensorStatistic],
     ):
         for shapes in reduction_axes_vs_ref_statistic:
             scale_shape, reducer_axes = shapes
@@ -203,8 +202,8 @@ class TestCollectedStatistics:
     )
     def test_collected_statistics(
         self,
-        collector: Type[TensorStatisticCollectorBase],
-        reduction_axes_vs_ref_statistic: Dict[ReductionAxes, TensorStatistic],
+        collector: type[TensorStatisticCollectorBase],
+        reduction_axes_vs_ref_statistic: dict[ReductionAxes, TensorStatistic],
     ):
         for reduction_axes in reduction_axes_vs_ref_statistic:
             if len(reduction_axes) > 1:

--- a/tests/torch/test_algo_common.py
+++ b/tests/torch/test_algo_common.py
@@ -12,7 +12,6 @@ import copy
 import logging
 import os
 from functools import reduce
-from typing import Dict, List
 
 import onnx
 import pytest
@@ -146,7 +145,7 @@ class ConfigCreator:
             self._config["compression"].append(algo_section)
         return copy.deepcopy(self._config)
 
-    def add_algo(self, name: str, params: Dict = None):
+    def add_algo(self, name: str, params: dict = None):
         self._algorithm_sections[name] = params
         return self
 
@@ -155,7 +154,7 @@ class ConfigCreator:
 
 
 class CompressionStageTestStruct:
-    def __init__(self, config_provider: "ConfigCreator", compression_stages: List[CompressionStage]):
+    def __init__(self, config_provider: "ConfigCreator", compression_stages: list[CompressionStage]):
         self.config_provider = config_provider
         self.compression_stages = compression_stages
 
@@ -438,7 +437,7 @@ def test_raise_validationerror_for_not_matched_scope_names(algo_name, validate_s
         ["magnitude_sparsity", "filter_pruning"],
     ),
 )
-def test_compressed_model_has_controller_references(algos: List[str]):
+def test_compressed_model_has_controller_references(algos: list[str]):
     model = BasicLinearTestModel()
     cc = ConfigCreator()
     for algo_name in algos:

--- a/tests/torch/test_compressed_graph.py
+++ b/tests/torch/test_compressed_graph.py
@@ -15,7 +15,7 @@ from abc import ABC
 from abc import abstractmethod
 from copy import deepcopy
 from functools import partial
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Callable, Union
 
 import networkx as nx
 import pytest
@@ -77,7 +77,7 @@ from tests.torch.test_models.synthetic import TransposeModel
 
 
 def get_basic_quantization_config(
-    quantization_type="symmetric", input_sample_sizes=None, input_info: Union[List, Dict] = None
+    quantization_type="symmetric", input_sample_sizes=None, input_info: Union[list, dict] = None
 ):
     config = get_empty_config(input_sample_sizes=input_sample_sizes, input_info=input_info)
     config["compression"] = {
@@ -203,7 +203,7 @@ def sr_wrap_inputs_fn(model_args, model_kwargs):
     return model_args, model_kwargs
 
 
-def sr_dummy_forward_fn(model_, input_sample_sizes: Tuple[List[int]]):
+def sr_dummy_forward_fn(model_, input_sample_sizes: tuple[list[int]]):
     device = get_model_device(model_)
     config = NNCFConfig.from_dict({"input_info": [{"sample_size": sizes} for sizes in input_sample_sizes]})
     input_info = FillerInputInfo.from_nncf_config(config)
@@ -433,7 +433,7 @@ class IModelDesc(ABC):
 class BaseDesc(IModelDesc):
     def __init__(
         self,
-        input_sample_sizes: Union[Tuple[List[int], ...], List[int]] = None,
+        input_sample_sizes: Union[tuple[list[int], ...], list[int]] = None,
         model_name: str = None,
         wrap_inputs_fn: Callable = None,
         input_info=None,
@@ -473,11 +473,11 @@ class BaseDesc(IModelDesc):
 class GeneralModelDesc(BaseDesc):
     def __init__(
         self,
-        input_sample_sizes: Union[Tuple[List[int], ...], List[int]] = None,
+        input_sample_sizes: Union[tuple[list[int], ...], list[int]] = None,
         model_name: str = None,
         wrap_inputs_fn: Callable = None,
         model_builder=None,
-        input_info: Union[Dict, List] = None,
+        input_info: Union[dict, list] = None,
     ):
         super().__init__(input_sample_sizes, model_name, wrap_inputs_fn, input_info)
         if not model_name and hasattr(model_builder, "__name__"):
@@ -492,7 +492,7 @@ class SingleLayerModelDesc(BaseDesc):
     def __init__(
         self,
         layer: nn.Module,
-        input_sample_sizes: Union[Tuple[List[int], ...], List[int]] = None,
+        input_sample_sizes: Union[tuple[list[int], ...], list[int]] = None,
         model_name: str = None,
         wrap_inputs_fn: Callable = None,
         input_info=None,
@@ -589,7 +589,7 @@ class ConvLayerConvModelDesc(BaseDesc):
         self,
         layer: nn.Module,
         conv_class: nn.Module,
-        input_sample_sizes: Union[Tuple[List[int], ...], List[int]] = None,
+        input_sample_sizes: Union[tuple[list[int], ...], list[int]] = None,
         model_name: str = None,
     ):
         super().__init__(input_sample_sizes, model_name)
@@ -887,8 +887,8 @@ def _case_dir(type_hw_config):
 
 def prepare_potential_quantizer_graph(graph: PTNNCFGraph, quantizer_setup: SingleConfigQuantizerSetup) -> nx.DiGraph:
     quantizers_weights_attr = {}
-    pre_hooked_quantizers_activations_attr: Dict[NNCFNodeName, Tuple[int, str]] = {}
-    post_hooked_quantizers_activations_attr: Dict[NNCFNodeName, str] = {}
+    pre_hooked_quantizers_activations_attr: dict[NNCFNodeName, tuple[int, str]] = {}
+    post_hooked_quantizers_activations_attr: dict[NNCFNodeName, str] = {}
 
     for qp in quantizer_setup.quantization_points.values():
         if qp.is_weight_quantization_point():

--- a/tests/torch/test_compression_lr_multiplier.py
+++ b/tests/torch/test_compression_lr_multiplier.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import copy
-from typing import Callable, Dict, List, Tuple
+from typing import Callable
 
 import pytest
 import torch
@@ -48,7 +48,7 @@ def get_sparsity_config() -> NNCFConfig:
     return config
 
 
-def get_config_algorithms(config: NNCFConfig) -> List[Dict]:
+def get_config_algorithms(config: NNCFConfig) -> list[dict]:
     if isinstance(config["compression"], list):
         algorithms = config["compression"]
     else:
@@ -73,7 +73,7 @@ def add_multiplier_to_config(
     return config
 
 
-def get_multipliers_from_config(config: NNCFConfig) -> Dict[str, float]:
+def get_multipliers_from_config(config: NNCFConfig) -> dict[str, float]:
     algo_to_multipliers = {}
 
     algorithms = get_config_algorithms(config)
@@ -85,7 +85,7 @@ def get_multipliers_from_config(config: NNCFConfig) -> Dict[str, float]:
     return algo_to_multipliers
 
 
-def merge_configs(configs: List[NNCFConfig], use_algo_list: bool = True) -> NNCFConfig:
+def merge_configs(configs: list[NNCFConfig], use_algo_list: bool = True) -> NNCFConfig:
     res_config = None
     algorithms = []
 
@@ -111,7 +111,7 @@ def merge_configs(configs: List[NNCFConfig], use_algo_list: bool = True) -> NNCF
     return res_config
 
 
-def get_configs_building_params() -> List[Dict]:
+def get_configs_building_params() -> list[dict]:
     res = []
     get_orig_config_fns = [get_quantization_config, get_sparsity_config]
     num_orig_configs = len(get_orig_config_fns)
@@ -165,7 +165,7 @@ def get_configs_building_params() -> List[Dict]:
     return res
 
 
-def create_initialized_lenet_model_and_dataloader(config: NNCFConfig) -> Tuple[nn.Module, DataLoader]:
+def create_initialized_lenet_model_and_dataloader(config: NNCFConfig) -> tuple[nn.Module, DataLoader]:
     with set_torch_seed():
         train_loader = create_random_mock_dataloader(config, num_samples=10)
         model = LeNet()
@@ -176,12 +176,12 @@ def create_initialized_lenet_model_and_dataloader(config: NNCFConfig) -> Tuple[n
 
 
 @pytest.fixture(name="configs_building_params", params=get_configs_building_params())
-def configs_building_params_(request) -> Dict:
+def configs_building_params_(request) -> dict:
     return request.param
 
 
 @pytest.fixture(name="ref_configs")
-def ref_configs_(configs_building_params: Dict) -> List[NNCFConfig]:
+def ref_configs_(configs_building_params: dict) -> list[NNCFConfig]:
     return [get_ref_config_fn() for get_ref_config_fn in configs_building_params["get_orig_config_fns"]]
 
 
@@ -191,7 +191,7 @@ def ref_config_(ref_configs, configs_building_params) -> NNCFConfig:
 
 
 @pytest.fixture(name="target_configs")
-def target_configs_(ref_configs: List[NNCFConfig], configs_building_params: Dict) -> List[NNCFConfig]:
+def target_configs_(ref_configs: list[NNCFConfig], configs_building_params: dict) -> list[NNCFConfig]:
     return [
         add_multiplier_to_config(config, local_multiplier=multiplier)
         for config, multiplier in zip(ref_configs, configs_building_params["multipliers"])
@@ -199,13 +199,13 @@ def target_configs_(ref_configs: List[NNCFConfig], configs_building_params: Dict
 
 
 @pytest.fixture(name="target_config")
-def target_config_(target_configs: List[NNCFConfig], configs_building_params: Dict) -> NNCFConfig:
+def target_config_(target_configs: list[NNCFConfig], configs_building_params: dict) -> NNCFConfig:
     target_config = merge_configs(target_configs, configs_building_params["use_algo_list"])
     return add_multiplier_to_config(target_config, global_multiplier=configs_building_params["global_multiplier"])
 
 
 @pytest.fixture(name="get_ref_lenet_model_and_dataloader")
-def get_ref_lenet_model_and_dataloader_(ref_config: NNCFConfig) -> Callable[[], Tuple[nn.Module, DataLoader]]:
+def get_ref_lenet_model_and_dataloader_(ref_config: NNCFConfig) -> Callable[[], tuple[nn.Module, DataLoader]]:
     def f():
         return create_initialized_lenet_model_and_dataloader(ref_config)
 
@@ -213,7 +213,7 @@ def get_ref_lenet_model_and_dataloader_(ref_config: NNCFConfig) -> Callable[[], 
 
 
 @pytest.fixture(name="get_target_lenet_model_and_dataloader")
-def get_target_lenet_model_and_dataloader_(target_config: NNCFConfig) -> Callable[[], Tuple[nn.Module, DataLoader]]:
+def get_target_lenet_model_and_dataloader_(target_config: NNCFConfig) -> Callable[[], tuple[nn.Module, DataLoader]]:
     def f():
         return create_initialized_lenet_model_and_dataloader(target_config)
 
@@ -231,7 +231,7 @@ class OneParameterModel(nn.Module):
         return self.param.sum()
 
 
-def get_one_parameter_model_creation_params(for_training: bool = False) -> List[Dict]:
+def get_one_parameter_model_creation_params(for_training: bool = False) -> list[dict]:
     params = []
     for init_requires_grad in [False, True]:
         requires_grad_settings_list = [
@@ -266,7 +266,7 @@ def get_one_parameter_model_creation_params(for_training: bool = False) -> List[
 def create_initialized_one_parameter_model_and_dataloader(
     parameter_cls: type,
     init_requires_grad: bool,
-    requires_grad_settings: List[Tuple[str, bool]],
+    requires_grad_settings: list[tuple[str, bool]],
     multiplier: float = None,
 ) -> [nn.Module, DataLoader]:
     with set_torch_seed():
@@ -297,8 +297,8 @@ def create_initialized_one_parameter_model_and_dataloader(
 
 @pytest.fixture(name="get_ref_one_parameter_model_and_dataloader")
 def get_ref_one_parameter_model_and_dataloader_(
-    one_parameter_model_creation_params: Dict,
-) -> Callable[[], Tuple[nn.Module, DataLoader]]:
+    one_parameter_model_creation_params: dict,
+) -> Callable[[], tuple[nn.Module, DataLoader]]:
     def f():
         return create_initialized_one_parameter_model_and_dataloader(
             nn.Parameter, **one_parameter_model_creation_params
@@ -309,8 +309,8 @@ def get_ref_one_parameter_model_and_dataloader_(
 
 @pytest.fixture(name="get_target_one_parameter_model_and_dataloader")
 def get_target_one_parameter_model_and_dataloader_(
-    one_parameter_model_creation_params: Dict,
-) -> Callable[[], Tuple[nn.Module, DataLoader]]:
+    one_parameter_model_creation_params: dict,
+) -> Callable[[], tuple[nn.Module, DataLoader]]:
     def f():
         return create_initialized_one_parameter_model_and_dataloader(
             CompressionParameter, **one_parameter_model_creation_params
@@ -336,7 +336,7 @@ def perform_model_training_steps(model: nn.Module, train_loader: DataLoader, num
     return model
 
 
-def get_params_grouped_by_algorithms(model: nn.Module) -> Dict[str, List[nn.Parameter]]:
+def get_params_grouped_by_algorithms(model: nn.Module) -> dict[str, list[nn.Parameter]]:
     cls_name_to_params = {}
     for module in model.modules():
         params = list(module.parameters(recurse=False))
@@ -365,7 +365,7 @@ def get_params_grouped_by_algorithms(model: nn.Module) -> Dict[str, List[nn.Para
 
 def get_lenet_params_after_training_steps(
     model: nn.Module, train_loader: DataLoader, num_steps: int = 1
-) -> Dict[str, List[nn.Parameter]]:
+) -> dict[str, list[nn.Parameter]]:
     with set_torch_seed():
         model = perform_model_training_steps(model, train_loader, num_steps)
     return get_params_grouped_by_algorithms(model)
@@ -373,14 +373,14 @@ def get_lenet_params_after_training_steps(
 
 def get_one_parameter_model_params_after_training_steps(
     model: nn.Module, train_loader: DataLoader, num_steps: int = 1
-) -> List[nn.Parameter]:
+) -> list[nn.Parameter]:
     with set_torch_seed():
         model = perform_model_training_steps(model, train_loader, num_steps)
     return list(model.parameters())
 
 
 def test_if_algorithms_add_params(
-    get_target_lenet_model_and_dataloader: Callable[[], Tuple[nn.Module, DataLoader]], ref_config: NNCFConfig
+    get_target_lenet_model_and_dataloader: Callable[[], tuple[nn.Module, DataLoader]], ref_config: NNCFConfig
 ):
     algo_to_params = get_lenet_params_after_training_steps(*get_target_lenet_model_and_dataloader(), num_steps=0)
     algo_names = get_multipliers_from_config(ref_config).keys()
@@ -390,8 +390,8 @@ def test_if_algorithms_add_params(
 
 @pytest.mark.parametrize("one_parameter_model_creation_params", get_one_parameter_model_creation_params())
 def test_if_parameter_is_initialized_correctly(
-    get_ref_one_parameter_model_and_dataloader: Callable[[], Tuple[nn.Module, DataLoader]],
-    get_target_one_parameter_model_and_dataloader: Callable[[], Tuple[nn.Module, DataLoader]],
+    get_ref_one_parameter_model_and_dataloader: Callable[[], tuple[nn.Module, DataLoader]],
+    get_target_one_parameter_model_and_dataloader: Callable[[], tuple[nn.Module, DataLoader]],
 ):
     ref_model, _ref_loader = get_ref_one_parameter_model_and_dataloader()
     target_model, target_loader = get_target_one_parameter_model_and_dataloader()
@@ -406,7 +406,7 @@ def test_if_parameter_is_initialized_correctly(
             get_one_parameter_model_params_after_training_steps(target_model, target_loader)
 
 
-def check_if_grads_are_multiplied(ref_params: List[nn.Parameter], target_params: List[nn.Parameter], multiplier: float):
+def check_if_grads_are_multiplied(ref_params: list[nn.Parameter], target_params: list[nn.Parameter], multiplier: float):
     ref_grads = get_grads(ref_params)
     ref_grads = [multiplier * grad for grad in ref_grads]
     target_grads = get_grads(target_params)
@@ -415,8 +415,8 @@ def check_if_grads_are_multiplied(ref_params: List[nn.Parameter], target_params:
 
 
 def test_if_setting_multipliers_in_config_multiplies_grads_values(
-    get_ref_lenet_model_and_dataloader: Callable[[], Tuple[nn.Module, DataLoader]],
-    get_target_lenet_model_and_dataloader: Callable[[], Tuple[nn.Module, DataLoader]],
+    get_ref_lenet_model_and_dataloader: Callable[[], tuple[nn.Module, DataLoader]],
+    get_target_lenet_model_and_dataloader: Callable[[], tuple[nn.Module, DataLoader]],
     target_config: NNCFConfig,
 ):
     ref_params = get_lenet_params_after_training_steps(*get_ref_lenet_model_and_dataloader())
@@ -432,9 +432,9 @@ def test_if_setting_multipliers_in_config_multiplies_grads_values(
     "one_parameter_model_creation_params", get_one_parameter_model_creation_params(for_training=True)
 )
 def test_if_setting_multiplier_in_parameter_multiplies_grads_values(
-    get_ref_one_parameter_model_and_dataloader: Callable[[], Tuple[nn.Module, DataLoader]],
-    get_target_one_parameter_model_and_dataloader: Callable[[], Tuple[nn.Module, DataLoader]],
-    one_parameter_model_creation_params: Dict,
+    get_ref_one_parameter_model_and_dataloader: Callable[[], tuple[nn.Module, DataLoader]],
+    get_target_one_parameter_model_and_dataloader: Callable[[], tuple[nn.Module, DataLoader]],
+    one_parameter_model_creation_params: dict,
 ):
     ref_params = get_one_parameter_model_params_after_training_steps(*get_ref_one_parameter_model_and_dataloader())
     target_params = get_one_parameter_model_params_after_training_steps(
@@ -446,7 +446,7 @@ def test_if_setting_multiplier_in_parameter_multiplies_grads_values(
 
 
 def check_if_zero_multiplier_freezes_training(
-    orig_params: List[nn.Parameter], params: List[nn.Parameter], multiplier: float
+    orig_params: list[nn.Parameter], params: list[nn.Parameter], multiplier: float
 ):
     if multiplier == 0:
         PTTensorListComparator.check_equal(orig_params, params)
@@ -454,7 +454,7 @@ def check_if_zero_multiplier_freezes_training(
         PTTensorListComparator.check_not_equal(orig_params, params)
 
 
-def get_params_diff(orig_params: List[nn.Parameter], params: List[nn.Parameter]) -> List[torch.Tensor]:
+def get_params_diff(orig_params: list[nn.Parameter], params: list[nn.Parameter]) -> list[torch.Tensor]:
     param_diffs = []
     for param, orig_param in zip(params, orig_params):
         param_diffs.append((param - orig_param).abs())
@@ -462,9 +462,9 @@ def get_params_diff(orig_params: List[nn.Parameter], params: List[nn.Parameter])
 
 
 def check_params_affect_training_speed(
-    orig_params: List[nn.Parameter],
-    ref_params: List[nn.Parameter],
-    target_params: List[nn.Parameter],
+    orig_params: list[nn.Parameter],
+    ref_params: list[nn.Parameter],
+    target_params: list[nn.Parameter],
     compression_lr_multiplier: float,
 ):
     assert len(ref_params) == len(orig_params)
@@ -482,8 +482,8 @@ def check_params_affect_training_speed(
 
 
 def test_if_setting_multipliers_in_config_affect_training_speed(
-    get_ref_lenet_model_and_dataloader: Callable[[], Tuple[nn.Module, DataLoader]],
-    get_target_lenet_model_and_dataloader: Callable[[], Tuple[nn.Module, DataLoader]],
+    get_ref_lenet_model_and_dataloader: Callable[[], tuple[nn.Module, DataLoader]],
+    get_target_lenet_model_and_dataloader: Callable[[], tuple[nn.Module, DataLoader]],
     target_config: NNCFConfig,
 ):
     orig_params = get_lenet_params_after_training_steps(*get_ref_lenet_model_and_dataloader(), num_steps=0)
@@ -499,9 +499,9 @@ def test_if_setting_multipliers_in_config_affect_training_speed(
     "one_parameter_model_creation_params", get_one_parameter_model_creation_params(for_training=True)
 )
 def test_if_setting_multiplier_in_parameter_affect_training_speed(
-    get_ref_one_parameter_model_and_dataloader: Callable[[], Tuple[nn.Module, DataLoader]],
-    get_target_one_parameter_model_and_dataloader: Callable[[], Tuple[nn.Module, DataLoader]],
-    one_parameter_model_creation_params: Dict,
+    get_ref_one_parameter_model_and_dataloader: Callable[[], tuple[nn.Module, DataLoader]],
+    get_target_one_parameter_model_and_dataloader: Callable[[], tuple[nn.Module, DataLoader]],
+    one_parameter_model_creation_params: dict,
 ):
     orig_params = get_one_parameter_model_params_after_training_steps(
         *get_ref_one_parameter_model_and_dataloader(), num_steps=0

--- a/tests/torch/test_distributed_data_parallel_mode.py
+++ b/tests/torch/test_distributed_data_parallel_mode.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 import time
-from typing import Tuple
 
 import pytest
 import torch
@@ -25,7 +24,7 @@ from tests.torch.helpers import create_random_mock_dataloader
 
 class ModelWithChangedTrain(nn.Module):
     def __init__(
-        self, in_out_channels: Tuple[Tuple[int, int]] = ((1, 3), (3, 5), (5, 7), (7, 10)), freezing_stages: int = -1
+        self, in_out_channels: tuple[tuple[int, int]] = ((1, 3), (3, 5), (5, 7), (7, 10)), freezing_stages: int = -1
     ):
         super().__init__()
         self.freezing_stages = freezing_stages

--- a/tests/torch/test_graph_building.py
+++ b/tests/torch/test_graph_building.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Union
 from unittest.mock import MagicMock
 
 import pytest
@@ -130,7 +130,7 @@ def test_forward_trace_function():
 
 
 @pytest.mark.parametrize("input_shape", ModelForGraphBuildingTest.INPUT_SHAPES)
-def test_activation_shape_tracing(input_shape: Tuple[int, ...]):
+def test_activation_shape_tracing(input_shape: tuple[int, ...]):
     model = ModelForGraphBuildingTest()
     graph_builder = GraphBuilder(
         create_dummy_forward_fn(
@@ -251,7 +251,7 @@ class MockModel(torch.nn.Module):
 
 
 class RandomRefTensor:
-    def __init__(self, shape: List[int]):
+    def __init__(self, shape: list[int]):
         self.tensor = torch.rand(shape)
 
 
@@ -268,7 +268,7 @@ class MockInputInfo(ModelInputInfo):
     MOCK_ARGS = (torch.Tensor([42.0]),)
     MOCK_KWARGS = {"foo": torch.ones([1, 3])}
 
-    def get_forward_inputs(self, device: str = None) -> Tuple[Tuple, Dict]:
+    def get_forward_inputs(self, device: str = None) -> tuple[tuple, dict]:
         return MockInputInfo.MOCK_ARGS, MockInputInfo.MOCK_KWARGS
 
 
@@ -301,9 +301,9 @@ def test_input_info_args_are_passed_into_forward(mock_model_with_stub_forward: M
 
 @dataclass
 class FillerInputInfoGenerationTestStruct:
-    config_input_info_subdict: Union[List[Dict], Dict]
-    ref_args: Tuple[torch.Tensor, ...]
-    ref_kwargs: Dict[str, torch.Tensor]
+    config_input_info_subdict: Union[list[dict], dict]
+    ref_args: tuple[torch.Tensor, ...]
+    ref_kwargs: dict[str, torch.Tensor]
 
 
 TEST_KEYWORD_1 = "keyword1"
@@ -387,7 +387,7 @@ def test_input_infos_respect_device_setting(input_info: ModelInputInfo, use_cuda
 
 
 class MockInitDataLoader(PTInitializingDataLoader):
-    def get_inputs(self, dataloader_output: Any) -> Tuple[Tuple, Dict]:
+    def get_inputs(self, dataloader_output: Any) -> tuple[tuple, dict]:
         return dataloader_output[0], dataloader_output[1]
 
     def get_target(self, dataloader_output: Any) -> Any:

--- a/tests/torch/test_input_management.py
+++ b/tests/torch/test_input_management.py
@@ -11,7 +11,6 @@
 
 import inspect
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
 
 import pytest
 import torch
@@ -44,9 +43,9 @@ def forward(arg1=None, arg2=None, arg3=None, arg4=None, arg5=TENSOR_DEFAULT):
 @dataclass
 class InputWrappingTestStruct:
     input_info: ModelInputInfo
-    model_args: Tuple
-    model_kwargs: Dict
-    ref_wrapping_sequence: List[torch.Tensor]
+    model_args: tuple
+    model_kwargs: dict
+    ref_wrapping_sequence: list[torch.Tensor]
     case_id: str
 
     def get_case_id(self) -> str:

--- a/tests/torch/test_knowledge_distillation.py
+++ b/tests/torch/test_knowledge_distillation.py
@@ -12,7 +12,6 @@
 from collections.abc import Iterable
 from copy import deepcopy
 from functools import reduce
-from typing import List, Tuple
 
 import pytest
 import torch
@@ -92,7 +91,7 @@ def test_knowledge_distillation_training_process(inference_type: str):
 
 def run_actual(
     model: nn.Module, config: NNCFConfig, inference_type: str, mock_dataloader: Iterable, ngpus_per_node=None
-) -> Tuple[List[torch.Tensor], NNCFNetwork]:
+) -> tuple[list[torch.Tensor], NNCFNetwork]:
     config = get_kd_config(config)
     model, compression_ctrl = create_compressed_model_and_algo_for_test(model, config)
     if inference_type == "DDP":
@@ -115,7 +114,7 @@ def run_actual(
 
 def run_reference(
     model: nn.Module, config: NNCFConfig, inference_type: str, mock_dataloader: Iterable, ngpus_per_node=None
-) -> List[torch.Tensor]:
+) -> list[torch.Tensor]:
     model = deepcopy(model)
     kd_model = deepcopy(model)
     mse = torch.nn.MSELoss().cuda()
@@ -399,7 +398,7 @@ def run_training_for_device_testing(
 
 
 class KDOutputModel(torch.nn.Module):
-    def __init__(self, target_shapes: List[Tuple[int]]):
+    def __init__(self, target_shapes: list[tuple[int]]):
         super().__init__()
         self.mock_param = torch.nn.Parameter(torch.ones([1]))
         self.target_shapes = target_shapes
@@ -412,7 +411,7 @@ class KDOutputModel(torch.nn.Module):
 
 
 class CustomOutputWeightedModel(torch.nn.Module):
-    def __init__(self, input_shape: List[int], outputs_dim_numbers_list: List[int]):
+    def __init__(self, input_shape: list[int], outputs_dim_numbers_list: list[int]):
         super().__init__()
         self.outputs_dim_numbers_list = outputs_dim_numbers_list
         # linear layer would be compressed and will lead to different teacher (FP) and student (compressed) model

--- a/tests/torch/test_layer_attributes.py
+++ b/tests/torch/test_layer_attributes.py
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Callable, Optional, Type
+from typing import Callable, Optional
 
 import pytest
 from torch import Size
@@ -67,7 +67,7 @@ from tests.torch.test_models.synthetic import ModelWithPermute
 class RefNodeDesc:
     def __init__(
         self,
-        metatype_cls: Type[OperatorMetatype],
+        metatype_cls: type[OperatorMetatype],
         layer_attributes: Optional[BaseLayerAttributes] = None,
         layer_attributes_comparator: Optional[Callable[[BaseLayerAttributes, BaseLayerAttributes], bool]] = None,
     ):
@@ -111,7 +111,7 @@ class LayerAttributesTestDesc:
         module_fn: nn.Module,
         model_input_info: ModelInputInfo,
         layer_attributes: BaseLayerAttributes,
-        metatype_cls: Type[OperatorMetatype],
+        metatype_cls: type[OperatorMetatype],
         layer_attributes_comparator: COMPARATOR_TYPE = default_comparator,
     ):
         self.module_fn = module_fn

--- a/tests/torch/test_load_model_state.py
+++ b/tests/torch/test_load_model_state.py
@@ -11,7 +11,6 @@
 import logging
 import os
 import re
-from typing import Dict, List, Set
 
 import pytest
 import torch
@@ -104,12 +103,12 @@ class MatchKeyDesc:
         num_loaded=0,
         is_resume=True,
         expects_error=False,
-        state_dict_to_load: Dict[str, torch.Tensor] = None,
-        model_state_dict: Dict[str, torch.Tensor] = None,
+        state_dict_to_load: dict[str, torch.Tensor] = None,
+        model_state_dict: dict[str, torch.Tensor] = None,
     ):
         self.state_dict_to_load = state_dict_to_load if state_dict_to_load else {}
         self.model_state_dict = model_state_dict if model_state_dict else {}
-        self.new_dict: Dict[str, torch.Tensor] = {}
+        self.new_dict: dict[str, torch.Tensor] = {}
         self.num_loaded = num_loaded
         self.processed_keys = ProcessedKeys()
         self.ignored_keys = []
@@ -129,37 +128,37 @@ class MatchKeyDesc:
     def setup_test(self, mocker):
         pass
 
-    def keys_to_load(self, keys: List[str]):
+    def keys_to_load(self, keys: list[str]):
         for k in keys:
             self.state_dict_to_load[k] = self.MOCKED_VALUE
         return self
 
-    def model_keys(self, keys: List[str]):
+    def model_keys(self, keys: list[str]):
         for k in keys:
             self.model_state_dict[k] = self.MOCKED_VALUE
         return self
 
-    def keys_to_ignore(self, keys: List[str]):
+    def keys_to_ignore(self, keys: list[str]):
         self.ignored_keys = keys
         return self
 
-    def missing(self, keys: List[str]):
+    def missing(self, keys: list[str]):
         self.processed_keys.extend_keys(keys, ProcessedKeyStatus.MISSING)
         return self
 
-    def unexpected(self, keys: List[str]):
+    def unexpected(self, keys: list[str]):
         self.processed_keys.extend_keys(keys, ProcessedKeyStatus.UNEXPECTED)
         return self
 
-    def size_mismatched(self, keys: List[str]):
+    def size_mismatched(self, keys: list[str]):
         self.processed_keys.extend_keys(keys, ProcessedKeyStatus.SIZE_MISMATCHED)
         return self
 
-    def matched(self, keys: List[str]):
+    def matched(self, keys: list[str]):
         self.processed_keys.extend_keys(keys, ProcessedKeyStatus.MATCHED)
         return self
 
-    def skipped(self, keys: List[str]):
+    def skipped(self, keys: list[str]):
         self.processed_keys.extend_keys(keys, ProcessedKeyStatus.SKIPPED)
         return self
 
@@ -195,7 +194,7 @@ OP2_MIDDLE = f"{PREFIX}.{OP2}.{SUFFIX}"
 
 class OptionalMatchKeyDesc(MatchKeyDesc):
     def setup_test(self, mocker):
-        def fn() -> Set["str"]:
+        def fn() -> set["str"]:
             return {OP1, OP2}
 
         mocked_registry_get = mocker.patch.object(OPTIONAL_PARAMETERS_REGISTRY, "get_parameters_names")

--- a/tests/torch/test_model_graph_manager.py
+++ b/tests/torch/test_model_graph_manager.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Dict, Tuple
 
 import pytest
 import torch
@@ -76,7 +75,7 @@ MODELS_LIST = [
 class TestManagerForOriginalModels:
     @pytest.fixture(autouse=True, scope="function")
     def init_models(self):
-        self.models: Dict[str, ModelDesc] = {
+        self.models: dict[str, ModelDesc] = {
             "ConvBiasBNTestModel": ModelDesc(helpers.ConvBiasBNTestModel, "ConvBiasBNTestModel/Conv2d[conv]/conv2d_0"),
             "ConvBNTestModel": ModelDesc(helpers.ConvBNTestModel, "ConvBNTestModel/Conv2d[conv]/conv2d_0"),
             "ConvTestModel": ModelDesc(helpers.ConvTestModel, "ConvTestModel/Conv2d[conv]/conv2d_0"),
@@ -103,7 +102,7 @@ class TestManagerForOriginalModels:
     }
 
     @pytest.fixture(params=MODELS_LIST)
-    def model_desc(self, request) -> Tuple[str, ModelDesc]:
+    def model_desc(self, request) -> tuple[str, ModelDesc]:
         return request.param, self.models[request.param]
 
     def test_get_potential_fused_node(self, model_desc):

--- a/tests/torch/test_model_transformer.py
+++ b/tests/torch/test_model_transformer.py
@@ -14,7 +14,6 @@ from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import List
 
 import networkx as nx
 import pytest
@@ -261,7 +260,7 @@ class TestInsertionCommands:
         assert len(model.nncf._groups_vs_hooks_handlers[test_hook_group]) == 1
 
     @staticmethod
-    def check_order(iterable1: List, iterable2: List, ordering: List):
+    def check_order(iterable1: list, iterable2: list, ordering: list):
         for idx, order in enumerate(ordering):
             assert iterable1[idx] is iterable2[order]
 

--- a/tests/torch/test_pytorch_patch.py
+++ b/tests/torch/test_pytorch_patch.py
@@ -11,7 +11,6 @@
 
 import inspect
 import os
-from typing import List
 
 import pytest
 import torch
@@ -54,7 +53,7 @@ def test_get_all_aliases_is_valid():
 def test_patch_magic_functions(name_space):
     patched_magic_fns = MagicFunctionsToPatch.MAGIC_FUNCTIONS_TO_PATCH.get(name_space, [])
     for op_name, operator in PT_OPERATOR_METATYPES.registry_dict.items():
-        op_fns: List[str] = operator.module_to_function_names.get(name_space, [])
+        op_fns: list[str] = operator.module_to_function_names.get(name_space, [])
         op_magic_fns = [x for x in op_fns if x.startswith("__") and x.endswith("__")]
         for fn_name in op_magic_fns:
             assert fn_name in patched_magic_fns, f"{op_name} contains not patched magic function {fn_name}"
@@ -64,9 +63,9 @@ def test_patch_magic_functions(name_space):
 def test_op_for_patch_magic_functions(name_space):
     patched_magic_fns = MagicFunctionsToPatch.MAGIC_FUNCTIONS_TO_PATCH.get(name_space, [])
 
-    all_magic_fns_in_op: List[str] = []
+    all_magic_fns_in_op: list[str] = []
     for operator in PT_OPERATOR_METATYPES.registry_dict.values():
-        op_fns: List[str] = operator.module_to_function_names.get(name_space, [])
+        op_fns: list[str] = operator.module_to_function_names.get(name_space, [])
         all_magic_fns_in_op += [x for x in op_fns if x.startswith("__") and x.endswith("__")]
 
     for patched_fn in patched_magic_fns:

--- a/tests/torch/test_sota_checkpoints.py
+++ b/tests/torch/test_sota_checkpoints.py
@@ -16,7 +16,7 @@ import sys
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import pandas as pd
 import pytest
@@ -97,7 +97,7 @@ class ResultInfo:
         }
 
 
-def read_reference_file(ref_path: Path) -> List[EvalRunParamsStruct]:
+def read_reference_file(ref_path: Path) -> list[EvalRunParamsStruct]:
     """
     Reads the reference file to get a list of `EvalRunParamsStruct` objects.
 
@@ -262,7 +262,7 @@ class TestSotaCheckpoints:
         Fixture to collect information about tests in `ResultInfo` struct
         and dump it to `metrics_dump_dir / results.csv`.
         """
-        data: List[ResultInfo] = []
+        data: list[ResultInfo] = []
         yield data
         if metrics_dump_dir and data:
             path = metrics_dump_dir / "results.csv"
@@ -324,7 +324,7 @@ class TestSotaCheckpoints:
         ]  # fmt: skip
         return " ".join(cmd)
 
-    def get_reference_fp32_metric(self, metrics_dump_path: Path, reference_name: str) -> Tuple[Optional[float], bool]:
+    def get_reference_fp32_metric(self, metrics_dump_path: Path, reference_name: str) -> tuple[Optional[float], bool]:
         """
         Get reference metric to not compressed model.
         In case of exists reference data will get reference metric from it others reference data gets
@@ -389,7 +389,7 @@ class TestSotaCheckpoints:
         sota_checkpoints_dir: str,
         sota_data_dir: str,
         eval_run_param: EvalRunParamsStruct,
-        collected_data: List[ResultInfo],
+        collected_data: list[ResultInfo],
         metrics_dump_dir: Path,
     ):
         """
@@ -521,7 +521,7 @@ class TestSotaCheckpoints:
         ov_data_dir: Path,
         openvino: bool,
         ov_config_dir: str,
-        collected_data: List[ResultInfo],
+        collected_data: list[ResultInfo],
         metrics_dump_dir: Path,
     ):
         """
@@ -622,7 +622,7 @@ class TestSotaCheckpoints:
         distributed_mode_sync_port: str,
         sota_data_dir: Path,
         sota_checkpoints_dir: Path,
-        collected_data: List[ResultInfo],
+        collected_data: list[ResultInfo],
         metrics_dump_dir: Path,
     ):
         """

--- a/tests/torch/test_statistics_aggregator.py
+++ b/tests/torch/test_statistics_aggregator.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, List, Type
+from typing import Callable
 
 import numpy as np
 import pytest
@@ -60,13 +60,13 @@ MinMaxTestParameters = TemplateTestStatisticsAggregator.MinMaxTestParameters
 
 class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
     @staticmethod
-    def get_min_max_algo_backend_cls() -> Type[PTMinMaxAlgoBackend]:
+    def get_min_max_algo_backend_cls() -> type[PTMinMaxAlgoBackend]:
         return PTMinMaxAlgoBackend
 
     def get_bias_correction_algo_backend_cls(self) -> None:
         pytest.skip("PTBiasCorrectionAlgoBackend is not implemented")
 
-    def get_fast_bias_correction_algo_backend_cls(self) -> Type[PTFastBiasCorrectionAlgoBackend]:
+    def get_fast_bias_correction_algo_backend_cls(self) -> type[PTFastBiasCorrectionAlgoBackend]:
         return PTFastBiasCorrectionAlgoBackend
 
     def get_backend_model(self, dataset_samples):
@@ -103,7 +103,7 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
     def get_target_point_cls(self):
         return PTTargetPoint
 
-    def reducers_map(self) -> List[TensorReducerBase]:
+    def reducers_map(self) -> list[TensorReducerBase]:
         return None
 
     @pytest.fixture

--- a/tests/torch/test_statistics_serializer.py
+++ b/tests/torch/test_statistics_serializer.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict
 
 import torch
 
@@ -19,7 +18,7 @@ from tests.cross_fw.test_templates.test_statistics_serializer import TemplateTes
 
 
 class TestTorchStatisticsSerializer(TemplateTestStatisticsSerializer):
-    def _get_backend_statistics(self) -> Dict[str, Dict[str, Tensor]]:
+    def _get_backend_statistics(self) -> dict[str, dict[str, Tensor]]:
         return {
             "layer/1/activation": {"mean": Tensor(torch.tensor([0.1, 0.2, 0.3]))},
             "layer/2/activation": {"variance": Tensor(torch.tensor([0.05, 0.06, 0.07]))},
@@ -28,7 +27,7 @@ class TestTorchStatisticsSerializer(TemplateTestStatisticsSerializer):
     def _get_backend(self) -> TensorBackend:
         return BackendType.TORCH
 
-    def is_equal(self, a1: Dict[str, Tensor], a2: Dict[str, Tensor]) -> bool:
+    def is_equal(self, a1: dict[str, Tensor], a2: dict[str, Tensor]) -> bool:
         for key in a1:
             if key not in a2:
                 return False

--- a/tests/torch2/function_hook/graph/test_build_graph_mode.py
+++ b/tests/torch2/function_hook/graph/test_build_graph_mode.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Union
+from typing import Union
 
 import pytest
 import torch
@@ -123,7 +123,7 @@ def test_execute_pre_hooks():
 
 
 @pytest.fixture(params=["tensor", "list", "torch_return_type"])
-def example_outputs(request: FixtureRequest) -> Union[torch.Tensor, List[torch.Tensor], torch.return_types.max]:
+def example_outputs(request: FixtureRequest) -> Union[torch.Tensor, list[torch.Tensor], torch.return_types.max]:
     return {
         "tensor": torch.tensor(1.0),
         "list": [torch.tensor(1), torch.tensor([2])],
@@ -131,7 +131,7 @@ def example_outputs(request: FixtureRequest) -> Union[torch.Tensor, List[torch.T
     }.get(request.param)
 
 
-def test_execute_post_hooks(example_outputs: Union[torch.Tensor, List[torch.Tensor], torch.return_types.max]):
+def test_execute_post_hooks(example_outputs: Union[torch.Tensor, list[torch.Tensor], torch.return_types.max]):
     ctx = GraphBuilderMode(nn.Identity(), HookStorage())
     op_meta = OpMeta("/relu/0", torch.relu, {"node_id": 0})
     ctx.execute_post_hooks(example_outputs, op_meta)

--- a/tests/torch2/function_hook/nncf_graph/test_nncf_graph.py
+++ b/tests/torch2/function_hook/nncf_graph/test_nncf_graph.py
@@ -11,7 +11,7 @@
 
 from dataclasses import dataclass
 from functools import partial
-from typing import Callable, List, Tuple, Union
+from typing import Callable, Union
 
 import networkx as nx
 import pytest
@@ -118,7 +118,7 @@ def test_convert_to_nncf_graph_multi_edges(regen_ref_data: bool):
 class ModelDesc:
     model_name: str
     model_builder: callable
-    inputs_info: Union[List[List[int]], Tuple[List[int], ...]]
+    inputs_info: Union[list[list[int]], tuple[list[int], ...]]
 
     def __str__(self):
         return self.model_name
@@ -233,7 +233,7 @@ def _no_missed_input_edge_for_conv() -> PTNNCFGraph:
         (_no_missed_input_edge_for_conv, []),
     ),
 )
-def test_get_nodes_with_missed_input_edges(graph_builder: Callable[[], PTNNCFGraph], ref: List[str]):
+def test_get_nodes_with_missed_input_edges(graph_builder: Callable[[], PTNNCFGraph], ref: list[str]):
     graph = graph_builder()
     ret = graph.get_nodes_with_missed_input_edges()
     ret_names = [node.node_name for node in ret]

--- a/tests/torch2/function_hook/quantization/helper.py
+++ b/tests/torch2/function_hook/quantization/helper.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import Optional
 
 import torch
 
@@ -95,7 +95,7 @@ def get_sum_aggregation_nncf_graph() -> NNCFGraphToTestSumAggregation:
     )
 
 
-def get_nncf_network(model: torch.nn.Module, input_shape: Optional[List[int]] = None):
+def get_nncf_network(model: torch.nn.Module, input_shape: Optional[list[int]] = None):
     if input_shape is None:
         input_shape = [1, 3, 32, 32]
     model = model.eval()

--- a/tests/torch2/function_hook/quantization/strip/test_strip_dequantize.py
+++ b/tests/torch2/function_hook/quantization/strip/test_strip_dequantize.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Any, Type
+from typing import Any
 
 import pytest
 import torch
@@ -39,7 +39,7 @@ from tests.torch.helpers import LinearModel
 
 def check_compression_modules(
     model: nn.Module,
-    expected_class: Type,
+    expected_class: type,
 ) -> None:
     hook_storage = get_hook_storage(model)
     hooks = list(hook_storage.named_hooks())
@@ -51,7 +51,7 @@ def check_compression_modules(
 @dataclass
 class ParamStripLora:
     mode: CompressWeightsMode
-    decompressor_class: Type
+    decompressor_class: type
     torch_dtype: torch.dtype
     atol: float
     weight_dtype: torch.dtype

--- a/tests/torch2/function_hook/quantization/test_fast_bias_correction.py
+++ b/tests/torch2/function_hook/quantization/test_fast_bias_correction.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 
 import pytest
 import torch
@@ -24,7 +23,7 @@ from tests.cross_fw.test_templates.test_fast_bias_correction import TemplateTest
 
 class TestTorchFBCAlgorithm(TemplateTestFBCAlgorithm):
     @staticmethod
-    def list_to_backend_type(data: List) -> torch.Tensor:
+    def list_to_backend_type(data: list) -> torch.Tensor:
         return torch.Tensor(data)
 
     @staticmethod
@@ -66,7 +65,7 @@ class TestTorchFBCAlgorithm(TemplateTestFBCAlgorithm):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skipping for CPU-only setups")
 class TestTorchCudaFBCAlgorithm(TestTorchFBCAlgorithm):
     @staticmethod
-    def list_to_backend_type(data: List) -> torch.Tensor:
+    def list_to_backend_type(data: list) -> torch.Tensor:
         return torch.Tensor(data).cuda()
 
     @staticmethod

--- a/tests/torch2/function_hook/quantization/test_fq_params_calculation.py
+++ b/tests/torch2/function_hook/quantization/test_fq_params_calculation.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 import pytest
@@ -34,7 +34,7 @@ REFERENCE_SCALES_DIR = TEST_ROOT / "torch2" / "data" / "reference_scales"
 
 
 def min_max_quantize_model(
-    original_model: torch.nn.Module, quantization_params: Dict[str, Any] = None
+    original_model: torch.nn.Module, quantization_params: dict[str, Any] = None
 ) -> torch.nn.Module:
     config = nncf.NNCFConfig.from_dict({"input_info": {"sample_size": [1, 1, 10, 10]}})
 
@@ -61,7 +61,7 @@ def min_max_quantize_model(
     return quantized_model
 
 
-def get_fq_nodes(model: NNCFNetwork) -> Dict[Scope, torch.nn.Module]:
+def get_fq_nodes(model: NNCFNetwork) -> dict[Scope, torch.nn.Module]:
     quantization_types = tuple(class_type for class_type in QUANTIZATION_MODULES.registry_dict.values())
     ret = {}
     for name, module in model.named_modules():
@@ -70,7 +70,7 @@ def get_fq_nodes(model: NNCFNetwork) -> Dict[Scope, torch.nn.Module]:
     return ret
 
 
-def get_fq_nodes_params(nncf_module_quantizations: Dict[Scope, torch.nn.Module]) -> Dict[str, np.ndarray]:
+def get_fq_nodes_params(nncf_module_quantizations: dict[Scope, torch.nn.Module]) -> dict[str, np.ndarray]:
     output = {}
     for name, nncf_module_quantization in nncf_module_quantizations.items():
         input_low, input_high = nncf_module_quantization.get_input_low_input_high()

--- a/tests/torch2/function_hook/quantization/test_min_max.py
+++ b/tests/torch2/function_hook/quantization/test_min_max.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Tuple
 
 import pytest
 
@@ -45,7 +44,7 @@ class TestTorchMinMaxAlgorithm(TemplateTestMinMaxAlgorithm):
 
 
 class TestTorchGetTargetPointShape(TemplateTestGetTargetPointShape, TestTorchMinMaxAlgorithm):
-    def get_nncf_graph(self, weight_port_id: int, weight_shape: Tuple[int]) -> NNCFGraph:
+    def get_nncf_graph(self, weight_port_id: int, weight_shape: tuple[int]) -> NNCFGraph:
         return NNCFGraphToTest(
             conv_metatype=PTConv2dMetatype, nncf_graph_cls=PTNNCFGraph, const_metatype=PTConstNoopMetatype
         ).nncf_graph
@@ -61,18 +60,18 @@ class TestTorchGetChannelAxes(TemplateTestGetChannelAxes, TestTorchMinMaxAlgorit
         return PTLinearMetatype
 
     @staticmethod
-    def get_conv_node_attrs(weight_port_id: int, weight_shape: Tuple[int]) -> BaseLayerAttributes:
+    def get_conv_node_attrs(weight_port_id: int, weight_shape: tuple[int]) -> BaseLayerAttributes:
         # This method isn't needed for Torch backend
         return None
 
     @staticmethod
-    def get_depthwiseconv_node_attrs(weight_port_id: int, weight_shape: Tuple[int]) -> BaseLayerAttributes:
+    def get_depthwiseconv_node_attrs(weight_port_id: int, weight_shape: tuple[int]) -> BaseLayerAttributes:
         # This method isn't needed for Torch backend
         return None
 
     @staticmethod
     def get_matmul_node_attrs(
-        weight_port_id: int, transpose_weight: Tuple[int], weight_shape: Tuple[int]
+        weight_port_id: int, transpose_weight: tuple[int], weight_shape: tuple[int]
     ) -> BaseLayerAttributes:
         # This method isn't needed for Torch backend
         return None

--- a/tests/torch2/function_hook/quantization/test_quantized_graphs.py
+++ b/tests/torch2/function_hook/quantization/test_quantized_graphs.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from functools import partial
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 import torch
@@ -70,7 +70,7 @@ TEST_MODELS_DESC = [
 @pytest.mark.parametrize(
     ("desc", "quantization_parameters"), TEST_MODELS_DESC, ids=[m[0].model_name for m in TEST_MODELS_DESC]
 )
-def test_quantized_graphs(desc: ModelDesc, quantization_parameters: Dict[str, Any], regen_ref_data: bool):
+def test_quantized_graphs(desc: ModelDesc, quantization_parameters: dict[str, Any], regen_ref_data: bool):
     model = desc.model_builder().eval()
 
     if isinstance(desc.input_sample_sizes, dict):

--- a/tests/torch2/function_hook/quantization/test_reducers_and_aggregators.py
+++ b/tests/torch2/function_hook/quantization/test_reducers_and_aggregators.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from abc import ABC
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional
 
 import numpy as np
 import pytest
@@ -60,7 +60,7 @@ class BaseTestReducersAggregators(TemplateTestReducersAggregators, ABC):
         ref_ = torch.tensor(ref).to(val_.device)
         return torch.allclose(val_, ref_) and val_.shape == ref_.shape
 
-    def squeeze_tensor(self, ref_tensor: List[Any], axes: Optional[Tuple[int]] = None):
+    def squeeze_tensor(self, ref_tensor: list[Any], axes: Optional[tuple[int]] = None):
         if axes is None:
             return torch.tensor(ref_tensor).squeeze()
         return torch.tensor(ref_tensor).squeeze(axes)

--- a/tests/torch2/function_hook/quantization/test_smooth_quant.py
+++ b/tests/torch2/function_hook/quantization/test_smooth_quant.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Dict, Type
+from typing import Callable
 
 import numpy as np
 import openvino as ov
@@ -56,7 +56,7 @@ class TestTorchSQAlgorithm(TemplateTestSQAlgorithm):
     def inplace_statistics(self, request) -> bool:
         return request.param
 
-    def get_node_name_map(self, model_cls) -> Dict[str, str]:
+    def get_node_name_map(self, model_cls) -> dict[str, str]:
         if model_cls is LinearMultiShapeModel:
             return PT_LINEAR_MODEL_MM_MAP
         if model_cls is ConvTestModel:
@@ -73,7 +73,7 @@ class TestTorchSQAlgorithm(TemplateTestSQAlgorithm):
         return transform_fn
 
     @staticmethod
-    def get_backend() -> Type[PTSmoothQuantAlgoBackend]:
+    def get_backend() -> type[PTSmoothQuantAlgoBackend]:
         return PTSmoothQuantAlgoBackend()
 
     @staticmethod
@@ -81,7 +81,7 @@ class TestTorchSQAlgorithm(TemplateTestSQAlgorithm):
         return GraphModelWrapper(wrap_model(model.eval()), torch.rand(model.INPUT_SIZE))
 
     @staticmethod
-    def check_scales(model: GraphModelWrapper, reference_values: Dict[str, np.ndarray], model_cls) -> None:
+    def check_scales(model: GraphModelWrapper, reference_values: dict[str, np.ndarray], model_cls) -> None:
         names_map = PT_LINEAR_MODEL_SQ_MAP if model_cls is LinearMultiShapeModel else PT_CONV_MODEL_SQ_MAP
         data_map = {n: x for n, x in model.model.named_parameters()}
 

--- a/tests/torch2/function_hook/quantization/test_weights_compression.py
+++ b/tests/torch2/function_hook/quantization/test_weights_compression.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List
 
 import pytest
 import torch
@@ -475,7 +474,7 @@ class TestPTTemplateWeightCompression(TemplateWeightCompression):
         return cast_to(x, dtype)
 
     @staticmethod
-    def check_weights(model: torch.nn.Module, ref_ids: List[int]) -> None:
+    def check_weights(model: torch.nn.Module, ref_ids: list[int]) -> None:
         all_names = model.get_weight_names_in_exec_order()
         low_precision_nodes = list(map(lambda i: all_names[i], ref_ids))
         decompressed_modules = list(
@@ -487,7 +486,7 @@ class TestPTTemplateWeightCompression(TemplateWeightCompression):
                     assert isinstance(op, INT4SymmetricWeightsDecompressor)
 
     @staticmethod
-    def get_not_supported_algorithms() -> List[str]:
+    def get_not_supported_algorithms() -> list[str]:
         return ["lora_correction", "gptq"]
 
     @staticmethod
@@ -547,7 +546,7 @@ class TestPTTemplateWeightCompression(TemplateWeightCompression):
         return awq_num
 
     @staticmethod
-    def get_reference_for_test_awq_scale_reference() -> Dict[str, Tensor]:
+    def get_reference_for_test_awq_scale_reference() -> dict[str, Tensor]:
         return {
             "linear3/linear/0": Tensor(
                 torch.tensor([[1.226455, 1.205499, 1.141340, 1.097436, 1.064355, 1.037971, 1.016118, 0.997526]])

--- a/tests/torch2/function_hook/sparsify_activations/test_algo.py
+++ b/tests/torch2/function_hook/sparsify_activations/test_algo.py
@@ -11,7 +11,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, Optional
+from typing import Callable, Optional
 
 import openvino as ov
 import pytest
@@ -44,9 +44,9 @@ class SparsifyActivationsAlgorithmTestDesc:
     name: str
     model_getter: Callable[[], nn.Module]
     dataset_getter: Callable[[torch.device], nncf.Dataset]
-    target_sparsity_by_scope: Dict[TargetScope, float]
+    target_sparsity_by_scope: dict[TargetScope, float]
     ignored_scope: Optional[nncf.IgnoredScope]
-    ref_sparsifier_target_sparsity: Dict[str, float]
+    ref_sparsifier_target_sparsity: dict[str, float]
     ref_num_batches_tracked: int
     ref_num_patterns_in_ov: int
 
@@ -214,9 +214,9 @@ class TestSparsifyActivationsAlgorithm:
 
 @dataclass
 class TargetSparsityByNodeTestDesc:
-    target_sparsity_by_scope: Dict[TargetScope, float]
+    target_sparsity_by_scope: dict[TargetScope, float]
     ignored_scope: IgnoredScope
-    ref_target_sparsity_by_node_name: Optional[Dict[str, float]] = None
+    ref_target_sparsity_by_node_name: Optional[dict[str, float]] = None
     raised_error_message: Optional[str] = None
 
 

--- a/tests/torch2/function_hook/sparsify_activations/test_components.py
+++ b/tests/torch2/function_hook/sparsify_activations/test_components.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import List
 
 import pytest
 import torch
@@ -37,9 +36,9 @@ from tests.torch2.function_hook.sparsify_activations.helpers import convert_igno
 class SparsifierForwardTestDesc:
     target_sparsity: float
     alpha: float
-    input_batches: List[torch.Tensor]
-    ref_running_thresholds: List[torch.Tensor]
-    ref_outputs: List[torch.Tensor]
+    input_batches: list[torch.Tensor]
+    ref_running_thresholds: list[torch.Tensor]
+    ref_outputs: list[torch.Tensor]
 
 
 sparsifier_forward_during_calibration_test_descs = {
@@ -280,7 +279,7 @@ class TestTargetScope:
         assert hash(target_scope1) != hash(target_scope2)
 
     @pytest.mark.parametrize("target_scope,ref_target_names", TARGET_SCOPE_MATCH_DATA)
-    def test_get_target_node_names_from_target_scope(self, target_scope: TargetScope, ref_target_names: List[str]):
+    def test_get_target_node_names_from_target_scope(self, target_scope: TargetScope, ref_target_names: list[str]):
         nncf_graph = NNCFGraphToTestIgnoredScope(CONV_TYPE, LINEAR_TYPE).nncf_graph
         target_names = get_target_node_names_from_target_scope(target_scope, nncf_graph)
         assert sorted(target_names) == sorted(ref_target_names)

--- a/tests/torch2/function_hook/test_function_hook_mode.py
+++ b/tests/torch2/function_hook/test_function_hook_mode.py
@@ -11,7 +11,7 @@
 
 
 from dataclasses import dataclass
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 import pytest
 import torch
@@ -93,7 +93,7 @@ def test_get_current_executed_op_name():
 
 
 @pytest.fixture(params=["tensor", "list", "torch_return_type"])
-def example_outputs(request: FixtureRequest) -> Union[torch.Tensor, List[torch.Tensor], torch.return_types.max]:
+def example_outputs(request: FixtureRequest) -> Union[torch.Tensor, list[torch.Tensor], torch.return_types.max]:
     return {
         "tensor": torch.tensor(1),
         "list": [torch.tensor(1), torch.tensor([2])],
@@ -101,7 +101,7 @@ def example_outputs(request: FixtureRequest) -> Union[torch.Tensor, List[torch.T
     }.get(request.param)
 
 
-def test_execute_post_hooks(example_outputs: Union[torch.Tensor, List[torch.Tensor], torch.return_types.max]):
+def test_execute_post_hooks(example_outputs: Union[torch.Tensor, list[torch.Tensor], torch.return_types.max]):
     op_name = "/relu/0"
     hook_storage = HookStorage()
     hook_port_0 = CallCount()

--- a/tests/torch2/function_hook/test_handle_inner_functions.py
+++ b/tests/torch2/function_hook/test_handle_inner_functions.py
@@ -11,7 +11,6 @@
 
 import ast
 import inspect
-from typing import Tuple
 
 import pytest
 import torch
@@ -30,7 +29,7 @@ REF_DIR = TEST_ROOT / "torch2" / "data" / "function_hook" / "handle_inner_functi
 
 class ReluModel(nn.Module):
     @staticmethod
-    def example_input() -> Tuple[torch.Tensor, ...]:
+    def example_input() -> tuple[torch.Tensor, ...]:
         return (torch.rand(1, 1, 1),)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -43,7 +42,7 @@ class ReluModel(nn.Module):
 
 class BatchNormModel(nn.Module):
     @staticmethod
-    def example_input() -> Tuple[torch.Tensor, ...]:
+    def example_input() -> tuple[torch.Tensor, ...]:
         return (torch.rand(1, 1, 1),)
 
     def __init__(self):
@@ -62,7 +61,7 @@ class MultiHeadAttention(nn.Module):
     num_heads = 4
 
     @classmethod
-    def example_input(cls) -> Tuple[torch.Tensor, ...]:
+    def example_input(cls) -> tuple[torch.Tensor, ...]:
         query = torch.rand((cls.seq_length, cls.batch_size, cls.embed_dim))
         key = torch.rand((cls.seq_length, cls.batch_size, cls.embed_dim))
         value = torch.rand((cls.seq_length, cls.batch_size, cls.embed_dim))

--- a/tests/torch2/function_hook/test_hook_storage.py
+++ b/tests/torch2/function_hook/test_hook_storage.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 
 import pytest
 import torch
@@ -64,7 +63,7 @@ def test_remove_handle():
 
 
 class CheckPriority(nn.Module):
-    def __init__(self, storage: List, name: str):
+    def __init__(self, storage: list, name: str):
         super().__init__()
         self.storage = storage
         self.name = name


### PR DESCRIPTION
### Changes

[PEP585](https://peps.python.org/pep-0585/) for test
Enable UP006 ruff rule  https://docs.astral.sh/ruff/rules/non-pep585-annotation/

### Reason for changes

https://docs.python.org/3/library/typing.html#deprecated-aliases
Preparing to enable ruff rule UP006

### Related tickets

160796
https://github.com/openvinotoolkit/nncf/pull/3449
https://github.com/openvinotoolkit/nncf/pull/3447


