### PR TITLE
Data generation: check inheritance from `GenerationMixin` instead of `PreTrainedModel.__bases__`

### DIFF
--- a/nncf/data/generators.py
+++ b/nncf/data/generators.py
@@ -54,7 +54,7 @@ def generate_text_data(
         raise nncf.ModuleNotFoundError(msg)
 
     try:
-        from transformers import PreTrainedModel  # type: ignore
+        from transformers import GenerationMixin  # type: ignore
         from transformers import PreTrainedTokenizerBase
         from transformers.utils import logging  # type: ignore
 
@@ -63,8 +63,8 @@ def generate_text_data(
         msg = "transformers is required in order to generate text data: `pip install transformers`."
         raise nncf.ModuleNotFoundError(msg)
 
-    if not isinstance(model, PreTrainedModel.__bases__):
-        msg = "Model should be instance of the `transformers.PreTrainedModel`."
+    if not isinstance(model, GenerationMixin):
+        msg = "Model should be instance of the `transformers.GenerationMixin`."
         raise nncf.ValidationError(msg)
 
     if not isinstance(tokenizer, PreTrainedTokenizerBase.__bases__):

--- a/tests/torch/test_dataset_generators.py
+++ b/tests/torch/test_dataset_generators.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import pytest
+from optimum.intel.openvino import OVModelForCausalLM
 from transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
 
@@ -45,12 +46,13 @@ def test_generate_text_data_usage(model, tokenizer, usage_error):
             assert isinstance(e, nncf.ValidationError), "Expected exception."
 
 
-def test_generate_text_data_functional():
+@pytest.mark.parametrize("model_cls", [AutoModelForCausalLM, OVModelForCausalLM])
+def test_generate_text_data_functional(model_cls):
     seq_len = 12
     max_seq_len = seq_len + seq_len // 2
     dataset_size = 6
 
-    model = AutoModelForCausalLM.from_pretrained(BASE_TEST_MODEL_ID)
+    model = model_cls.from_pretrained(BASE_TEST_MODEL_ID)
     tokenizer = AutoTokenizer.from_pretrained(BASE_TEST_MODEL_ID)
 
     with set_torch_seed(0):


### PR DESCRIPTION
### Changes

During data generation, check that the model is an instance of `transformers.GenerationMixin` instead one of `PreTrainedModel.__bases__`. Because of the fact that during generation, we require the model to have `model.device`, `model.config` and `model.generate()` properties available, `transformers.GenerationMixin` satisfies these requirements. 

### Reason for changes

Starting from transformers 4.52, `PreTrainedModel` does not inherit from `GenerationMixin` no more. Because of this the current isinstance check fails for `OVModelForCausalLM` which inherits from `GenerationMixin` but not `PreTrainedModel`.

### Tests

Extended `tests.torch.test_dataset_generators::test_generate_text_data_functional`.
