### PR TITLE
[PT] Save module path in serialized config

### DIFF
--- a/src/nncf/torch/function_hook/hook_storage.py
+++ b/src/nncf/torch/function_hook/hook_storage.py
@@ -232,6 +232,26 @@ class HookStorage(nn.Module):
         if not storage_dict[hook_key]:
             del storage_dict[hook_key]
 
+    def insert_hook_by_name(self, hook_name: str, hook: nn.Module) -> None:
+        """
+        Inserts a hook at the exact slot identified by hook_name.
+        The name must follow the format produced by `named_hooks` method, like `pre_hooks.linear__0.0`.
+
+        :param hook_name: Full hook name.
+        :param hook: The hook module to insert.
+        """
+        hook_type, op_name, port_id = decode_hook_name(hook_name)
+        hook_id = hook_name.split(".")[-1]
+        storage_dict: nn.ModuleDict = getattr(self, hook_type)
+        hook_key = self._generate_key(op_name, port_id)
+        if hook_key not in storage_dict:
+            storage_dict[hook_key] = nn.ModuleDict()
+        hooks_dict = cast(nn.ModuleDict, storage_dict[hook_key])
+        if hook_id in hooks_dict:
+            msg = f"Hook slot '{hook_name}' is already occupied."
+            raise ValueError(msg)
+        hooks_dict[hook_id] = hook
+
     def is_empty(self) -> bool:
         """
         Check if there are no hooks stored.

--- a/src/nncf/torch/function_hook/hook_storage.py
+++ b/src/nncf/torch/function_hook/hook_storage.py
@@ -16,6 +16,8 @@ from typing import Any, Iterator, cast
 
 from torch import nn
 
+from nncf.errors import InternalError
+
 
 class RemovableHookHandle:
     """
@@ -249,7 +251,7 @@ class HookStorage(nn.Module):
         hooks_dict = cast(nn.ModuleDict, storage_dict[hook_key])
         if hook_id in hooks_dict:
             msg = f"Hook slot '{hook_name}' is already occupied."
-            raise ValueError(msg)
+            raise InternalError(msg)
         hooks_dict[hook_id] = hook
 
     def is_empty(self) -> bool:

--- a/src/nncf/torch/function_hook/hook_storage.py
+++ b/src/nncf/torch/function_hook/hook_storage.py
@@ -239,13 +239,14 @@ class HookStorage(nn.Module):
         if not storage_dict[hook_key]:
             del storage_dict[hook_key]
 
-    def insert_hook_by_name(self, hook_name: str, hook: nn.Module) -> None:
+    def insert_hook_by_name(self, hook_name: str, hook: nn.Module) -> RemovableHookHandle:
         """
         Inserts a hook at the exact slot identified by hook_name.
         The name must follow the format produced by `named_hooks` method, like `pre_hooks.linear__0.0`.
 
         :param hook_name: Full hook name.
         :param hook: The hook module to insert.
+        :return: A handle for removing the registered hook.
         """
         hook_type, op_name, port_id = decode_hook_name(hook_name)
         hook_id = hook_name.split(".")[-1]

--- a/src/nncf/torch/function_hook/hook_storage.py
+++ b/src/nncf/torch/function_hook/hook_storage.py
@@ -105,7 +105,7 @@ class HookStorage(nn.Module):
 
     @classmethod
     def _insert_hook(
-        cls, storage_dict: nn.ModuleDict, op_name: str, port_id: int, hook: nn.Module
+        cls, storage_dict: nn.ModuleDict, op_name: str, port_id: int, hook: nn.Module, hook_id: str = ""
     ) -> RemovableHookHandle:
         """
         Inserts a hook into the storage under the appropriate key.
@@ -114,6 +114,7 @@ class HookStorage(nn.Module):
         :param op_name: The operation name the hook is associated with.
         :param port_id: The port ID the hook is associated with.
         :param hook: The hook module to be stored.
+        :param hook_id: The unique identifier for the hook. If not provided, it will be automatically generated.
         :return: A handle that can be used to remove the hook later.
         """
         hook_key = cls._generate_key(op_name, port_id)
@@ -125,7 +126,11 @@ class HookStorage(nn.Module):
             msg = f"Expected nn.ModuleDict for key={hook_key}, got {type(hooks_dict)}"
             raise TypeError(msg)
 
-        hook_id = cls._get_next_hook_id(hooks_dict)
+        hook_id = hook_id or cls._get_next_hook_id(hooks_dict)
+        if hook_id in hooks_dict:
+            msg = f"Hook slot '{hook_key}.{hook_id}' is already occupied."
+            raise InternalError(msg)
+
         hooks_dict[hook_id] = hook
 
         return RemovableHookHandle(storage_dict, hook_key, hook_id)
