### PR TITLE
[pt] Trace parameters in list

### DIFF
--- a/nncf/torch/function_hook/hook_executor_mode.py
+++ b/nncf/torch/function_hook/hook_executor_mode.py
@@ -362,9 +362,24 @@ class FunctionHookMode(TorchFunctionMode):
         :return: The modified arguments and keyword arguments after pre-hooks.
         """
         for idx, value in enumerate(args):
-            args[idx] = self.execute_hooks_for_parameter(value)
+            if isinstance(value, (list, tuple)):
+                is_tuple = isinstance(value, tuple)
+                list_args = list(value) if is_tuple else value
+                for list_idx, tensor in enumerate(list_args):
+                    list_args[list_idx] = self.execute_hooks_for_parameter(tensor)
+                args[idx] = tuple(list_args) if is_tuple else list_args
+            else:
+                args[idx] = self.execute_hooks_for_parameter(value)
+
         for kw_name, value in kwargs.items():
-            kwargs[kw_name] = self.execute_hooks_for_parameter(value)
+            if isinstance(value, (list, tuple)):
+                is_tuple = isinstance(value, tuple)
+                list_args = list(value) if is_tuple else value
+                for list_idx, tensor in enumerate(list_args):
+                    list_args[list_idx] = self.execute_hooks_for_parameter(tensor)
+                kwargs[kw_name] = tuple(list_args) if is_tuple else list_args
+            else:
+                kwargs[kw_name] = self.execute_hooks_for_parameter(value)
         return args, kwargs
 
     def execute_pre_hooks(

--- a/tests/torch2/data/function_hook/nncf_graph/model_graph_gru.dot
+++ b/tests/torch2/data/function_hook/nncf_graph/model_graph_gru.dot
@@ -1,0 +1,19 @@
+strict digraph {
+x [id=0, type="nncf_model_input", metatype=PTInputNoopMetatype];
+"gru/zeros/0" [id=1, type=zeros, metatype=UnknownMetatype];
+"gru.weight_ih_l0" [id=2, type="nncf_model_const", metatype=PTConstNoopMetatype];
+"gru.weight_hh_l0" [id=3, type="nncf_model_const", metatype=PTConstNoopMetatype];
+"gru.bias_ih_l0" [id=4, type="nncf_model_const", metatype=PTConstNoopMetatype];
+"gru.bias_hh_l0" [id=5, type="nncf_model_const", metatype=PTConstNoopMetatype];
+"gru/gru/0" [id=6, type=gru, metatype=UnknownMetatype];
+output_0 [id=7, type="nncf_model_output", metatype=PTOutputNoopMetatype];
+output_1 [id=8, type="nncf_model_output", metatype=PTOutputNoopMetatype];
+x -> "gru/gru/0" [dtype=float, shape="(1, 3, 3)", out_port_id=0, in_port_id=0];
+"gru/zeros/0" -> "gru/gru/0" [dtype=float, shape="(1, 1, 4)", out_port_id=0, in_port_id=1];
+"gru.weight_ih_l0" -> "gru/gru/0" [dtype=float, shape="(12, 3)", out_port_id=0, in_port_id=2];
+"gru.weight_hh_l0" -> "gru/gru/0" [dtype=float, shape="(12, 4)", out_port_id=0, in_port_id=3];
+"gru.bias_ih_l0" -> "gru/gru/0" [dtype=float, shape="(12,)", out_port_id=0, in_port_id=4];
+"gru.bias_hh_l0" -> "gru/gru/0" [dtype=float, shape="(12,)", out_port_id=0, in_port_id=5];
+"gru/gru/0" -> output_0 [dtype=float, shape="(1, 3, 4)", out_port_id=0, in_port_id=0];
+"gru/gru/0" -> output_1 [dtype=float, shape="(1, 1, 4)", out_port_id=1, in_port_id=0];
+}

--- a/tests/torch2/function_hook/helpers.py
+++ b/tests/torch2/function_hook/helpers.py
@@ -180,3 +180,12 @@ class HookWithState(torch.nn.Module, StatefulModuleInterface):
     @classmethod
     def from_config(cls, state: str):
         return cls(state)
+
+
+class ModelGRU(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gru = torch.nn.GRU(3, 4, batch_first=True)
+
+    def forward(self, x):
+        return self.gru(x)

--- a/tests/torch2/function_hook/nncf_graph/test_nncf_graph.py
+++ b/tests/torch2/function_hook/nncf_graph/test_nncf_graph.py
@@ -125,24 +125,25 @@ class ModelDesc:
 
 
 TEST_MODELS_DESC = [
-    ModelDesc("convnext_small", models.convnext_small, [1, 3, 64, 64]),
-    ModelDesc("densenet121", models.densenet121, [1, 3, 64, 64]),
-    ModelDesc("efficientnet_b0", models.efficientnet_b0, [1, 3, 64, 64]),
-    ModelDesc("inception_v3", partial(models.inception_v3, init_weights=False), [1, 3, 300, 300]),
-    ModelDesc("mobilenet_v2", models.mobilenet_v2, [1, 3, 64, 64]),
-    ModelDesc("mobilenet_v3_small", models.mobilenet_v3_small, [1, 3, 64, 64]),
-    ModelDesc("resnet18", models.resnet18, [1, 3, 64, 64]),
-    ModelDesc("resnext50_32x4d", models.resnext50_32x4d, [1, 3, 64, 64]),
-    ModelDesc("shufflenet_v2_x0_5", models.shufflenet_v2_x0_5, [1, 3, 224, 224]),
-    ModelDesc("squeezenet1_0", models.squeezenet1_0, [1, 3, 64, 64]),
-    ModelDesc("swin_v2_b", models.swin_v2_b, [1, 3, 64, 64]),
-    ModelDesc("vgg16", models.vgg16, [1, 3, 32, 32]),
+    ModelDesc("convnext_small", partial(models.convnext_small, weights=None), [1, 3, 64, 64]),
+    ModelDesc("densenet121", partial(models.densenet121, weights=None), [1, 3, 64, 64]),
+    ModelDesc("efficientnet_b0", partial(models.efficientnet_b0, weights=None), [1, 3, 64, 64]),
+    ModelDesc("inception_v3", partial(models.inception_v3, init_weights=False, weights=None), [1, 3, 300, 300]),
+    ModelDesc("mobilenet_v2", partial(models.mobilenet_v2, weights=None), [1, 3, 64, 64]),
+    ModelDesc("mobilenet_v3_small", partial(models.mobilenet_v3_small, weights=None), [1, 3, 64, 64]),
+    ModelDesc("resnet18", partial(models.resnet18, weights=None), [1, 3, 64, 64]),
+    ModelDesc("resnext50_32x4d", partial(models.resnext50_32x4d, weights=None), [1, 3, 64, 64]),
+    ModelDesc("shufflenet_v2_x0_5", partial(models.shufflenet_v2_x0_5, weights=None), [1, 3, 224, 224]),
+    ModelDesc("squeezenet1_0", partial(models.squeezenet1_0, weights=None), [1, 3, 64, 64]),
+    ModelDesc("swin_v2_b", partial(models.swin_v2_b, weights=None), [1, 3, 64, 64]),
+    ModelDesc("vgg16", partial(models.vgg16, weights=None), [1, 3, 32, 32]),
+    ModelDesc("gru", helpers.ModelGRU, [1, 3, 3]),
 ]
 
 
 @pytest.mark.parametrize("desc", TEST_MODELS_DESC, ids=str)
 def test_model_graph(desc: ModelDesc, regen_ref_data: bool):
-    model: torch.nn.Module = desc.model_builder(weights=None)
+    model: torch.nn.Module = desc.model_builder()
     model = model.eval()
     model = wrap_model(model)
     nncf_graph = build_nncf_graph(model, torch.randn(desc.inputs_info))


### PR DESCRIPTION
### Changes

Trace parameters in list, like `foo([self.w1, self.w2])`.

### Reason for changes

Ignoring parameters in list or tuple.
Fail on build_graph.

