### PR TITLE
Initialize result_scale with default scale in ScaleEstimation

### DIFF
--- a/src/nncf/quantization/algorithms/weight_compression/scale_estimation.py
+++ b/src/nncf/quantization/algorithms/weight_compression/scale_estimation.py
@@ -302,7 +302,7 @@ class ScaleEstimation:
 
             if i < initial_steps - 1:
                 if not config.is_integer:
-                    compressed_weight = do_float_quantization(weight, config, precomputed_scale=near_to_ideal_scale)
+                    compressed_weight = do_float_quantization(weight, config, precomputed_scale=result_scale)
                 else:
                     compressed_weight = do_integer_quantization(
                         weight,

--- a/src/nncf/quantization/algorithms/weight_compression/scale_estimation.py
+++ b/src/nncf/quantization/algorithms/weight_compression/scale_estimation.py
@@ -307,7 +307,7 @@ class ScaleEstimation:
                     compressed_weight = do_integer_quantization(
                         weight,
                         config,
-                        precomputed_scale=near_to_ideal_scale,
+                        precomputed_scale=result_scale,
                         precomputed_zero_point=zp,
                     )
                 compressed_weight = compressed_weight.get_unscaled_tensor()

--- a/src/nncf/quantization/algorithms/weight_compression/scale_estimation.py
+++ b/src/nncf/quantization/algorithms/weight_compression/scale_estimation.py
@@ -247,8 +247,6 @@ class ScaleEstimation:
         importance = importance / (denum + eps)
 
         X, _ = reshape_weight_for_grouped_quantization(X, -2, group_size)
-        best_diffs = None
-        result_scale = None
         fp_outs = fns.matmul(fns.moveaxis(weight, -2, -3), X)
         q_outs = fns.matmul(fns.moveaxis(q_weights, -2, -3), X)
 
@@ -259,6 +257,10 @@ class ScaleEstimation:
 
         if weight_penalty > 0.0:
             min_max_scale_diffs += weight_penalty * fns.mean((q_weights - weight) ** 2, axis=-1)
+
+        # Baseline values ensure correct behaviour when initial_steps=0 and/or scale_steps=0.
+        best_diffs = min_max_scale_diffs
+        result_scale = scale
 
         scale_sign = scale / fns.abs(scale)
         zero_scale = 0.001
@@ -290,20 +292,13 @@ class ScaleEstimation:
             if weight_penalty > 0.0:
                 ideal_scale_diffs += weight_penalty * fns.mean((q_weights_ - weight) ** 2, axis=-1)
 
-            if best_diffs is None:
-                best_diffs = min_max_scale_diffs
-
             mask = (ideal_scale_diffs > best_diffs).astype(best_diffs.dtype)
 
             best_diffs = mask * best_diffs + (1.0 - mask) * ideal_scale_diffs
 
             mask = fns.unsqueeze(mask, axis=-1)
 
-            if result_scale is None:
-                near_to_ideal_scale = mask * scale + (1.0 - mask) * near_to_ideal_scale
-            else:
-                near_to_ideal_scale = mask * result_scale + (1.0 - mask) * near_to_ideal_scale
-            result_scale = near_to_ideal_scale
+            result_scale = mask * result_scale + (1.0 - mask) * near_to_ideal_scale
 
             if i < initial_steps - 1:
                 if not config.is_integer:
@@ -362,11 +357,7 @@ class ScaleEstimation:
 
             mask = fns.unsqueeze(mask, axis=-1)
 
-            if result_scale is None:
-                near_to_ideal_scale = mask * scale + (1.0 - mask) * near_to_ideal_scale
-            else:
-                near_to_ideal_scale = mask * result_scale + (1.0 - mask) * near_to_ideal_scale
-            result_scale = near_to_ideal_scale
+            result_scale = mask * result_scale + (1.0 - mask) * near_to_ideal_scale
 
         if config.group_size == -1:
             result_scale = fns.squeeze(result_scale, axis=-2)

--- a/src/nncf/quantization/algorithms/weight_compression/scale_estimation.py
+++ b/src/nncf/quantization/algorithms/weight_compression/scale_estimation.py
@@ -169,7 +169,7 @@ class ScaleEstimation:
         initial_steps: int = 5,
         scale_steps: int = 10,
         weight_penalty: float = -1.0,
-    ) -> Tensor:
+    ) -> tuple[Tensor, Tensor | None]:
         """
         Calculates the quantization parameters for a given set of weights and activations.
         This function estimates the optimal quantization scale for weight compression by
@@ -258,7 +258,7 @@ class ScaleEstimation:
         if weight_penalty > 0.0:
             min_max_scale_diffs += weight_penalty * fns.mean((q_weights - weight) ** 2, axis=-1)
 
-        # Baseline values ensure correct behaviour when initial_steps=0 and/or scale_steps=0.
+        # Baseline values ensure correct behavior when initial_steps=0 and/or scale_steps=0.
         best_diffs = min_max_scale_diffs
         result_scale = scale
 

--- a/tests/cross_fw/test_templates/template_test_weights_compression.py
+++ b/tests/cross_fw/test_templates/template_test_weights_compression.py
@@ -363,75 +363,24 @@ class TemplateWeightCompression(ABC):
         [
             (
                 WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=8),
-                np.array(
-                    [
-                        [[-0.22218132]],
-                        [[-0.19778779]],
-                        [[-0.24689576]],
-                        [[-0.21622597]],
-                        [[0.1586609]],
-                        [[-0.15784486]],
-                        [[0.238651]],
-                        [[0.17156479]],
-                    ],
-                    dtype=np.float32,
-                ),
+                [-0.22218132, -0.19778779, -0.24689576, -0.21622597, 0.1586609, -0.15784486, 0.238651, 0.17156479],
                 None,
             ),
             (
                 WeightCompressionConfig(mode=CompressWeightsMode.INT4_ASYM, group_size=8),
-                np.array(
-                    [
-                        [[0.22218132]],
-                        [[0.19778779]],
-                        [[0.22600587]],
-                        [[0.22510362]],
-                        [[0.12782802]],
-                        [[0.14118923]],
-                        [[0.2070494]],
-                        [[0.15438876]],
-                    ],
-                    dtype=np.float32,
-                ),
-                np.array(
-                    [[[7.0]], [[7.0]], [[7.0]], [[7.0]], [[10.0]], [[6.0]], [[9.0]], [[9.0]]],
-                    dtype=np.float32,
-                ),
+                [0.22218132, 0.19778779, 0.22600587, 0.22510362, 0.12782802, 0.14118923, 0.2070494, 0.15438876],
+                [7.0, 7.0, 7.0, 7.0, 10.0, 6.0, 9.0, 9.0],
             ),
             (
                 WeightCompressionConfig(mode=CompressWeightsMode.NF4, group_size=8),
-                np.array(
-                    [
-                        [[1.9024894]],
-                        [[1.6864889]],
-                        [[2.0698037]],
-                        [[1.870039]],
-                        [[1.480314]],
-                        [[1.3043315]],
-                        [[1.863365]],
-                        [[1.5413069]],
-                    ],
-                    dtype=np.float32,
-                ),
+                [1.9024894, 1.6864889, 2.0698037, 1.870039, 1.480314, 1.3043315, 1.863365, 1.5413069],
                 None,
             ),
             (
                 WeightCompressionConfig(
                     mode=CompressWeightsMode.CODEBOOK, group_size=8, codebook_values=Tensor(CB4_QUANTILES)
                 ),
-                np.array(
-                    [
-                        [[0.54356843]],
-                        [[0.4866096]],
-                        [[0.4948216]],
-                        [[0.5342969]],
-                        [[0.42294687]],
-                        [[0.3495965]],
-                        [[0.53673494]],
-                        [[0.44053704]],
-                    ],
-                    dtype=np.float32,
-                ),
+                [0.54356843, 0.4866096, 0.4948216, 0.5342969, 0.42294687, 0.3495965, 0.53673494, 0.44053704],
                 None,
             ),
         ],
@@ -456,12 +405,14 @@ class TemplateWeightCompression(ABC):
             statistics, weight, reduction_axes, config, subset_size=2, initial_steps=2, scale_steps=3
         )
 
+        ref_scale = np.array(ref_scale, dtype=np.float32).reshape(8, 1, 1)
         assert fns.allclose(Tensor(ref_scale), scale, atol=1e-6), (
             f"Scale for {config.mode.value} doesn't match reference.\nActual:\n{scale.data}"
         )
         if ref_zp is None:
             assert zp is None, f"Expected no zero point for {config.mode.value}, got: {zp}"
         else:
+            ref_zp = np.array(ref_zp, dtype=np.float32).reshape(8, 1, 1)
             assert fns.allclose(Tensor(ref_zp), zp, atol=1e-6), (
                 f"Zero point for {config.mode.value} doesn't match reference.\nActual:\n{zp.data}"
             )

--- a/tests/cross_fw/test_templates/template_test_weights_compression.py
+++ b/tests/cross_fw/test_templates/template_test_weights_compression.py
@@ -374,77 +374,77 @@ class TemplateWeightCompression(ABC):
         [
             ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=8),
+                initial_steps=2,
+                scale_steps=3,
                 ref_scale=[-0.2221, -0.1977, -0.2468, -0.2162, 0.1586, -0.1578, 0.2386, 0.1716],
                 ref_zp=None,
-                initial_steps=2,
-                scale_steps=3,
             ),
             ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=8),
-                ref_scale=None,
-                ref_zp=None,
                 initial_steps=0,
                 scale_steps=0,
+                ref_scale=[-0.2378, -0.2134, -0.2353, -0.2338, 0.185, -0.1663, 0.2463, 0.1927],
+                ref_zp=None,
             ),
             ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=8),
-                ref_scale=[-0.2405, -0.2133, -0.2468, -0.2299, 0.1586, -0.1578, 0.2386, 0.1927],
-                ref_zp=None,
                 initial_steps=1,
                 scale_steps=0,
+                ref_scale=[-0.2405, -0.2133, -0.2468, -0.2299, 0.1586, -0.1578, 0.2386, 0.1927],
+                ref_zp=None,
             ),
             ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=8),
-                ref_scale=None,
-                ref_zp=None,
                 initial_steps=0,
                 scale_steps=1,
+                ref_scale=[-0.2406, -0.2134, -0.2469, -0.23, 0.1587, -0.1578, 0.2387, 0.1927],
+                ref_zp=None,
             ),
             ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_ASYM, group_size=8),
+                initial_steps=2,
+                scale_steps=3,
                 ref_scale=[0.2221, 0.1977, 0.2260, 0.2251, 0.1278, 0.1412, 0.2070, 0.1544],
                 ref_zp=[7.0, 7.0, 7.0, 7.0, 10.0, 6.0, 9.0, 9.0],
-                initial_steps=2,
-                scale_steps=3,
             ),
             ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_ASYM, group_size=8),
-                ref_scale=None,
-                ref_zp=[7.0, 7.0, 7.0, 7.0, 10.0, 6.0, 9.0, 9.0],
                 initial_steps=0,
                 scale_steps=0,
+                ref_scale=[0.2351, 0.213, 0.2418, 0.2463, 0.144, 0.1452, 0.2079, 0.1735],
+                ref_zp=[7.0, 7.0, 7.0, 7.0, 10.0, 6.0, 9.0, 9.0],
             ),
             ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(mode=CompressWeightsMode.NF4, group_size=8),
+                initial_steps=2,
+                scale_steps=3,
                 ref_scale=[1.9024, 1.6864, 2.0698, 1.8700, 1.4803, 1.3043, 1.8633, 1.5413],
                 ref_zp=None,
-                initial_steps=2,
-                scale_steps=3,
             ),
             ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(mode=CompressWeightsMode.NF4, group_size=8),
-                ref_scale=None,
-                ref_zp=None,
                 initial_steps=0,
                 scale_steps=0,
+                ref_scale=[1.9024, 1.7070, 1.8827, 1.8700, 1.4803, 1.3307, 1.9705, 1.5418],
+                ref_zp=None,
             ),
             ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(
                     mode=CompressWeightsMode.CODEBOOK, group_size=8, codebook_values=Tensor(CB4_QUANTILES)
                 ),
-                ref_scale=[0.5435, 0.4866, 0.4948, 0.5343, 0.4229, 0.3496, 0.5367, 0.4405],
-                ref_zp=None,
                 initial_steps=2,
                 scale_steps=3,
+                ref_scale=[0.5435, 0.4866, 0.4948, 0.5343, 0.4229, 0.3496, 0.5367, 0.4405],
+                ref_zp=None,
             ),
             ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(
                     mode=CompressWeightsMode.CODEBOOK, group_size=8, codebook_values=Tensor(CB4_QUANTILES)
                 ),
-                ref_scale=None,
-                ref_zp=None,
                 initial_steps=0,
                 scale_steps=0,
+                ref_scale=[0.5435, 0.4877, 0.5379, 0.5342, 0.4229, 0.3802, 0.5630, 0.4405],
+                ref_zp=None,
             ),
         ],
         ids=str,
@@ -474,20 +474,23 @@ class TemplateWeightCompression(ABC):
             scale_steps=case.scale_steps,
         )
 
-        if case.ref_scale is None:
-            assert scale is None, f"Expected no scale for {case.config.mode.value}, got: {scale.data}"
-        else:
-            ref_scale = np.array(case.ref_scale, dtype=np.float32).reshape(8, 1, 1)
-            assert fns.allclose(Tensor(ref_scale), scale, atol=1e-3), (
-                f"Scale for {case.config.mode.value} doesn't match reference.\nActual:\n{scale.data}"
-            )
+        ref_scale = self.to_tensor(case.ref_scale).reshape(8, 1, 1)
+        assert fns.allclose(Tensor(ref_scale), scale, atol=1e-3), (
+            f"Scale for {case.config.mode.value} doesn't match reference.\nActual:\n{scale.data}"
+        )
+        assert scale.dtype == TensorDataType.float32, (
+            f"Expected float32 scale, got {scale.dtype} for {case.config.mode.value}"
+        )
 
         if case.ref_zp is None:
             assert zp is None, f"Expected no zero point for {case.config.mode.value}, got: {zp}"
         else:
-            ref_zp = np.array(case.ref_zp, dtype=np.float32).reshape(8, 1, 1)
+            ref_zp = self.to_tensor(case.ref_zp).reshape(8, 1, 1)
             assert fns.allclose(Tensor(ref_zp), zp, atol=1e-3), (
                 f"Zero point for {case.config.mode.value} doesn't match reference.\nActual:\n{zp.data}"
+            )
+            assert zp.dtype == TensorDataType.float32, (
+                f"Expected float32 zero point, got {zp.dtype} for {case.config.mode.value}"
             )
 
     # AWQ Tests

--- a/tests/cross_fw/test_templates/template_test_weights_compression.py
+++ b/tests/cross_fw/test_templates/template_test_weights_compression.py
@@ -358,36 +358,73 @@ class TemplateWeightCompression(ABC):
         assert fns.argsort(error_after_se)[0] == OUTLIER_CHANNEL  # the smallest error on the outlier channel
         assert error_before_se[OUTLIER_CHANNEL] > error_after_se[OUTLIER_CHANNEL]
 
+    @dataclass
+    class ScaleEstimationQuantizationParamsTestCase:
+        config: WeightCompressionConfig
+        ref_scale: list[float]
+        ref_zp: list[float] | None
+        initial_steps: int
+        scale_steps: int
+
+        def __str__(self) -> str:
+            return f"{self.config.mode.value}_{self.initial_steps}_{self.scale_steps}"
+
     @pytest.mark.parametrize(
-        "config,ref_scale,ref_zp",
+        "case",
         [
-            (
-                WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=8),
-                [-0.22218132, -0.19778779, -0.24689576, -0.21622597, 0.1586609, -0.15784486, 0.238651, 0.17156479],
-                None,
+            ScaleEstimationQuantizationParamsTestCase(
+                config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=8),
+                ref_scale=[
+                    -0.22218132,
+                    -0.19778779,
+                    -0.24689576,
+                    -0.21622597,
+                    0.1586609,
+                    -0.15784486,
+                    0.238651,
+                    0.17156479,
+                ],
+                ref_zp=None,
+                initial_steps=2,
+                scale_steps=3,
             ),
-            (
-                WeightCompressionConfig(mode=CompressWeightsMode.INT4_ASYM, group_size=8),
-                [0.22218132, 0.19778779, 0.22600587, 0.22510362, 0.12782802, 0.14118923, 0.2070494, 0.15438876],
-                [7.0, 7.0, 7.0, 7.0, 10.0, 6.0, 9.0, 9.0],
+            ScaleEstimationQuantizationParamsTestCase(
+                config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_ASYM, group_size=8),
+                ref_scale=[
+                    0.22218132,
+                    0.19778779,
+                    0.22600587,
+                    0.22510362,
+                    0.12782802,
+                    0.14118923,
+                    0.2070494,
+                    0.15438876,
+                ],
+                ref_zp=[7.0, 7.0, 7.0, 7.0, 10.0, 6.0, 9.0, 9.0],
+                initial_steps=2,
+                scale_steps=3,
             ),
-            (
-                WeightCompressionConfig(mode=CompressWeightsMode.NF4, group_size=8),
-                [1.9024894, 1.6864889, 2.0698037, 1.870039, 1.480314, 1.3043315, 1.863365, 1.5413069],
-                None,
+            ScaleEstimationQuantizationParamsTestCase(
+                config=WeightCompressionConfig(mode=CompressWeightsMode.NF4, group_size=8),
+                ref_scale=[1.9024894, 1.6864889, 2.0698037, 1.870039, 1.480314, 1.3043315, 1.863365, 1.5413069],
+                ref_zp=None,
+                initial_steps=2,
+                scale_steps=3,
             ),
-            (
-                WeightCompressionConfig(
+            ScaleEstimationQuantizationParamsTestCase(
+                config=WeightCompressionConfig(
                     mode=CompressWeightsMode.CODEBOOK, group_size=8, codebook_values=Tensor(CB4_QUANTILES)
                 ),
-                [0.54356843, 0.4866096, 0.4948216, 0.5342969, 0.42294687, 0.3495965, 0.53673494, 0.44053704],
-                None,
+                ref_scale=[0.54356843, 0.4866096, 0.4948216, 0.5342969, 0.42294687, 0.3495965, 0.53673494, 0.44053704],
+                ref_zp=None,
+                initial_steps=2,
+                scale_steps=3,
             ),
         ],
-        ids=["int4_sym", "int4_asym", "nf4", "codebook"],
+        ids=str,
     )
     def test_scale_estimation_calculate_quantization_params(
-        self, config: WeightCompressionConfig, ref_scale: np.ndarray, ref_zp: np.ndarray | None
+        self, case: ScaleEstimationQuantizationParamsTestCase
     ) -> None:
         """Verifies that scale estimation produces correct scales for all 4-bit compression modes."""
         rng = np.random.default_rng(42)
@@ -402,19 +439,25 @@ class TemplateWeightCompression(ABC):
         statistics = ScaleEstimation.activations_to_wc_statistics(activations)
 
         scale, zp = ScaleEstimation.calculate_quantization_params(
-            statistics, weight, reduction_axes, config, subset_size=2, initial_steps=2, scale_steps=3
+            statistics,
+            weight,
+            reduction_axes,
+            case.config,
+            subset_size=2,
+            initial_steps=case.initial_steps,
+            scale_steps=case.scale_steps,
         )
 
-        ref_scale = np.array(ref_scale, dtype=np.float32).reshape(8, 1, 1)
+        ref_scale = np.array(case.ref_scale, dtype=np.float32).reshape(8, 1, 1)
         assert fns.allclose(Tensor(ref_scale), scale, atol=1e-6), (
-            f"Scale for {config.mode.value} doesn't match reference.\nActual:\n{scale.data}"
+            f"Scale for {case.config.mode.value} doesn't match reference.\nActual:\n{scale.data}"
         )
-        if ref_zp is None:
-            assert zp is None, f"Expected no zero point for {config.mode.value}, got: {zp}"
+        if case.ref_zp is None:
+            assert zp is None, f"Expected no zero point for {case.config.mode.value}, got: {zp}"
         else:
-            ref_zp = np.array(ref_zp, dtype=np.float32).reshape(8, 1, 1)
+            ref_zp = np.array(case.ref_zp, dtype=np.float32).reshape(8, 1, 1)
             assert fns.allclose(Tensor(ref_zp), zp, atol=1e-6), (
-                f"Zero point for {config.mode.value} doesn't match reference.\nActual:\n{zp.data}"
+                f"Zero point for {case.config.mode.value} doesn't match reference.\nActual:\n{zp.data}"
             )
 
     # AWQ Tests

--- a/tests/cross_fw/test_templates/template_test_weights_compression.py
+++ b/tests/cross_fw/test_templates/template_test_weights_compression.py
@@ -429,6 +429,13 @@ class TemplateWeightCompression(ABC):
                 ref_zp=None,
             ),
             ScaleEstimationQuantizationParamsTestCase(
+                config=WeightCompressionConfig(mode=CompressWeightsMode.NF4, group_size=8),
+                initial_steps=10,
+                scale_steps=0,
+                ref_scale=[1.9024, 1.7070, 2.0698, 1.8700, 1.4803, 1.3307, 1.9705, 1.5413],
+                ref_zp=None,
+            ),
+            ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(
                     mode=CompressWeightsMode.CODEBOOK, group_size=8, codebook_values=Tensor(CB4_QUANTILES)
                 ),

--- a/tests/cross_fw/test_templates/template_test_weights_compression.py
+++ b/tests/cross_fw/test_templates/template_test_weights_compression.py
@@ -68,6 +68,18 @@ def get_relative_error(weight_1: Tensor, weight_2: Tensor, axis: int = 0) -> Ten
 spy_instance = None
 
 
+@dataclass
+class ScaleEstimationQuantizationParamsTestCase:
+    config: WeightCompressionConfig
+    ref_scale: list[float]
+    ref_zp: list[float] | None
+    initial_steps: int
+    scale_steps: int
+
+    def __str__(self) -> str:
+        return f"{self.config.mode.value}_{self.initial_steps}_{self.scale_steps}"
+
+
 class SpyAWQ(AWQ):
     def __init__(self, *agrs, **kwargs):
         global spy_instance
@@ -357,17 +369,6 @@ class TemplateWeightCompression(ABC):
         error_after_se = get_relative_error(original_weight, decompressed_weight_after_se, axis=1 - reduction_axes)
         assert fns.argsort(error_after_se)[0] == OUTLIER_CHANNEL  # the smallest error on the outlier channel
         assert error_before_se[OUTLIER_CHANNEL] > error_after_se[OUTLIER_CHANNEL]
-
-    @dataclass
-    class ScaleEstimationQuantizationParamsTestCase:
-        config: WeightCompressionConfig
-        ref_scale: list[float] | None
-        ref_zp: list[float] | None
-        initial_steps: int
-        scale_steps: int
-
-        def __str__(self) -> str:
-            return f"{self.config.mode.value}_{self.initial_steps}_{self.scale_steps}"
 
     @pytest.mark.parametrize(
         "case",

--- a/tests/cross_fw/test_templates/template_test_weights_compression.py
+++ b/tests/cross_fw/test_templates/template_test_weights_compression.py
@@ -361,7 +361,7 @@ class TemplateWeightCompression(ABC):
     @dataclass
     class ScaleEstimationQuantizationParamsTestCase:
         config: WeightCompressionConfig
-        ref_scale: list[float]
+        ref_scale: list[float] | None
         ref_zp: list[float] | None
         initial_steps: int
         scale_steps: int
@@ -374,39 +374,65 @@ class TemplateWeightCompression(ABC):
         [
             ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=8),
-                ref_scale=[
-                    -0.22218132,
-                    -0.19778779,
-                    -0.24689576,
-                    -0.21622597,
-                    0.1586609,
-                    -0.15784486,
-                    0.238651,
-                    0.17156479,
-                ],
+                ref_scale=[-0.2221, -0.1977, -0.2468, -0.2162, 0.1586, -0.1578, 0.2386, 0.1716],
                 ref_zp=None,
                 initial_steps=2,
                 scale_steps=3,
             ),
             ScaleEstimationQuantizationParamsTestCase(
+                config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=8),
+                ref_scale=None,
+                ref_zp=None,
+                initial_steps=0,
+                scale_steps=0,
+            ),
+            ScaleEstimationQuantizationParamsTestCase(
+                config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=8),
+                ref_scale=[-0.2405, -0.2133, -0.2468, -0.2299, 0.1586, -0.1578, 0.2386, 0.1927],
+                ref_zp=None,
+                initial_steps=1,
+                scale_steps=0,
+            ),
+            ScaleEstimationQuantizationParamsTestCase(
+                config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_SYM, group_size=8),
+                ref_scale=None,
+                ref_zp=None,
+                initial_steps=0,
+                scale_steps=1,
+            ),
+            ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_ASYM, group_size=8),
-                ref_scale=[
-                    0.22218132,
-                    0.19778779,
-                    0.22600587,
-                    0.22510362,
-                    0.12782802,
-                    0.14118923,
-                    0.2070494,
-                    0.15438876,
-                ],
+                ref_scale=[0.2221, 0.1977, 0.2260, 0.2251, 0.1278, 0.1412, 0.2070, 0.1544],
                 ref_zp=[7.0, 7.0, 7.0, 7.0, 10.0, 6.0, 9.0, 9.0],
                 initial_steps=2,
                 scale_steps=3,
             ),
             ScaleEstimationQuantizationParamsTestCase(
+                config=WeightCompressionConfig(mode=CompressWeightsMode.INT4_ASYM, group_size=8),
+                ref_scale=None,
+                ref_zp=[7.0, 7.0, 7.0, 7.0, 10.0, 6.0, 9.0, 9.0],
+                initial_steps=0,
+                scale_steps=0,
+            ),
+            ScaleEstimationQuantizationParamsTestCase(
                 config=WeightCompressionConfig(mode=CompressWeightsMode.NF4, group_size=8),
-                ref_scale=[1.9024894, 1.6864889, 2.0698037, 1.870039, 1.480314, 1.3043315, 1.863365, 1.5413069],
+                ref_scale=[1.9024, 1.6864, 2.0698, 1.8700, 1.4803, 1.3043, 1.8633, 1.5413],
+                ref_zp=None,
+                initial_steps=2,
+                scale_steps=3,
+            ),
+            ScaleEstimationQuantizationParamsTestCase(
+                config=WeightCompressionConfig(mode=CompressWeightsMode.NF4, group_size=8),
+                ref_scale=None,
+                ref_zp=None,
+                initial_steps=0,
+                scale_steps=0,
+            ),
+            ScaleEstimationQuantizationParamsTestCase(
+                config=WeightCompressionConfig(
+                    mode=CompressWeightsMode.CODEBOOK, group_size=8, codebook_values=Tensor(CB4_QUANTILES)
+                ),
+                ref_scale=[0.5435, 0.4866, 0.4948, 0.5343, 0.4229, 0.3496, 0.5367, 0.4405],
                 ref_zp=None,
                 initial_steps=2,
                 scale_steps=3,
@@ -415,10 +441,10 @@ class TemplateWeightCompression(ABC):
                 config=WeightCompressionConfig(
                     mode=CompressWeightsMode.CODEBOOK, group_size=8, codebook_values=Tensor(CB4_QUANTILES)
                 ),
-                ref_scale=[0.54356843, 0.4866096, 0.4948216, 0.5342969, 0.42294687, 0.3495965, 0.53673494, 0.44053704],
+                ref_scale=None,
                 ref_zp=None,
-                initial_steps=2,
-                scale_steps=3,
+                initial_steps=0,
+                scale_steps=0,
             ),
         ],
         ids=str,
@@ -448,15 +474,19 @@ class TemplateWeightCompression(ABC):
             scale_steps=case.scale_steps,
         )
 
-        ref_scale = np.array(case.ref_scale, dtype=np.float32).reshape(8, 1, 1)
-        assert fns.allclose(Tensor(ref_scale), scale, atol=1e-6), (
-            f"Scale for {case.config.mode.value} doesn't match reference.\nActual:\n{scale.data}"
-        )
+        if case.ref_scale is None:
+            assert scale is None, f"Expected no scale for {case.config.mode.value}, got: {scale.data}"
+        else:
+            ref_scale = np.array(case.ref_scale, dtype=np.float32).reshape(8, 1, 1)
+            assert fns.allclose(Tensor(ref_scale), scale, atol=1e-3), (
+                f"Scale for {case.config.mode.value} doesn't match reference.\nActual:\n{scale.data}"
+            )
+
         if case.ref_zp is None:
             assert zp is None, f"Expected no zero point for {case.config.mode.value}, got: {zp}"
         else:
             ref_zp = np.array(case.ref_zp, dtype=np.float32).reshape(8, 1, 1)
-            assert fns.allclose(Tensor(ref_zp), zp, atol=1e-6), (
+            assert fns.allclose(Tensor(ref_zp), zp, atol=1e-3), (
                 f"Zero point for {case.config.mode.value} doesn't match reference.\nActual:\n{zp.data}"
             )
 


### PR DESCRIPTION
### Changes

Support initial_steps and scale_steps to be zero for `calculate_quantization_params`
Add tests case for differ steps

### Reason for changes

https://github.com/openvinotoolkit/nncf/pull/3997

### Related tickets

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/24425425305
https://github.com/openvinotoolkit/nncf/actions/runs/24425387669