### PR TITLE
[ci] fix fail on no tests found if run with pytest_args

### DIFF
--- a/.github/workflows/conformance_weight_compression.yml
+++ b/.github/workflows/conformance_weight_compression.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           name: wc_results_${{ matrix.group }}
           path: tmp/results.csv
+          if-no-files-found: ignore
       - name: Test Summary
         if: ${{ !cancelled() }}
         run: |

--- a/.github/workflows/conformance_weight_compression.yml
+++ b/.github/workflows/conformance_weight_compression.yml
@@ -45,6 +45,7 @@ jobs:
         run: pip list
       - name: Run examples test scope
         run: |
+          set +e
           python -m pytest -s -ra tests/post_training/test_quantize_conformance.py::test_weight_compression \
             --junit-xml=pytest-results.xml \
             --durations-path=tests/post_training/data/wc_test_durations.json \

--- a/.github/workflows/conformance_weight_compression.yml
+++ b/.github/workflows/conformance_weight_compression.yml
@@ -11,6 +11,7 @@ on:
       pytest_args:
         description: 'Pytest arguments'
         default: ''
+  pull_request:
 
 jobs:
   examples-cpu:
@@ -52,9 +53,9 @@ jobs:
             --splitting-algorithm=least_duration \
             --splits 4 \
             --group ${{ matrix.group }} \
-            ${{ github.event.inputs.pytest_args || '' }}
+            ${{ github.event.inputs.pytest_args || '-k tinyllama_data_free_backend_ONNX' }}
           ret=$?
-          [ $ret -eq 5 ] && [ -n "${{ github.event.inputs.pytest_args || '' }}" ]  && exit 0 || exit $ret
+          [ $ret -eq 5 ] && [ -n "${{ github.event.inputs.pytest_args || '-k tinyllama_data_free_backend_ONNX' }}" ]  && exit 0 || exit $ret
         env:
           TQDM_DISABLE: 1
           HOME_HF: "/home/runner/hf_home"

--- a/.github/workflows/conformance_weight_compression.yml
+++ b/.github/workflows/conformance_weight_compression.yml
@@ -11,7 +11,6 @@ on:
       pytest_args:
         description: 'Pytest arguments'
         default: ''
-  pull_request:
 
 jobs:
   examples-cpu:
@@ -53,9 +52,9 @@ jobs:
             --splitting-algorithm=least_duration \
             --splits 4 \
             --group ${{ matrix.group }} \
-            ${{ github.event.inputs.pytest_args || '-k tinyllama_data_free_backend_ONNX' }}
+            ${{ github.event.inputs.pytest_args || '' }}
           ret=$?
-          [ $ret -eq 5 ] && [ -n "${{ github.event.inputs.pytest_args || '-k tinyllama_data_free_backend_ONNX' }}" ]  && exit 0 || exit $ret
+          [ $ret -eq 5 ] && [ -n "${{ github.event.inputs.pytest_args || '' }}" ]  && exit 0 || exit $ret
         env:
           TQDM_DISABLE: 1
           HOME_HF: "/home/runner/hf_home"


### PR DESCRIPTION
### Changes

Set `set -e` to dont fail on pytest command, and run script forward to suppress `no_test_found` return code if action runs with `pytest_args` 
Disable "no file found" warning in upload step

### Reason for changes

https://github.com/openvinotoolkit/nncf/actions/runs/15164300318/job/42637948116

### Related tickets

168252


### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/16051113240/job/45293751022?pr=3572
