### PR TITLE
[Solver] Move most of quantizer_config into the QuantizerConfig itself

### DIFF
--- a/nncf/common/quantization/quantizer_propagation/solver.py
+++ b/nncf/common/quantization/quantizer_propagation/solver.py
@@ -157,7 +157,7 @@ class QuantizationProposal:
                 if strict:
                     compatible_initial_qconfs = list(
                         filter(
-                            final_qconfig.is_compatible,
+                            final_qconfig.is_compatible_with,
                             self.quantizer_setup.quantization_points[qp_id].possible_qconfigs,
                         )
                     )

--- a/nncf/common/quantization/structs.py
+++ b/nncf/common/quantization/structs.py
@@ -142,7 +142,7 @@ class QuantizerConfig:
         is_redundant = is_redundant and (downstream_qconfig.narrow_range == self.narrow_range)
         return is_redundant
 
-    def is_compatible(self, other: "QuantizerConfig") -> bool:
+    def is_compatible_with(self, other: "QuantizerConfig") -> bool:
         """
         Return True if the current QuantizerConfig and the other QuantizerConfig
         do not contradict each other.


### PR DESCRIPTION
### Changes

Most QuantizerConfig logic is moved to the QuantizerConfig class

### Reason for changes

To separate logic of QuantizerConfig from the Solver to make it easier to process new QuantizerConfigs in future

