### PR TITLE
[PT] Update torch API

### DIFF
--- a/tests/torch/conftest.py
+++ b/tests/torch/conftest.py
@@ -34,8 +34,8 @@ pytest.register_assert_rewrite("tests.torch.helpers")
 @pytest.fixture(scope="session", autouse=True)
 def disable_tf32_precision():
     if torch:
-        torch.backends.cuda.matmul.allow_tf32 = False
-        torch.backends.cudnn.allow_tf32 = False
+        torch.backends.cuda.matmul.fp32_precision = "ieee"
+        torch.backends.cudnn.conv.fp32_precision = "ieee"
 
 
 def pytest_addoption(parser: Parser):

--- a/tests/torch2/conftest.py
+++ b/tests/torch2/conftest.py
@@ -27,8 +27,8 @@ pytest.register_assert_rewrite("tests.torch.helpers")
 @pytest.fixture(scope="session", autouse=True)
 def disable_tf32_precision():
     if torch:
-        torch.backends.cuda.matmul.allow_tf32 = False
-        torch.backends.cudnn.allow_tf32 = False
+        torch.backends.cuda.matmul.fp32_precision = "ieee"
+        torch.backends.cudnn.conv.fp32_precision = "ieee"
 
 
 def pytest_addoption(parser: Parser):


### PR DESCRIPTION

### Reason for changes

```bash 
  /opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/torch/backends/__init__.py:46: UserWarning: Please use the new API settings to control TF32 behavior, such as torch.backends.cudnn.conv.fp32_precision = 'tf32' or torch.backends.cuda.matmul.fp32_precision = 'ieee'. Old settings, e.g, torch.backends.cuda.matmul.allow_tf32 = True, torch.backends.cudnn.allow_tf32 = True, allowTF32CuDNN() and allowTF32CuBLAS() will be deprecated after Pytorch 2.9. Please see https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices (Triggered internally at /pytorch/aten/src/ATen/Context.cpp:80.)
    self.setter(val)
```
https://github.com/openvinotoolkit/nncf/actions/runs/20375527137/job/58552873149

