### PR TITLE
[Torch FX] Changes to Support OpenVINO Quantizer

### DIFF
--- a/src/nncf/experimental/torch/fx/transformations.py
+++ b/src/nncf/experimental/torch/fx/transformations.py
@@ -190,7 +190,7 @@ def constant_update_fn(
     value: torch.Tensor,
     input_port_id: int = 1,
     updated_node_name: Optional[str] = None,
-):
+) -> torch.fx.Node:
     """
     Updates constant of given node on the given input port id with given value.
 
@@ -199,6 +199,7 @@ def constant_update_fn(
     :param value: New value to use as the node constant.
     :param input_port_id: Target constant input port id.
     :param updated_node_name: Name of the constant node after updating. Default is `nodename` + `_updated_constant`.
+    :return: Updated constant node.
     """
     graph = model.graph
     old_const = _get_node_by_input_port_id(node, input_port_id)
@@ -220,6 +221,8 @@ def constant_update_fn(
 
     old_const.replace_all_uses_with(new_const, propagate_meta=True)
     graph.eliminate_dead_code()
+
+    return new_const
 
 
 def qdq_insertion_transformation_builder(

--- a/src/nncf/experimental/torch/fx/transformations.py
+++ b/src/nncf/experimental/torch/fx/transformations.py
@@ -190,7 +190,7 @@ def constant_update_fn(
     value: torch.Tensor,
     input_port_id: int = 1,
     updated_node_name: Optional[str] = None,
-) -> torch.fx.Node:
+):
     """
     Updates constant of given node on the given input port id with given value.
 
@@ -199,7 +199,6 @@ def constant_update_fn(
     :param value: New value to use as the node constant.
     :param input_port_id: Target constant input port id.
     :param updated_node_name: Name of the constant node after updating. Default is `nodename` + `_updated_constant`.
-    :return: Updated constant node.
     """
     graph = model.graph
     old_const = _get_node_by_input_port_id(node, input_port_id)
@@ -221,8 +220,6 @@ def constant_update_fn(
 
     old_const.replace_all_uses_with(new_const, propagate_meta=True)
     graph.eliminate_dead_code()
-
-    return new_const
 
 
 def qdq_insertion_transformation_builder(

--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -339,6 +339,14 @@ class WeightCompression(Algorithm):
     def available_backends(self) -> list[BackendType]:
         return [BackendType.OPENVINO, BackendType.TORCH, BackendType.TORCH_FX]
 
+    def set_ignored_scope(self, ignored_scope: IgnoredScope) -> None:
+        """
+        Set target ignored scope for the Weight Compression algorithm.
+
+        :param ignored_scope: The ignored scope to set to the Weight Compression algorithm.
+        """
+        self._ignored_scope = ignored_scope
+
     def set_backend_entity(self, model: TModel) -> None:
         """
         Creates a helper class with a backed-specific logic of the algorithm.


### PR DESCRIPTION
### Changes

1. Add method to set ignored scope in Weight Compression algorithm. 

### Reason for changes

1. This is to allow the user of OpenVINO quantizer to set the ignored scope from the instance without passing it in the quantizer initialization.