### PR TITLE
Use pooch package instead of fastdownload

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -23,5 +23,4 @@ pytest-split==0.11.0
 
 datasets==4.5.0
 matplotlib==3.10.8
-fastprogress==1.0.5
-fastcore==1.11.5
+pooch==1.9.0

--- a/examples/post_training_quantization/onnx/mobilenet_v2/requirements.txt
+++ b/examples/post_training_quantization/onnx/mobilenet_v2/requirements.txt
@@ -1,8 +1,6 @@
 torch==2.9.0
 torchvision==0.24.0
-fastdownload==0.0.7
-fastprogress==1.0.5
-fastcore==1.11.5
+pooch==1.9.0
 onnx==1.17.0
 onnxruntime==1.21.1
 openvino==2025.4.1

--- a/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/requirements.txt
+++ b/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/requirements.txt
@@ -1,3 +1,4 @@
 anomalib==0.6.0
 openvino==2025.4.1
 numpy<2
+setuptools==81.0.0

--- a/examples/post_training_quantization/openvino/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/openvino/mobilenet_v2/main.py
@@ -33,12 +33,16 @@ DATASET_CLASSES = 10
 
 
 def download(url: str, path: Path) -> Path:
+    extracted_dir = path / "extracted"
     files = pooch.retrieve(
         url=url,
         path=path / "downloaded",
-        processor=pooch.Untar(extract_dir=path / "extracted"),
+        processor=pooch.Untar(extract_dir=extracted_dir),
     )
-    return path / "extracted" / Path(files[0]).relative_to(path / "extracted").parts[0]
+    first_file_relative = Path(files[0]).relative_to(extracted_dir)
+    if len(first_file_relative.parts) == 1:
+        return extracted_dir
+    return extracted_dir / first_file_relative.parts[0]
 
 
 def validate(model: ov.Model, val_loader: torch.utils.data.DataLoader) -> float:

--- a/examples/post_training_quantization/openvino/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/openvino/mobilenet_v2/main.py
@@ -15,8 +15,8 @@ from pathlib import Path
 
 import numpy as np
 import openvino as ov
+import pooch
 import torch
-from fastdownload import FastDownload
 from rich.progress import track
 from sklearn.metrics import accuracy_score
 from torchvision import datasets
@@ -33,8 +33,12 @@ DATASET_CLASSES = 10
 
 
 def download(url: str, path: Path) -> Path:
-    downloader = FastDownload(base=path.resolve(), archive="downloaded", data="extracted")
-    return downloader.get(url)
+    files = pooch.retrieve(
+        url=url,
+        path=path / "downloaded",
+        processor=pooch.Untar(extract_dir=path / "extracted"),
+    )
+    return path / "extracted" / Path(files[0]).relative_to(path / "extracted").parts[0]
 
 
 def validate(model: ov.Model, val_loader: torch.utils.data.DataLoader) -> float:

--- a/examples/post_training_quantization/openvino/mobilenet_v2/requirements.txt
+++ b/examples/post_training_quantization/openvino/mobilenet_v2/requirements.txt
@@ -1,7 +1,5 @@
 torchvision
 tqdm
 scikit-learn
-fastdownload==0.0.7
-fastprogress==1.0.5
-fastcore==1.11.5
+pooch==1.9.0
 openvino==2025.4.1

--- a/examples/post_training_quantization/torch/mobilenet_v2/requirements.txt
+++ b/examples/post_training_quantization/torch/mobilenet_v2/requirements.txt
@@ -1,6 +1,4 @@
-fastdownload==0.0.7
-fastprogress==1.0.5
-fastcore==1.11.5
+pooch==1.9.0
 openvino==2025.4.1
 scikit-learn
 torch==2.9.0

--- a/examples/post_training_quantization/torch/ssd300_vgg16/main.py
+++ b/examples/post_training_quantization/torch/ssd300_vgg16/main.py
@@ -39,7 +39,7 @@ def download_dataset() -> Path:
     files = pooch.retrieve(
         url=DATASET_URL,
         path=DATASET_PATH / "downloaded",
-        processor=pooch.Untar(extract_dir=EXTRACTED_DATASET_PATH),
+        processor=pooch.Unzip(extract_dir=EXTRACTED_DATASET_PATH),
     )
     # pooch.Untar returns a list of extracted files
     dataset_root = EXTRACTED_DATASET_PATH / Path(files[0]).relative_to(EXTRACTED_DATASET_PATH).parts[0]

