### PR TITLE
Fix QuantizationConstraints

### DIFF
--- a/src/nncf/common/quantization/structs.py
+++ b/src/nncf/common/quantization/structs.py
@@ -265,6 +265,7 @@ class QuantizerSpec:
 
 
 class QuantizationConstraints:
+    # TODO(AlexanderDokuchaev): Refactor this class. Ticket-185344
     REF_QCONF_OBJ = QuantizerConfig()
 
     def __init__(self, **kwargs: Any) -> None:
@@ -302,12 +303,12 @@ class QuantizationConstraints:
 
     @classmethod
     def from_config_dict(cls, config_dict: dict[str, Any]) -> "QuantizationConstraints":
-        return cls(
-            num_bits=config_dict.get("bits"),
-            mode=config_dict.get("mode"),
-            per_channel=config_dict.get("per_channel"),
-            signedness_to_force=config_dict.get("signed"),
-        )
+        renamed_keys = {
+            "bits": "num_bits",
+            "signed": "signedness_to_force",
+        }
+        new_dict = {renamed_keys.get(k, k): v for k, v in config_dict.items()}
+        return cls(**new_dict)
 
     def constrain_qconfig_list(
         self,

--- a/tests/openvino/native/quantization/test_quantization_pipeline.py
+++ b/tests/openvino/native/quantization/test_quantization_pipeline.py
@@ -290,10 +290,9 @@ def test_sdpa_quantize_activations_with_8_16_bits(num_bits: int | None, target_d
             activations_quantization_params=QuantizationParameters(num_bits=num_bits),
         ),
     )
-    levels = 2**num_bits if num_bits is not None else 256
+    expected_levels = 2**num_bits if num_bits is not None else 256
     fq_nodes = get_nodes_by_type(quantized_model, type_name="FakeQuantize")
 
     for node in fq_nodes:
-        print(node.get_attributes())
         levels = node.get_attributes()["levels"]
-        assert levels in [levels, levels - 1]
+        assert levels in [expected_levels, expected_levels - 1]

--- a/tests/openvino/native/quantization/test_quantization_pipeline.py
+++ b/tests/openvino/native/quantization/test_quantization_pipeline.py
@@ -26,6 +26,7 @@ from tests.openvino.native.common import get_dataset_for_test
 from tests.openvino.native.models import ConvModel
 from tests.openvino.native.models import LinearModel
 from tests.openvino.native.models import MatMul2DModel
+from tests.openvino.native.models import ScaledDotProductAttentionModel
 from tests.openvino.native.models import WeightsModel
 from tests.openvino.native.test_model_transformer import get_nodes_by_type
 
@@ -269,3 +270,30 @@ def test_ignored_scope_dump(ignored_options, expected_dump, tmp_path):
             assert dumped_model.get_rt_info(rt_path) == value
         else:
             assert dumped_model.has_rt_info(rt_path) is False
+
+
+@pytest.mark.parametrize("target_device", TargetDevice)
+@pytest.mark.parametrize("num_bits", [None, 8, 16])
+def test_sdpa_quantize_activations_with_8_16_bits(num_bits: int | None, target_device: TargetDevice):
+    model = ScaledDotProductAttentionModel(with_weights=True).ov_model
+    dataset = get_dataset_for_test(model)
+
+    compressed_model = nncf.compress_weights(model, mode=nncf.CompressWeightsMode.INT8_SYM)
+    quantized_model = quantize_impl(
+        compressed_model,
+        dataset,
+        preset=QuantizationPreset.MIXED,
+        target_device=target_device,
+        subset_size=1,
+        advanced_parameters=AdvancedQuantizationParameters(
+            disable_bias_correction=True,
+            activations_quantization_params=QuantizationParameters(num_bits=num_bits),
+        ),
+    )
+    levels = 2**num_bits if num_bits is not None else 256
+    fq_nodes = get_nodes_by_type(quantized_model, type_name="FakeQuantize")
+
+    for node in fq_nodes:
+        print(node.get_attributes())
+        levels = node.get_attributes()["levels"]
+        assert levels in [levels, levels - 1]

--- a/tests/openvino/native/quantization/test_quantization_pipeline.py
+++ b/tests/openvino/native/quantization/test_quantization_pipeline.py
@@ -272,7 +272,7 @@ def test_ignored_scope_dump(ignored_options, expected_dump, tmp_path):
             assert dumped_model.has_rt_info(rt_path) is False
 
 
-@pytest.mark.parametrize("target_device", TargetDevice)
+@pytest.mark.parametrize("target_device", [TargetDevice.CPU, TargetDevice.GPU, TargetDevice.NPU])
 @pytest.mark.parametrize("num_bits", [None, 8, 16])
 def test_sdpa_quantize_activations_with_8_16_bits(num_bits: int | None, target_device: TargetDevice):
     model = ScaledDotProductAttentionModel(with_weights=True).ov_model


### PR DESCRIPTION
### Changes

Update  `QuantizationConstraints.from_config_dict` to avoid unexpected behavior on using `from_config_dict`

### Reason for changes

https://github.com/openvinotoolkit/nncf/blob/f12f4ca93195f342825e30127b4a96ccf9d0a9e2/src/nncf/quantization/algorithms/min_max/algorithm.py#L658-L659

Overriding unexpected attributes by using QuantizationConstraints

https://github.com/openvinotoolkit/nncf/blob/f12f4ca93195f342825e30127b4a96ccf9d0a9e2/src/nncf/common/quantization/quantizer_propagation/solver.py#L1041-L1045

Before
```python 
local = QuantizationConstraints(num_bits=8)
# {'num_bits': 8}
scope_constraints = QuantizationConstraints.from_config_dict({"mode": "symmetric"})
# {'num_bits': None, 'mode': 'symmetric', 'per_channel': None, 'signedness_to_force': None}
new = local.get_updated_constraints(scope_constraints)
# {'num_bits': None, 'mode': 'symmetric', 'per_channel': None, 'signedness_to_force': None}
```

After 
```python 
local = QuantizationConstraints(num_bits=8)
# {'num_bits': 8}
scope_constraints = QuantizationConstraints.from_config_dict({"mode": "symmetric"})
# {'mode': 'symmetric'}
new = local.get_updated_constraints(scope_constraints)
# {'num_bits': 8, 'mode': 'symmetric'}
```

### Related tickets

CVS-183279
https://github.com/openvinotoolkit/nncf/pull/4002

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/24669694021
https://github.com/openvinotoolkit/nncf/actions/runs/24669719478
PTQ-848