### PR TITLE
[release 2.17.0] xfail 168947

### DIFF
--- a/tests/torch/sparsity/movement/test_model_saving.py
+++ b/tests/torch/sparsity/movement/test_model_saving.py
@@ -184,15 +184,18 @@ class TestONNXExport:
                     classifier_proj_size=3,
                 ),
             ),
-            Dict(
-                nncf_weight_ratio=0.43,
-                ov_weight_ratio=0.33,
-                recipe=SwinRunRecipe().model_config_(
-                    num_heads=[4],
-                    num_labels=1,
-                    num_channels=4,
-                    window_size=1,
+            pytest.param(
+                Dict(
+                    nncf_weight_ratio=0.43,
+                    ov_weight_ratio=0.33,
+                    recipe=SwinRunRecipe().model_config_(
+                        num_heads=[4],
+                        num_labels=1,
+                        num_channels=4,
+                        window_size=1,
+                    ),
                 ),
+                marks=pytest.mark.xfail(reason="Issue-168947: regression in OV 2025.2"),
             ),
             Dict(
                 nncf_weight_ratio=0.25,


### PR DESCRIPTION
### Changes

set xfail for tests/torch/sparsity/movement/test_model_saving.py::TestONNXExport::test_ngraph_pruning[desc3]

### Reason for changes

```
E       RuntimeError: Check 'backward_compatible_check || in_out_elements_equal' failed at src/core/shape_inference/include/reshape_shape_inference.hpp:370:
E       While validating node 'opset1::Reshape /swin/encoder/layers.0/blocks.0/Reshape_9 (opset1::Reshape /swin/encoder/layers.0/blocks.0/Reshape_8[0]:f32[4,4,4,4], opset1::Constant /swin/encoder/layers.0/blocks.0/Constant_43[0]:i64[3]) -> (f32[1,16,4])' with friendly_name '/swin/encoder/layers.0/blocks.0/Reshape_9':
E       Shape inference input shapes {[4,4,4,4],[3]}
E       Requested output shape [1,16,4] is incompatible with input shape
```
### Related tickets

168947


