### PR TITLE
[Weight Compression] Rework WC Algorithm to Return WC Params

### DIFF
--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -780,7 +780,7 @@ class WeightCompression(Algorithm):
         Collects and processes weight compression parameters for all nodes in the model,
         applies all processing steps including group size fallback handling and compression
         configuration setting.
-        
+
         :param model: Backend-specific input model.
         :param graph: NNCFGraph instance.
         :param statistic_points: Optional pre-collected statistic points.
@@ -790,15 +790,15 @@ class WeightCompression(Algorithm):
             Statistics collected for data-aware compression. None if data-free compression.
         """
         nodes_to_compress = self.get_nodes_to_compress(graph)
-        
+
         initial_all_weight_params: list[WeightCompressionParameters] = []
         skipped_weight_params: list[WeightCompressionParameters] = []
-        
+
         weight_names = set()
         is_last_layer_skipped = False
         n = len(nodes_to_compress)
         ignored_names = self.get_ignored_node_names(graph)
-        
+
         for i, node in enumerate(nodes_to_compress):
             is_target_node = should_consider_scope(node.node_name, ignored_names)
             for weight_name, weight_port_id in self._backend_entity.get_weight_names_and_port_ids(node, graph):
@@ -840,7 +840,7 @@ class WeightCompression(Algorithm):
                         )
                         if self.is_weight_compression_supported(weight_dtype, mode):
                             wc_config = WeightCompressionConfig(mode=mode)
-                            
+
                     weight_params = WeightCompressionParameters(
                         weight_name, node, weight_port_id, weight_dtype, weight_shape, reduction_axes, wc_config
                     )
@@ -890,10 +890,11 @@ class WeightCompression(Algorithm):
             self._get_bitwidth_distribution_str(all_weight_params, ratio_defining_params, skipped_weight_params)
         )
 
-        final_all_weight_params = list(filter(lambda w_params: w_params.compression_config is not None, all_weight_params))
-        
-        return final_all_weight_params, skipped_weight_params, statistics
+        final_all_weight_params = list(
+            filter(lambda w_params: w_params.compression_config is not None, all_weight_params)
+        )
 
+        return final_all_weight_params, statistics
 
     def apply(
         self,
@@ -905,7 +906,7 @@ class WeightCompression(Algorithm):
         self.set_backend_entity(model)
 
         # Get processed weight compression parameters ready for compression
-        all_weight_params, skipped_weight_params, statistics = self.get_processed_weight_compression_parameters(
+        all_weight_params, statistics = self.get_processed_weight_compression_parameters(
             model, graph, statistic_points, dataset
         )
 

--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -775,7 +775,7 @@ class WeightCompression(Algorithm):
         graph: NNCFGraph,
         statistic_points: Optional[StatisticPointsContainer] = None,
         dataset: Optional[Dataset] = None,
-    ) -> tuple[list[WeightCompressionParameters], dict[str, Any]]:
+    ) -> tuple[list[WeightCompressionParameters], Optional[dict[str, WCTensorStatistic]]]:
         """
         Generates a list of weight compression parameters based on the Weight Compression algorithm
         configuration. Determines the appropriate precision, group size, and other parameters for

--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -777,9 +777,11 @@ class WeightCompression(Algorithm):
         dataset: Optional[Dataset] = None,
     ) -> tuple[list[WeightCompressionParameters], Optional[dict[str, WCTensorStatistic]]]:
         """
-        Generates a mapping of target node names to the collected statistics based on the provided
-        statistic_points. If statistic_points is None, collects required compression statistics on
-        the given dataset.
+        Generates a list of weight compression parameters based on the Weight Compression algorithm
+        configuration. Determines the appropriate quantization parameters for each node eligible for 
+        weight compression. Also, Generates a mapping of target node names to the collected statistics 
+        based on the provided statistic_points. If statistic_points is None, collects required 
+        compression statistics on the given dataset.
 
         :param model: Backend-specific input model.
         :param graph: NNCFGraph instance.

--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -778,8 +778,8 @@ class WeightCompression(Algorithm):
     ) -> tuple[list[WeightCompressionParameters], list[WeightCompressionParameters], dict[str, Any]]:
         """
         Collects and processes weight compression parameters for all nodes in the model,
-        applies all processing steps including group size fallback handling and compression
-        configuration setting.
+        applies all processing steps including mixed precision assignment, group size fallback 
+        handling and compression configuration setting.
 
         :param model: Backend-specific input model.
         :param graph: NNCFGraph instance.

