### PR TITLE
Aligned bf16 tuning vs f32 inference for 4bit compression

### DIFF
--- a/examples/llm_compression/torch/qat_with_lora/README.md
+++ b/examples/llm_compression/torch/qat_with_lora/README.md
@@ -64,28 +64,37 @@ Where:
 - `PPL_PTWC` is the perplexity after applying the best Post-Training Weight Compression method identified
 for each specific model: this was "AWQ + Scale Estimation + GPTQ" for "HuggingFaceTB/SmolLM-1.7B-Instruct",
 and "AWQ + Scale Estimation" for all other models evaluated.
-- `PPL_QAT+LoRA` is the perplexity after applying Quantization-Aware Training with LoRA.
+- `PPL_QAT+LoRA` is the perplexity after applying Quantization-Aware Training with LoRA for 10 epochs.
 
 All quantization methods compressed the models to `INT4_ASYM` precision with a group size of `64`.
 
-| Model                              | Precision         | Wikitext,<br>word_ppl | Improvement |
-|------------------------------------|-------------------|-----------------------|-------------|
-| google/gemma-2-2b-it               | BF16              | 15.02                 |             |
-| google/gemma-2-2b-it               | INT4 (QAT + LoRA) | 15.13                 | 86%         |
-| google/gemma-2-2b-it               | INT4 (best PTWC)  | 15.80                 |             |
-| microsoft/phi3-mini-4k-instruct    | BF16              | 9.49                  |             |
-| microsoft/phi3-mini-4k-instruct    | INT4 (QAT + LoRA) | 10.12                 | 27%         |
-| microsoft/phi3-mini-4k-instruct    | INT4 (best PTWC)  | 10.36                 |             |
-| Qwen/Qwen2.5-3B-Instruct           | BF16              | 11.01                 |             |
-| Qwen/Qwen2.5-3B-Instruct           | INT4 (QAT + LoRA) | 11.49                 | 25%         |
-| Qwen/Qwen2.5-3B-Instruct           | INT4 (best PTWC)  | 11.65                 |             |
-| HuggingFaceTB/SmolLM-1.7B-Instruct | BF16              | 19.11                 |             |
-| HuggingFaceTB/SmolLM-1.7B-Instruct | INT4 (QAT + LoRA) | 19.25                 | 79%         |
-| HuggingFaceTB/SmolLM-1.7B-Instruct | INT4 (best PTWC)  | 19.79                 |             |
-| mistralai/Mistral-7B-v0.3          | BF16              | 8.21                  |             |
-| mistralai/Mistral-7B-v0.3          | INT4 (QAT + LoRA) | 8.38                  | 12%         |
-| mistralai/Mistral-7B-v0.3          | INT4 (best PTWC)  | 8.40                  |             |
-| meta-llama/Llama-3.2-3B-Instruct   | BF16              | 12.67                 |             |
-| meta-llama/Llama-3.2-3B-Instruct   | INT4 (QAT + LoRA) | 12.82                 | 73%         |
-| meta-llama/Llama-3.2-3B-Instruct   | INT4 (best PTWC)  | 13.22                 |             |
-|                                    |                   |               Average | 50.4%       |
+| Model                               | Precision         | Wikitext,<br>word_ppl | Improvement |
+|-------------------------------------|-------------------|-----------------------|-------------|
+| google/gemma-2-2b-it                | BF16              | 15.02                 |             |
+| google/gemma-2-2b-it                | INT4 (QAT + LoRA) | 15.09                 | 91%         |
+| google/gemma-2-2b-it                | INT4 (best PTWC)  | 15.80                 |             |
+| microsoft/phi3-mini-4k-instruct     | BF16              | 9.49                  |             |
+| microsoft/phi3-mini-4k-instruct     | INT4 (QAT + LoRA) | 10.04                 | 37%         |
+| microsoft/phi3-mini-4k-instruct     | INT4 (best PTWC)  | 10.36                 |             |
+| Qwen/Qwen2.5-3B-Instruct            | BF16              | 11.01                 |             |
+| Qwen/Qwen2.5-3B-Instruct            | INT4 (QAT + LoRA) | 11.44                 | 33%         |
+| Qwen/Qwen2.5-3B-Instruct            | INT4 (best PTWC)  | 11.65                 |             |
+| HuggingFaceTB/SmolLM-1.7B-Instruct  | BF16              | 19.11                 |             |
+| HuggingFaceTB/SmolLM-1.7B-Instruct  | INT4 (QAT + LoRA) | 19.34                 | 66%         |
+| HuggingFaceTB/SmolLM-1.7B-Instruct  | INT4 (best PTWC)  | 19.79                 |             |
+| mistralai/Mistral-7B-v0.3           | BF16              | 8.21                  |             |
+| mistralai/Mistral-7B-v0.3           | INT4 (QAT + LoRA) | 8.36                  | 20%         |
+| mistralai/Mistral-7B-v0.3           | INT4 (best PTWC)  | 8.40                  |             |
+| meta-llama/Llama-3.2-1B-Instruct    | BF16              | 16.30                 |             |
+| meta-llama/Llama-3.2-1B-Instruct    | INT4 (QAT + LoRA) | 17.12                 | 40%         |
+| meta-llama/Llama-3.2-1B-Instruct    | INT4 (best PTWC)  | 17.67                 |             |
+| meta-llama/Llama-3.2-3B-Instruct    | BF16              | 12.67                 |             |
+| meta-llama/Llama-3.2-3B-Instruct    | INT4 (QAT + LoRA) | 13.00                 | 39%         |
+| meta-llama/Llama-3.2-3B-Instruct    | INT4 (best PTWC)  | 13.22                 |             |
+| meta-llama/Meta-Llama-3-8B-Instruct | BF16              | 10.22                 |             |
+| meta-llama/Meta-Llama-3-8B-Instruct | INT4 (QAT + LoRA) | 10.30                 | 62%         |
+| meta-llama/Meta-Llama-3-8B-Instruct | INT4 (best PTWC)  | 10.45                 |             |
+| microsoft/phi3.5-mini-instruct      | BF16              | 10.00                 |             |
+| microsoft/phi3.5-mini-instruct      | INT4 (QAT + LoRA) | 10.53                 | 37%         |
+| microsoft/phi3.5-mini-instruct      | INT4 (best PTWC)  | 10.71                 |             |
+|                                     |                   |               Average | 46%         |

