### PR TITLE
[TorchFX] TorchAOAdapter microfixes

### DIFF
--- a/tests/torch/test_models/synthetic.py
+++ b/tests/torch/test_models/synthetic.py
@@ -725,3 +725,11 @@ class SimpleConcatModel(torch.nn.Module):
         b = self.conv1(x)
         c = torch.cat([a, b], dim=1)
         return self.conv2(c)
+
+
+class ConcatModelWithTwoOutputs(SimpleConcatModel):
+    def forward(self, x):
+        a = self.conv(x)
+        b = self.conv1(x)
+        c = torch.cat([a, b], dim=1)
+        return self.conv2(c), a


### PR DESCRIPTION
### Changes
In `TorchAOAdapter`:
* _get_node_args is used for the input quantization point branch
* A possible case with `quant_min` or `quant_max` are None is managed (faced with CoreMLQuantizer)

### Reason for changes

* To fix some issues of `quantize_pt2e` quantization with the `CoreMLQuantizer`

### Related tickets

169070

### Tests
in `test_quantizer.py`:
* test_none_q_min_q_max_quantizer
* test_adapter_inp_concat_idx
