### PR TITLE
Initialize result_scale with default scale in ScaleEstimation

### DIFF
--- a/src/nncf/quantization/algorithms/weight_compression/scale_estimation.py
+++ b/src/nncf/quantization/algorithms/weight_compression/scale_estimation.py
@@ -248,7 +248,7 @@ class ScaleEstimation:
 
         X, _ = reshape_weight_for_grouped_quantization(X, -2, group_size)
         best_diffs = None
-        result_scale = None
+        result_scale = scale
         fp_outs = fns.matmul(fns.moveaxis(weight, -2, -3), X)
         q_outs = fns.matmul(fns.moveaxis(q_weights, -2, -3), X)
 


### PR DESCRIPTION
### Changes

Initialized `result_scale` with the default `scale` value at the start of the `calculate_quantization_params` function. I noticed that if both `initial_steps` and `scale_steps` are set to zero, the variable remains uninitialized, which would cause an error during the subsequent `fns.squeeze` call.

### Reason for changes

This ensures the algorithm is robust even when optimization steps are disabled by the user. While the default configuration uses several steps, I want to make sure the code doesn't crash if someone decides to skip the estimation process entirely.

### Related tickets

None

### Tests

Verified the fix by manually checking the logic for the edge case where steps are zero. Everything is green in the local environment and the change is a simple safety initialization that doesn't affect the default behavior.