### PR TITLE
Fix group size table test on Windows

### DIFF
--- a/tests/cross_fw/test_templates/template_test_weights_compression.py
+++ b/tests/cross_fw/test_templates/template_test_weights_compression.py
@@ -521,6 +521,7 @@ class TemplateWeightCompression(ABC):
                     "int4_asym, group size 16  │ 25% (1 / 9)                 │ 25% (1 / 9)",
                 ]
                 for row in table_rows:
+                    # On Windows "|" is printed instead of "│"
                     assert any(row in msg.replace("|", "│") for msg in info_messages), "\n".join(info_messages)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Changes

Update test to take into account a different vertical bar symbol.

### Reason for changes

Test failure on Windows platform.

### Related tickets

<!--- Post the numerical ID of the ticket, if available -->

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/19136564834?pr=3723
