### PR TITLE
Allow data-free compression with 3D weights

### DIFF
--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -877,7 +877,7 @@ class WeightCompression(Algorithm):
                     ):
                         # MoE operations are usually matmuls, so the check for matmul metatype is done
                         # This is to avoid raising the error for non-MoE cases with 3D weights.
-                        msg = f"""NNCF algorithms do not support 3D weights with current version of 
+                        msg = f"""NNCF compression algorithms do not support 3D weights with current version of 
                                 Openvino {ov_version} due to a known issue in statistics collection Ticket - 176465. 
                                 Node with weight: {node.node_name}."""
                         raise nncf.UnsupportedModelError(msg)


### PR DESCRIPTION
### Changes

Update the condition introduced in https://github.com/openvinotoolkit/nncf/pull/3706 to allow data-free compression with 3D weights.

### Reason for changes

Only data-aware compression is not possible. Caught with optimum-intel tests https://github.com/huggingface/optimum-intel/actions/runs/19623687915/job/56188570802.
