### PR TITLE
Fix llm_compression_torch_gptqmodel_convertor example

### DIFF
--- a/examples/llm_compression/torch/gptq_model_convertor/requirements.txt
+++ b/examples/llm_compression/torch/gptq_model_convertor/requirements.txt
@@ -1,3 +1,4 @@
 torch==2.9.0
 # TODO(AlexanderDokuchaev): remove transformers next release gptqmodel https://github.com/ModelCloud/GPTQModel/issues/2328
 transformers==4.57.6
+numpy==2.2.6

--- a/examples/llm_compression/torch/gptq_model_convertor/requirements_extra.txt
+++ b/examples/llm_compression/torch/gptq_model_convertor/requirements_extra.txt
@@ -1,1 +1,7 @@
 gptqmodel==5.6.12
+torch==2.9.0
+# TODO(AlexanderDokuchaev): remove transformers next release gptqmodel https://github.com/ModelCloud/GPTQModel/issues/2328
+transformers==4.57.6
+huggingface_hub==0.36.2
+numpy==2.2.6
+kernels==0.12.3


### PR DESCRIPTION
### Changes

Fix requarements for llm_compression_torch_gptqmodel_convertor example
Dubplicate some requarements to prevent install another versions

### Reason for changes

https://github.com/openvinotoolkit/nncf/actions/runs/24425387669/job/71358100145

```
  File "/tmp/pytest-of-runner/pytest-0/test_examples_llm_compression_2/venv/lib/python3.12/site-packages/gptqmodel/models/loader.py", line 28, in <module>
    from transformers.modeling_utils import no_init_weights
ImportError: cannot import name 'no_init_weights' from 'transformers.modeling_utils' (/tmp/pytest-of-runner/pytest-0/test_examples_llm_compression_2/venv/lib/python3.12/site-packages/transformers/modeling_utils.py)
```
### Related tickets

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/24442012799
