### PR TITLE
Set xfail for quantization_aware_training_torch_anomalib

### DIFF
--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -293,7 +293,8 @@
             "fp32_model_size": 21.37990665435791,
             "int8_model_size": 5.677968978881836,
             "model_compression_rate": 3.7654144877995197
-        }
+        },
+        "xfail": "https://github.com/open-edge-platform/anomalib/issues/3121"
     },
     "fp8_llm_quantization": {
         "backend": "openvino",

--- a/tests/cross_fw/examples/test_examples.py
+++ b/tests/cross_fw/examples/test_examples.py
@@ -46,7 +46,13 @@ RETRY_TIMEOUT = 60
 def example_test_cases():
     example_scope = load_json(EXAMPLE_SCOPE_PATH)
     for example_name, example_params in example_scope.items():
-        marks = pytest.mark.cuda if example_params.get("device") == "cuda" else ()
+        marks = []
+        if example_params.get("device") == "cuda":
+            marks.append(pytest.mark.cuda)
+        if example_params.get("skip"):
+            marks.append(pytest.mark.skip(reason=example_params.get("skip")))
+        if example_params.get("xfail"):
+            marks.append(pytest.mark.xfail(reason=example_params.get("xfail")))
         yield pytest.param(example_name, example_params, id=example_name, marks=marks)
 
 


### PR DESCRIPTION
### Changes

Add option to set skip or xfail marks for example
Set xfail for quantization_aware_training_torch_anomalib

### Reason for changes

https://github.com/openvinotoolkit/nncf/actions/runs/19449063330

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/19479239298

