### PR TITLE
Fix build docs 

### DIFF
--- a/docs/api/requirements.txt
+++ b/docs/api/requirements.txt
@@ -2,3 +2,4 @@ astroid==2.15.8
 Sphinx==6.1.3
 sphinx-autoapi==2.1.0
 furo==2023.3.27
+snowballstemmer==2.2.0


### PR DESCRIPTION
### Changes

Set `snowballstemmer==2.2.0` 

### Reason for changes

```
Exception occurred:
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/snowballstemmer/__init__.py", line 27, in stemmer
    raise KeyError("Stemming algorithm '%s' not found" % lang)
KeyError: "Stemming algorithm 'porter' not found"
```

