### PR TITLE
[PTQ Conformance][FX] Fix Torch Compile OV Model Caching

### DIFF
--- a/tests/post_training/pipelines/base.py
+++ b/tests/post_training/pipelines/base.py
@@ -506,7 +506,7 @@ class PTQTestPipeline(BaseTestPipeline):
             mod = torch.compile(
                 exported_model.module(),
                 backend="openvino",
-                options={"model_caching": True, "cache_dir": str(self.output_model_dir)},
+                options={"model_caching": True, "cache_dir": str(self.output_model_dir), "aot_autograd": True},
             )
             mod(self.dummy_tensor)
 


### PR DESCRIPTION
### Changes

Save Torch Compile using torch compile with `aot_autograd` tracing.

### Reason for changes

To have OV model cached with torch.compile and `aot_autograd` tracing mechanism similar to the torch.compile used in inference.

### Tests
Category | Job | Status | Job Number | Notes
-- | -- | -- | -- | --
PTQ | PTQ | Running | 663 |

