### PR TITLE
[release_v300] openvino==2026.0.0rc3

### DIFF
--- a/examples/llm_compression/onnx/tiny_llama/requirements.txt
+++ b/examples/llm_compression/onnx/tiny_llama/requirements.txt
@@ -1,5 +1,5 @@
 transformers==4.53.0
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 optimum-intel[openvino]==1.27.0
 optimum-onnx==0.1.0

--- a/examples/llm_compression/onnx/tiny_llama_scale_estimation/requirements.txt
+++ b/examples/llm_compression/onnx/tiny_llama_scale_estimation/requirements.txt
@@ -1,6 +1,6 @@
 torch==2.9.0
 transformers==4.53.0
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 optimum-intel[openvino]==1.27.0
 optimum-onnx==0.1.0

--- a/examples/llm_compression/openvino/smollm2_360m_adaptive_codebook/requirements.txt
+++ b/examples/llm_compression/openvino/smollm2_360m_adaptive_codebook/requirements.txt
@@ -1,5 +1,5 @@
 datasets==4.5.0
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 optimum-intel[openvino]==1.27.0
 optimum-onnx==0.1.0

--- a/examples/llm_compression/openvino/smollm2_360m_codebook/requirements.txt
+++ b/examples/llm_compression/openvino/smollm2_360m_codebook/requirements.txt
@@ -1,4 +1,4 @@
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 optimum-intel[openvino]==1.27.0
 optimum-onnx==0.1.0

--- a/examples/llm_compression/openvino/smollm2_360m_fp8/requirements.txt
+++ b/examples/llm_compression/openvino/smollm2_360m_fp8/requirements.txt
@@ -1,5 +1,5 @@
 datasets==4.5.0
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 optimum-intel[openvino]==1.27.0
 optimum-onnx==0.1.0

--- a/examples/llm_compression/openvino/tiny_llama/requirements.txt
+++ b/examples/llm_compression/openvino/tiny_llama/requirements.txt
@@ -1,6 +1,6 @@
 datasets==4.5.0
 onnx==1.17.0
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 optimum-intel[openvino]==1.27.0
 optimum-onnx==0.1.0

--- a/examples/llm_compression/openvino/tiny_llama_find_hyperparams/requirements.txt
+++ b/examples/llm_compression/openvino/tiny_llama_find_hyperparams/requirements.txt
@@ -1,7 +1,7 @@
 whowhatbench @ git+https://github.com/openvinotoolkit/openvino.genai@releases/2026/0#subdirectory=tools/who_what_benchmark
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 numpy==1.26.4
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 optimum-intel==1.27.0
 optimum-onnx==0.1.0

--- a/examples/llm_compression/openvino/tiny_llama_synthetic_data/requirements.txt
+++ b/examples/llm_compression/openvino/tiny_llama_synthetic_data/requirements.txt
@@ -1,7 +1,7 @@
 torch==2.9.0
 datasets==4.5.0
 numpy>=1.23.5,<2
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 optimum-intel==1.27.0
 optimum-onnx==0.1.0

--- a/examples/llm_compression/torch/distillation_qat_with_lora/requirements.txt
+++ b/examples/llm_compression/torch/distillation_qat_with_lora/requirements.txt
@@ -1,7 +1,7 @@
 tensorboard==2.13.0
 torch==2.9.0
 numpy>=1.23.5,<2
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 optimum-intel==1.27.0
 optimum-onnx==0.1.0

--- a/examples/llm_compression/torch/downstream_qat_with_nls/requirements.txt
+++ b/examples/llm_compression/torch/downstream_qat_with_nls/requirements.txt
@@ -1,7 +1,7 @@
 tensorboard==2.13.0
 torch==2.9.0
 numpy>=1.23.5,<2
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 optimum-intel==1.27.0
 optimum-onnx==0.1.0

--- a/examples/llm_compression/torch_fx/tiny_llama/requirements.txt
+++ b/examples/llm_compression/torch_fx/tiny_llama/requirements.txt
@@ -1,6 +1,6 @@
 transformers==4.53.0
 datasets==4.5.0
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 optimum==2.1.0
 torch==2.9.0

