### PR TITLE
Fix DeformConv2d operator registration for torchvision.ops

### DIFF
--- a/src/nncf/torch/graph/operator_metatypes.py
+++ b/src/nncf/torch/graph/operator_metatypes.py
@@ -284,11 +284,17 @@ class PTConvTranspose3dMetatype(PTOperatorMetatype):
 
 @PT_OPERATOR_METATYPES.register()
 class PTDeformConv2dMetatype(PTOperatorMetatype):
+    """
+    Deformable Conv2D operator metatype.
+    NOTE: torchvision.ops.deform_conv2d is NOT part of torch.nn.functional.
+    Therefore, it must be registered as an external operator.
+    """
     name = "DeformConv2dOp"
-    module_to_function_names = {NamespaceTarget.TORCH_NN_FUNCTIONAL: ["deform_conv2d"]}
-    subtypes = []
+    # Correct: deform_conv2d comes from torchvision.ops (other library)
+    external_op_names = ["deform_conv2d"]
     num_expected_input_edges = 4
     weight_port_ids = [2]
+    subtypes = []
 
 
 @PT_OPERATOR_METATYPES.register()
@@ -1050,3 +1056,5 @@ CONVOLUTION_METATYPES = [
     PTConvTranspose2dMetatype,
     PTConvTranspose3dMetatype,
 ]
+
+


### PR DESCRIPTION
### Changes
- Fixed the registration of the `DeformConv2d` operator metatype to correctly reflect its actual namespace.
- `torchvision.ops.deform_conv2d` was previously registered under `torch.nn.functional`, which prevented NNCF from recognizing and quantizing deformable convolution operations.
- The operator is now registered via `external_op_names`, allowing NNCF to correctly detect it during graph tracing and quantization.

### Reason for changes
`DeformConv2d` is implemented in `torchvision.ops`, not in `torch.nn.functional`.  
Due to the incorrect namespace mapping, the operator was not matched to its metatype, resulting in missing quantizers and incomplete INT8 coverage for models using deformable convolutions.

Correcting the registration ensures:
- Proper operator detection in the NNCF graph
- Expected quantization behavior for models using `torchvision.ops.DeformConv2d`
- Consistency between operator implementation and metatype definition

### Related tickets
- Fixes: #2794

### Tests
- Verified using a minimal PyTorch reproduction with `torchvision.ops.DeformConv2d`
- Confirmed that the deformable convolution operator is now detected and quantization hooks are correctly inserted during NNCF quantization