--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -282,8 +282,8 @@
         "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
         "accuracy_tolerance": 0.1,
         "accuracy_metrics": {
-            "perplexity_diff_torch": 0.6,
-            "best_ov_perplexity": 35.1
+            "perplexity_diff_torch": 0.75,
+            "best_ov_perplexity": 34.94
         }
     },
     "quantization_aware_training_tensorflow_mobilenet_v2": {

--- a/tests/torch2/function_hook/quantization/test_fq_lora.py
+++ b/tests/torch2/function_hook/quantization/test_fq_lora.py
@@ -166,9 +166,10 @@ def test_fq_lora_tuning(tmp_path, mode, backup_mode, compression_kwargs, ref_num
         tuned_vs_stripped = vm.calculate_similarity(tuned_output, stripped_output)
         tuned_vs_stripped_ov = vm.calculate_similarity(tuned_output, stripped_ov_output)
 
-        atol = 0.03 if mode == nncf.CompressWeightsMode.INT4_SYM else 0.01  # torch.compile introduces bigger diff
-        assert torch.allclose(tuned_vs_stripped, vm.validation_ref, atol=atol)
-        assert torch.allclose(tuned_vs_stripped_ov, vm.validation_ref, atol=atol)
+        # torch.compiled version of FQ+LoRA leads to a small error
+        atol = 1e-2 if mode == nncf.CompressWeightsMode.INT4_SYM else 1e-8
+        assert torch.allclose(tuned_vs_stripped, vm.validation_ref, atol)
+        assert torch.allclose(tuned_vs_stripped_ov, vm.validation_ref, atol)
 
 
 def test_checkpoint_loading(tmp_path: Path, use_cuda: bool):


### PR DESCRIPTION
### Changes

Always cast input to float32 inside FQ + LoRA.

Benchmark results with new schema on the https://github.com/ljaljushkin/nncf_pytorch/tree/nl/ref_benchmark with small modifications from @nikita-malininn's branch https://github.com/nikita-malininn/nncf/tree/nm/ref_benchmark:  

device | dtype | exec_type | tensor_type | granularity | symmetric | narrow_range | timing_mode | num_runs | input_size
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
cuda | bfloat16 | ExecutionType.REGULAR | TensorType.WEIGHTS | GranularityType.PER_CHANNEL | TRUE | FALSE | TimingMode.KERNEL | 1000 | [2048, 128256]

name | Mode | forward_avg, ms | backward_avg, ms | memory, Gb
-- | -- | -- | -- | --
compile (PR) | sym | 6.5 | 10.7 | 3.9
compile (PR) | asym | 6.8 | 10.7 | 3.9
compile (before) | sym | 1.6 | 9.5 | 4.2
compile (before) | asym | 1.9 | 9.5 | 3.9
not compiled (PR) | sym | 19.0 | 46.6 | 5.9
not compiled (PR) | asym | 19.6 | 47.0 | 5.9
not compiled (before)  | sym | 9.2 | 37.0 | 5.4
not compiled (before) | asym | 9.6 | 37.0 | 5.4

There's an overhead on forward, but it's leveled up by using torch.compile.

There's a 1-6% overhead on RTX per epoch, and on A100, depending on the setup, there can even be a boost of 6% or a slowdown of 3%.
![image](https://github.com/user-attachments/assets/a7eb98e9-a906-4462-98a3-c4e2e061eb5a)
![image](https://github.com/user-attachments/assets/1e803a51-1a2b-4a44-9603-b7987e940bb2)


### Reason for changes

Minimize the disparity in precision between the Torch model and its exported OV equivalent.
The full alignment would be very inefficient, so here's a compromise: align accuracy with minimal overhead on the forward pass.

e2e test on `facebook/opt-125m` proves that output is the same now within default absolute tolerance (1e-8) instead of 1e-2 one:
https://github.com/openvinotoolkit/nncf/pull/3493/files#diff-7a4f90fe4f07d515df355d6fb618112d7d3fe88eb8ba777e502c695a7c715010R170

Previously, there were 3 problematic models with significant difference in accuracy, now it's much more aligned:
![image](https://github.com/user-attachments/assets/a22c855a-7c00-4f77-895f-91ce5713387c)


### Related tickets

166195

### Tests

test examples - https://github.com/openvinotoolkit/nncf/actions/runs/15024278726/job/42221028011
