### PR TITLE
[PT] Check allowed modules on `load_from_config`

### DIFF
--- a/examples/llm_compression/torch/distillation_qat_with_lora/main.py
+++ b/examples/llm_compression/torch/distillation_qat_with_lora/main.py
@@ -42,8 +42,8 @@ from nncf.parameters import StripFormat
 from nncf.quantization.advanced_parameters import AdvancedAWQParameters
 from nncf.quantization.advanced_parameters import AdvancedCompressionParameters
 from nncf.quantization.quantize_model import compress_weights
+from nncf.torch import load_from_config
 from nncf.torch.function_hook.wrapper import get_hook_storage
-from nncf.torch.model_creation import load_from_config
 from nncf.torch.quantization.layers import AsymmetricLoraQuantizer
 from nncf.torch.quantization.layers import SymmetricLoraQuantizer
 

--- a/examples/llm_compression/torch/downstream_qat_with_nls/main.py
+++ b/examples/llm_compression/torch/downstream_qat_with_nls/main.py
@@ -46,8 +46,8 @@ from nncf.parameters import CompressWeightsMode
 from nncf.parameters import StripFormat
 from nncf.quantization.advanced_parameters import AdvancedCompressionParameters
 from nncf.quantization.quantize_model import compress_weights
+from nncf.torch import load_from_config
 from nncf.torch.function_hook.wrapper import get_hook_storage
-from nncf.torch.model_creation import load_from_config
 from nncf.torch.quantization.layers import AsymmetricLoraNLSQuantizer
 from nncf.torch.quantization.layers import AsymmetricLoraQuantizer
 from nncf.torch.quantization.layers import SymmetricLoraNLSQuantizer

--- a/src/nncf/torch/__init__.py
+++ b/src/nncf/torch/__init__.py
@@ -15,23 +15,23 @@ Base subpackage for NNCF PyTorch functionality.
 """
 
 import torch
-from packaging import version
 
 # Functions most commonly used in integrating NNCF into training pipelines are
 # listed below for importing convenience
 
-from nncf.torch.model_creation import is_wrapped_model
-from nncf.torch.model_creation import wrap_model
-from nncf.torch.model_creation import load_from_config
-from nncf.torch.model_creation import get_config
-from nncf.torch.function_hook.hook_executor_mode import disable_tracing
-from nncf.torch.strip import strip
+from nncf.torch.model_creation import is_wrapped_model as is_wrapped_model
+from nncf.torch.model_creation import wrap_model as wrap_model
+from nncf.torch.function_hook.serialization import load_from_config as load_from_config
+from nncf.torch.function_hook.serialization import get_config as get_config
+from nncf.torch.function_hook.hook_executor_mode import disable_tracing as disable_tracing
+from nncf.torch.strip import strip as strip
 
 # NNCF relies on tracing PyTorch operations. Each code that uses NNCF
 # should be executed with PyTorch operators wrapped via a call to "patch_torch_operators",
 # so this call is moved to package __init__ to ensure this.
 
-from nncf.torch.extensions import force_build_cpu_extensions, force_build_cuda_extensions
+from nncf.torch.extensions import force_build_cpu_extensions as force_build_cpu_extensions
+from nncf.torch.extensions import force_build_cuda_extensions as force_build_cuda_extensions
 
 # This is required since torchvision changes a dictionary inside of pytorch mapping
 # different ops and their role in torch fx graph. Once the nncf mapping is done, it is

--- a/src/nncf/torch/function_hook/serialization.py
+++ b/src/nncf/torch/function_hook/serialization.py
@@ -9,8 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from fnmatch import fnmatchcase
 from importlib import import_module
-from typing import Any, TypedDict, TypeVar, cast
+from typing import Any, Sequence, TypedDict, TypeVar, cast
 
 from torch import nn
 
@@ -23,6 +24,7 @@ from nncf.torch.utils import get_model_device
 from nncf.torch.utils import is_multidevice
 
 COMPRESSION_STATE_ATTR = "compression_state"
+DEFAULT_ALLOWED_MODULES = ("nncf.*",)
 TModel = TypeVar("TModel", bound=nn.Module)
 
 
@@ -88,7 +90,9 @@ MODULE_NAME_MAP = {
 }
 
 
-def load_from_config(model: TModel, config: dict[str, Any]) -> TModel:
+def load_from_config(
+    model: TModel, config: dict[str, Any], allowed_modules: Sequence[str] = DEFAULT_ALLOWED_MODULES
+) -> TModel:
     """
     Initialize model with compressed modules from config file.
 
