### PR TITLE
Bump pytest packages

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -14,11 +14,11 @@ onnxruntime==1.24.3; python_version >= '3.11'
 onnxscript==0.6.2
 
 # Tests and examples
-pytest==8.0.2
-pytest-cov==4.1.0
-pytest-mock==3.12.0
+pytest==9.0.3
+pytest-cov==7.1.0
+pytest-mock==3.15.1
 pytest-ordering==0.6
-pytest-xdist==3.5.0
+pytest-xdist==3.8.0
 pytest-forked==1.6.0
 pytest-split==0.11.0
 

--- a/tests/executorch/requirements.txt
+++ b/tests/executorch/requirements.txt
@@ -29,12 +29,11 @@ fastdownload==0.0.7
 
 
 # Tests and examples
-pytest==8.0.2
-pytest-cov==4.1.0
-pytest-mock==3.12.0
-pytest-dependency==0.6.0
+pytest==9.0.3
+pytest-cov==7.1.0
+pytest-mock==3.15.1
 pytest-ordering==0.6
-pytest-xdist==3.5.0
+pytest-xdist==3.8.0
 pytest-forked==1.6.0
-pytest-split==0.9.0
+pytest-split==0.11.0
 fastprogress==1.0.5

--- a/tests/integration/gptq_model/requirements.txt
+++ b/tests/integration/gptq_model/requirements.txt
@@ -1,3 +1,3 @@
 torch==2.9.0
 transformers==4.57.6
-pytest==8.0.2
+pytest==9.0.3


### PR DESCRIPTION
### Changes

Bump pytests pacakges:

- `pytest` from 8.0.2 to 9.0.3
- `pytest-cov` from 4.1.0 to 7.1.0
- `pytest-mock` from 3.12.0 to 3.15.1
- `pytest-xdist` from 3.5.0 to 3.8.0
- `pytest-split` from 0.9.0 to 0.11.0

### Reason for changes

https://github.com/openvinotoolkit/nncf/security/dependabot/257

### Related tickets


### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/24413543139

