### PR TITLE
[Conformance] Use Nightly Commit for Optimum in Conformance Test

### DIFF
--- a/tests/post_training/data/wc_reference_data.yaml
+++ b/tests/post_training/data/wc_reference_data.yaml
@@ -66,32 +66,32 @@ tinyllama_int8_data_free_backend_FX_TORCH:
   num_int4: 0
   num_int8: 312
   exception_xfail_reason:
-    type: "TypeError"
-    error_message: "'function' object is not iterable"
+    type: "InternalError"
+    error_message: "Graph break encountered in torch compile!"
     message: "Issue-165013"
 tinyllama_int4_data_free_backend_FX_TORCH:
   metric_value: 0.73873
   num_int4: 114
   num_int8: 84
   exception_xfail_reason:
-    type: "TypeError"
-    error_message: "'function' object is not iterable"
+    type: "FileNotFoundError"
+    error_message: "Openvino Model Files Not Found!"
     message: "Issue-165013"
 tinyllama_data_aware_backend_FX_TORCH:
   metric_value: 0.85811
   num_int4: 94
   num_int8: 124
   exception_xfail_reason:
-    type: "TypeError"
-    error_message: "'function' object is not iterable"
+    type: "FileNotFoundError"
+    error_message: "Openvino Model Files Not Found!"
     message: "Issue-165013"
 tinyllama_scale_estimation_per_channel_backend_FX_TORCH:
   metric_value: 0.80873
   num_int4: 188
   num_int8: 124
   exception_xfail_reason:
-    type: "TypeError"
-    error_message: "'function' object is not iterable"
+    type: "FileNotFoundError"
+    error_message: "Openvino Model Files Not Found!"
     message: "Issue-165013"
   atol: 0.006 # difference across devices: 0.80873 vs 0.81389
 tinyllama_data_aware_awq_scale_estimation_backend_FX_TORCH:
@@ -99,6 +99,6 @@ tinyllama_data_aware_awq_scale_estimation_backend_FX_TORCH:
   num_int4: 94
   num_int8: 124
   exception_xfail_reason:
-    type: "TypeError"
-    error_message: "'function' object is not iterable"
+    type: "FileNotFoundError"
+    error_message: "Openvino Model Files Not Found!"
     message: "Issue-165013"

--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -11,7 +11,7 @@ pytest-split
 librosa==0.10.0
 memory-profiler==0.61.0
 optimum-intel==1.22.0
-optimum==1.24.0
+optimum @ git+https://github.com/huggingface/optimum.git@9438b863e11acf25c69d78450f48e78690fce10f
 scikit-learn>=1.2.2,<=1.5.0
 soundfile==0.12.1
 tensorboard==2.13.0


### PR DESCRIPTION
### Changes

Use Optimum Commit with PR https://github.com/huggingface/optimum/pull/2237 in conformance test.

### Reason for changes

This change is necessary because PT WC conformance test in NNCF uses `optimum.exporters.openvino.convert.export_from_model` which corrupts the PT namespace due to patching leading to errors in using torch.export. This issue is resolved in the exact commit used to run the Conformance test resolving the issue with FX backend conformance tests.

### Related tickets

Issue 165013

### Tests

Category | Job | Status | Job Number | Notes
-- | -- | -- | -- | --
GH WC | WC test on GHA | Pass | <a href="https://github.com/openvinotoolkit/nncf/actions/runs/14705449313">72</a> |
Manual | job/manual/job/post_training_quantization/664/ | Pass | 664 |