@@ -110,6 +114,8 @@ def load_from_config(model: TModel, config: dict[str, Any]) -> TModel:
 
     :param model: The original uncompressed model.
     :param config: The configuration dictionary containing the compressed model information.
+    :param allowed_modules: Allowed patterns for deserialized module import paths.
+        Default is `("nncf.*",)`.
     :return: The compressed model.
     """
     wrapped_model = wrap_model(model)
@@ -127,6 +133,7 @@ def load_from_config(model: TModel, config: dict[str, Any]) -> TModel:
             module_path=command.get("module_path", ""),  # Use get to avoid KeyError for backward compatibility
             cls_name=command["module_cls_name"],
             module_config=command["module_config"],
+            allowed_modules=allowed_modules,
         )
         if device is not None:
             restored_module.to(device)
@@ -136,18 +143,41 @@ def load_from_config(model: TModel, config: dict[str, Any]) -> TModel:
     return wrapped_model
 
 
-def restore_module(module_path: str, cls_name: str, module_config: dict[str, Any]) -> nn.Module:
+def _is_allowed_module(module_path: str, allowed_modules: Sequence[str]) -> bool:
+    """
+    Check if the module path matches any of the allowed patterns.
+
+    :param module_path: The import path of the module.
+    :param allowed_modules: Allowed patterns for module import paths.
+    :return: True if the module path is allowed, False otherwise.
+    """
+    return any(fnmatchcase(module_path, pattern) for pattern in allowed_modules)
+
+
+def restore_module(
+    module_path: str,
+    cls_name: str,
+    module_config: dict[str, Any],
+    allowed_modules: Sequence[str] = DEFAULT_ALLOWED_MODULES,
+) -> nn.Module:
     """
     Restores a compression module from a serialized command.
 
     :param module_path: The import path of the module class.
     :param cls_name: The name of the module class.
     :param module_config: The configuration dictionary for the module.
+    :param allowed_modules: Allowed patterns for module import paths. Default is `("nncf.*",)`.
     :return: Restored compression module.
     """
     try:
         # Backward compatibility: if module_path is not specified, get it from MODULE_NAME_MAP
         module_path = module_path or MODULE_NAME_MAP[cls_name]
+        if not _is_allowed_module(module_path, allowed_modules):
+            msg = (
+                f"Refusing to import module '{cls_name}' from untrusted path '{module_path}'. "
+                f"Allowed patterns: {tuple(allowed_modules)}"
+            )
+            raise nncf.InternalError(msg)
         imported_module = import_module(module_path)
         module_cls = getattr(imported_module, cls_name)
     except Exception as e:

--- a/src/nncf/torch/function_hook/serialization.py
+++ b/src/nncf/torch/function_hook/serialization.py
@@ -17,6 +17,10 @@ from torch import nn
 
 import nncf
 from nncf.common.logging import nncf_logger
+from nncf.common.utils.api_marker import api
+from nncf.telemetry import tracked_function
+from nncf.telemetry.events import NNCF_PT_CATEGORY
+from nncf.telemetry.extractors import FunctionCallTelemetryExtractor
 from nncf.torch.function_hook.wrapper import get_hook_storage
 from nncf.torch.function_hook.wrapper import wrap_model
 from nncf.torch.layer_utils import StatefulModuleInterface
@@ -35,6 +39,13 @@ class S_COMMAND(TypedDict):
     module_config: dict[str, Any]
 
 
+@api(canonical_alias="nncf.torch.get_config")
+@tracked_function(
+    NNCF_PT_CATEGORY,
+    [
+        FunctionCallTelemetryExtractor("nncf.torch.get_config"),
+    ],
+)
 def get_config(model: nn.Module) -> dict[str, Any]:
     """
     Returns serializable config which contains all information required to recover all additional modules placement.
