### PR TITLE
[OpenVINO] Introduce a way to control resetting of the state of stateful OV models

### DIFF
--- a/src/nncf/data/dataset.py
+++ b/src/nncf/data/dataset.py
@@ -30,6 +30,11 @@ class Dataset:
     usually contains both examples and labels. So transformation function should extract
     the examples from the data item.
 
+    A special input key nncf.definitions.NNCF_DATASET_RESET_STATE_KEY can be used by OpenVINO backend to control
+    resetting of internal model state between model inferences. This key can be added to a dataset sample input
+    dictionary with either `True` or `False` value. With `True` value, the model state will be reset before inference
+    on the corresponding sample, and with `False` the state will not be reset.
+
     :param data_source: The iterable object serving as the source of data items.
     :param transform_func: The function that is used to extract the model's input
         from the data item. The data item here is the data item that is returned from
@@ -37,12 +42,6 @@ class Dataset:
         the data item cannot be directly used as model's input. If this is not specified, then the data item
         will be passed into the model as-is.
     """
-
-    # RESET_STATE_KEY is a special input key used by OpenVINO backend to control resetting of internal model state
-    # between model inferences. This key can be added to a dataset sample input dictionary with either
-    # `True` or `False` value. With `True` value, the model state will be reset before inference on the corresponding
-    # sample, and with `False` the state will not be reset.
-    RESET_STATE_KEY = "nncf_reset_state"
 
     def __init__(self, data_source: Iterable[Any], transform_func: Optional[Callable[..., Any]] = None):
         self._data_source = data_source

--- a/src/nncf/definitions.py
+++ b/src/nncf/definitions.py
@@ -23,3 +23,9 @@ CACHE_MODELS_PATH = NNCF_CACHE_PATH / Path("models")
 # debug dumps, are performed or not performed
 NNCF_CI_ENV_VAR_NAME = "NNCF_CI"  # Must be set in CI environments
 NNCF_DEV_ENV_VAR_NAME = "NNCF_DEV"  # Must be set in environments of the NNCF dev team machines
+
+# This is a special input key used by OpenVINO backend to control resetting of internal model state
+# between model inferences. This key can be added to a dataset sample input dictionary with either
+# `True` or `False` value. With `True` value, the model state will be reset before inference on the corresponding
+# sample, and with `False` the state will not be reset.
+NNCF_DATASET_RESET_STATE_KEY = "nncf_reset_state"

--- a/src/nncf/openvino/engine.py
+++ b/src/nncf/openvino/engine.py
@@ -16,8 +16,8 @@ import openvino as ov
 from openvino import Type
 from openvino.properties.hint import inference_precision
 
-import nncf
 from nncf.common.engine import Engine
+from nncf.definitions import NNCF_DATASET_RESET_STATE_KEY
 from nncf.openvino.graph.model_utils import model_has_state
 
 
@@ -44,10 +44,10 @@ class OVCompiledModelEngine(Engine):
         :param input_data: Inputs for the model.
         :return output_data: Model's output.
         """
-        if isinstance(input_data, dict) and nncf.Dataset.RESET_STATE_KEY in input_data:
+        if isinstance(input_data, dict) and NNCF_DATASET_RESET_STATE_KEY in input_data:
             # In this case state resetting is controlled by the input data flag
             input_data = input_data.copy()
-            if input_data.pop(nncf.Dataset.RESET_STATE_KEY):
+            if input_data.pop(NNCF_DATASET_RESET_STATE_KEY):
                 if self.reset_state:
                     self.infer_request.reset_state()
                 else:

--- a/tests/openvino/native/test_engine.py
+++ b/tests/openvino/native/test_engine.py
@@ -13,7 +13,7 @@ from functools import wraps
 import numpy as np
 import pytest
 
-import nncf
+from nncf.definitions import NNCF_DATASET_RESET_STATE_KEY
 from nncf.openvino.engine import OVNativeEngine
 from tests.openvino.native.models import ConvModel
 from tests.openvino.native.models import LinearModel
@@ -95,10 +95,10 @@ def test_stateful_model_inference_with_controlled_resetting():
 
     model = StatefulModel(True).ov_model
     inp = model.get_parameters()[0]
-    input_data = [{"input_data": np.ones(inp.shape), nncf.Dataset.RESET_STATE_KEY: False} for _ in range(10)]
+    input_data = [{"input_data": np.ones(inp.shape), NNCF_DATASET_RESET_STATE_KEY: False} for _ in range(10)]
     reset_ind = [2, 5, 7]
     for ind in reset_ind:
-        input_data[ind][nncf.Dataset.RESET_STATE_KEY] = True
+        input_data[ind][NNCF_DATASET_RESET_STATE_KEY] = True
 
     engine = OVNativeEngine(model)
     reset_order = []


### PR DESCRIPTION
### Changes

Added `nncf.definitions.NNCF_DATASET_RESET_STATE_KEY` constant to specify when to reset model state. This constant is used by OpenVINO backend to control resetting of internal model state between model inferences. This key can be added to a dataset sample input dictionary with either `True` or `False` value. With `True` value, the model state will be reset before inference on the corresponding sample, and with `False` the state will not be reset.

For an example of usage please see https://github.com/huggingface/optimum-intel/pull/1505.

### Reason for changes

Without this logic static quantization quality of stateful Whisper models is poor because a state of a stateful model must be cleared with the same schedule as it is done during calibration input data collection.

### Related tickets

172705

### Tests

Added `tests/openvino/native/test_engine.py::test_stateful_model_inference_with_controlled_resetting`.
