### PR TITLE
[TorchFX] quantize_pt2e Ignored Scope

### DIFF
--- a/src/nncf/experimental/quantization/algorithms/post_training/algorithm.py
+++ b/src/nncf/experimental/quantization/algorithms/post_training/algorithm.py
@@ -13,6 +13,7 @@ import itertools
 from typing import Callable, Optional, TypeVar
 
 from nncf import Dataset
+from nncf import IgnoredScope
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
 from nncf.common.utils.backend import BackendType
@@ -45,6 +46,7 @@ class ExperimentalPostTrainingQuantization(Algorithm):
         smooth_quant_params: Optional[AdvancedSmoothQuantParameters] = None,
         activations_range_estimator_params: Optional[RangeEstimatorParameters] = None,
         weights_range_estimator_params: Optional[RangeEstimatorParameters] = None,
+        ignored_scope: Optional[IgnoredScope] = None,
         batchwise_statistics: bool = False,
     ):
         """
@@ -61,6 +63,8 @@ class ExperimentalPostTrainingQuantization(Algorithm):
             of activations of the model.
         :param weights_range_estimator_params: Contains parameters for estimating the range
             of weights of the model.
+        :param ignored_scope: An ignored scope that defined the list of model control
+            flow graph nodes to be ignored during quantization.
         :param batchwise_statistics: Determines whether quantizer statistics should be calculated
             for each item of the batch or for the entire batch, default is False.
         """
@@ -73,6 +77,7 @@ class ExperimentalPostTrainingQuantization(Algorithm):
             smooth_quant_params=smooth_quant_params,
             activations_range_estimator_params=activations_range_estimator_params,
             weights_range_estimator_params=weights_range_estimator_params,
+            ignored_scope=ignored_scope,
             batchwise_statistics=batchwise_statistics,
         )
 

--- a/src/nncf/experimental/quantization/algorithms/post_training/pipeline.py
+++ b/src/nncf/experimental/quantization/algorithms/post_training/pipeline.py
@@ -11,6 +11,7 @@
 
 from typing import Optional, TypeVar
 
+from nncf import IgnoredScope
 from nncf.experimental.quantization.algorithms.range_estimator.algorithm import MinMaxRangeEstimator
 from nncf.experimental.quantization.quantizer import Quantizer
 from nncf.quantization.advanced_parameters import AdvancedBiasCorrectionParameters
