### PR TITLE
[release_v2180] [ci] Fix bandit workflow (#3638)

### DIFF
--- a/.github/workflows/sdl.yml
+++ b/.github/workflows/sdl.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: 3.10.14
       - name: Install bandit
-        run: pip install bandit[toml]==1.7.4
+        run: pip install bandit[toml]==1.7.4 stevedore==5.4.1
       - name: Run bandit
         run: bandit -c pyproject.toml -r .
 


### PR DESCRIPTION
### Changes

Set version of stevedore==5.4.1 

### Reason for changes


https://github.com/openvinotoolkit/nncf/actions/runs/17211295443/job/48824963052 stevedore==5.5.0 
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.14/x64/bin/bandit", line 3, in <module>
    from bandit.cli.main import main
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/bandit/__init__.py", line 5, in <module>
    import pbr.version
ModuleNotFoundError: No module named 'pbr'
```
