### PR TITLE
[release_v300] onnx-ir==0.1.15 (#3914)

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -9,6 +9,7 @@ torchvision==0.24.0
 # ONNX
 onnx==1.17.0; python_version < '3.13'
 onnx==1.18.0; python_version >= '3.13'
+onnx-ir==0.1.15
 onnxruntime==1.21.1
 onnxscript==0.5.7
 

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -1,6 +1,7 @@
 -c ../../constraints.txt
 onnx
 onnxruntime
+onnx-ir
 onnxscript
 openvino
 pytest


### PR DESCRIPTION
cherry-pick https://github.com/openvinotoolkit/nncf/commit/a2826bf206712215bcd7e535b2ccb252d6e70668

### Changes

Pins `onnx-ir` to `0.1.15` 

### Reason for changes

With new version `0.1.16` it falls 

```
/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/onnx_ir/passes/_pass_infra.py:127: in __call__
    result = self.call(model)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <onnx_ir.passes.Sequential object at 0x7f8097440d60>
model = Model(
    ir_version=10,
    opset_imports={'pkg.onnxscript.torch_lib.common': 1, '': 18},
    producer_name='pytorch...ing: tensor(2., requires_grad=True), name='__nncf_hooks.post_hooks./relu/0__0.0.w')}
        ),
        len()=3
    )
)

    def call(self, model: ir.Model) -> PassResult:
        modified = False
        for i, pass_ in enumerate(self.passes):
            logger.debug("Running the %s-th pass '%s'", i, pass_)
            try:
                pass_result = pass_(model)
            except Exception as e:
                prev_pass_names = [str(p) for p in self.passes[:i]]
>               raise PassError(
                    f"An error occurred when running the '{pass_}' pass after the "
                    f"following passes: {prev_pass_names}"
                ) from e
E               onnx_ir.passes.PassError: An error occurred when running the '<onnxscript.version_converter._ConvertVersionPassRequiresInline object at 0x7f80944b4a60>' pass after the following passes: ['<onnx_ir.passes.common.inliner.InlinePass object at 0x7f8097499900>']

/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/onnx_ir/passes/_pass_infra.py:253: PassError

FAILED tests/torch/function_hook/test_wrapper.py::test_export_onnx[True] - onnx_ir.passes.PassError: An error occurred when running the '<onnxscript.version_converter._ConvertVersionPassRequiresInline object at 0x7f80944b4a60>' pass after the following passes: ['<onnx_ir.passes.common.inliner.InlinePass object at 0x7f8097499900>']
```

https://github.com/openvinotoolkit/nncf/actions/runs/21862609596/job/63095425067
