### PR TITLE
Fix Bandit B404: Consider possible security implications associated with the subprocess module

### DIFF
--- a/src/custom_version.py
+++ b/src/custom_version.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 import contextlib
 import os
 import re
-import subprocess
+import subprocess  # nosec
 from pathlib import Path
 
 NNCF_VERSION_FILE = "src/nncf/version.py"
@@ -81,12 +81,12 @@ def get_custom_version() -> str:
     # Get commit hash
     with contextlib.suppress(subprocess.CalledProcessError):
         dev_version_id = (
-            subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], cwd=repo_root).strip().decode()  # nosec
+            subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], cwd=repo_root).strip().decode()
         )
 
     # Detect modified files
     with contextlib.suppress(subprocess.CalledProcessError):
-        run = subprocess.run(["git", "diff-index", "--quiet", "HEAD"], cwd=repo_root)  # nosec
+        run = subprocess.run(["git", "diff-index", "--quiet", "HEAD"], cwd=repo_root)
         if run.returncode == 1:
             dev_version_id += "dirty"
 

--- a/src/nncf/torch/quantization/extensions.py
+++ b/src/nncf/torch/quantization/extensions.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import os.path
-import subprocess
+from subprocess import CalledProcessError  # nosec
 
 import torch
 
@@ -93,7 +93,7 @@ class QuantizedFunctionsCUDALoader(ExtensionLoader):
             )
         except ExtensionLoaderTimeoutException as e:
             raise e
-        except (subprocess.CalledProcessError, OSError, RuntimeError) as e:
+        except (CalledProcessError, OSError, RuntimeError) as e:
             assert torch.cuda.is_available()
             msg = (
                 "CUDA is available for PyTorch, but NNCF could not compile "


### PR DESCRIPTION
### Changes

Ignore possible warning/errors detected by Bandit scans associated with usage of subprocess module.

### Reason for changes

Bandit scan detect issues that needs to be addressed.

### Related tickets

CVS-177669

### Tests

-
