### PR TITLE
Fix post_training_quantization_openvino_anomaly_stfpm_quantize_with_accuracy_control  (#3903)

### DIFF
--- a/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/requirements.txt
+++ b/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/requirements.txt
@@ -2,3 +2,4 @@ anomalib==0.6.0
 openvino==2026.0.0rc2
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 numpy<2
+setuptools==81.0.0


### PR DESCRIPTION
Cherry-pick #3903

### Changes

Use `setuptools==81.0.0` for
`post_training_quantization_openvino_anomaly_stfpm_quantize_with_accuracy_control` example

### Reason for changes


https://github.com/openvinotoolkit/nncf/actions/runs/21808087861/job/62914842052

```python 
  File "/tmp/pytest-of-runner/pytest-0/test_examples_post_training_qu0/venv/lib/python3.10/site-packages/anomalib/data/base/datamodule.py", line 13, in <module>
    from pytorch_lightning import LightningDataModule
  File "/tmp/pytest-of-runner/pytest-0/test_examples_post_training_qu0/venv/lib/python3.10/site-packages/pytorch_lightning/__init__.py", line 34, in <module>
    from lightning_fabric.utilities.seed import seed_everything  # noqa: E402
  File "/tmp/pytest-of-runner/pytest-0/test_examples_post_training_qu0/venv/lib/python3.10/site-packages/lightning_fabric/__init__.py", line 29, in <module>
    __import__("pkg_resources").declare_namespace(__name__)
ModuleNotFoundError: No module named 'pkg_resources'
```

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/21832474690