--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -778,17 +778,17 @@ class WeightCompression(Algorithm):
     ) -> tuple[list[WeightCompressionParameters], Optional[dict[str, WCTensorStatistic]]]:
         """
         Generates a list of weight compression parameters based on the Weight Compression algorithm
-        configuration. Determines the appropriate quantization parameters for each node eligible for 
-        weight compression. Also, Generates a mapping of target node names to the collected statistics 
-        based on the provided statistic_points. If statistic_points is None, collects required 
+        configuration. Determines the appropriate quantization parameters for each node eligible for
+        weight compression. Also, Generates a mapping of target node names to the collected statistics
+        based on the provided statistic_points. If statistic_points is None, collects required
         compression statistics on the given dataset.
 
         :param model: Backend-specific input model.
         :param graph: NNCFGraph instance.
         :param statistic_points: Optional pre-collected statistic points.
         :param dataset: Optional dataset for statistics collection.
-        :return: A tuple consisting of a list of weight compression parameters, based on the Weight 
-            Compression algorithm configuration, and a mapping of target node names to the 
+        :return: A tuple consisting of a list of weight compression parameters, based on the Weight
+            Compression algorithm configuration, and a mapping of target node names to the
             collected statistics.
         """
         nodes_to_compress = self.get_nodes_to_compress(graph)

--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -775,7 +775,7 @@ class WeightCompression(Algorithm):
         graph: NNCFGraph,
         statistic_points: Optional[StatisticPointsContainer] = None,
         dataset: Optional[Dataset] = None,
-    ) -> tuple[list[WeightCompressionParameters], list[WeightCompressionParameters], dict[str, Any]]:
+    ) -> tuple[list[WeightCompressionParameters], dict[str, Any]]:
         """
         Generates a list of weight compression parameters based on the Weight Compression algorithm
         configuration. Determines the appropriate precision, group size, and other parameters for

--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -769,42 +769,6 @@ class WeightCompression(Algorithm):
 
         return is_supported_dtype and not no_bit_reduction
 
-    def collect_weight_compression_statistics(
-        self,
-        model: TModel,
-        graph: NNCFGraph,
-        dataset: Dataset,
-        weight_params: list[WeightCompressionParameters],
-        statistic_points: Optional[StatisticPointsContainer] = None,
-    ) -> Optional[dict[str, Any]]:
-        """
-        Collects statistics for weight compression if data-aware compression or
-        mixed-precision is enabled.
-
-        :param model: Backend-specific input model.
-        :param graph: NNCFGraph instance.
-        :param dataset: Dataset for statistics collection.
-        :param weight_params: Weight parameters for which to collect statistics.
-        :param statistic_points: Optional pre-collected statistic points.
-        :return: Statistics and Statistic points container.
-        """
-        statistics = None
-        if not (self._data_aware_mixed_precision or self._data_aware_compression) and not dataset:
-            return statistics, statistic_points
-        matmul_nodes_to_compress = [
-            wp.node_with_weight
-            for wp in weight_params
-            if wp.node_with_weight.metatype in self._backend_entity.matmul_metatypes
-        ]
-        matmul_input_to_output_nodes_map = self.get_matmul_input_to_output_nodes_map(matmul_nodes_to_compress, graph)
-
-        if statistic_points is None:
-            statistic_points = self.get_statistic_points(model, graph, matmul_input_to_output_nodes_map.keys())
-            statistic_points = self._collect_statistics(dataset, graph, model, statistic_points)
-
-        statistics = self._get_statistics_for_weights_compression(matmul_input_to_output_nodes_map, statistic_points)
-        return statistics, statistic_points
-
     def get_weight_compression_parameters(
         self,
         model: TModel,
@@ -902,10 +866,23 @@ class WeightCompression(Algorithm):
             group_size_values = {w_params.weight_name: self._group_size for w_params in ratio_defining_params}
 
         # Collect statistics for the weights compression
-        weight_params = ratio_defining_params if self._backup_mode == BackupMode.NONE else all_weight_params
-        statistics, statistic_points = self.collect_weight_compression_statistics(
-            model, graph, dataset, weight_params, statistic_points
-        )
+        statistics = None
+        if (self._data_aware_mixed_precision or self._data_aware_compression) and dataset:
+            weight_params = ratio_defining_params if self._backup_mode == BackupMode.NONE else all_weight_params
+            matmul_nodes_to_compress = [
+                wp.node_with_weight
+                for wp in weight_params
+                if wp.node_with_weight.metatype in self._backend_entity.matmul_metatypes
+            ]
+            matmul_input_to_output_nodes_map = self.get_matmul_input_to_output_nodes_map(
+                matmul_nodes_to_compress, graph
+            )
+            if statistic_points is None:
+                statistic_points = self.get_statistic_points(model, graph, matmul_input_to_output_nodes_map.keys())
+                statistic_points = self._collect_statistics(dataset, graph, model, statistic_points)
+            statistics = self._get_statistics_for_weights_compression(
+                matmul_input_to_output_nodes_map, statistic_points
+            )
 
         # Set weight compression configuration
         self._set_weight_compression_config(ratio_defining_params, model, graph, statistic_points, group_size_values)

--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -778,7 +778,7 @@ class WeightCompression(Algorithm):
     ) -> tuple[list[WeightCompressionParameters], list[WeightCompressionParameters], dict[str, Any]]:
         """
         Collects and processes weight compression parameters for all nodes in the model,
-        applies all processing steps including mixed precision assignment, group size fallback 
+        applies all processing steps including mixed precision assignment, group size fallback
         handling and compression configuration setting.
 
         :param model: Backend-specific input model.
