### PR TITLE
[ci] parallel pytorch2-cpu

### DIFF
--- a/.github/workflows/call_precommit.yml
+++ b/.github/workflows/call_precommit.yml
@@ -227,7 +227,7 @@ jobs:
       - name: Print installed modules
         run: pip list
       - name: Run torch2 precommit test scope
-        run: pytest -ra -n4 --durations=30 tests/torch2 -m "not cuda"
+        run: pytest -ra -n2 --durations=30 tests/torch2 -m "not cuda"
 
   pytorch2-cuda:
     timeout-minutes: 40


### PR DESCRIPTION
### Changes

Add arguments  `-n2 --durations=30` for tests/torch2 

### Reason for changes

Speed up tests
