### PR TITLE
Fix qat anomalib example

### DIFF
--- a/examples/quantization_aware_training/torch/anomalib/requirements.txt
+++ b/examples/quantization_aware_training/torch/anomalib/requirements.txt
@@ -1,2 +1,3 @@
 anomalib[core,openvino]==1.0.1
 matplotlib<3.10.0
+numpy==1.26.4


### PR DESCRIPTION
### Changes

Set numpy version 1.26.4 in examples/quantization_aware_training/torch/anomalib/requirements.txt

### Reason for changes

https://github.com/openvinotoolkit/nncf/actions/runs/16157111182/job/45622233944
`AttributeError: `np.sctypes` was removed in the NumPy 2.0 release. Access dtypes explicitly instead.`

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/16178671797
