### PR TITLE
Update license field in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "nncf"
 description = "Neural Networks Compression Framework"
 readme="docs/PyPiPublishing.md"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 authors = [{ name = "Intel" }, { email = "maksim.proshin@intel.com" }]
 requires-python = ">=3.9"
 dynamic = ["version"]
@@ -28,7 +28,6 @@ keywords = [
     "transformers",
 ]
 classifiers = [
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
 ]


### PR DESCRIPTION
### Changes

Update license field 

### Reason for changes

```
        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

```

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/15870556490