### PR TITLE
[ONNX] Compress quantize weights transformation

### DIFF
--- a/src/nncf/onnx/graph/onnx_helper.py
+++ b/src/nncf/onnx/graph/onnx_helper.py
@@ -377,20 +377,24 @@ def pack_int4_to_uint8(weight: np.ndarray, block_size: int, signed: bool) -> np.
 
 def get_node_attr_value(node: onnx.NodeProto, attr_name: str) -> Optional[Any]:
     """
-    TODO
+    Retrieves the value of a specified attribute from a node.
 
-    :param node:
-    :param attr_name:
-    :return:
+    This function searches for an attribute with the given name in the provided
+    node. If the attribute exists, its value is returned. If the attribute is
+    not found, `None` is returned. If multiple attributes with the same name are
+    found, a `ValueError` is raised.
+
+    :param node: The node to retrieve the attribute from.
+    :param attr_name: The name of the attribute to retrieve.
+    :return: The value of the attribute if found; otherwise, `None`.
     """
     matching = [x for x in node.attribute if x.name == attr_name]
-    attr_value = None
+
     if len(matching) > 1:
-        raise ValueError(f"Node has multiple attributes with name {attr_name}")
+        msg = f"Node has multiple attributes with name {attr_name}."
+        raise ValueError(msg)
+
     if len(matching) < 1:
-        # raise ValueError(f"Node has no attribute with name {attr_name}")
         return None
 
-    attr_value = onnx.helper.get_attribute_value(matching[0])
-
-    return attr_value
+    return onnx.helper.get_attribute_value(matching[0])

--- a/src/nncf/onnx/graph/onnx_helper.py
+++ b/src/nncf/onnx/graph/onnx_helper.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import defaultdict
-from typing import Iterator, Optional, Union
+from typing import Iterator, Optional, Union, Any
 
 import numpy as np
 import onnx
@@ -373,3 +373,24 @@ def pack_int4_to_uint8(weight: np.ndarray, block_size: int, signed: bool) -> np.
     packed_weight = packed.transpose(2, 0, 1)
 
     return packed_weight
+
+
+def get_node_attr_value(node: onnx.NodeProto, attr_name: str) -> Optional[Any]:
+    """
+    TODO
+
+    :param node:
+    :param attr_name:
+    :return:
+    """
+    matching = [x for x in node.attribute if x.name == attr_name]
+    attr_value = None
+    if len(matching) > 1:
+        raise ValueError(f"Node has multiple attributes with name {attr_name}")
+    if len(matching) < 1:
+        # raise ValueError(f"Node has no attribute with name {attr_name}")
+        return None
+
+    attr_value = onnx.helper.get_attribute_value(matching[0])
+
+    return attr_value

--- a/src/nncf/onnx/graph/onnx_helper.py
+++ b/src/nncf/onnx/graph/onnx_helper.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import defaultdict
-from typing import Iterator, Optional, Union, Any
+from typing import Any, Iterator, Optional, Union
 
 import numpy as np
 import onnx

--- a/src/nncf/onnx/graph/passes.py
+++ b/src/nncf/onnx/graph/passes.py
@@ -96,7 +96,7 @@ def compress_quantize_weights_transformation(model: onnx.ModelProto):
     initializer = {x.name: x for x in model.graph.initializer}
     nodes_to_remove = []
 
-    version = model.opset_import[0].version
+    version = max(model.opset_import[0].version, 19)
     QuantizeLinear = load_op("", "QuantizeLinear", version)
 
     for node in model.graph.node:

--- a/src/nncf/onnx/quantization/backend_parameters.py
+++ b/src/nncf/onnx/quantization/backend_parameters.py
@@ -19,7 +19,9 @@ class BackendParameters:
     """
     :param EXTERNAL_DATA_DIR: An absolute path to the directory where the external data
         files are stored. All external data files must be located in the same folder.
-    :param COMPRESS_WEIGHTS: TODO
+    :param COMPRESS_WEIGHTS: If `True` compresses constant quantized weights by folding
+        `QuantizeLinear` nodes into pre-quantized initializers. If `False`, this transformation
+        is skipped.
     """
 
     COMPRESS_WEIGHTS = "compress_weights"
