### PR TITLE
FQLoRA: use last checkpoint with AWQ+SE as initialization

### DIFF
--- a/examples/llm_compression/torch/distillation_qat_with_lora/README.md
+++ b/examples/llm_compression/torch/distillation_qat_with_lora/README.md
@@ -55,37 +55,37 @@ Where:
 
 The training dataset comprises 1024 samples (each 1024 tokens long) from the training split of the `wikitext-2-raw-v1` dataset. Validation occurs after each epoch using [lm-eval-harness](https://github.com/EleutherAI/lm-evaluation-harness) on the validation split of the same dataset.
 Final perplexity measurements are conducted using OpenVINO with dynamic quantization and float16 KV-cache enabled on the test split of `wikitext-2-raw-v1`.
-For `HuggingFaceTB/SmolLM-1.7B-Instruct` model training with evaluation for 10 epochs requires about 30 minutes on a single A100 GPU or approximately 60 minutes using three RTX 3090 GPUs.
+For `HuggingFaceTB/SmolLM-1.7B-Instruct` model training with evaluation for 10 epochs requires about 25 minutes on a single A100 GPU or approximately 50 minutes using three RTX 3090 GPUs.
 
 All quantization methods compressed the models to `INT4_ASYM` precision with a group size of `64`.
 
 | Model                               | Precision         | Wikitext,<br>word_ppl | Improvement |
 |-------------------------------------|-------------------|-----------------------|-------------|
-| google/gemma-2-2b-it                | BF16              | 15.02                 |             |
-| google/gemma-2-2b-it                | INT4 (QAT + LoRA) | 15.09                 | 91%         |
+| google/gemma-2-2b-it                | BF16              | 15.05                 |             |
+| google/gemma-2-2b-it                | INT4 (QAT + LoRA) | 15.28                 | 69%         |
 | google/gemma-2-2b-it                | INT4 (best PTWC)  | 15.80                 |             |
 | HuggingFaceTB/SmolLM-1.7B-Instruct  | BF16              | 19.11                 |             |
-| HuggingFaceTB/SmolLM-1.7B-Instruct  | INT4 (QAT + LoRA) | 19.25                 | 79%         |
+| HuggingFaceTB/SmolLM-1.7B-Instruct  | INT4 (QAT + LoRA) | 19.57                 | 30%         |
 | HuggingFaceTB/SmolLM-1.7B-Instruct  | INT4 (best PTWC)  | 19.77                 |             |
-| meta-llama/Llama-3.2-1B-Instruct    | BF16              | 16.30                 |             |
-| meta-llama/Llama-3.2-1B-Instruct    | INT4 (QAT + LoRA) | 17.01                 | 41%         |
+| meta-llama/Llama-3.2-1B-Instruct    | BF16              | 16.29                 |             |
+| meta-llama/Llama-3.2-1B-Instruct    | INT4 (QAT + LoRA) | 17.02                 | 40%         |
 | meta-llama/Llama-3.2-1B-Instruct    | INT4 (best PTWC)  | 17.51                 |             |
 | meta-llama/Llama-3.2-3B-Instruct    | BF16              | 12.67                 |             |
-| meta-llama/Llama-3.2-3B-Instruct    | INT4 (QAT + LoRA) | 13.03                 | 33%         |
+| meta-llama/Llama-3.2-3B-Instruct    | INT4 (QAT + LoRA) | 13.00                 | 40%         |
 | meta-llama/Llama-3.2-3B-Instruct    | INT4 (best PTWC)  | 13.22                 |             |
-| meta-llama/Meta-Llama-3-8B-Instruct | BF16              | 10.22                 |             |
-| meta-llama/Meta-Llama-3-8B-Instruct | INT4 (QAT + LoRA) | 10.30                 | 64%         |
+| meta-llama/Meta-Llama-3-8B-Instruct | BF16              | 10.20                 |             |
+| meta-llama/Meta-Llama-3-8B-Instruct | INT4 (QAT + LoRA) | 10.34                 | 44%         |
 | meta-llama/Meta-Llama-3-8B-Instruct | INT4 (best PTWC)  | 10.45                 |             |
-| microsoft/phi3.5-mini-instruct      | BF16              | 10.00                 |             |
-| microsoft/phi3.5-mini-instruct      | INT4 (QAT + LoRA) | 10.52                 | 26%         |
+| microsoft/phi3.5-mini-instruct      | BF16              | 9.98                  |             |
+| microsoft/phi3.5-mini-instruct      | INT4 (QAT + LoRA) | 10.46                 | 34%         |
 | microsoft/phi3.5-mini-instruct      | INT4 (best PTWC)  | 10.71                 |             |
-| microsoft/phi3-mini-4k-instruct     | BF16              | 9.49                  |             |
-| microsoft/phi3-mini-4k-instruct     | INT4 (QAT + LoRA) | 10.04                 | 26%         |
+| microsoft/phi3-mini-4k-instruct     | BF16              | 9.48                  |             |
+| microsoft/phi3-mini-4k-instruct     | INT4 (QAT + LoRA) | 10.03                 | 28%         |
 | microsoft/phi3-mini-4k-instruct     | INT4 (best PTWC)  | 10.24                 |             |
 | mistralai/Mistral-7B-v0.3           | BF16              | 8.21                  |             |
-| mistralai/Mistral-7B-v0.3           | INT4 (QAT + LoRA) | 8.36                  | 21%         |
+| mistralai/Mistral-7B-v0.3           | INT4 (QAT + LoRA) | 8.35                  | 23%         |
 | mistralai/Mistral-7B-v0.3           | INT4 (best PTWC)  | 8.40                  |             |
-| Qwen/Qwen2.5-3B-Instruct            | BF16              | 11.01                 |             |
-| Qwen/Qwen2.5-3B-Instruct            | INT4 (QAT + LoRA) | 11.45                 | 29%         |
+| Qwen/Qwen2.5-3B-Instruct            | BF16              | 11.02                 |             |
+| Qwen/Qwen2.5-3B-Instruct            | INT4 (QAT + LoRA) | 11.48                 | 27%         |
 | Qwen/Qwen2.5-3B-Instruct            | INT4 (best PTWC)  | 11.64                 |             |
-|                                     |                   |               Average | 46%         |
+|                                     |                   |               Average | 39%         |

--- a/examples/llm_compression/torch/distillation_qat_with_lora/main.py
+++ b/examples/llm_compression/torch/distillation_qat_with_lora/main.py
@@ -419,9 +419,7 @@ def main(argv) -> float:
                 total_steps += 1
                 tb.add_scalar("loss", aggregated_loss, total_steps)
 
-        # No need to save the model's state, since it isn't changed after initialization.
-        # Saving the NNCF checkpoint is sufficient regardless of the --basic_init option.
-        save_checkpoint(model, ckpt_file, model_state=False)
+        save_checkpoint(model, ckpt_file, model_state=not args.basic_init)
 
     del model
     # Export the best tuned model to OpenVINO and evaluate it using LM-Evaluation-Harness.

--- a/src/nncf/quantization/algorithms/weight_compression/torch_backend.py
+++ b/src/nncf/quantization/algorithms/weight_compression/torch_backend.py
@@ -40,7 +40,6 @@ from nncf.experimental.common.tensor_statistics.statistics import WCTensorStatis
 from nncf.parameters import CompressionFormat
 from nncf.parameters import CompressWeightsMode
 from nncf.quantization.advanced_parameters import AdvancedCompressionParameters
-from nncf.quantization.algorithms.smooth_quant.torch_backend import SQMultiply
 from nncf.quantization.algorithms.weight_compression.awq_patterns import get_awq_patterns
 from nncf.quantization.algorithms.weight_compression.backend import AWQAlgoBackend
 from nncf.quantization.algorithms.weight_compression.backend import MixedPrecisionAlgoBackend
@@ -75,6 +74,7 @@ from nncf.torch.quantization.layers import INT8SymmetricWeightsDecompressor
 from nncf.torch.quantization.layers import PTLoraNLSSpec
 from nncf.torch.quantization.layers import PTLoraSpec
 from nncf.torch.quantization.layers import PTQuantizerSpec
+from nncf.torch.quantization.layers import SQMultiply
 
 
 class PTWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):

