### PR TITLE
[mypy] Enable mypy for wc config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,8 @@ files = [
     "src/nncf/tensor/",
     "src/nncf/*py",
     "src/nncf/experimental/torch/gptqmodel/",
+    "src/nncf/quantization/algorithms/weight_compression/config.py",
+    "src/nncf/quantization/algorithms/weight_compression/constants.py",
     "examples/llm_compression/torch/gptq_model_convertor/main.py",
 ]
 disable_error_code = ["import-untyped"]

--- a/src/nncf/experimental/quantization/algorithms/weight_compression/codebook_estimation.py
+++ b/src/nncf/experimental/quantization/algorithms/weight_compression/codebook_estimation.py
@@ -323,9 +323,9 @@ class CodebookEstimation(Algorithm):
 
         diff = float("inf")
 
-        if self._num_elements == config.get_numpy_codebook().size:
+        if self._num_elements == config.codebook_values.as_numpy_tensor().size:
             variants[0] = fns.tensor(
-                config.get_numpy_codebook().data, backend=weight.backend, dtype=TensorDataType.float16
+                config.codebook_values.as_numpy_tensor().data, backend=weight.backend, dtype=TensorDataType.float16
             )
         variants[1] = fns.tensor(
             list(range(-self._num_elements // 2, self._num_elements - self._num_elements // 2)),
@@ -422,9 +422,9 @@ class CodebookEstimation(Algorithm):
 
         diff = float("inf")
 
-        if self._num_elements == config.get_numpy_codebook().size:
+        if self._num_elements == config.codebook_values.as_numpy_tensor().size:
             variants[0] = fns.tensor(
-                config.get_numpy_codebook().data, backend=weight.backend, dtype=TensorDataType.float16
+                config.codebook_values.as_numpy_tensor().data, backend=weight.backend, dtype=TensorDataType.float16
             )
         variants[1] = fns.tensor(
             list(range(-self._num_elements // 2, self._num_elements - self._num_elements // 2)),

--- a/src/nncf/quantization/algorithms/weight_compression/config.py
+++ b/src/nncf/quantization/algorithms/weight_compression/config.py
@@ -134,9 +134,6 @@ class WeightCompressionConfig:
     def __hash__(self) -> int:
         return hash((self.mode.value, self.group_size))
 
-    def __str__(self) -> str:
-        return f"{self.mode.value}_{self.group_size}"
-
 
 @dataclass
 class WeightCompressionParameters:

--- a/src/nncf/quantization/algorithms/weight_compression/config.py
+++ b/src/nncf/quantization/algorithms/weight_compression/config.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 import operator
 from dataclasses import dataclass
-from dataclasses import field
 from functools import cached_property
 from functools import reduce
 
@@ -50,6 +49,17 @@ class WeightCompressionConfig:
         """
         :return: number of bits that is used for storing a single quantized value in the given mode.
         """
+        if self.is_codebook:
+            if self.codebook_values is None:
+                msg = f"Codebook values must be provided for {self.mode}"
+                raise InternalError(msg)
+            n_quants = self.codebook_values.size
+            if n_quants <= 16:
+                return 4
+            if n_quants <= 256:
+                return 8
+            return 16
+
         if self.mode in [
             CompressWeightsMode.INT8_SYM,
             CompressWeightsMode.INT8_ASYM,
@@ -153,7 +163,7 @@ class WeightCompressionParameters:
     weight_dtype: TensorDataType
     weight_shape: tuple[int, ...]
     reduction_axes: tuple[int, ...]
-    compression_config: WeightCompressionConfig = field(default_factory=WeightCompressionConfig)
+    compression_config: WeightCompressionConfig | None
 
     @cached_property
     def num_weights(self) -> np.uint64:

--- a/src/nncf/quantization/algorithms/weight_compression/config.py
+++ b/src/nncf/quantization/algorithms/weight_compression/config.py
@@ -131,12 +131,6 @@ class WeightCompressionConfig:
         }
         return dtype_per_mode[self.mode]
 
-    def get_numpy_codebook(self) -> Tensor:
-        if self.codebook_values is None:
-            msg = "Codebook values not provided"
-            raise InternalError(msg)
-        return self.codebook_values.as_numpy_tensor()
-
     def __hash__(self) -> int:
         return hash((self.mode.value, self.group_size))
 

--- a/src/nncf/quantization/algorithms/weight_compression/config.py
+++ b/src/nncf/quantization/algorithms/weight_compression/config.py
@@ -11,17 +11,16 @@
 import operator
 from dataclasses import dataclass
 from dataclasses import field
+from functools import cached_property
 from functools import reduce
-from typing import TypeVar
 
 import numpy as np
 
 from nncf.common.graph.graph import NNCFNode
+from nncf.errors import InternalError
 from nncf.parameters import CompressWeightsMode
+from nncf.tensor import Tensor
 from nncf.tensor.definitions import TensorDataType
-
-TWeightType = TypeVar("TWeightType")
-TTensor = TypeVar("TTensor")
 
 
 @dataclass
@@ -33,16 +32,21 @@ class WeightCompressionConfig:
     :param group_size: Number of weights (e.g. 128) in the channel dimension that share quantization parameters (scale).
         The value -1 means no grouping. Defaults to -1.
     :param codebook_values: Optional codebook values for CODEBOOK compression mode.
-        Must be fns.Tensor which wraps numpy array or ov tensor. Storing ov tensor is useful for having
+        Must be nncf.tensor.Tensor which wraps numpy array or ov tensor. Storing ov tensor is useful for having
         destination data type information available.
     """
 
-    mode: CompressWeightsMode | None = CompressWeightsMode.INT8_ASYM
-    group_size: int | None = -1
-    codebook_values: TTensor | None = None
+    mode: CompressWeightsMode = CompressWeightsMode.INT8_ASYM
+    group_size: int = -1
+    codebook_values: Tensor | None = None
+
+    def __post_init__(self) -> None:
+        if self.group_size == 0 or self.group_size < -1:
+            msg = f"Invalid group_size={self.group_size}. Group size must be a positive integer or -1."
+            raise InternalError(msg)
 
     @property
-    def num_bits(self):
+    def num_bits(self) -> int:
         """
         :return: number of bits that is used for storing a single quantized value in the given mode.
         """
@@ -56,11 +60,11 @@ class WeightCompressionConfig:
         return 4
 
     @property
-    def is_asym_mode(self):
+    def is_asym_mode(self) -> bool:
         return self.mode in [CompressWeightsMode.INT4_ASYM, CompressWeightsMode.INT8_ASYM]
 
     @property
-    def is_integer(self):
+    def is_integer(self) -> bool:
         """
         :return: True if compression type in integer, else False.
         """
@@ -77,7 +81,7 @@ class WeightCompressionConfig:
         ]
 
     @property
-    def is_codebook(self):
+    def is_codebook(self) -> bool:
         """
         :return: True if compression type is codebook, else False.
         """
@@ -93,6 +97,9 @@ class WeightCompressionConfig:
         :return: data type that is used to store compressed weights.
         """
         if self.is_codebook:
+            if self.codebook_values is None:
+                msg = f"Codebook values must be provided for {self.mode}"
+                raise InternalError(msg)
             n_quants = self.codebook_values.size
             if n_quants <= 16:
                 return TensorDataType.uint4
@@ -113,13 +120,16 @@ class WeightCompressionConfig:
         }
         return dtype_per_mode[self.mode]
 
-    def get_numpy_codebook(self):
+    def get_numpy_codebook(self) -> Tensor:
+        if self.codebook_values is None:
+            msg = "Codebook values not provided"
+            raise InternalError(msg)
         return self.codebook_values.as_numpy_tensor()
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.mode.value, self.group_size))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.mode.value}_{self.group_size}"
 
 
@@ -130,7 +140,7 @@ class WeightCompressionParameters:
 
     :param weight_name: Unique weight name.
     :param node_with_weight: Node with weight in the NNCF graph.
-    :param weight_port_id: Number of elements in the weight array.
+    :param weight_port_id: Port id of the weight in the node with weight in the NNCF graph.
     :param weight_dtype: Data type of the weight tensor.
     :param weight_shape: Shape of the weight array.
     :param reduction_axes: Axes, along which to reduce (collect) different statistics (e.g. min, max).
@@ -143,10 +153,13 @@ class WeightCompressionParameters:
     weight_dtype: TensorDataType
     weight_shape: tuple[int, ...]
     reduction_axes: tuple[int, ...]
-    compression_config: WeightCompressionConfig | None = field(default_factory=WeightCompressionConfig)
+    compression_config: WeightCompressionConfig = field(default_factory=WeightCompressionConfig)
 
-    @property
+    @cached_property
     def num_weights(self) -> np.uint64:
-        if not hasattr(self, "_num_weights"):
-            self._num_weights = np.uint64(reduce(operator.mul, self.weight_shape, 1))
-        return self._num_weights
+        """
+        :return: Total number of weights in the weight tensor.
+        """
+        # Explicitly use unsigned 64-bit integer for number of weight in weight compression.
+        # To avoid overflow when calculating the total number of weights for large models.
+        return np.uint64(reduce(operator.mul, self.weight_shape, 1))

--- a/src/nncf/quantization/algorithms/weight_compression/config.py
+++ b/src/nncf/quantization/algorithms/weight_compression/config.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from nncf.common.graph.graph import NNCFNode
 from nncf.errors import InternalError
+from nncf.errors import ValidationError
 from nncf.parameters import CompressWeightsMode
 from nncf.tensor import Tensor
 from nncf.tensor.definitions import TensorDataType
@@ -42,7 +43,7 @@ class WeightCompressionConfig:
     def __post_init__(self) -> None:
         if self.group_size == 0 or self.group_size < -1:
             msg = f"Invalid group_size={self.group_size}. Group size must be a positive integer or -1."
-            raise InternalError(msg)
+            raise ValidationError(msg)
 
     @property
     def num_bits(self) -> int:

--- a/src/nncf/quantization/algorithms/weight_compression/weight_lowering.py
+++ b/src/nncf/quantization/algorithms/weight_compression/weight_lowering.py
@@ -108,7 +108,7 @@ def calculate_float_quantization_params(
         if config.compression_dtype in FP_MAX_VALUES:
             max_val = FP_MAX_VALUES[config.compression_dtype]
         else:
-            max_val = fns.max(fns.abs(config.get_numpy_codebook()))
+            max_val = fns.max(fns.abs(config.codebook_values.as_numpy_tensor()))
         scale = scale / max_val
 
     # NOTE: adding machine epsilon to avoid division by zero
@@ -233,7 +233,7 @@ def _do_float_quantization_single_scale(
         scale = calculate_float_quantization_params(weight, reduction_axes, config)
     norm_weight = _calculate_normalized_weight(weight, scale)
     if config.is_codebook:
-        indexes = _calculate_codebook_indexes(norm_weight, quantiles=config.get_numpy_codebook())
+        indexes = _calculate_codebook_indexes(norm_weight, quantiles=config.codebook_values.as_numpy_tensor())
         return CompressedWeight(
             indexes,
             scale,

--- a/tests/openvino/native/quantization/test_gptq.py
+++ b/tests/openvino/native/quantization/test_gptq.py
@@ -429,8 +429,8 @@ def test_calculate_scale_linear(is_3d_weights: bool):
         weight_dtype=TensorDataType.float32,
         weight_shape=weights.shape,
         reduction_axes=reduction_axes,
+        compression_config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=group_size),
     )
-    wc_param.compression_config = WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=group_size)
     wc_params = [wc_param]
 
     _, res = gptq.apply(ov_model, graph, nncf_dataset, wc_params)

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -1034,7 +1034,7 @@ def test_call_max_var_criterion_with_dataset_awq_neg_group_size(mode):
 
 def test_data_type_for_num_weights(mocker):
     stub = mocker.stub()
-    params = WeightCompressionParameters(stub, stub, stub, stub, (1,), stub)
+    params = WeightCompressionParameters(stub, stub, stub, stub, (1,), stub, stub)
     assert isinstance(params.num_weights, np.uint64)
 
 

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -12,6 +12,8 @@
 import inspect
 import os
 from collections import defaultdict
+from dataclasses import dataclass
+from dataclasses import field
 from typing import Callable
 from unittest.mock import patch
 
@@ -19,7 +21,6 @@ import numpy as np
 import openvino as ov
 import pandas as pd
 import pytest
-from attr import dataclass
 from openvino import opset13 as opset
 
 import nncf
@@ -684,10 +685,10 @@ def test_shared_gather_all_layers(all_layers):
 class QuantErrorDesc:
     weight: list[float]
     ref_error: int = 0
-    axis = (1,)
+    axis: tuple[int, ...] = (1,)
     name: str = ""
     atol: float = None
-    config: WeightCompressionConfig = WeightCompressionConfig()
+    config: WeightCompressionConfig = field(default_factory=WeightCompressionConfig)
 
     def __str__(self):
         prefix = "exact_match_" if self.ref_error == 0 else ""


### PR DESCRIPTION
### Changes

- Add mypy check for: 
`src/nncf/quantization/algorithms/weight_compression/config.py`
`src/nncf/quantization/algorithms/weight_compression/constants.py`
- Add annotation for `WeightCompressionConfig`
- Use `cached_property` for num_weights, instead of implementation by `hasattr`
- Removed unused typevar
- Fix incorrect import of dataclass in `tests/openvino/native/quantization/test_weights_compression.py` 
- Removed `__str__` it's nmot used 
- Removed `get_codebook_as_nypy` - it'sould not be a part of config 

### Reason for changes

Improving code quality 

### Related tickets

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/23735632904
https://github.com/openvinotoolkit/nncf/actions/runs/24042598835