@@ -244,15 +249,11 @@ class HookStorage(nn.Module):
         """
         hook_type, op_name, port_id = decode_hook_name(hook_name)
         hook_id = hook_name.split(".")[-1]
+        if not hook_id.isdigit():
+            msg = f"Invalid hook name, hook id should be a digit, got {hook_id}"
+            raise ValueError(msg)
         storage_dict: nn.ModuleDict = getattr(self, hook_type)
-        hook_key = self._generate_key(op_name, port_id)
-        if hook_key not in storage_dict:
-            storage_dict[hook_key] = nn.ModuleDict()
-        hooks_dict = cast(nn.ModuleDict, storage_dict[hook_key])
-        if hook_id in hooks_dict:
-            msg = f"Hook slot '{hook_name}' is already occupied."
-            raise InternalError(msg)
-        hooks_dict[hook_id] = hook
+        return self._insert_hook(storage_dict, op_name, port_id, hook, hook_id)
 
     def is_empty(self) -> bool:
         """

--- a/src/nncf/torch/function_hook/pruning/magnitude/modules.py
+++ b/src/nncf/torch/function_hook/pruning/magnitude/modules.py
@@ -16,7 +16,6 @@ from torch import nn
 from torch.overrides import handle_torch_function
 from torch.overrides import has_torch_function_unary
 
-from nncf.torch.layer_utils import COMPRESSION_MODULES
 from nncf.torch.layer_utils import StatefulModuleInterface
 
 
@@ -35,7 +34,6 @@ def apply_magnitude_binary_mask(input_: torch.Tensor, mask: torch.Tensor) -> tor
     return input_ * mask
 
 
-@COMPRESSION_MODULES.register()
 class UnstructuredPruningMask(nn.Module, StatefulModuleInterface):
     """
     A module that applies a binary mask for magnitude-based sparsity.

--- a/src/nncf/torch/function_hook/pruning/rb/modules.py
+++ b/src/nncf/torch/function_hook/pruning/rb/modules.py
@@ -20,7 +20,6 @@ from torch.overrides import has_torch_function_unary
 
 from nncf.torch.functions import STThreshold
 from nncf.torch.functions import logit
-from nncf.torch.layer_utils import COMPRESSION_MODULES
 from nncf.torch.layer_utils import StatefulModuleInterface
 
 
@@ -59,7 +58,6 @@ def apply_rb_binary_mask(input_: torch.Tensor, mask: torch.Tensor, training: boo
     return input_ * binary_mask(mask)
 
 
-@COMPRESSION_MODULES.register()
 class RBPruningMask(nn.Module, StatefulModuleInterface):
     """
     A module that applies a binary pruning mask to the input tensor.

--- a/src/nncf/torch/function_hook/serialization.py
+++ b/src/nncf/torch/function_hook/serialization.py
@@ -54,7 +54,11 @@ def get_config(model: nn.Module) -> dict[str, Any]:
     for module, names in modules_map.items():
         compression_module_name = module.__class__.__name__
         if not isinstance(module, StatefulModuleInterface):
-            msg = "Support only StatefulModuleInterface modules"
+            msg = (
+                "Support only StatefulModuleInterface modules. "
+                f"Got hook module '{module.__class__.__module__}.{module.__class__.__name__}' "
+                f"registered for hook names: {names}."
+            )
             raise nncf.InternalError(msg)
 
         serialized_transformations.append(
@@ -124,7 +128,8 @@ def load_from_config(model: TModel, config: dict[str, Any]) -> TModel:
             cls_name=command["module_cls_name"],
             module_config=command["module_config"],
         )
-        restored_module.to(device)
+        if device is not None:
+            restored_module.to(device)
         for target_name in command["hook_names_in_model"]:
             hook_storage.insert_hook_by_name(target_name, restored_module)
 