--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -307,7 +307,7 @@
         "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
         "accuracy_tolerance": 0.1,
         "accuracy_metrics": {
-            "best_ov_perplexity": 32.64
+            "best_ov_perplexity": 32.26
         }
     },
     "llm_compression_qat_with_nls": {

--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -307,7 +307,7 @@
         "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
         "accuracy_tolerance": 0.1,
         "accuracy_metrics": {
-            "best_ov_perplexity": 32.26
+            "best_ov_perplexity": 34.91
         }
     },
     "llm_compression_qat_with_nls": {

--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -307,8 +307,7 @@
         "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
         "accuracy_tolerance": 0.1,
         "accuracy_metrics": {
-            "perplexity_diff_torch": 0.75,
-            "best_ov_perplexity": 34.94
+            "best_ov_perplexity": 32.64
         }
     },
     "llm_compression_qat_with_nls": {

--- a/tests/cross_fw/examples/run_example.py
+++ b/tests/cross_fw/examples/run_example.py
@@ -224,9 +224,9 @@ def llm_compression_distillation_qat_with_lora() -> float:
         "--limit=0.2",
     ]
 
-    perplexity_diff_torch, best_ov_perplexity = distillation_qat_with_lora_main(args)
+    best_ov_perplexity = distillation_qat_with_lora_main(args)
 