@@ -32,7 +34,7 @@ def is_weight_compression_needed(advanced_parameters: Optional[AdvancedQuantizat
     advanced quantization parameters.
 
     :param advanced_parameters: Advanced quantization parameters.
-    :return: True if weight compression is needed, False otherwise.
+    :return: `True` if weight compression is needed, `False` otherwise.
     """
     if advanced_parameters is not None and advanced_parameters.backend_params is not None:
         return advanced_parameters.backend_params.get(BackendParameters.COMPRESS_WEIGHTS, True)

--- a/src/nncf/onnx/quantization/backend_parameters.py
+++ b/src/nncf/onnx/quantization/backend_parameters.py
@@ -19,9 +19,24 @@ class BackendParameters:
     """
     :param EXTERNAL_DATA_DIR: An absolute path to the directory where the external data
         files are stored. All external data files must be located in the same folder.
+    :param COMPRESS_WEIGHTS: TODO
     """
 
+    COMPRESS_WEIGHTS = "compress_weights"
     EXTERNAL_DATA_DIR = "external_data_dir"
+
+
+def is_weight_compression_needed(advanced_parameters: Optional[AdvancedQuantizationParameters]) -> bool:
+    """
+    Determines whether weight compression is needed based on the provided
+    advanced quantization parameters.
+
+    :param advanced_parameters: Advanced quantization parameters.
+    :return: True if weight compression is needed, False otherwise.
+    """
+    if advanced_parameters is not None and advanced_parameters.backend_params is not None:
+        return advanced_parameters.backend_params.get(BackendParameters.COMPRESS_WEIGHTS, True)
+    return True
 
 
 def get_external_data_dir(

--- a/src/nncf/onnx/quantization/quantize_model.py
+++ b/src/nncf/onnx/quantization/quantize_model.py
@@ -30,7 +30,9 @@ from nncf.onnx.graph.model_metadata import remove_metadata
 from nncf.onnx.graph.model_metadata import set_metadata
 from nncf.onnx.graph.nncf_graph_builder import GraphConverter
 from nncf.onnx.graph.passes import apply_preprocess_passes
+from nncf.onnx.graph.passes import compress_quantize_weights_transformation
 from nncf.onnx.quantization.backend_parameters import get_external_data_dir
+from nncf.onnx.quantization.backend_parameters import is_weight_compression_needed
 from nncf.parameters import BackupMode
 from nncf.parameters import CompressionFormat
 from nncf.parameters import CompressWeightsMode
@@ -177,6 +179,9 @@ def quantize_impl(
         remove_metadata(quantized_model, MetadataKey.EXTERNAL_DATA_DIR)
         load_external_data_for_model(quantized_model, external_data_dir)
 
+    if is_weight_compression_needed(advanced_parameters):
+        compress_quantize_weights_transformation(quantized_model)
+
     return quantized_model
 
 
@@ -291,6 +296,9 @@ def quantize_with_accuracy_control_impl(
             validation_dataset_size,
             evaluator,
         )
+
+    if is_weight_compression_needed(advanced_quantization_parameters):
+        compress_quantize_weights_transformation(quantized_model)
 
     return quantized_model
 

--- a/src/nncf/onnx/quantization/quantize_model.py
+++ b/src/nncf/onnx/quantization/quantize_model.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import sys
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, TypeVar, Union
 
@@ -31,6 +32,7 @@ from nncf.onnx.graph.model_metadata import set_metadata
 from nncf.onnx.graph.nncf_graph_builder import GraphConverter
 from nncf.onnx.graph.passes import apply_preprocess_passes
 from nncf.onnx.graph.passes import compress_quantize_weights_transformation
+from nncf.onnx.quantization.backend_parameters import BackendParameters
 from nncf.onnx.quantization.backend_parameters import get_external_data_dir
 from nncf.onnx.quantization.backend_parameters import is_weight_compression_needed
 from nncf.parameters import BackupMode
@@ -207,8 +209,13 @@ def quantize_with_accuracy_control_impl(
     if advanced_accuracy_restorer_parameters is None:
         advanced_accuracy_restorer_parameters = AdvancedAccuracyRestorerParameters()
 
+    compress_weights = is_weight_compression_needed(advanced_quantization_parameters)
+
     if advanced_quantization_parameters is None:
-        advanced_quantization_parameters = AdvancedQuantizationParameters()
+        copied_parameters = AdvancedQuantizationParameters()
+    else:
+        copied_parameters = deepcopy(advanced_quantization_parameters)
+    copied_parameters.backend_params[BackendParameters.COMPRESS_WEIGHTS] = False
 
     quantized_model = quantize_impl(
         model=model,
@@ -219,7 +226,7 @@ def quantize_with_accuracy_control_impl(
         fast_bias_correction=fast_bias_correction,
         model_type=model_type,
         ignored_scope=ignored_scope,
-        advanced_parameters=advanced_quantization_parameters,
+        advanced_parameters=copied_parameters,
     )
 
     if advanced_accuracy_restorer_parameters.intermediate_model_dir:
@@ -259,7 +266,7 @@ def quantize_with_accuracy_control_impl(
             fast_bias_correction,
             model_type,
             ignored_scope,
-            advanced_quantization_parameters,
+            copied_parameters,
         )
         tuned_quantized_metric_results = evaluator.collect_metric_results(
             tuned_quantized_model, validation_dataset, model_name="tuned"
@@ -297,7 +304,7 @@ def quantize_with_accuracy_control_impl(
             evaluator,
         )
 
-    if is_weight_compression_needed(advanced_quantization_parameters):
+    if compress_weights:
         compress_quantize_weights_transformation(quantized_model)
 
     return quantized_model

--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -12,6 +12,11 @@
             "fp32_fps": 1732.8,
             "int8_fps": 6013.68,
             "performance_speed_up": 3.470498614958449
+        },
+        "model_size_metrics": {
+            "fp32_model_size": 9.01850414276123,
+            "int8_model_size": 2.9374523162841797,
+            "model_compression_rate": 3.0701789073360906
         }
     },
     "post_training_quantization_openvino_mobilenet_v2_quantize": {

--- a/tests/onnx/test_passes.py
+++ b/tests/onnx/test_passes.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import numpy as np
 import onnx
 

--- a/tests/onnx/test_passes.py
+++ b/tests/onnx/test_passes.py
@@ -48,6 +48,7 @@ def check_operation_count(model: onnx.ModelProto, op_type_to_count: dict[str, in
             count[node.op_type] = count.get(node.op_type, 0) + 1
     assert count == op_type_to_count
 
+
 def test_compress_quantize_weights_transformation():
     model = _build_model()
 

--- a/tests/onnx/test_passes.py
+++ b/tests/onnx/test_passes.py
@@ -9,7 +9,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import onnx
+
+import nncf
 from nncf.onnx.graph.passes import apply_preprocess_passes
+from nncf.onnx.graph.passes import compress_quantize_weights_transformation
+from nncf.onnx.quantization.backend_parameters import BackendParameters
+from tests.onnx.common import ModelBuilder
 from tests.onnx.models import build_matmul_model_with_nop_cast
 
 
@@ -21,3 +28,42 @@ def test_apply_preprocess_passes():
 
     assert set(after_nodes) - set(before_nodes) == set()
     assert set(before_nodes) - set(after_nodes) == set(["cast"])
+
+
+def _build_model():
+    w = np.array([[0.1, 0.3, 0.2, -0.1], [-0.9, 0.1, 0.5, -0.3], [0.0, -0.1, -0.4, -0.9]], dtype=np.float32)
+
+    b = np.array([0.1, 0.1, 0.1, 0.1], dtype=np.float32)
+
+    mb = ModelBuilder()
+    x = mb.add_input("X", (2, 3))
+    x = mb.add_gemm(x, w.shape, weight_data=w, bias_data=b)
+    mb.add_output(x, (2, 4))
+    return mb.build(opset_version=19, ir_version=9)
+
+
+def check_operation_count(model: onnx.ModelProto, op_type_to_count: dict[str, int]):
+    count = {}
+    for node in model.graph.node:
+        if node.op_type in op_type_to_count:
+            count[node.op_type] = count.get(node.op_type, 0) + 1
+    assert count == op_type_to_count
+
+def test_compress_quantize_weights_transformation():
+    model = _build_model()
+
+    x = np.array([[0.2, -0.1, 0.9], [-0.1, -0.9, 0.5]], dtype=np.float32)
+
+    # Prepare quantized model without weight compression
+    calibration_dataset = nncf.Dataset([{"X": x}])
+    quantized_model = nncf.quantize(
+        model,
+        calibration_dataset,
+        advanced_parameters=nncf.AdvancedQuantizationParameters(
+            backend_params={BackendParameters.COMPRESS_WEIGHTS: False}
+        ),
+    )
+
+    check_operation_count(quantized_model, {"QuantizeLinear": 2, "DequantizeLinear": 2})
+    compress_quantize_weights_transformation(quantized_model)
+    check_operation_count(quantized_model, {"QuantizeLinear": 1, "DequantizeLinear": 2})

--- a/tests/post_training/pipelines/image_classification_timm.py
+++ b/tests/post_training/pipelines/image_classification_timm.py
@@ -20,6 +20,7 @@ from timm.layers.config import set_fused_attn
 from tests.post_training.pipelines.base import OV_BACKENDS
 from tests.post_training.pipelines.base import PT_BACKENDS
 from tests.post_training.pipelines.base import BackendType
+from tests.post_training.pipelines.base import get_model_size
 from tests.post_training.pipelines.image_classification_base import ImageClassificationBase
 
 # Disable using aten::scaled_dot_product_attention
@@ -50,6 +51,7 @@ class ImageClassificationTimm(ImageClassificationBase):
             torch.onnx.export(
                 timm_model, self.dummy_tensor, onnx_path, export_params=True, opset_version=13, **additional_kwargs
             )
+            self.run_info.fp32_model_size = get_model_size(onnx_path)
             self.model = onnx.load(onnx_path)
             self.input_name = self.model.graph.input[0].name
 

--- a/tests/post_training/pipelines/image_classification_torchvision.py
+++ b/tests/post_training/pipelines/image_classification_torchvision.py
@@ -21,6 +21,7 @@ from torchvision import models
 from tests.post_training.pipelines.base import FX_BACKENDS
 from tests.post_training.pipelines.base import PT_BACKENDS
 from tests.post_training.pipelines.base import BackendType
+from tests.post_training.pipelines.base import get_model_size
 from tests.post_training.pipelines.image_classification_base import ImageClassificationBase
 
 
@@ -97,6 +98,7 @@ class ImageClassificationTorchvision(ImageClassificationBase):
             torch.onnx.export(
                 model, self.dummy_tensor, onnx_path, export_params=True, opset_version=13, **additional_kwargs
             )
+            self.run_info.fp32_model_size = get_model_size(onnx_path)
             self.model = onnx.load(onnx_path)
             self.input_name = self.model.graph.input[0].name
 


### PR DESCRIPTION
### Changes

Added the `compress_quantize_weights_transformation()` method that transforms the model by folding `QuantizeLinear` nodes with constant inputs into precomputed, quantized initializers.

### Reason for changes

- Models after NNCF PTQ should be saved with INT8 weights for the ONNX backend.

### Related tickets

Ref: 101733

### Tests

-  tests/cross_fw/examples/test_examples.py[post_training_quantization_onnx_mobilenet_v2]
- tests/onnx/test_passes.py
