### PR TITLE
[ci] fix fastcore==1.11.5

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -24,3 +24,4 @@ pytest-split==0.9.0
 datasets==4.4.2
 matplotlib==3.10.8
 fastprogress==1.0.5
+fastcore==1.11.5

--- a/examples/post_training_quantization/onnx/mobilenet_v2/requirements.txt
+++ b/examples/post_training_quantization/onnx/mobilenet_v2/requirements.txt
@@ -2,6 +2,7 @@ torch==2.9.0
 torchvision==0.24.0
 fastdownload==0.0.7
 fastprogress==1.0.5
+fastcore==1.11.5
 onnx==1.17.0
 onnxruntime==1.21.1
 openvino==2025.4.1

--- a/examples/post_training_quantization/openvino/mobilenet_v2/requirements.txt
+++ b/examples/post_training_quantization/openvino/mobilenet_v2/requirements.txt
@@ -3,4 +3,5 @@ tqdm
 scikit-learn
 fastdownload==0.0.7
 fastprogress==1.0.5
+fastcore==1.11.5
 openvino==2025.4.1

--- a/examples/post_training_quantization/torch/mobilenet_v2/requirements.txt
+++ b/examples/post_training_quantization/torch/mobilenet_v2/requirements.txt
@@ -1,5 +1,6 @@
 fastdownload==0.0.7
 fastprogress==1.0.5
+fastcore==1.11.5
 openvino==2025.4.1
 scikit-learn
 torch==2.9.0

--- a/examples/post_training_quantization/torch/ssd300_vgg16/requirements.txt
+++ b/examples/post_training_quantization/torch/ssd300_vgg16/requirements.txt
@@ -1,5 +1,6 @@
 fastdownload==0.0.7
 fastprogress==1.0.5
+fastcore==1.11.5
 onnx==1.17.0
 openvino==2025.4.1
 pycocotools==2.0.7

--- a/examples/post_training_quantization/torch_fx/resnet18/requirements.txt
+++ b/examples/post_training_quantization/torch_fx/resnet18/requirements.txt
@@ -1,5 +1,6 @@
 fastdownload==0.0.7
 fastprogress==1.0.5
+fastcore==1.11.5
 openvino==2025.4.1
 torch==2.9.0
 torchvision==0.24.0

--- a/examples/pruning/torch/resnet18/requirements.txt
+++ b/examples/pruning/torch/resnet18/requirements.txt
@@ -1,5 +1,6 @@
 fastdownload==0.0.7
 fastprogress==1.0.5
+fastcore==1.11.5
 openvino==2025.4.1
 torch==2.9.0
 torchvision==0.24.0

--- a/examples/quantization_aware_training/torch/resnet18/requirements.txt
+++ b/examples/quantization_aware_training/torch/resnet18/requirements.txt
@@ -1,5 +1,6 @@
 fastdownload==0.0.7
 fastprogress==1.0.5
+fastcore==1.11.5
 openvino==2025.4.1
 torch==2.9.0
 torchvision==0.24.0


### PR DESCRIPTION
### Changes

Fix version of `fastcore` to 1.11.5

### Reason for changes

https://github.com/openvinotoolkit/nncf/actions/runs/21121090708

Broken new release on python3.10

```sh
    sig_str = f"def {get_name(self.obj)}(\n    {'\n    '.join(lines)}\n{self._ret_str}"
                                                                                       ^
SyntaxError: f-string expression part cannot include a backslash
```

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/21130717198
https://github.com/openvinotoolkit/nncf/actions/runs/21130712774