-    return {"perplexity_diff_torch": perplexity_diff_torch, "best_ov_perplexity": best_ov_perplexity}
+    return {"best_ov_perplexity": best_ov_perplexity}
 
 
 def llm_compression_qat_with_nls() -> float:

--- a/tests/cross_fw/examples/run_example.py
+++ b/tests/cross_fw/examples/run_example.py
@@ -220,7 +220,6 @@ def llm_compression_distillation_qat_with_lora() -> float:
         "--batch_size=16",
         "--microbatch_size=4",
         "--lr=5e-4",
-        "--fast_eval",
         "--limit=0.2",
     ]
 

--- a/tests/cross_fw/examples/run_example.py
+++ b/tests/cross_fw/examples/run_example.py
@@ -215,7 +215,7 @@ def llm_compression_distillation_qat_with_lora() -> float:
         "--epochs=1",
         "--pretrained=HuggingFaceTB/SmolLM2-135M-Instruct",
         "--num_train_samples=128",
-        "--calib_seqlen=128",
+        "--train_seqlen=128",
         "--lora_rank=8",
         "--batch_size=16",
         "--microbatch_size=4",


### PR DESCRIPTION
### Changes

- Fixed support for more advanced compression methods (AWQ+Scale Estimation) as initialization for QAT with absorbable LoRA. 
Previously RTN baseline was used, but now with data-aware AWQ + Scale Estimation tuning starts with more accurate model and achieves superior accuracy: 

![image](https://github.com/user-attachments/assets/24c5d912-8563-47c1-85a4-62d17222fa1a)

- Removed selection of the best checkpoint based on validation set. It significantly reduces overall tuning time and max allocated memory. The best results are slightly worse on wikitext, but it should provide more fair and faster tuning pipeline (from 32 min to 25 min for SmoLM-1.7B). 

### Reason for changes

Improvements in QAT + absorbable LoRA.

### Related tickets

ticket - 169140

### Tests

test_examples - https://github.com/openvinotoolkit/nncf/actions/runs/16223789950