--- a/examples/post_training_quantization/torch/ssd300_vgg16/requirements.txt
+++ b/examples/post_training_quantization/torch/ssd300_vgg16/requirements.txt
@@ -1,6 +1,4 @@
-fastdownload==0.0.7
-fastprogress==1.0.5
-fastcore==1.11.5
+pooch==1.9.0
 onnx==1.17.0
 openvino==2025.4.1
 pycocotools==2.0.7

--- a/examples/post_training_quantization/torch_fx/resnet18/main.py
+++ b/examples/post_training_quantization/torch_fx/resnet18/main.py
@@ -15,6 +15,7 @@ from time import time
 
 # We need to import openvino.torch for torch.compile() with openvino backend to work.
 import openvino.torch  # noqa
+import pooch
 import torch
 import torch.nn as nn
 import torch.nn.parallel
@@ -24,7 +25,6 @@ import torch.utils.data.distributed
 import torchvision.datasets as datasets
 import torchvision.models as models
 import torchvision.transforms as transforms
-from fastdownload import FastDownload
 from rich.progress import track
 from torch._dynamo.exc import BackendCompilerFailed
 
@@ -42,11 +42,18 @@ CHECKPOINT_URL = (
 )
 DATASET_URL = "http://cs231n.stanford.edu/tiny-imagenet-200.zip"
 DATASET_PATH = Path().home() / ".cache" / "nncf" / "datasets"
+EXTRACTED_DATASET_PATH = DATASET_PATH / "extracted"
 
 
 def download_dataset() -> Path:
-    downloader = FastDownload(base=DATASET_PATH.resolve(), archive="downloaded", data="extracted")
-    return downloader.get(DATASET_URL)
+    files = pooch.retrieve(
+        url=DATASET_URL,
+        path=DATASET_PATH / "downloaded",
+        processor=pooch.Untar(extract_dir=EXTRACTED_DATASET_PATH),
+    )
+    # pooch.Untar returns a list of extracted files
+    dataset_root = EXTRACTED_DATASET_PATH / Path(files[0]).relative_to(EXTRACTED_DATASET_PATH).parts[0]
+    return dataset_root
 
 
 def load_checkpoint(model: torch.nn.Module) -> torch.nn.Module:

--- a/examples/post_training_quantization/torch_fx/resnet18/main.py
+++ b/examples/post_training_quantization/torch_fx/resnet18/main.py
@@ -49,7 +49,7 @@ def download_dataset() -> Path:
     files = pooch.retrieve(
         url=DATASET_URL,
         path=DATASET_PATH / "downloaded",
-        processor=pooch.Untar(extract_dir=EXTRACTED_DATASET_PATH),
+        processor=pooch.Unzip(extract_dir=EXTRACTED_DATASET_PATH),
     )
     # pooch.Untar returns a list of extracted files
     dataset_root = EXTRACTED_DATASET_PATH / Path(files[0]).relative_to(EXTRACTED_DATASET_PATH).parts[0]

--- a/examples/post_training_quantization/torch_fx/resnet18/requirements.txt
+++ b/examples/post_training_quantization/torch_fx/resnet18/requirements.txt
@@ -1,6 +1,4 @@
-fastdownload==0.0.7
-fastprogress==1.0.5
-fastcore==1.11.5
+pooch==1.9.0
 openvino==2025.4.1
 torch==2.9.0
 torchvision==0.24.0

--- a/examples/pruning/torch/resnet18/main.py
+++ b/examples/pruning/torch/resnet18/main.py
@@ -70,7 +70,7 @@ def download_dataset() -> Path:
     files = pooch.retrieve(
         url=DATASET_URL,
         path=DATASET_PATH / "downloaded",
-        processor=pooch.Untar(extract_dir=EXTRACTED_DATASET_PATH),
+        processor=pooch.Unzip(extract_dir=EXTRACTED_DATASET_PATH),
     )
     # pooch.Untar returns a list of extracted files
     dataset_root = EXTRACTED_DATASET_PATH / Path(files[0]).relative_to(EXTRACTED_DATASET_PATH).parts[0]

