### PR TITLE
[PT] Remvoe bkc version

### DIFF
--- a/src/nncf/common/logging/logger.py
+++ b/src/nncf/common/logging/logger.py
@@ -91,11 +91,3 @@ def disable_logging() -> None:
 
 
 NNCFDeprecationWarning = FutureWarning
-
-
-def warn_bkc_version_mismatch(backend: str, bkc_version: str, current_version: str) -> None:
-    nncf_logger.warning(
-        f"NNCF provides best results with {backend}{bkc_version}, "
-        f"while current {backend} version is {current_version}. "
-        f"If you encounter issues, consider switching to {backend}{bkc_version}"
-    )

--- a/src/nncf/torch/__init__.py
+++ b/src/nncf/torch/__init__.py
@@ -14,25 +14,9 @@
 Base subpackage for NNCF PyTorch functionality.
 """
 
-import os
-from nncf import nncf_logger
-from nncf.common.logging.logger import warn_bkc_version_mismatch
-
-from nncf.version import BKC_TORCH_SPEC
-
 import torch
 from packaging import version
 from packaging.specifiers import SpecifierSet
-
-try:
-    _torch_version = version.parse(version.parse(torch.__version__).base_version)
-except:  # noqa: E722
-    nncf_logger.debug("Could not parse torch version")
-    _torch_version = version.parse("0.0.0")
-
-if _torch_version not in SpecifierSet(BKC_TORCH_SPEC):
-    warn_bkc_version_mismatch("torch", BKC_TORCH_SPEC, torch.__version__)
-
 
 # Required for correct COMPRESSION_ALGORITHMS registry functioning
 from nncf.torch.quantization import algo as quantization_algo

--- a/src/nncf/version.py
+++ b/src/nncf/version.py
@@ -10,6 +10,3 @@
 # limitations under the License.
 
 __version__ = "3.0.0"
-
-
-BKC_TORCH_SPEC = "==2.9.*"


### PR DESCRIPTION
### Changes

Remove bkc version for pytorch 

### Reason for changes

- Using bkc version is not provide best results
- Warning message is ignored by all 
- Require manually updating

