### PR TITLE
Fix test_matmulnbits_gemm for Python 3.13

### DIFF
--- a/tests/onnx/quantization/test_weights_compression.py
+++ b/tests/onnx/quantization/test_weights_compression.py
@@ -317,10 +317,6 @@ def test_matmulnbits():
     assert np.allclose(output21, output19, rtol=rtol, atol=1e-6)
 
 
-@pytest.mark.xfail(
-    version.parse(onnx.__version__) >= version.parse("1.18.0"),
-    reason="onnxruntime not support default IR for onnx==1.18.0",
-)
 @pytest.mark.parametrize("trans_b", [0, 1])
 def test_matmulnbits_gemm(trans_b: int):
     # Build the model with a single Gemm operation


### PR DESCRIPTION
### Changes

Fix test_matmulnbits_gemm for Python 3.13

### Reason for changes

FAILED tests/onnx/quantization/test_weights_compression.py::test_matmulnbits_gemm[0]
FAILED tests/onnx/quantization/test_weights_compression.py::test_matmulnbits_gemm[1]

### Related tickets

N/A

### Tests

weekly
