### PR TITLE
[PT] Removed `example_input` from load_from_config arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ resuming_checkpoint = torch.load(path_to_checkpoint)
 nncf_config = resuming_checkpoint['nncf_config']
 state_dict = resuming_checkpoint['state_dict']
 
-quantized_model = nncf.torch.load_from_config(model, nncf_config, example_input)
+quantized_model = nncf.torch.load_from_config(model, nncf_config)
 model.load_state_dict(state_dict)
 # ... the rest of the usual PyTorch-powered training pipeline
 ```

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ nncf_config = resuming_checkpoint['nncf_config']
 state_dict = resuming_checkpoint['state_dict']
 
 quantized_model = nncf.torch.load_from_config(model, nncf_config)
-model.load_state_dict(state_dict)
+quantized_model.load_state_dict(state_dict)
 # ... the rest of the usual PyTorch-powered training pipeline
 ```
 

--- a/docs/usage/training_time_compression/quantization_aware_training/Usage.md
+++ b/docs/usage/training_time_compression/quantization_aware_training/Usage.md
@@ -44,7 +44,7 @@ The model characterizes the weights and topology of the network. The NNCF config
 The NNCF config can be obtained by `nncf.torch.get_config` on saving and passed to the
 `nncf.torch.load_from_config` helper function to load additional modules from the given NNCF config.
 The quantized model saving allows to load quantized modules to the target model in a new python process and
-requires only example input for the target module, corresponding NNCF config and the quantized model state dict.
+requires only corresponding NNCF config and the quantized model state dict.
 
 ```python
 import nncf

--- a/docs/usage/training_time_compression/quantization_aware_training/Usage.md
+++ b/docs/usage/training_time_compression/quantization_aware_training/Usage.md
@@ -44,7 +44,7 @@ The model characterizes the weights and topology of the network. The NNCF config
 The NNCF config can be obtained by `nncf.torch.get_config` on saving and passed to the
 `nncf.torch.load_from_config` helper function to load additional modules from the given NNCF config.
 The quantized model saving allows to load quantized modules to the target model in a new python process and
-requires only corresponding NNCF config and the quantized model state dict.
+requires only the corresponding NNCF config and the quantized model state dict.
 
 ```python
 import nncf

--- a/docs/usage/training_time_compression/quantization_aware_training/Usage.md
+++ b/docs/usage/training_time_compression/quantization_aware_training/Usage.md
@@ -64,7 +64,7 @@ resuming_checkpoint = torch.load(path)
 nncf_config = resuming_checkpoint['nncf_config']
 state_dict = resuming_checkpoint['state_dict']
 
-quantized_model = nncf.torch.load_from_config(model, nncf_config, dummy_input)
+quantized_model = nncf.torch.load_from_config(model, nncf_config)
 quantized_model.load_state_dict(state_dict)
 ```
 

--- a/examples/quantization_aware_training/torch/resnet18/main.py
+++ b/examples/quantization_aware_training/torch/resnet18/main.py
@@ -291,9 +291,7 @@ def main():
 
     # Load quantization modules and parameters from best checkpoint to the source model.
     ckpt = torch.load(ROOT / BEST_CKPT_NAME, weights_only=False)
-    quantized_model = nncf.torch.load_from_config(
-        deepcopy(model), ckpt["compression_config"], torch.ones((1, 3, IMAGE_SIZE, IMAGE_SIZE)).to(device)
-    )
+    quantized_model = nncf.torch.load_from_config(deepcopy(model), ckpt["compression_config"])
     quantized_model.load_state_dict(ckpt["model_state_dict"])
 
     # Evaluate on validation set after Quantization-Aware Training (QAT case).

--- a/src/nncf/torch/model_creation.py
+++ b/src/nncf/torch/model_creation.py
@@ -77,16 +77,13 @@ def is_wrapped_model(model: Any) -> bool:
         FunctionCallTelemetryExtractor("nncf.torch.load_from_config"),
     ],
 )
-def load_from_config(model: nn.Module, config: dict[str, Any], example_input: Any | None = None) -> nn.Module:
+def load_from_config(model: nn.Module, config: dict[str, Any]) -> nn.Module:
     """
     Wraps given model and recovers additional modules from given config.
     Does not recover additional modules weights as they are located in a corresponded state_dict.
 
     :param model: PyTorch model.
-    :param config: NNCNetwork config.
-    :param example_input: An example input that will be used for model tracing. A tuple is interpreted
-        as an example input of a set of non keyword arguments, and a dict as an example input of a set
-        of keywords arguments. Required with enabled legacy tracing mode.
+    :param config: Compressed config.
     :return: Wrapped model with additional modules recovered from given config.
     """
     return pt2_load_from_config(model, config)

--- a/tests/torch/function_hook/pruning/magnitude/test_algo.py
+++ b/tests/torch/function_hook/pruning/magnitude/test_algo.py
@@ -138,7 +138,7 @@ def test_save_load(tmpdir: Path):
     orig_output = pruned_model(example_inputs)
 
     loaded_model = ConvModel()
-    loaded_pruned_model = nncf.torch.load_from_config(loaded_model, nncf_config, example_inputs)
+    loaded_pruned_model = nncf.torch.load_from_config(loaded_model, nncf_config)
     loaded_pruned_model.load_state_dict(state_dict)
     loaded_output = loaded_pruned_model(example_inputs)
     hook_storage = get_hook_storage(loaded_pruned_model)

--- a/tests/torch/function_hook/pruning/rb/test_algo.py
+++ b/tests/torch/function_hook/pruning/rb/test_algo.py
@@ -101,7 +101,7 @@ def test_save_load(tmpdir: Path):
     state_dict = resuming_checkpoint["state_dict"]
 
     loaded_model = ConvModel()
-    loaded_pruned_model = nncf.torch.load_from_config(loaded_model, nncf_config, example_inputs)
+    loaded_pruned_model = nncf.torch.load_from_config(loaded_model, nncf_config)
     loaded_pruned_model.load_state_dict(state_dict)
     loaded_pruned_model.eval()
     loaded_output = loaded_pruned_model(example_inputs)

--- a/tests/torch/function_hook/quantization/test_fq_lora.py
+++ b/tests/torch/function_hook/quantization/test_fq_lora.py
@@ -175,7 +175,7 @@ def test_checkpoint_loading(tmp_path: Path, use_cuda: bool):
     # load checkpoint
     nncf_ckpt = torch.load(ckpt_path, weights_only=False)
     model = ShortTransformer(8, 16, share_weights=True).to(device)
-    model = load_from_config(model, nncf_ckpt["nncf_config"], example_input=input_ids)
+    model = load_from_config(model, nncf_ckpt["nncf_config"])
     model.load_state_dict(nncf_ckpt["model_state_dict"])
 
     with torch.no_grad():


### PR DESCRIPTION
### Changes

Removed the `example_input` parameter from the `load_from_config` function

### Reason for changes

Unused since 3.0.0

### Related tickets

### Tests

[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/26058648266) - success