### PR TITLE
[CI] nightly tests on ubuntu

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
-  pull_request:
 
 jobs:
   install:


### PR DESCRIPTION
### Changes

Run tests on ubuntu in nightly jobs

### Reason for changes

Tests currently run on Ubuntu for pull requests and on a weekly schedule.
This change ensures the develop branch is also continuously validated and remains stable.

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/20711605556