### PR TITLE
Remove WA for optimum-intel

### DIFF
--- a/examples/llm_compression/onnx/tiny_llama/main.py
+++ b/examples/llm_compression/onnx/tiny_llama/main.py
@@ -27,11 +27,6 @@ ROOT = Path(__file__).parent.resolve()
 MODEL_ID = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
 OUTPUT_DIR = ROOT / "tinyllama_compressed"
 
-# TODO(AlexanderDokuchaev): WA for https://github.com/huggingface/optimum-intel/issues/1498
-from optimum.exporters.tasks import TasksManager  # noqa: E402
-
-TasksManager._TRANSFORMERS_TASKS_TO_MODEL_LOADERS["image-text-to-text"] = "AutoModelForImageTextToText"
-
 
 def main():
     # Export the pretrained model in ONNX format. The OUTPUT_DIR directory

--- a/examples/llm_compression/onnx/tiny_llama_scale_estimation/main.py
+++ b/examples/llm_compression/onnx/tiny_llama_scale_estimation/main.py
@@ -34,11 +34,6 @@ OUTPUT_DIR = ROOT / "tinyllama_compressed"
 warnings.filterwarnings("ignore", category=torch.jit.TracerWarning)
 warnings.filterwarnings("ignore", category=OnnxExporterWarning)
 
-# TODO(AlexanderDokuchaev): WA for https://github.com/huggingface/optimum-intel/issues/1498
-from optimum.exporters.tasks import TasksManager  # noqa: E402
-
-TasksManager._TRANSFORMERS_TASKS_TO_MODEL_LOADERS["image-text-to-text"] = "AutoModelForImageTextToText"
-
 
 def tiny_llama_transform_func(
     item: dict[str, str], tokenizer: LlamaTokenizerFast, onnx_model: onnx.ModelProto

--- a/tests/post_training/test_quantize_conformance.py
+++ b/tests/post_training/test_quantize_conformance.py
@@ -36,12 +36,6 @@ from tests.post_training.pipelines.base import RunInfo
 DATA_ROOT = Path(__file__).parent / "data"
 
 
-# TODO(AlexanderDokuchaev): WA for https://github.com/huggingface/optimum-intel/issues/1498
-from optimum.exporters.tasks import TasksManager  # noqa: E402
-
-TasksManager._TRANSFORMERS_TASKS_TO_MODEL_LOADERS["image-text-to-text"] = "AutoModelForImageTextToText"
-
-
 @pytest.fixture(scope="function", name="use_avx2")
 def fixture_use_avx2():
     old_value = os.environ.get("ONEDNN_MAX_CPU_ISA")


### PR DESCRIPTION
### Changes

Remove WA
```
# TODO(AlexanderDokuchaev): WA for https://github.com/huggingface/optimum-intel/issues/1498
from optimum.exporters.tasks import TasksManager  # noqa: E402

TasksManager._TRANSFORMERS_TASKS_TO_MODEL_LOADERS["image-text-to-text"] = "AutoModelForImageTextToText"
```

### Reason for changes

Fixed by optimum-intel 

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/21210731103
PTQ-787
