### PR TITLE
Require setuptools >=77 to comply with new license def recommendation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "nncf"
 description = "Neural Networks Compression Framework"
 readme = "docs/PyPiPublishing.md"
+license = "Apache-2.0"
 authors = [{ name = "Intel" }, { email = "maksim.proshin@intel.com" }]
 requires-python = ">=3.9"
 dynamic = ["version"]
@@ -48,9 +49,6 @@ dependencies = [
     "scipy>=1.3.2",
     "tabulate>=0.9.0",
 ]
-
-[project.license]
-text = "Apache-2.0"
 
 [project.optional-dependencies]
 plots = [


### PR DESCRIPTION
### Changes

Fix license definition after https://github.com/openvinotoolkit/nncf/pull/3561

### Reason for changes

```
[2025-06-26T06:07:13.497Z]       ValueError: invalid pyproject.toml config: `project.license`.
[2025-06-26T06:07:13.497Z]       configuration error: `project.license` must be valid exactly by one definition (2 matches found):
[2025-06-26T06:07:13.497Z]       
[2025-06-26T06:07:13.497Z]           - keys:
[2025-06-26T06:07:13.497Z]               'file': {type: string}
[2025-06-26T06:07:13.497Z]             required: ['file']
[2025-06-26T06:07:13.497Z]           - keys:
[2025-06-26T06:07:13.497Z]               'text': {type: string}
[2025-06-26T06:07:13.497Z]             required: ['text']
[2025-06-26T06:07:13.497Z]       
[2025-06-26T06:07:13.497Z]       [end of output]
[2025-06-26T06:07:13.497Z]   
[2025-06-26T06:07:13.497Z]   note: This error originates from a subprocess, and is likely not a problem with pip.
[2025-06-26T06:07:13.497Z] error: subprocess-exited-with-error
```