--- a/examples/pruning/torch/resnet18/requirements.txt
+++ b/examples/pruning/torch/resnet18/requirements.txt
@@ -1,6 +1,4 @@
-fastdownload==0.0.7
-fastprogress==1.0.5
-fastcore==1.11.5
+pooch==1.9.0
 openvino==2025.4.1
 torch==2.9.0
 torchvision==0.24.0

--- a/examples/quantization_aware_training/torch/resnet18/main.py
+++ b/examples/quantization_aware_training/torch/resnet18/main.py
@@ -57,7 +57,7 @@ def download_dataset() -> Path:
     files = pooch.retrieve(
         url=DATASET_URL,
         path=DATASET_PATH / "downloaded",
-        processor=pooch.Untar(extract_dir=EXTRACTED_DATASET_PATH),
+        processor=pooch.Unzip(extract_dir=EXTRACTED_DATASET_PATH),
     )
     # pooch.Untar returns a list of extracted files
     dataset_root = EXTRACTED_DATASET_PATH / Path(files[0]).relative_to(EXTRACTED_DATASET_PATH).parts[0]

--- a/examples/quantization_aware_training/torch/resnet18/requirements.txt
+++ b/examples/quantization_aware_training/torch/resnet18/requirements.txt
@@ -1,6 +1,4 @@
-fastdownload==0.0.7
-fastprogress==1.0.5
-fastcore==1.11.5
+pooch==1.9.0
 openvino==2025.4.1
 torch==2.9.0
 torchvision==0.24.0

--- a/tests/cross_fw/examples/run_example.py
+++ b/tests/cross_fw/examples/run_example.py
@@ -376,14 +376,6 @@ def main(argv):
     parser.add_argument("-o", "--output", help="Path to the json file to save example metrics", required=True)
     args = parser.parse_args(args=argv)
 
-    # Disable progress bar for fastdownload module
-    try:
-        import fastprogress.fastprogress
-
-        fastprogress.fastprogress.NO_BAR = True
-    except ImportError:
-        pass
-
     if args.name == "quantization_aware_training_torch_anomalib":
         metrics = globals()[args.name](args.data)
     else:

--- a/tests/executorch/requirements.txt
+++ b/tests/executorch/requirements.txt
@@ -24,8 +24,7 @@ sentence-transformers==4.1.0
 optimum-intel==1.24.0
 optimum==1.26.0
 accelerate==1.9.0
-fastdownload==0.0.7
-
+pooch
 
 # Tests and examples
 pytest==8.0.2

--- a/tests/onnx/quantization/test_ptq_regression.py
+++ b/tests/onnx/quantization/test_ptq_regression.py
@@ -14,9 +14,9 @@ from pathlib import Path
 import numpy as np
 import onnx
 import openvino as ov
+import pooch
 import pytest
 import torch
-from fastdownload import FastDownload
 from onnx import version_converter
 from openvino import Core
 from sklearn.metrics import accuracy_score
@@ -83,13 +83,17 @@ def models(request, tmp_path):
 
 
 def download_dataset(dataset_path: Path) -> Path:
-    downloader = FastDownload(base=dataset_path, archive="downloaded", data="extracted")
-    return downloader.get(DATASET_URL)
+    files = pooch.retrieve(
+        url=DATASET_URL,
+        path=dataset_path / "downloaded",
+        processor=pooch.Untar(extract_dir=dataset_path / "extracted"),
+    )
+    return dataset_path / "extracted" / Path(files[0]).relative_to(dataset_path / "extracted").parts[0]
 
 
 def download_model(model_url, tmp_path) -> Path:
-    downloader = FastDownload(base=tmp_path)
-    return downloader.download(model_url)
+    model_file = pooch.retrieve(url=model_url, path=tmp_path, known_hash=None)
+    return Path(model_file)
 
 
 def validate(quantized_model_path: Path, data_loader: torch.utils.data.DataLoader) -> float:

--- a/tests/onnx/requirements.txt
+++ b/tests/onnx/requirements.txt
@@ -10,7 +10,7 @@ pytest-xdist
 torch
 torchvision
 
-fastdownload==0.0.7
+pooch
 scikit-learn>=1.2.2,<=1.5.0
 tqdm>=4.54.1
 yattag>=1.14.0