@@ -90,8 +101,18 @@ MODULE_NAME_MAP = {
 }
 
 
+@api(canonical_alias="nncf.torch.load_from_config")
+@tracked_function(
+    NNCF_PT_CATEGORY,
+    [
+        FunctionCallTelemetryExtractor("nncf.torch.load_from_config"),
+    ],
+)
 def load_from_config(
-    model: TModel, config: dict[str, Any], allowed_modules: Sequence[str] = DEFAULT_ALLOWED_MODULES
+    model: TModel,
+    config: dict[str, Any],
+    *,
+    allowed_modules: Sequence[str] = DEFAULT_ALLOWED_MODULES,
 ) -> TModel:
     """
     Initialize model with compressed modules from config file.
@@ -114,8 +135,7 @@ def load_from_config(
 
     :param model: The original uncompressed model.
     :param config: The configuration dictionary containing the compressed model information.
-    :param allowed_modules: Allowed patterns for deserialized module import paths.
-        Default is `("nncf.*",)`.
+    :param allowed_modules: Allowed patterns for deserialized module import paths. Default is `("nncf.*",)`.
     :return: The compressed model.
     """
     wrapped_model = wrap_model(model)

--- a/src/nncf/torch/function_hook/serialization.py
+++ b/src/nncf/torch/function_hook/serialization.py
@@ -11,7 +11,7 @@
 
 from fnmatch import fnmatchcase
 from importlib import import_module
-from typing import Any, Sequence, TypedDict, TypeVar, cast
+from typing import Any, TypedDict, TypeVar, cast
 
 from torch import nn
 
@@ -112,7 +112,7 @@ def load_from_config(
     model: TModel,
     config: dict[str, Any],
     *,
-    allowed_modules: Sequence[str] = DEFAULT_ALLOWED_MODULES,
+    allowed_modules: tuple[str] = DEFAULT_ALLOWED_MODULES,
 ) -> TModel:
     """
     Initialize model with compressed modules from config file.
@@ -163,7 +163,7 @@ def load_from_config(
     return wrapped_model
 
 
-def _is_allowed_module(module_path: str, allowed_modules: Sequence[str]) -> bool:
+def _is_allowed_module(module_path: str, allowed_modules: tuple[str, ...]) -> bool:
     """
     Check if the module path matches any of the allowed patterns.
 
@@ -178,7 +178,7 @@ def restore_module(
     module_path: str,
     cls_name: str,
     module_config: dict[str, Any],
-    allowed_modules: Sequence[str] = DEFAULT_ALLOWED_MODULES,
+    allowed_modules: tuple[str, ...] = DEFAULT_ALLOWED_MODULES,
 ) -> nn.Module:
     """
     Restores a compression module from a serialized command.

--- a/src/nncf/torch/function_hook/serialization.py
+++ b/src/nncf/torch/function_hook/serialization.py
@@ -189,20 +189,22 @@ def restore_module(
     :param allowed_modules: Allowed patterns for module import paths. Default is `("nncf.*",)`.
     :return: Restored compression module.
     """
+    # Backward compatibility: if module_path is not specified, get it from MODULE_NAME_MAP
+    module_path = module_path or MODULE_NAME_MAP[cls_name]
+    if not _is_allowed_module(module_path, allowed_modules):
+        msg = (
+            f"Refusing to import module '{cls_name}' from untrusted path '{module_path}'. "
+            f"Allowed patterns: {tuple(allowed_modules)}"
+        )
+        raise nncf.InternalError(msg)
+
     try:
