### PR TITLE
Disable progress bar if total is 0

### DIFF
--- a/src/nncf/common/logging/track_progress.py
+++ b/src/nncf/common/logging/track_progress.py
@@ -213,7 +213,7 @@ class track(Generic[ProgressType]):
             )
         )
 
-        disable = disable or (hasattr(sequence, "__len__") and len(sequence) == 0)  # type: ignore[arg-type]
+        disable = disable or (hasattr(sequence, "__len__") and len(sequence) == 0) or self.total == 0  # type: ignore[arg-type]
 
         progress_cls = Progress if weights is None else WeightedProgress
         self.progress = progress_cls(

--- a/tests/common/utils/test_progress_tracking.py
+++ b/tests/common/utils/test_progress_tracking.py
@@ -84,3 +84,10 @@ def test_track_context_manager(n, is_weighted):
         for i in range(n):
             assert pbar.progress._tasks[pbar.task].completed == (sum(weights[:i]) if is_weighted else i)
             pbar.update(advance=1)
+
+
+def test_disable_with_total_0():
+    pbar = track(iter(get_sequence(0)), total=0)
+    assert pbar.progress.disable is True
+    pbar = track(iter(get_sequence(0)))
+    assert pbar.progress.disable is False


### PR DESCRIPTION
### Changes

Disable progress bar if total is 0

### Reason for changes

To avoid print progress bar if total is 0 
```
Working... ━━━━━━━━━━━━━━━━━━━   0% 0/0 • 0:00:00 • 0:00:00
```

### Tests

tests/common/utils/test_progress_tracking.py::test_disable_with_total_0