@@ -35,6 +36,7 @@ def experimental_create_ptq_pipeline(
     smooth_quant_params: Optional[AdvancedSmoothQuantParameters] = None,
     activations_range_estimator_params: Optional[RangeEstimatorParameters] = None,
     weights_range_estimator_params: Optional[RangeEstimatorParameters] = None,
+    ignored_scope: Optional[IgnoredScope] = None,
     batchwise_statistics: bool = False,
 ) -> Pipeline:
     """
@@ -58,6 +60,8 @@ def experimental_create_ptq_pipeline(
         of activations of the model.
     :param weights_range_estimator_params: Contains parameters for estimating the range
         of weights of the model.
+    :param ignored_scope: An ignored scope that defined the list of model control
+        flow graph nodes to be ignored during quantization.
     :param batchwise_statistics: Determines whether quantizer statistics should be calculated
         for each item of the batch or for the entire batch, default is False.
     :return: An experimental post-training quantization pipeline.
@@ -82,6 +86,7 @@ def experimental_create_ptq_pipeline(
                 batchwise_statistics=batchwise_statistics,
                 activations_range_estimator_params=activations_range_estimator_params,
                 weights_range_estimator_params=weights_range_estimator_params,
+                ignored_scope=ignored_scope,
             )
         ]
     )

--- a/src/nncf/experimental/torch/fx/quantization/quantize_pt2e.py
+++ b/src/nncf/experimental/torch/fx/quantization/quantize_pt2e.py
@@ -23,6 +23,7 @@ from torch.fx.passes.infra.pass_manager import PassManager
 
 import nncf
 from nncf import Dataset
+from nncf import IgnoredScope
 from nncf.common.factory import NNCFGraphFactory
 from nncf.common.logging import nncf_logger
 from nncf.common.utils.api_marker import api
@@ -52,6 +53,7 @@ def quantize_pt2e(
     activations_range_estimator_params: Optional[RangeEstimatorParameters] = None,
     weights_range_estimator_params: Optional[RangeEstimatorParameters] = None,
     batchwise_statistics: Optional[bool] = None,
+    ignored_scope: Optional[IgnoredScope] = None,
     fold_quantize: bool = True,
     do_copy: bool = False,
 ) -> torch.fx.GraphModule:
@@ -79,6 +81,8 @@ def quantize_pt2e(
     :param batchwise_statistics: Determines whether quantizer statistics should be calculated
         for each item of the batch or for the entire batch, default is None, which means
         it set True if batch_size > 1 otherwise False.
+    :param ignored_scope: An ignored scope that defined the list of model control
+        flow graph nodes to be ignored during quantization.
     :param fold_quantize: Boolean flag for whether fold the quantize op or not. The value is True by default.
     :param do_copy: The copy of the given model is being quantized if do_copy == True,
         otherwise the model is quantized inplace. Default value is False.
@@ -117,6 +121,7 @@ def quantize_pt2e(
         smooth_quant_params=smooth_quant_params,
         activations_range_estimator_params=activations_range_estimator_params,
         weights_range_estimator_params=weights_range_estimator_params,
+        ignored_scope=ignored_scope,
         batchwise_statistics=batchwise_statistics,
     )
 

--- a/tests/torch/test_models/synthetic.py
+++ b/tests/torch/test_models/synthetic.py
@@ -733,3 +733,11 @@ class ConcatModelWithTwoOutputs(SimpleConcatModel):
         b = self.conv1(x)
         c = torch.cat([a, b], dim=1)
         return self.conv2(c), a
+
+
+class SimpleResidualConcatModel(SimpleConcatModel):
+    def forward(self, x):
+        a = self.conv(x)
+        b = self.conv1(x)
+        c = torch.cat([a, b], dim=1)
+        return self.conv2(c) + a

--- a/tests/torch2/data/fx/after_ignored_scope.dot
+++ b/tests/torch2/data/fx/after_ignored_scope.dot
@@ -1,0 +1,23 @@
+strict digraph {
+"0 conv_weight" [id=0, type="get_attr"];
+"1 conv1_weight" [id=1, type="get_attr"];
+"2 conv2_weight" [id=2, type="get_attr"];
+"3 x" [id=3, type=input];
+"4 conv2d" [id=4, type=conv2d];
+"5 conv2d_1" [id=5, type=conv2d];
+"6 cat" [id=6, type=cat];
+"7 conv2d_2" [id=7, type=conv2d];
+"8 add" [id=8, type=add];
+"9 output" [id=9, type=output];
+"0 conv_weight" -> "4 conv2d" [style=solid, label="(1, 3, 1, 1)"];
+"1 conv1_weight" -> "5 conv2d_1" [style=solid, label="(1, 3, 1, 1)"];
+"2 conv2_weight" -> "7 conv2d_2" [style=solid, label="(1, 2, 1, 1)"];
+"3 x" -> "4 conv2d" [style=solid, label="(1, 3, 3, 3)"];
+"3 x" -> "5 conv2d_1" [style=solid, label="(1, 3, 3, 3)"];
+"4 conv2d" -> "6 cat" [style=solid, label="(1, 1, 3, 3)"];
+"4 conv2d" -> "8 add" [style=solid, label="(1, 1, 3, 3)"];
+"5 conv2d_1" -> "6 cat" [style=solid, label="(1, 1, 3, 3)"];
+"6 cat" -> "7 conv2d_2" [style=solid, label="(1, 2, 3, 3)"];
+"7 conv2d_2" -> "8 add" [style=solid, label="(1, 1, 3, 3)"];
+"8 add" -> "9 output" [style=solid, label="(1, 1, 3, 3)"];
+}

--- a/tests/torch2/data/fx/before_ignored_scope.dot
+++ b/tests/torch2/data/fx/before_ignored_scope.dot
@@ -1,0 +1,35 @@
+strict digraph {
+"0 conv1_weight" [id=0, type="get_attr"];
+"1 conv2_weight" [id=1, type="get_attr"];
+"2 x" [id=2, type=input];
+"3 _frozen_param0" [id=3, type="get_attr"];
+"4 dequantize_per_tensor_default" [id=4, type="dequantize_per_tensor"];
+"5 conv2d" [id=5, type=conv2d];
+"6 quantize_per_tensor_default_1" [id=6, type="quantize_per_tensor"];
+"7 dequantize_per_tensor_default_4" [id=7, type="dequantize_per_tensor"];
+"8 dequantize_per_tensor_default_3" [id=8, type="dequantize_per_tensor"];
+"9 conv2d_1" [id=9, type=conv2d];
+"10 quantize_per_tensor_default_2" [id=10, type="quantize_per_tensor"];
+"11 dequantize_per_tensor_default_2" [id=11, type="dequantize_per_tensor"];
+"12 cat" [id=12, type=cat];
+"13 conv2d_2" [id=13, type=conv2d];
+"14 add" [id=14, type=add];
+"15 output" [id=15, type=output];
+"0 conv1_weight" -> "9 conv2d_1" [style=solid, label="(1, 3, 1, 1)"];
+"1 conv2_weight" -> "13 conv2d_2" [style=solid, label="(1, 2, 1, 1)"];
+"2 x" -> "5 conv2d" [style=solid, label="(1, 3, 3, 3)"];
+"2 x" -> "9 conv2d_1" [style=solid, label="(1, 3, 3, 3)"];
+"3 _frozen_param0" -> "4 dequantize_per_tensor_default" [style=solid, label="(1, 3, 1, 1)"];
+"4 dequantize_per_tensor_default" -> "5 conv2d" [style=solid, label="(1, 3, 1, 1)"];
+"5 conv2d" -> "6 quantize_per_tensor_default_1" [style=solid, label="(1, 1, 3, 3)"];
+"6 quantize_per_tensor_default_1" -> "7 dequantize_per_tensor_default_4" [style=solid, label="(1, 1, 3, 3)"];
+"6 quantize_per_tensor_default_1" -> "8 dequantize_per_tensor_default_3" [style=solid, label="(1, 1, 3, 3)"];
+"7 dequantize_per_tensor_default_4" -> "12 cat" [style=solid, label="(1, 1, 3, 3)"];
+"8 dequantize_per_tensor_default_3" -> "14 add" [style=solid, label="(1, 1, 3, 3)"];
+"9 conv2d_1" -> "10 quantize_per_tensor_default_2" [style=solid, label="(1, 1, 3, 3)"];
+"10 quantize_per_tensor_default_2" -> "11 dequantize_per_tensor_default_2" [style=solid, label="(1, 1, 3, 3)"];
+"11 dequantize_per_tensor_default_2" -> "12 cat" [style=solid, label="(1, 1, 3, 3)"];
+"12 cat" -> "13 conv2d_2" [style=solid, label="(1, 2, 3, 3)"];
+"13 conv2d_2" -> "14 add" [style=solid, label="(1, 1, 3, 3)"];
+"14 add" -> "15 output" [style=solid, label="(1, 1, 3, 3)"];
+}


### PR DESCRIPTION
### Changes

New parameter: `ignored_scope` is introduced in the `quantize_pt2e` API

### Reason for changes

To make it possible to ignore some nodes for external quantization.
Particularly - to enable performant quantization of Yolo12 models with `XNNPACKQuantizer` ignoring the postprocessing branch of the models

### Related tickets

169070

### Tests

tests/torch2/fx/test_quantizer.py::test_quantize_pt2e_ignored_scope is introduced
