### PR TITLE
Increase atol for quantization_aware_training_tensorflow_mobilenet_v2

### DIFF
--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -337,7 +337,7 @@
         "backend": "tf",
         "requirements": "examples/quantization_aware_training/tensorflow/mobilenet_v2/requirements.txt",
         "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
-        "accuracy_tolerance": 0.003,
+        "accuracy_tolerance": 0.01,
         "accuracy_metrics": {
             "fp32_top1": 0.987770676612854,
             "int8_top1": 0.9737579822540283,


### PR DESCRIPTION
### Changes

Increase atol for quantization_aware_training_tensorflow_mobilenet_v2

### Reason for changes

Sporadic falls 
```
FAILED tests/cross_fw/examples/test_examples.py::test_examples[quantization_aware_training_tensorflow_mobilenet_v2] - AssertionError: metric int8_top1: 0.9701910614967346 != 0.9737579822540283
assert 0.9701910614967346 == 0.9737579822540283 ± 3.0e-03
```

