### PR TITLE
Fix for `quantization_aware_training_torch_*` tests' Python dependencies installation

### DIFF
--- a/tests/cross_fw/examples/test_examples.py
+++ b/tests/cross_fw/examples/test_examples.py
@@ -13,6 +13,7 @@ import os
 import subprocess
 import sys
 import time
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +43,7 @@ PERFORMANCE_METRICS = "performance_metrics"
 NUM_RETRY_ON_CONNECTION_ERROR = 2
 RETRY_TIMEOUT = 60
 
+logger = logging.getLogger(__name__)
 
 def example_test_cases():
     example_scope = load_json(EXAMPLE_SCOPE_PATH)
@@ -92,6 +94,7 @@ def test_examples(
     if "requirements" in example_params:
         requirements = PROJECT_ROOT / example_params["requirements"]
         run_cmd_line = f"{pip_with_venv} install -r {requirements}"
+        logger.info(f"Installing requirements: {run_cmd_line}")
         subprocess.run(run_cmd_line, check=True, shell=True)
 
     if ov_version_override is not None:
@@ -100,11 +103,16 @@ def test_examples(
         extra_index_url = "https://storage.openvinotoolkit.org/simple/wheels/nightly"
         wwb_module_string = "whowhatbench@git+https://github.com/openvinotoolkit/openvino.genai.git#subdirectory=tools/who_what_benchmark"
         wwb_override_cmd_line = f"{pip_with_venv} install --pre --extra-index-url {extra_index_url} {wwb_module_string}"
+        logger.info(f"Installing OpenVINO version override: {ov_version_cmd_line}")
         subprocess.run(ov_version_cmd_line, check=True, shell=True)
+        logger.info(f"Uninstalling OpenVINO packages: {uninstall_cmd_line}")
         subprocess.run(uninstall_cmd_line, check=True, shell=True)
+        logger.info(f"Installing WWB module: {wwb_override_cmd_line}")
         subprocess.run(wwb_override_cmd_line, check=True, shell=True)
 
-    subprocess.run(f"{pip_with_venv} list", check=True, shell=True)
+    cmd_list_packages = f"{pip_with_venv} list"
+    logger.info(f"Listing installed packages: {cmd_list_packages}")
+    subprocess.run(cmd_list_packages, check=True, shell=True)
 
     env = os.environ.copy()
     example_dir = Path(example_params["requirements"]).parent

--- a/tests/cross_fw/shared/helpers.py
+++ b/tests/cross_fw/shared/helpers.py
@@ -10,12 +10,14 @@
 # limitations under the License.
 import subprocess
 import sys
+import logging
 from pathlib import Path
 from typing import Callable
 
 from tests.cross_fw.shared.paths import GITHUB_REPO_URL
 from tests.cross_fw.shared.paths import PROJECT_ROOT
 
+logger = logging.getLogger(__name__)
 
 def is_windows() -> bool:
     return "win32" in sys.platform
@@ -64,15 +66,26 @@ def create_venv_with_nncf(tmp_path: Path, package_type: str, venv_type: str, bac
 
     if venv_type == "virtualenv":
         virtualenv = Path(sys.executable).parent / "virtualenv"
-        subprocess.check_call(f"{virtualenv} -ppython{version_string} {venv_path}", shell=True)
+        cmd_create_venv = f"{virtualenv} -ppython{version_string} {venv_path}"
+        logger.info(f"Creating virtualenv: {cmd_create_venv}")
+        subprocess.check_call(cmd_create_venv, shell=True)
     elif venv_type == "venv":
-        subprocess.check_call(f"{sys.executable} -m venv {venv_path}", shell=True)
+        cmd_create_venv = f"{sys.executable} -m venv {venv_path}"
+        logger.info(f"Creating venv: {cmd_create_venv}")
+        subprocess.check_call(cmd_create_venv, shell=True)
 
-    subprocess.check_call(f"{pip_with_venv} install --upgrade pip", shell=True)
-    subprocess.check_call(f"{pip_with_venv} install --upgrade wheel setuptools", shell=True)
+    cmd_upgrade_pip = f"{pip_with_venv} install --upgrade pip"
+    logger.info(f"Upgrading pip: {cmd_upgrade_pip}")
+    subprocess.check_call(cmd_upgrade_pip, shell=True)
+
+    cmd_upgrade_tools = f"{pip_with_venv} install --upgrade wheel setuptools"
+    logger.info(f"Upgrading wheel and setuptools: {cmd_upgrade_tools}")
+    subprocess.check_call(cmd_upgrade_tools, shell=True)
 
     if package_type in ["build_s", "build_w"]:
-        subprocess.check_call(f"{pip_with_venv} install build", shell=True)
+        cmd_install_build = f"{pip_with_venv} install build"
+        logger.info(f"Installing build: {cmd_install_build}")
+        subprocess.check_call(cmd_install_build, shell=True)
 
     run_path = tmp_path / "run"
     run_path.mkdir(exist_ok=True)
@@ -99,19 +112,23 @@ def create_venv_with_nncf(tmp_path: Path, package_type: str, venv_type: str, bac
         msg = f"Invalid package type: {package_type}"
         raise ValueError(msg)
 
+    logger.info(f"Running package command: {run_cmd_line}")
     subprocess.run(run_cmd_line, check=True, shell=True, cwd=PROJECT_ROOT)
 
     if package_type in ["build_s", "build_w"]:
         package_path = find_file_by_extension(dist_path, ".tar.gz" if package_type == "build_s" else ".whl")
         cmd_install_package = f"{pip_with_venv} install {package_path}"
+        logger.info(f"Installing package: {cmd_install_package}")
         subprocess.run(cmd_install_package, check=True, shell=True)
 
     if backends:
         # Install backend specific packages with according version from constraints.txt
         packages = [item for b in backends for item in MAP_BACKEND_PACKAGES[b]]
         extra_reqs = " ".join(packages)
+        cmd_install_backends = f"{pip_with_venv} install {extra_reqs} -c {PROJECT_ROOT}/constraints.txt"
+        logger.info(f"Installing backend packages: {cmd_install_backends}")
         subprocess.run(
-            f"{pip_with_venv} install {extra_reqs} -c {PROJECT_ROOT}/constraints.txt",
+            cmd_install_backends,
             check=True,
             shell=True,
             cwd=PROJECT_ROOT,


### PR DESCRIPTION
### Changes

Fixing a bug with Python modules installation during `openvino-nightly` weekly validation cycles

### Reason for changes

`quantization_aware_training_torch_*` tests from `tests/cross_fw/examples` fail due to Python dependencies conflict when `ov_version_override` is set

### Related tickets
Ticket ID: 169697
