### PR TITLE
Use OVModelForCausalLM for ONNX weight compression example

### DIFF
--- a/examples/llm_compression/onnx/tiny_llama/README.md
+++ b/examples/llm_compression/onnx/tiny_llama/README.md
@@ -1,6 +1,6 @@
 # Large Language Models Weight Compression Example
 
-This example demonstrates how to optimize Large Language Models (LLMs) in ONNX format using NNCF weight compression API. The example applies 4/8-bit mixed-precision quantization to weights of Linear (Fully-connected) layers of [TinyLlama/TinyLlama-1.1B-Chat-v1.0](https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0) model. This leads to a significant decrease in model footprint and performance improvement with ONNX Runtime.
+This example demonstrates how to optimize Large Language Models (LLMs) in ONNX format using NNCF weight compression API. The example applies 4/8-bit mixed-precision quantization to weights of Linear (Fully-connected) layers of [TinyLlama/TinyLlama-1.1B-Chat-v1.0](https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0) model. This leads to a significant decrease in model footprint and performance improvement with OpenVINO Runtime.
 
 ## Prerequisites
 

--- a/examples/llm_compression/onnx/tiny_llama/main.py
+++ b/examples/llm_compression/onnx/tiny_llama/main.py
@@ -13,6 +13,7 @@ import time
 from pathlib import Path
 
 import onnx
+from optimum.intel.openvino import OVModelForCausalLM
 from optimum.onnxruntime import ORTModelForCausalLM
 from transformers import AutoTokenizer
 
@@ -53,11 +54,22 @@ def main():
 
     # Infer Model.
     tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
-    ort_model = ORTModelForCausalLM.from_pretrained(OUTPUT_DIR)
+
+    ov_model = OVModelForCausalLM.from_pretrained(
+        OUTPUT_DIR,
+        trust_remote_code=True,
+        load_in_8bit=False,
+        compile=False,
+        stateful=False,
+        ov_config={"DYNAMIC_QUANTIZATION_GROUP_SIZE": "0", "KV_CACHE_PRECISION": "f16"},
+        export=False,
+        from_onnx=True,
+    )
+
     input_ids = tokenizer("What is PyTorch?", return_tensors="pt").to(device=model.device)
 
     start_t = time.time()
-    output = ort_model.generate(**input_ids, max_new_tokens=100)
+    output = ov_model.generate(**input_ids, max_new_tokens=100)
     print("Elapsed time: ", time.time() - start_t)
 
     output_text = tokenizer.decode(output[0])

--- a/examples/llm_compression/onnx/tiny_llama/main.py
+++ b/examples/llm_compression/onnx/tiny_llama/main.py
@@ -55,16 +55,7 @@ def main():
     # Infer Model.
     tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 
-    ov_model = OVModelForCausalLM.from_pretrained(
-        OUTPUT_DIR,
-        trust_remote_code=True,
-        load_in_8bit=False,
-        compile=False,
-        stateful=False,
-        ov_config={"DYNAMIC_QUANTIZATION_GROUP_SIZE": "0", "KV_CACHE_PRECISION": "f16"},
-        export=False,
-        from_onnx=True,
-    )
+    ov_model = OVModelForCausalLM.from_pretrained(OUTPUT_DIR, from_onnx=True)
 
     input_ids = tokenizer("What is PyTorch?", return_tensors="pt").to(device=model.device)
 


### PR DESCRIPTION
### Changes

- Use OVModelForCausalLM for ONNX weight compression example

### Reason for changes

- Better performance

### Related tickets

Ref: 168070

### Tests

Current scope
