### PR TITLE
xfail for sporadic fail

### DIFF
--- a/tests/tensorflow/test_compressed_graph.py
+++ b/tests/tensorflow/test_compressed_graph.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import os
+from urllib.error import HTTPError
 
 import networkx as nx
 import pytest
@@ -282,7 +283,7 @@ def get_test_models_desc(algorithm):
         ),
         pytest.param(
             ModelDesc("mobilenet_v2_slim.dot", test_models.HubMobileNetV2, [1, 224, 224, 3], True),
-            marks=SKIP_MAP[algorithm].get("mobilenet_v2_slim", ()),
+            marks=SKIP_MAP[algorithm].get("mobilenet_v2_slim", (pytest.mark.xfail(raises=HTTPError))),
         ),
     ]
 


### PR DESCRIPTION
### Changes

Add xfail for sporadic `403: Forbidden` error on downloading from `https://tfhub.dev/google/imagenet/mobilenet_v2_100_224/classification/4`

### Reason for changes

https://github.com/openvinotoolkit/nncf/actions/runs/15720727872/job/44300948459