-        # Backward compatibility: if module_path is not specified, get it from MODULE_NAME_MAP
-        module_path = module_path or MODULE_NAME_MAP[cls_name]
-        if not _is_allowed_module(module_path, allowed_modules):
-            msg = (
-                f"Refusing to import module '{cls_name}' from untrusted path '{module_path}'. "
-                f"Allowed patterns: {tuple(allowed_modules)}"
-            )
-            raise nncf.InternalError(msg)
         imported_module = import_module(module_path)
         module_cls = getattr(imported_module, cls_name)
     except Exception as e:
         msg = f"Error importing module {cls_name} from path {module_path}: {e}"
         raise nncf.InternalError(msg) from e
+
     if not isinstance(module_cls, type):
         msg = f"Expected a class for module '{cls_name}', but got {type(module_cls)}"
         raise nncf.InternalError(msg)

--- a/src/nncf/torch/function_hook/serialization.py
+++ b/src/nncf/torch/function_hook/serialization.py
@@ -163,17 +163,6 @@ def load_from_config(
     return wrapped_model
 
 
-def _is_allowed_module(module_path: str, allowed_modules: tuple[str, ...]) -> bool:
-    """
-    Check if the module path matches any of the allowed patterns.
-
-    :param module_path: The import path of the module.
-    :param allowed_modules: Allowed patterns for module import paths.
-    :return: True if the module path is allowed, False otherwise.
-    """
-    return any(fnmatchcase(module_path, pattern) for pattern in allowed_modules)
-
-
 def restore_module(
     module_path: str,
     cls_name: str,
@@ -191,7 +180,7 @@ def restore_module(
     """
     # Backward compatibility: if module_path is not specified, get it from MODULE_NAME_MAP
     module_path = module_path or MODULE_NAME_MAP[cls_name]
-    if not _is_allowed_module(module_path, allowed_modules):
+    if not any(fnmatchcase(module_path, pattern) for pattern in allowed_modules):
         msg = (
             f"Refusing to import module '{cls_name}' from untrusted path '{module_path}'. "
             f"Allowed patterns: {tuple(allowed_modules)}"

--- a/src/nncf/torch/model_creation.py
+++ b/src/nncf/torch/model_creation.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, TypeVar
+from typing import Any, Sequence, TypeVar
 
 from torch import nn
 
@@ -20,6 +20,7 @@ from nncf.telemetry.extractors import FunctionCallTelemetryExtractor
 from nncf.torch.function_hook import is_wrapped as pt2_is_wrapped
 from nncf.torch.function_hook import wrap_model as pt2_wrap_model
 from nncf.torch.function_hook.nncf_graph.nncf_graph_builder import GraphModelWrapper
+from nncf.torch.function_hook.serialization import DEFAULT_ALLOWED_MODULES
 from nncf.torch.function_hook.serialization import get_config as pt2_get_config
 from nncf.torch.function_hook.serialization import load_from_config as pt2_load_from_config
 
@@ -77,16 +78,22 @@ def is_wrapped_model(model: Any) -> bool:
         FunctionCallTelemetryExtractor("nncf.torch.load_from_config"),
     ],
 )
-def load_from_config(model: nn.Module, config: dict[str, Any]) -> nn.Module:
+def load_from_config(
+    model: nn.Module,
+    config: dict[str, Any],
+    allowed_modules: Sequence[str] = DEFAULT_ALLOWED_MODULES,
+) -> nn.Module:
     """
     Wraps given model and recovers additional modules from given config.
     Does not recover additional modules weights as they are located in a corresponded state_dict.
 
     :param model: PyTorch model.
     :param config: Compressed config.
+    :param allowed_modules: Allowed patterns for deserialized module import paths.
+        Default is `("nncf.*",)`.
     :return: Wrapped model with additional modules recovered from given config.
     """
-    return pt2_load_from_config(model, config)
+    return pt2_load_from_config(model, config, allowed_modules=allowed_modules)
 
 
 @tracked_function(

--- a/src/nncf/torch/model_creation.py
+++ b/src/nncf/torch/model_creation.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Sequence, TypeVar
+from typing import Any, TypeVar
 
 from torch import nn
 
@@ -20,9 +20,6 @@ from nncf.telemetry.extractors import FunctionCallTelemetryExtractor
 from nncf.torch.function_hook import is_wrapped as pt2_is_wrapped
 from nncf.torch.function_hook import wrap_model as pt2_wrap_model
 from nncf.torch.function_hook.nncf_graph.nncf_graph_builder import GraphModelWrapper
-from nncf.torch.function_hook.serialization import DEFAULT_ALLOWED_MODULES
-from nncf.torch.function_hook.serialization import get_config as pt2_get_config
-from nncf.torch.function_hook.serialization import load_from_config as pt2_load_from_config
 
 TModel = TypeVar("TModel", bound=nn.Module)
 
@@ -70,43 +67,3 @@ def is_wrapped_model(model: Any) -> bool:
     from nncf.torch.function_hook.nncf_graph.nncf_graph_builder import GraphModelWrapper
 
     return isinstance(model, GraphModelWrapper)
-
-
-@tracked_function(
-    NNCF_PT_CATEGORY,
-    [
-        FunctionCallTelemetryExtractor("nncf.torch.load_from_config"),
-    ],
-)
-def load_from_config(
-    model: nn.Module,
-    config: dict[str, Any],
-    allowed_modules: Sequence[str] = DEFAULT_ALLOWED_MODULES,
-) -> nn.Module:
-    """
-    Wraps given model and recovers additional modules from given config.
-    Does not recover additional modules weights as they are located in a corresponded state_dict.
-
-    :param model: PyTorch model.
-    :param config: Compressed config.
-    :param allowed_modules: Allowed patterns for deserialized module import paths.
-        Default is `("nncf.*",)`.
-    :return: Wrapped model with additional modules recovered from given config.
-    """
-    return pt2_load_from_config(model, config, allowed_modules=allowed_modules)
-
-
-@tracked_function(
-    NNCF_PT_CATEGORY,
-    [
-        FunctionCallTelemetryExtractor("nncf.torch.get_config"),
-    ],
-)
-def get_config(model: nn.Module) -> dict[str, Any]:
-    """
-    Returns the configuration object of the compressed model.
-
-    :param model: The compressed model.
-    :return: The configuration object of the compressed model.
-    """
-    return pt2_get_config(model)

--- a/tests/torch/function_hook/quantization/test_fq_lora.py
+++ b/tests/torch/function_hook/quantization/test_fq_lora.py
@@ -24,9 +24,9 @@ from nncf.parameters import CompressWeightsMode
 from nncf.parameters import StripFormat
 from nncf.quantization.advanced_parameters import AdvancedCompressionParameters
 from nncf.quantization.quantize_model import compress_weights
+from nncf.torch import get_config
 from nncf.torch import load_from_config
 from nncf.torch.function_hook.nncf_graph.nncf_graph_builder import build_nncf_graph
-from nncf.torch.model_creation import get_config
 from nncf.torch.model_creation import wrap_model
 from nncf.torch.quantization.layers import AsymmetricQuantizer as AQ
 from nncf.torch.quantization.layers import LoraMixin

--- a/tests/torch/function_hook/test_serialization.py
+++ b/tests/torch/function_hook/test_serialization.py
@@ -25,11 +25,14 @@ from nncf.torch.function_hook import get_hook_storage
 from nncf.torch.function_hook import register_post_function_hook
 from nncf.torch.function_hook import register_pre_function_hook
 from nncf.torch.function_hook import wrap_model
+from nncf.torch.function_hook.serialization import DEFAULT_ALLOWED_MODULES
 from nncf.torch.function_hook.serialization import MODULE_NAME_MAP
 from nncf.torch.function_hook.serialization import restore_module
 from nncf.torch.layer_utils import StatefulModuleInterface
 from tests.torch.function_hook.helpers import HookWithState
 from tests.torch.function_hook.helpers import SimpleModel
+
+TEST_ALLOWED_MODULES = DEFAULT_ALLOWED_MODULES + ("tests.*",)
 
 
 @pytest.mark.parametrize("is_shared_hook", [True, False], ids=["shared_hook", "not_shared_hook"])
@@ -56,7 +59,7 @@ def test_save_load(tmp_path: Path, is_shared_hook: bool, use_cuda: bool):
 
     ckpt = torch.load(tmp_path / "checkpoint.pth")
     config = ckpt["compression_config"]
-    restored_model = load_from_config(SimpleModel().to(device), config)
+    restored_model = load_from_config(SimpleModel().to(device), config, allowed_modules=TEST_ALLOWED_MODULES)
     restored_model.load_state_dict(ckpt["model_state_dict"])
 
     assert state_dict == restored_model.state_dict()
@@ -85,7 +88,7 @@ def test_error_duplicate_names():
         ]
     }
     with pytest.raises(nncf.InternalError, match="already occupied"):
-        load_from_config(SimpleModel(), config)
+        load_from_config(SimpleModel(), config, allowed_modules=TEST_ALLOWED_MODULES)
 
 
 def test_error_not_stateful_modules():
@@ -96,9 +99,19 @@ def test_error_not_stateful_modules():
 
 
 def test_restore_module():
-    module = restore_module("tests.torch.function_hook.helpers", "HookWithState", "hook1")
+    module = restore_module(
+        "tests.torch.function_hook.helpers",
+        "HookWithState",
+        "hook1",
+        allowed_modules=TEST_ALLOWED_MODULES,
+    )
     assert isinstance(module, HookWithState)
     assert module._state == "hook1"
+
+
+def test_restore_module_raises_on_untrusted_module_path():
+    with pytest.raises(nncf.InternalError, match="untrusted path"):
+        restore_module("tests.torch.function_hook.helpers", "HookWithState", "hook1")
 
 
 EXAMPLE_CONFIG = {
@@ -135,6 +148,22 @@ def test_restore_module_legacy_path_from_map():
 def test_restore_module_raises_on_invalid_input(module_path: str, cls_name: str, match: str):
     with pytest.raises(nncf.InternalError, match=match):
         restore_module(module_path, cls_name, {})
+
+
+def test_load_from_config_raises_on_untrusted_module_path():
+    config = {
+        "compression_state": [
+            {
+                "hook_names_in_model": ["pre_hooks.conv1/conv2d/0__0.0"],
+                "module_path": "tests.torch.function_hook.helpers",
+                "module_cls_name": "HookWithState",
+                "module_config": "hook1",
+            }
+        ]
+    }
+
+    with pytest.raises(nncf.InternalError, match="untrusted path"):
+        load_from_config(SimpleModel(), config)
 
 
 @pytest.mark.parametrize(

--- a/tests/torch/function_hook/test_serialization.py
+++ b/tests/torch/function_hook/test_serialization.py
@@ -141,8 +141,7 @@ def test_restore_module_legacy_path_from_map():
     ("module_path", "cls_name", "match"),
     [
         ("nncf.nonexistent.module", "SomeClass", "Error importing module"),
-        ("math", "MissingClass", "Error importing module"),
-        ("", "UnknownLegacyClass", "Error importing module"),
+        ("math", "MissingClass", "from untrusted path"),
     ],
 )
 def test_restore_module_raises_on_invalid_input(module_path: str, cls_name: str, match: str):


### PR DESCRIPTION
### Changes

- Added `allowed_modules` argument to `load_from_config`
- Removed duplcation defention in model_creation.py
- Added `api` marker
- Updated `src/nncf/torch/__init__py`, use as for imported objects

### Reason for changes

Possible loading any modules after https://github.com/openvinotoolkit/nncf/pull/4050

### Related tickets

CVS-185593

### Tests


[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/25043257889) - success