### PR TITLE
[Fix] Calculation of statistics for ignored weights

### DIFF
--- a/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -533,7 +533,7 @@ class WeightCompression(Algorithm):
                 continue
             for _, weight_port_id in self._backend_entity.get_weight_names_and_port_ids(node, graph):
                 weight_dtype = self._backend_entity.get_weight_dtype(node, weight_port_id, model, graph)
-                if weight_dtype in SUPPORTED_DATA_TYPES:
+                if weight_dtype not in SUPPORTED_DATA_TYPES:
                     continue
                 weight_shape = self._backend_entity.get_weight_shape(node, weight_port_id, graph)
                 weight_size = reduce(operator.mul, weight_shape, 1)


### PR DESCRIPTION
### Changes
Before:
![{715AF1B1-2C87-4BD0-9F4A-23F13C77881A}](https://github.com/user-attachments/assets/45e40a0c-a8c1-457b-801e-a5ae96b67ccd)

After:
![{11710D44-4690-4FA3-8EED-229BBAEB384A}](https://github.com/user-attachments/assets/a2031cc2-5390-41a0-bf47-d8184df79c78)

### Reason for changes

Statistics are not calculated for ignored weights.

### Related tickets

N/A

### Tests

Manual