--- a/examples/post_training_quantization/onnx/mobilenet_v2/requirements.txt
+++ b/examples/post_training_quantization/onnx/mobilenet_v2/requirements.txt
@@ -5,6 +5,6 @@ fastprogress==1.0.5
 fastcore==1.11.5
 onnx==1.17.0
 onnxruntime==1.21.1
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 numpy<2

--- a/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/requirements.txt
+++ b/examples/post_training_quantization/onnx/yolov8_quantize_with_accuracy_control/requirements.txt
@@ -1,6 +1,6 @@
 ultralytics==8.3.221
 onnx==1.17.0
 onnxruntime==1.21.1
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 torch==2.9.0

--- a/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/requirements.txt
+++ b/examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/requirements.txt
@@ -1,5 +1,5 @@
 anomalib==0.6.0
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 numpy<2
 setuptools==81.0.0

--- a/examples/post_training_quantization/openvino/mobilenet_v2/requirements.txt
+++ b/examples/post_training_quantization/openvino/mobilenet_v2/requirements.txt
@@ -4,5 +4,5 @@ scikit-learn
 fastdownload==0.0.7
 fastprogress==1.0.5
 fastcore==1.11.5
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre

--- a/examples/post_training_quantization/openvino/yolo26/requirements.txt
+++ b/examples/post_training_quantization/openvino/yolo26/requirements.txt
@@ -1,5 +1,5 @@
 ultralytics==8.4.7
 onnx==1.17.0
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 torch==2.9.0

--- a/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/requirements.txt
+++ b/examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/requirements.txt
@@ -1,5 +1,5 @@
 ultralytics==8.3.221
 onnx==1.17.0
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 torch==2.9.0

--- a/examples/post_training_quantization/torch/mobilenet_v2/requirements.txt
+++ b/examples/post_training_quantization/torch/mobilenet_v2/requirements.txt
@@ -1,7 +1,7 @@
 fastdownload==0.0.7
 fastprogress==1.0.5
 fastcore==1.11.5
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 scikit-learn
 torch==2.9.0

--- a/examples/post_training_quantization/torch/ssd300_vgg16/requirements.txt
+++ b/examples/post_training_quantization/torch/ssd300_vgg16/requirements.txt
@@ -2,7 +2,7 @@ fastdownload==0.0.7
 fastprogress==1.0.5
 fastcore==1.11.5
 onnx==1.17.0
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 pycocotools==2.0.7
 torch==2.9.0

--- a/examples/post_training_quantization/torch_fx/resnet18/requirements.txt
+++ b/examples/post_training_quantization/torch_fx/resnet18/requirements.txt
@@ -1,7 +1,7 @@
 fastdownload==0.0.7
 fastprogress==1.0.5
 fastcore==1.11.5
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 torch==2.9.0
 torchvision==0.24.0

--- a/examples/pruning/torch/resnet18/requirements.txt
+++ b/examples/pruning/torch/resnet18/requirements.txt
@@ -1,7 +1,7 @@
 fastdownload==0.0.7
 fastprogress==1.0.5
 fastcore==1.11.5
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 torch==2.9.0
 torchvision==0.24.0

--- a/examples/quantization_aware_training/torch/anomalib/requirements.txt
+++ b/examples/quantization_aware_training/torch/anomalib/requirements.txt
@@ -1,6 +1,6 @@
 anomalib==2.2.0
 torch==2.9.0
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 requests==2.32.5
 matplotlib==3.10.7

--- a/examples/quantization_aware_training/torch/resnet18/requirements.txt
+++ b/examples/quantization_aware_training/torch/resnet18/requirements.txt
@@ -1,7 +1,7 @@
 fastdownload==0.0.7
 fastprogress==1.0.5
 fastcore==1.11.5
-openvino==2026.0.0rc2
+openvino==2026.0.0rc3
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly --pre
 torch==2.9.0
 torchvision==0.24.0


### PR DESCRIPTION
### Changes

Bump openvino to  `2026.0.0rc3`

### Related tickets

CVS-180374

### Tests

PTQ-806
https://github.com/openvinotoolkit/nncf/actions/runs/21987484168
https://github.com/openvinotoolkit/nncf/actions/runs/21987486703