@@ -148,7 +153,9 @@ def restore_module(module_path: str, cls_name: str, module_config: dict[str, Any
     except Exception as e:
         msg = f"Error importing module {cls_name} from path {module_path}: {e}"
         raise nncf.InternalError(msg) from e
-
+    if not isinstance(module_cls, type):
+        msg = f"Expected a class for module '{cls_name}', but got {type(module_cls)}"
+        raise nncf.InternalError(msg)
     if not issubclass(module_cls, StatefulModuleInterface) or not issubclass(module_cls, nn.Module):
         msg = (
             "Support deserialization of modules which are subclasses of StatefulModuleInterface and nn.Module."

--- a/src/nncf/torch/function_hook/serialization.py
+++ b/src/nncf/torch/function_hook/serialization.py
@@ -119,21 +119,43 @@ def load_from_config(model: TModel, config: dict[str, Any]) -> TModel:
         nncf_logger.warning("Model is on multiple devices. Cannot determine device for loaded modules.")
 
     for command in transformation_commands:
-        module_path = command.get("module_path") or MODULE_NAME_MAP[command["module_cls_name"]]
-        imported_module = import_module(module_path)
-        module_cls = getattr(imported_module, command["module_cls_name"])
-        if not issubclass(module_cls, StatefulModuleInterface):
-            msg = "Support only StatefulModuleInterface modules"
-            raise nncf.InternalError(msg)
-        module = module_cls.from_config(command["module_config"])
-        module.to(device)
+        restored_module = restore_module(
+            module_path=command.get("module_path", ""),  # Use get to avoid KeyError for backward compatibility
+            cls_name=command["module_cls_name"],
+            module_config=command["module_config"],
+        )
+        restored_module.to(device)
         for target_name in command["hook_names_in_model"]:
-            hook_type, hook_key, hook_id = target_name.split(".")
-            storage_dict = getattr(hook_storage, hook_type)
-            if hook_key not in storage_dict:
-                storage_dict[hook_key] = nn.ModuleDict()
-            if hook_id in storage_dict[hook_key]:
-                msg = f"{hook_id=} for {hook_type}.{hook_key} already registered"
-                raise nncf.InternalError(msg)
-            storage_dict[hook_key][hook_id] = module
+            hook_storage.insert_hook_by_name(target_name, restored_module)
+
     return wrapped_model
+
+
+def restore_module(
+    module_path: str, cls_name: str, module_config: dict[str, Any]
+) -> nn.Module | StatefulModuleInterface:
+    """
+    Restores a compression module from a serialized command.
+
+    :param module_path: The import path of the module class.
+    :param cls_name: The name of the module class.
+    :param module_config: The configuration dictionary for the module.
+    :return: Restored compression module.
+    """
+    try:
+        # Backward compatibility: if module_path is not specified, get it from MODULE_NAME_MAP
+        module_path = module_path or MODULE_NAME_MAP[cls_name]
+        imported_module = import_module(module_path)
+        module_cls = getattr(imported_module, cls_name)
+    except Exception as e:
+        msg = f"Error importing module {cls_name} from path {module_path}: {e}"
+        raise nncf.InternalError(msg) from e
+
+    if not issubclass(module_cls, StatefulModuleInterface) or not issubclass(module_cls, nn.Module):
+        msg = (
+            "Support deserialization of modules which are subclasses of StatefulModuleInterface and nn.Module."
+            f"But got module class {module_cls} which is not."
+        )
+        raise nncf.InternalError(msg)
+
+    return module_cls.from_config(module_config)

--- a/src/nncf/torch/function_hook/serialization.py
+++ b/src/nncf/torch/function_hook/serialization.py
@@ -131,9 +131,7 @@ def load_from_config(model: TModel, config: dict[str, Any]) -> TModel:
     return wrapped_model
 
 
-def restore_module(
-    module_path: str, cls_name: str, module_config: dict[str, Any]
-) -> nn.Module | StatefulModuleInterface:
+def restore_module(module_path: str, cls_name: str, module_config: dict[str, Any]) -> nn.Module:
     """
     Restores a compression module from a serialized command.
 
@@ -158,4 +156,4 @@ def restore_module(
         )
         raise nncf.InternalError(msg)
 
-    return module_cls.from_config(module_config)
+    return cast(nn.Module, module_cls.from_config(module_config))

--- a/src/nncf/torch/function_hook/serialization.py
+++ b/src/nncf/torch/function_hook/serialization.py
@@ -9,8 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from importlib import import_module
 from typing import Any, TypedDict, TypeVar, cast
-from weakref import WeakKeyDictionary
 
 from torch import nn
 
@@ -18,7 +18,6 @@ import nncf
 from nncf.common.logging import nncf_logger
 from nncf.torch.function_hook.wrapper import get_hook_storage
 from nncf.torch.function_hook.wrapper import wrap_model
-from nncf.torch.layer_utils import COMPRESSION_MODULES
 from nncf.torch.layer_utils import StatefulModuleInterface
 from nncf.torch.utils import get_model_device
 from nncf.torch.utils import is_multidevice
@@ -29,6 +28,7 @@ TModel = TypeVar("TModel", bound=nn.Module)
 
 class S_COMMAND(TypedDict):
     hook_names_in_model: list[str]
+    module_path: str
     module_cls_name: str
     module_config: dict[str, Any]
 
@@ -43,7 +43,7 @@ def get_config(model: nn.Module) -> dict[str, Any]:
     hook_storage = get_hook_storage(model)
 
     # Find shared modules
-    modules_map: WeakKeyDictionary[nn.Module, list[str]] = WeakKeyDictionary()
+    modules_map: dict[nn.Module, list[str]] = dict()
     for name, module in hook_storage.named_hooks(remove_duplicate=False):
         if module not in modules_map:
             modules_map[module] = []
@@ -53,12 +53,6 @@ def get_config(model: nn.Module) -> dict[str, Any]:
     serialized_transformations: list[S_COMMAND] = []
     for module, names in modules_map.items():
         compression_module_name = module.__class__.__name__
-        if compression_module_name not in COMPRESSION_MODULES.registry_dict:
-            msg = (
-                f"Could not serialize compression module with name {compression_module_name}. "
-                "Please register your module in the COMPRESSION_MODULES registry."
-            )
-            raise nncf.InternalError(msg)
         if not isinstance(module, StatefulModuleInterface):
             msg = "Support only StatefulModuleInterface modules"
             raise nncf.InternalError(msg)
@@ -66,12 +60,28 @@ def get_config(model: nn.Module) -> dict[str, Any]:
         serialized_transformations.append(
             {
                 "hook_names_in_model": names,
+                "module_path": module.__class__.__module__,
                 "module_cls_name": compression_module_name,
                 "module_config": module.get_config(),
             }
         )
 
     return {COMPRESSION_STATE_ATTR: serialized_transformations}
+
+
+# Use to map module class name to module import path for backward compatibility
+# TODO(AlexanderDokuchaev): Remove after several release (expected: 3.4.0)
+MODULE_NAME_MAP = {
+    "UnstructuredPruningMask": "nncf.torch.function_hook.pruning.magnitude.modules",
+    "RBPruningMask": "nncf.torch.function_hook.pruning.rb.modules",
+    "SymmetricQuantizer": "nncf.torch.quantization.layers",
+    "AsymmetricQuantizer": "nncf.torch.quantization.layers",
+    "AsymmetricLoraQuantizer": "nncf.torch.quantization.layers",
+    "AsymmetricLoraNLSQuantizer": "nncf.torch.quantization.layers",
+    "SymmetricLoraQuantizer": "nncf.torch.quantization.layers",
+    "SymmetricLoraNLSQuantizer": "nncf.torch.quantization.layers",
+    "SQMultiply": "nncf.torch.quantization.layers",
+}
 
 
 def load_from_config(model: TModel, config: dict[str, Any]) -> TModel:
@@ -109,7 +119,12 @@ def load_from_config(model: TModel, config: dict[str, Any]) -> TModel:
         nncf_logger.warning("Model is on multiple devices. Cannot determine device for loaded modules.")
 
     for command in transformation_commands:
-        module_cls = COMPRESSION_MODULES.get(command["module_cls_name"])
+        module_path = command.get("module_path") or MODULE_NAME_MAP[command["module_cls_name"]]
+        imported_module = import_module(module_path)
+        module_cls = getattr(imported_module, command["module_cls_name"])
+        if not issubclass(module_cls, StatefulModuleInterface):
+            msg = "Support only StatefulModuleInterface modules"
+            raise nncf.InternalError(msg)
         module = module_cls.from_config(command["module_config"])
         module.to(device)
         for target_name in command["hook_names_in_model"]:

--- a/src/nncf/torch/layer_utils.py
+++ b/src/nncf/torch/layer_utils.py
@@ -16,10 +16,6 @@ from typing import Any
 import torch
 from torch import nn
 
-from nncf.common.utils.registry import Registry
-
-COMPRESSION_MODULES = Registry("compression modules")
-
 
 class StatefulModuleInterface(ABC):
     """

--- a/src/nncf/torch/layer_utils.py
+++ b/src/nncf/torch/layer_utils.py
@@ -11,10 +11,12 @@
 
 from abc import ABC
 from abc import abstractmethod
-from typing import Any
+from typing import Any, TypeVar
 
 import torch
 from torch import nn
+
+TObj = TypeVar("TObj", bound="StatefulModuleInterface")
 
 
 class StatefulModuleInterface(ABC):
@@ -39,7 +41,7 @@ class StatefulModuleInterface(ABC):
 
     @classmethod
     @abstractmethod
-    def from_config(cls, state: dict[str, Any]) -> object:
+    def from_config(cls: type[TObj], state: dict[str, Any]) -> TObj:
         """
         Creates a compression module instance from the given config.
         """

--- a/src/nncf/torch/quantization/layers.py
+++ b/src/nncf/torch/quantization/layers.py
@@ -35,7 +35,6 @@ from nncf.common.utils.debug import is_debug
 from nncf.common.utils.registry import Registry
 from nncf.torch.graph.transformations.commands import PTTargetPoint
 from nncf.torch.graph.transformations.commands import TargetType
-from nncf.torch.layer_utils import COMPRESSION_MODULES
 from nncf.torch.layer_utils import CompressionParameter
 from nncf.torch.layer_utils import StatefulModuleInterface
 from nncf.torch.quantization.quantize_functions import ExportQuantizeToFakeQuantize
@@ -661,7 +660,6 @@ class StorageRedirectingStateDictHook:
         state_dict[prefix + self._name_in_state_dict] = v
 
 
-@COMPRESSION_MODULES.register()
 @QUANTIZATION_MODULES.register(QuantizationMode.SYMMETRIC)
 class SymmetricQuantizer(BaseQuantizer):
     SCALE_PARAM_NAME = "scale"
@@ -843,7 +841,6 @@ class SymmetricQuantizer(BaseQuantizer):
         )
 
 
-@COMPRESSION_MODULES.register()
 @QUANTIZATION_MODULES.register(QuantizationMode.ASYMMETRIC)
 class AsymmetricQuantizer(BaseQuantizer):
     INPUT_LOW_PARAM_NAME = "input_low"
@@ -1089,7 +1086,6 @@ class LoraNLSMixin(LoraMixin):
         return lora_A, lora_B
 
 
-@COMPRESSION_MODULES.register()
 @QUANTIZATION_MODULES.register(QuantizationMode.ASYMMETRIC_LORA)
 class AsymmetricLoraQuantizer(AsymmetricQuantizer, LoraMixin):
     _arg_names = ["qspec", "lspec"]
@@ -1140,7 +1136,6 @@ class AsymmetricLoraQuantizer(AsymmetricQuantizer, LoraMixin):
         return cls(qspec, lspec)
 
 
-@COMPRESSION_MODULES.register()
 @QUANTIZATION_MODULES.register(QuantizationMode.ASYMMETRIC_LORA_NLS)
 class AsymmetricLoraNLSQuantizer(AsymmetricLoraQuantizer, LoraNLSMixin):
     def quantize(self, x: torch.Tensor, execute_traced_op_as_identity: bool = False):
@@ -1170,7 +1165,6 @@ class AsymmetricLoraNLSQuantizer(AsymmetricLoraQuantizer, LoraNLSMixin):
         return cls(qspec, lspec)
 
 
-@COMPRESSION_MODULES.register()
 @QUANTIZATION_MODULES.register(QuantizationMode.SYMMETRIC_LORA)
 class SymmetricLoraQuantizer(SymmetricQuantizer, LoraMixin):
     def __init__(self, qspec: PTQuantizerSpec, lspec: PTLoraSpec):
@@ -1218,7 +1212,6 @@ class SymmetricLoraQuantizer(SymmetricQuantizer, LoraMixin):
         return cls(qspec, lspec)
 
 
-@COMPRESSION_MODULES.register()
 @QUANTIZATION_MODULES.register(QuantizationMode.SYMMETRIC_LORA_NLS)
 class SymmetricLoraNLSQuantizer(SymmetricLoraQuantizer, LoraNLSMixin):
     def quantize(self, x, execute_traced_op_as_identity: bool = False):
@@ -1467,7 +1460,6 @@ class INT4SymmetricWeightsDecompressor(BaseWeightsDecompressor):
         return result
 
 
-@COMPRESSION_MODULES.register()
 class SQMultiply(torch.nn.Module, StatefulModuleInterface):
     SCALE_SHAPE_KEY = "scale_shape"
 

--- a/tests/torch/function_hook/helpers.py
+++ b/tests/torch/function_hook/helpers.py
@@ -14,7 +14,6 @@ from torch import nn
 
 from nncf.torch.function_hook.wrapper import register_post_function_hook
 from nncf.torch.function_hook.wrapper import wrap_model
-from nncf.torch.layer_utils import COMPRESSION_MODULES
 from nncf.torch.layer_utils import StatefulModuleInterface
 
 
@@ -177,7 +176,6 @@ class CounterHook(nn.Module):
         return x + 1
 
 
-@COMPRESSION_MODULES.register()
 class HookWithState(torch.nn.Module, StatefulModuleInterface):
     def __init__(self, state: str):
         super().__init__()

--- a/tests/torch/function_hook/test_hook_storage.py
+++ b/tests/torch/function_hook/test_hook_storage.py
@@ -228,3 +228,25 @@ def test_is_empty():
     assert not hook_storage.is_empty()
     handle.remove()
     assert hook_storage.is_empty()
+
+
+def test_insert_hook_by_name():
+    """Inserted hooks appear in named_hooks output; duplicate slot raises."""
+    hook_storage = HookStorage()
+    pre_hook, post_hook = nn.Identity(), nn.Identity()
+
+    hook_storage.insert_hook_by_name("pre_hooks.foo__0.0", pre_hook)
+    hook_storage.insert_hook_by_name("post_hooks.foo__0.3", post_hook)
+
+    named = list(hook_storage.named_hooks(remove_duplicate=False))
+    assert ("pre_hooks.foo__0.0", pre_hook) in named
+    assert ("post_hooks.foo__0.3", post_hook) in named
+
+    with pytest.raises(ValueError, match="already occupied"):
+        hook_storage.insert_hook_by_name("pre_hooks.foo__0.0", nn.Identity())
+
+
+@pytest.mark.parametrize("hook_name", INVALID_HOOK_NAMES)
+def test_insert_hook_by_name_raises_on_invalid_name(hook_name: str):
+    with pytest.raises(ValueError, match="Invalid hook name"):
+        HookStorage().insert_hook_by_name(hook_name, nn.Identity())

--- a/tests/torch/function_hook/test_hook_storage.py
+++ b/tests/torch/function_hook/test_hook_storage.py
@@ -14,6 +14,7 @@ import pytest
 import torch
 from torch import nn
 
+from nncf.errors import InternalError
 from nncf.torch.function_hook.hook_storage import HookStorage
 from nncf.torch.function_hook.hook_storage import decode_hook_name
 from tests.torch.function_hook.helpers import CallCount
@@ -242,7 +243,7 @@ def test_insert_hook_by_name():
     assert ("pre_hooks.foo__0.0", pre_hook) in named
     assert ("post_hooks.foo__0.3", post_hook) in named
 
-    with pytest.raises(ValueError, match="already occupied"):
+    with pytest.raises(InternalError, match="already occupied"):
         hook_storage.insert_hook_by_name("pre_hooks.foo__0.0", nn.Identity())
 
 

--- a/tests/torch/function_hook/test_serialization.py
+++ b/tests/torch/function_hook/test_serialization.py
@@ -8,6 +8,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
+from importlib import import_module
 from pathlib import Path
 
 import pytest
@@ -15,12 +17,15 @@ import torch
 from torch import nn
 
 import nncf
+from nncf.common.quantization.structs import QuantizationScheme
 from nncf.torch import get_config
 from nncf.torch import load_from_config
 from nncf.torch.function_hook import get_hook_storage
 from nncf.torch.function_hook import register_post_function_hook
 from nncf.torch.function_hook import register_pre_function_hook
 from nncf.torch.function_hook import wrap_model
+from nncf.torch.function_hook.serialization import MODULE_NAME_MAP
+from nncf.torch.layer_utils import StatefulModuleInterface
 from tests.torch.function_hook.helpers import HookWithState
 from tests.torch.function_hook.helpers import SimpleModel
 
@@ -71,6 +76,7 @@ def test_error_duplicate_names():
         "compression_state": [
             {
                 "hook_names_in_model": ["pre_hooks.conv1/conv2d/0__0.0", "pre_hooks.conv1/conv2d/0__0.0"],
+                "module_path": "tests.torch.function_hook.helpers",
                 "module_cls_name": "HookWithState",
                 "module_config": "hook1",
             }
@@ -84,5 +90,67 @@ def test_error_not_registered_compression_modules():
     model = wrap_model(SimpleModel())
     register_pre_function_hook(model, "conv1/conv2d/0", 0, nn.ReLU())
 
-    with pytest.raises(nncf.InternalError, match="Please register your module in the COMPRESSION_MODULES registry."):
+    with pytest.raises(nncf.InternalError, match="StatefulModuleInterface"):
         get_config(model)
+
+
+@pytest.mark.parametrize(
+    "module_cls",
+    (
+        "UnstructuredPruningMask",
+        "RBPruningMask",
+        "SymmetricQuantizer",
+        "AsymmetricQuantizer",
+        "AsymmetricLoraQuantizer",
+        "AsymmetricLoraNLSQuantizer",
+        "SymmetricLoraQuantizer",
+        "SymmetricLoraNLSQuantizer",
+        "SQMultiply",
+    ),
+)
+def test_backward_compatibility_map(module_cls: str):
+    # validate that all module classes from MODULE_NAME_MAP are importable and are subclasses of StatefulModuleInterface
+    imported_module = import_module(MODULE_NAME_MAP[module_cls])
+    module_cls = getattr(imported_module, module_cls)
+    assert issubclass(module_cls, StatefulModuleInterface)
+
+
+@pytest.fixture()
+def _restore_sys_modules():
+    original_modules = sys.modules.copy()
+    yield
+    sys.modules = original_modules
+
+
+@pytest.mark.parametrize("with_module_path", [True, False], ids=["new_config", "legacy_config"])
+def test_load_from_config_without_manual_compression_class_import(with_module_path: bool, _restore_sys_modules: None):
+    module_path = "nncf.torch.quantization.layers"
+    sys.modules.pop(module_path, None)
+
+    compression_state = {
+        "hook_names_in_model": ["pre_hooks.conv1/conv2d/0__0.0"],
+        "module_cls_name": "AsymmetricQuantizer",
+        "module_config": {
+            "num_bits": 8,
+            "mode": QuantizationScheme.ASYMMETRIC,
+            "signedness_to_force": True,
+            "narrow_range": False,
+            "half_range": False,
+            "scale_shape": (1,),
+            "logarithm_scale": False,
+            "is_quantized_on_export": False,
+            "compression_lr_multiplier": None,
+        },
+    }
+    if with_module_path:
+        compression_state["module_path"] = "nncf.torch.quantization.layers"
+
+    restored_model = load_from_config(SimpleModel(), {"compression_state": [compression_state]})
+
+    hook_storage = get_hook_storage(restored_model)
+    quantizer = hook_storage.get_submodule("pre_hooks.conv1/conv2d/0__0.0")
+
+    assert quantizer.__class__.__name__ == "AsymmetricQuantizer"
+    assert quantizer.__class__.__module__ == module_path
+
+    assert module_path in sys.modules

--- a/tests/torch/function_hook/test_serialization.py
+++ b/tests/torch/function_hook/test_serialization.py
@@ -117,16 +117,15 @@ def test_backward_compatibility_map(module_cls: str):
 
 @pytest.fixture()
 def _restore_sys_modules():
-    original_modules = sys.modules.copy()
+    module_path = "nncf.torch.quantization.layers"
+    state = sys.modules.pop(module_path, None)
     yield
-    sys.modules = original_modules
+    if state is not None:
+        sys.modules[module_path] = state
 
 
 @pytest.mark.parametrize("with_module_path", [True, False], ids=["new_config", "legacy_config"])
 def test_load_from_config_without_manual_compression_class_import(with_module_path: bool, _restore_sys_modules: None):
-    module_path = "nncf.torch.quantization.layers"
-    sys.modules.pop(module_path, None)
-
     compression_state = {
         "hook_names_in_model": ["pre_hooks.conv1/conv2d/0__0.0"],
         "module_cls_name": "AsymmetricQuantizer",
@@ -151,6 +150,6 @@ def test_load_from_config_without_manual_compression_class_import(with_module_pa
     quantizer = hook_storage.get_submodule("pre_hooks.conv1/conv2d/0__0.0")
 
     assert quantizer.__class__.__name__ == "AsymmetricQuantizer"
-    assert quantizer.__class__.__module__ == module_path
+    assert quantizer.__class__.__module__ == "nncf.torch.quantization.layers"
 
-    assert module_path in sys.modules
+    assert "nncf.torch.quantization.layers" in sys.modules

--- a/tests/torch/function_hook/test_serialization.py
+++ b/tests/torch/function_hook/test_serialization.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
+from copy import deepcopy
 from importlib import import_module
 from pathlib import Path
 
@@ -25,6 +26,7 @@ from nncf.torch.function_hook import register_post_function_hook
 from nncf.torch.function_hook import register_pre_function_hook
 from nncf.torch.function_hook import wrap_model
 from nncf.torch.function_hook.serialization import MODULE_NAME_MAP
+from nncf.torch.function_hook.serialization import restore_module
 from nncf.torch.layer_utils import StatefulModuleInterface
 from tests.torch.function_hook.helpers import HookWithState
 from tests.torch.function_hook.helpers import SimpleModel
@@ -82,16 +84,57 @@ def test_error_duplicate_names():
             }
         ]
     }
-    with pytest.raises(nncf.InternalError, match="already registered"):
+    with pytest.raises(nncf.InternalError, match="already occupied"):
         load_from_config(SimpleModel(), config)
 
 
 def test_error_not_stateful_modules():
     model = wrap_model(SimpleModel())
-    register_pre_function_hook(model, "conv1/conv2d/0", 0, nn.ReLU())
-
+    register_pre_function_hook(model, "conv1/conv2d/0", 0, nn.Identity())
     with pytest.raises(nncf.InternalError, match="StatefulModuleInterface"):
         get_config(model)
+
+
+def test_restore_module():
+    module = restore_module("tests.torch.function_hook.helpers", "HookWithState", "hook1")
+    assert isinstance(module, HookWithState)
+    assert module._state == "hook1"
+
+
+EXAMPLE_CONFIG = {
+    "hook_names_in_model": ["pre_hooks.conv1/conv2d/0__0.0"],
+    "module_path": "nncf.torch.quantization.layers",
+    "module_cls_name": "AsymmetricQuantizer",
+    "module_config": {
+        "num_bits": 8,
+        "mode": QuantizationScheme.ASYMMETRIC,
+        "signedness_to_force": True,
+        "narrow_range": False,
+        "half_range": False,
+        "scale_shape": (1,),
+        "logarithm_scale": False,
+        "is_quantized_on_export": False,
+        "compression_lr_multiplier": None,
+    },
+}
+
+
+def test_restore_module_legacy_path_from_map():
+    module = restore_module("", EXAMPLE_CONFIG["module_cls_name"], EXAMPLE_CONFIG["module_config"])
+    assert module.__class__.__name__ == EXAMPLE_CONFIG["module_cls_name"]
+
+
+@pytest.mark.parametrize(
+    ("module_path", "cls_name", "match"),
+    [
+        ("nncf.nonexistent.module", "SomeClass", "Error importing module"),
+        ("math", "MissingClass", "Error importing module"),
+        ("", "UnknownLegacyClass", "Error importing module"),
+    ],
+)
+def test_restore_module_raises_on_invalid_input(module_path: str, cls_name: str, match: str):
+    with pytest.raises(nncf.InternalError, match=match):
+        restore_module(module_path, cls_name, {})
 
 
 @pytest.mark.parametrize(
@@ -126,23 +169,9 @@ def _restore_sys_modules():
 
 @pytest.mark.parametrize("with_module_path", [True, False], ids=["new_config", "legacy_config"])
 def test_load_from_config_without_manual_compression_class_import(with_module_path: bool, _restore_sys_modules: None):
-    compression_state = {
-        "hook_names_in_model": ["pre_hooks.conv1/conv2d/0__0.0"],
-        "module_cls_name": "AsymmetricQuantizer",
-        "module_config": {
-            "num_bits": 8,
-            "mode": QuantizationScheme.ASYMMETRIC,
-            "signedness_to_force": True,
-            "narrow_range": False,
-            "half_range": False,
-            "scale_shape": (1,),
-            "logarithm_scale": False,
-            "is_quantized_on_export": False,
-            "compression_lr_multiplier": None,
-        },
-    }
-    if with_module_path:
-        compression_state["module_path"] = "nncf.torch.quantization.layers"
+    compression_state = deepcopy(EXAMPLE_CONFIG)
+    if not with_module_path:
+        compression_state.pop("module_path")
 
     restored_model = load_from_config(SimpleModel(), {"compression_state": [compression_state]})
 

--- a/tests/torch/function_hook/test_serialization.py
+++ b/tests/torch/function_hook/test_serialization.py
@@ -86,7 +86,7 @@ def test_error_duplicate_names():
         load_from_config(SimpleModel(), config)
 
 
-def test_error_not_registered_compression_modules():
+def test_error_not_stateful_modules():
     model = wrap_model(SimpleModel())
     register_pre_function_hook(model, "conv1/conv2d/0", 0, nn.ReLU())
 


### PR DESCRIPTION
### Changes

- Removed `COMPRESSION_MODULES` registry, as it not garanty that all modules will be imported on using it
- Added `module_path` to config, to force import it inside `load_from_config` function
- Added backward compatible for existed modules.
- Add function `restore_module`
- Add method `insert_hook_by_name` to `HookStorage`
- Use simple dict instead of WeakKeyDictionary - no any reason to use it.

### Reason for changes

Fail on loading from config

```python
import nncf
from nncf.torch.model_creation import load_from_config

ckpt = torch.load(ckpt_file, weights_only=False, map_location="cpu")
model = load_from_config(model, ckpt["nncf_config"])
# KeyError: 'AsymmetricQuantizer is unknown type of compression modules '
```

### Related tickets

CVS-180919

### Tests


[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/24826005444) - success