### PR TITLE
[gha] parallel on 4 hosts for wc tests

### DIFF
--- a/.github/workflows/conformance_weight_compression.yml
+++ b/.github/workflows/conformance_weight_compression.yml
@@ -11,16 +11,17 @@ on:
       pytest_args:
         description: 'Pytest arguments'
         default: ''
+  pull_request:
 
 jobs:
   examples-cpu:
-    name: Weight compression [${{ matrix.group }}/3]
+    name: Weight compression [${{ matrix.group }}/4]
     runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3]
+        group: [1, 2, 3, 4]
     defaults:
       run:
         shell: bash
@@ -49,7 +50,7 @@ jobs:
             --junit-xml=pytest-results.xml \
             --durations-path=tests/post_training/data/wc_test_durations.json \
             --splitting-algorithm=least_duration \
-            --splits 3 \
+            --splits 4 \
             --group ${{ matrix.group }} \
             ${{ github.event.inputs.pytest_args || '' }}
           ret=$?

--- a/.github/workflows/conformance_weight_compression.yml
+++ b/.github/workflows/conformance_weight_compression.yml
@@ -11,7 +11,6 @@ on:
       pytest_args:
         description: 'Pytest arguments'
         default: ''
-  pull_request:
 
 jobs:
   examples-cpu:


### PR DESCRIPTION
### Changes

parallel on 4 hosts for wc tests
increase timeout

### Reason for changes

To avoid fails by timeout on adding new testcases


### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/15249451258/job/42882568423?pr=3510