--- a/tests/openvino/native/quantization/test_sanity.py
+++ b/tests/openvino/native/quantization/test_sanity.py
@@ -48,7 +48,7 @@ DATASET_URL = "https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz"
 def data(request):
     option = request.config.getoption("--data")
     if option is None:
-        return Path("~/.cache/nncf/datasets")
+        return Path.home() / ".cache" / "nncf" / "datasets"
     return Path(option)
 
 

--- a/tests/openvino/native/quantization/test_sanity.py
+++ b/tests/openvino/native/quantization/test_sanity.py
@@ -12,9 +12,9 @@ from pathlib import Path
 
 import numpy as np
 import openvino as ov
+import pooch
 import pytest
 import torch
-from fastdownload import FastDownload
 from sklearn.metrics import accuracy_score
 from torchvision import datasets
 from torchvision import transforms
@@ -61,13 +61,17 @@ def models(request, tmp_path):
 
 
 def download_dataset(dataset_path: Path) -> Path:
-    downloader = FastDownload(base=dataset_path, archive="downloaded", data="extracted")
-    return downloader.get(DATASET_URL)
+    files = pooch.retrieve(
+        url=DATASET_URL,
+        path=dataset_path / "downloaded",
+        processor=pooch.Untar(extract_dir=dataset_path / "extracted"),
+    )
+    return dataset_path / "extracted" / Path(files[0]).relative_to(dataset_path / "extracted").parts[0]
 
 
 def download_model(model_url, tmp_path) -> Path:
-    downloader = FastDownload(base=tmp_path)
-    return downloader.download(model_url)
+    model_file = pooch.retrieve(url=model_url, path=tmp_path, known_hash=None)
+    return Path(model_file)
 
 
 def validate(quantized_model_path: Path, data_loader: torch.utils.data.DataLoader) -> float:

--- a/tests/openvino/requirements.txt
+++ b/tests/openvino/requirements.txt
@@ -1,5 +1,4 @@
 -c ../../constraints.txt
-fastdownload==0.0.7
 matplotlib
 onnx
 openvino
@@ -19,3 +18,4 @@ transformers==4.53.0
 optimum-intel==1.27.0
 optimum-onnx==0.1.0
 optimum==2.1.0
+pooch

--- a/tests/torch/fx/helpers.py
+++ b/tests/torch/fx/helpers.py
@@ -12,6 +12,7 @@
 from pathlib import Path
 from typing import Union
 
+import pooch
 import torch.fx
 import torch.nn.parallel
 import torch.optim
@@ -19,7 +20,6 @@ import torch.utils.data
 import torch.utils.data.distributed
 import torchvision.datasets as datasets
 import torchvision.transforms as transforms
-from fastdownload import FastDownload
 from torch.fx.passes.graph_drawer import FxGraphDrawer
 
 from nncf.experimental.torch.fx.transformations import apply_quantization_transformations
@@ -43,8 +43,13 @@ class TinyImagenetDatasetManager:
 
     @staticmethod
     def download_dataset() -> Path:
-        downloader = FastDownload(base=TinyImagenetDatasetManager.DATASET_PATH, archive="downloaded", data="extracted")
-        return downloader.get(TinyImagenetDatasetManager.DATASET_URL)
+        files = pooch.retrieve(
+            url=TinyImagenetDatasetManager.DATASET_URL,
+            path=Path(TinyImagenetDatasetManager.DATASET_PATH).expanduser() / "downloaded",
+            processor=pooch.Unzip(extract_dir=Path(TinyImagenetDatasetManager.DATASET_PATH).expanduser() / "extracted"),
+        )
+        extracted_path = Path(TinyImagenetDatasetManager.DATASET_PATH).expanduser() / "extracted"
+        return extracted_path / Path(files[0]).relative_to(extracted_path).parts[0]
 
     @staticmethod
     def prepare_tiny_imagenet_200(dataset_dir: Path):

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -20,4 +20,4 @@ optimum-intel==1.27.0
 optimum-onnx==0.1.0
 optimum==2.1.0
 accelerate==1.9.0
-fastdownload==0.0.7
+pooch


### PR DESCRIPTION
### Changes

use [pooch](https://github.com/fatiando/pooch) instead of [fastdownload](https://github.com/fastai/fastdownloa)

### Reason for changes

The fastai packages are unstable and lack adequate testing and validation.

### Related tickets

CVS-180360

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/21833951560