@@ -895,9 +895,7 @@ class WeightCompression(Algorithm):
         )
 
         # Filter all_weight_params and by excluding nodes that should remain in their original floating-point precision
-        all_weight_params = list(
-            filter(lambda w_params: w_params.compression_config is not None, all_weight_params)
-        )
+        all_weight_params = list(filter(lambda w_params: w_params.compression_config is not None, all_weight_params))
 
         return all_weight_params, statistics
 

--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -785,7 +785,7 @@ class WeightCompression(Algorithm):
         :param graph: NNCFGraph instance.
         :param statistic_points: Optional pre-collected statistic points.
         :param dataset: Optional dataset for statistics collection.
-        :return: A list of weight compression parameters based on the Weight Compression algorithm configuration.
+        :return: A tuple of weight compression parameters based on the Weight Compression algorithm configuration.
         """
         nodes_to_compress = self.get_nodes_to_compress(graph)
 

--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -854,6 +854,7 @@ class WeightCompression(Algorithm):
                         )
                     )
 
+        # Get subset of nodes to define compression ratio
         ratio_defining_params = self._get_ratio_defining_params(all_weight_params, is_last_layer_skipped)
 
         # Handle group size fallback modes
@@ -866,6 +867,7 @@ class WeightCompression(Algorithm):
         else:
             group_size_values = {w_params.weight_name: self._group_size for w_params in ratio_defining_params}
 
+        # Collect statistics for the weights compression
         statistics = None
         if (self._data_aware_mixed_precision or self._data_aware_compression) and dataset:
             weight_params = ratio_defining_params if self._backup_mode == BackupMode.NONE else all_weight_params
@@ -884,17 +886,20 @@ class WeightCompression(Algorithm):
                 matmul_input_to_output_nodes_map, statistic_points
             )
 
+        # Set weight compression configuration
         self._set_weight_compression_config(ratio_defining_params, model, graph, statistic_points, group_size_values)
 
+        # Print statistics
         nncf_logger.info(
             self._get_bitwidth_distribution_str(all_weight_params, ratio_defining_params, skipped_weight_params)
         )
 
-        final_all_weight_params = list(
+        # Filter all_weight_params and by excluding nodes that should remain in their original floating-point precision
+        all_weight_params = list(
             filter(lambda w_params: w_params.compression_config is not None, all_weight_params)
         )
 
-        return final_all_weight_params, statistics
+        return all_weight_params, statistics
 
     def apply(
         self,

--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -777,15 +777,17 @@ class WeightCompression(Algorithm):
         dataset: Optional[Dataset] = None,
     ) -> tuple[list[WeightCompressionParameters], Optional[dict[str, WCTensorStatistic]]]:
         """
-        Generates a list of weight compression parameters based on the Weight Compression algorithm
-        configuration. Determines the appropriate precision, group size, and other parameters for
-        each node eligible for weight compression.
+        Generates a mapping of target node names to the collected statistics based on the provided
+        statistic_points. If statistic_points is None, collects required compression statistics on
+        the given dataset.
 
         :param model: Backend-specific input model.
         :param graph: NNCFGraph instance.
         :param statistic_points: Optional pre-collected statistic points.
         :param dataset: Optional dataset for statistics collection.
-        :return: A tuple of weight compression parameters based on the Weight Compression algorithm configuration.
+        :return: A tuple consisting of a list of weight compression parameters, based on the Weight 
+            Compression algorithm configuration, and a mapping of target node names to the 
+            collected statistics.
         """
         nodes_to_compress = self.get_nodes_to_compress(graph)
 

--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -866,7 +866,6 @@ class WeightCompression(Algorithm):
         else:
             group_size_values = {w_params.weight_name: self._group_size for w_params in ratio_defining_params}
 
-        # Step 4: Collect statistics for data-aware compression
         statistics = None
         if (self._data_aware_mixed_precision or self._data_aware_compression) and dataset:
             weight_params = ratio_defining_params if self._backup_mode == BackupMode.NONE else all_weight_params
@@ -885,15 +884,12 @@ class WeightCompression(Algorithm):
                 matmul_input_to_output_nodes_map, statistic_points
             )
 
-        # Step 5: Set weight compression configuration
         self._set_weight_compression_config(ratio_defining_params, model, graph, statistic_points, group_size_values)
 
-        # Step 6: Print statistics
         nncf_logger.info(
             self._get_bitwidth_distribution_str(all_weight_params, ratio_defining_params, skipped_weight_params)
         )
 
-        # Step 7: Filter out nodes that should remain in their original floating-point precision
         final_all_weight_params = list(filter(lambda w_params: w_params.compression_config is not None, all_weight_params))
         
         return final_all_weight_params, skipped_weight_params, statistics


### PR DESCRIPTION
### Changes

Re-worked the `apply` method in WC algorithm to use an extra method to return weights compression params such that the apply method is more concise and only contains algorithm, quantization logic etc.

### Reason for changes

This is done so that OpenVINO quantizer can obtain the final collection of weights compression parameters for all the nodes so that are to be compressed.
