### PR TITLE
Added logging for compilation trigger

### DIFF
--- a/tests/torch/test_utils.py
+++ b/tests/torch/test_utils.py
@@ -14,6 +14,7 @@ import torch
 from torch import nn
 
 import nncf
+from nncf.common.logging import nncf_logger
 from nncf.common.utils.os import is_windows
 from nncf.torch.initialization import DataLoaderBNAdaptationRunner
 from nncf.torch.utils import CompilationWrapper
@@ -134,6 +135,7 @@ def compilable_fn(x, y):
 def not_compilable_fn(x, y):
     if torch.compiler.is_compiling():
         msg = "Controlled exception!"
+        nncf_logger.debug(msg)
         raise nncf.InternalError(msg)
     a = torch.sin(x)
     b = torch.cos(y)

--- a/tests/torch/test_utils.py
+++ b/tests/torch/test_utils.py
@@ -146,7 +146,7 @@ def not_compilable_fn(x, y):
     "fn, is_compilation_successful",
     [
         (compilable_fn, True),
-        pytest.param(not_compilable_fn, False, marks=pytest.mark.xfail(reason="Issue-166894")),
+        (not_compilable_fn, False),
     ],
 )
 def test_compilation_wrapper(fn, is_compilation_successful):


### PR DESCRIPTION
### Changes

- As stated in the title. It is likely that Python side-effects like printing a message would not be compiled with `torch.compile` and would trigger `is_compiling`.

### Reason for changes

- Fix for Torch 2.7.0.

### Related tickets

- 166894

### Tests

- N/A
