### PR TITLE
[Torch FX][Conformance] Fix FX PTQ Conformance Test Issue with Torch Compile Call

### DIFF
--- a/tests/post_training/pipelines/base.py
+++ b/tests/post_training/pipelines/base.py
@@ -506,7 +506,7 @@ class PTQTestPipeline(BaseTestPipeline):
             mod = torch.compile(
                 exported_model.module(),
                 backend="openvino",
-                options={"model_caching": True, "cache_dir": str(self.output_model_dir)},
+                options={"aot_autograd": True, "model_caching": True, "cache_dir": str(self.output_model_dir)},
             )
             mod(self.dummy_tensor)
 


### PR DESCRIPTION
### Changes

Due to missing `aot_autograd` option, the torch compile call was not working as expected.

### Reason for changes

The torch.compile() call was silently falling back to eager execution due to using improper tracing mechanism(make_fx instead of aot_autograd) 

### Tests

Category | Job | Status | Job Number | Notes
-- | -- | -- | -- | --
Manual | job/manual/job/post_training_quantization/664/ | Failed | 677 | Swin model fails due to graph break which is fixed in PR https://github.com/openvinotoolkit/openvino/pull/30895

