### PR TITLE
Fix deployment of documentation 

### DIFF
--- a/.github/workflows/build_and_publish_doc.yml
+++ b/.github/workflows/build_and_publish_doc.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout main repo  # the github-pages-deploy-action seems to require this step
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Download HTML doc build artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0


### PR DESCRIPTION
### Changes

Set `persist-credentials: false` for `action/checkout` in `.github/workflows/build_and_publish_doc.yml`

### Reason for changes

https://github.com/openvinotoolkit/nncf/actions/runs/19885421336/job/56991691416 -failed after bump `action/checkout`
https://github.com/JamesIves/github-pages-deploy-action/issues/1928#issuecomment-3635092712


### Tests

Only after merge 