### PR TITLE
[OpenVINO] calibration_device parameter

### DIFF
--- a/src/nncf/openvino/engine.py
+++ b/src/nncf/openvino/engine.py
@@ -10,6 +10,10 @@
 # limitations under the License.
 
 
+import contextvars
+from collections.abc import Generator
+from contextlib import contextmanager
+
 import numpy as np
 import openvino as ov
 from openvino import Type
@@ -18,6 +22,17 @@ from openvino.properties.hint import inference_precision
 from nncf.common.engine import Engine
 from nncf.definitions import NNCF_DATASET_RESET_STATE_KEY
 from nncf.openvino.graph.model_utils import model_has_state
+
+_calibration_device: contextvars.ContextVar[str | None] = contextvars.ContextVar("_calibration_device", default=None)
+
+
+@contextmanager
+def calibration_device_context(device: str | None) -> Generator[None, None, None]:
+    token = _calibration_device.set(device)
+    try:
+        yield
+    finally:
+        _calibration_device.reset(token)
 
 
 class OVCompiledModelEngine(Engine):
@@ -79,12 +94,13 @@ class OVNativeEngine(Engine):
         :param use_fp32_precision: A flag that determines whether to force the engine to use FP32
             precision during inference.
         """
+        device_name = _calibration_device.get() or "CPU"
         config = None
-        if use_fp32_precision:
+        if use_fp32_precision and device_name == "CPU":
             config = {inference_precision: Type.f32}
         ie = ov.Core()
         stateful = model_has_state(model)
-        compiled_model = ie.compile_model(model, device_name="CPU", config=config)
+        compiled_model = ie.compile_model(model, device_name=device_name, config=config)
         self.engine = OVCompiledModelEngine(compiled_model, stateful)
 
     def infer(

--- a/src/nncf/openvino/engine.py
+++ b/src/nncf/openvino/engine.py
@@ -96,7 +96,7 @@ class OVNativeEngine(Engine):
         """
         device_name = _calibration_device.get() or "CPU"
         config = None
-        if use_fp32_precision and device_name == "CPU":
+        if use_fp32_precision:
             config = {inference_precision: Type.f32}
         ie = ov.Core()
         stateful = model_has_state(model)

--- a/src/nncf/openvino/quantization/quantize_model.py
+++ b/src/nncf/openvino/quantization/quantize_model.py
@@ -21,6 +21,7 @@ from nncf.common.factory import build_graph
 from nncf.common.logging import nncf_logger
 from nncf.common.quantization.structs import QuantizationPreset
 from nncf.data import Dataset
+from nncf.openvino.engine import calibration_device_context
 from nncf.openvino.graph.metatypes.groups import OPERATIONS_OUTPUT_HAS_NO_BATCH_AXIS
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVIfMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import get_node_metatype
@@ -119,9 +120,11 @@ def native_quantize_if_op_impl(
         f"The model consists of {if_ops_number} If node(-s) with then and else bodies. \
             Main model and all If bodies will be quantized recursively."
     )
-    quantized_model, _ = apply_algorithm_if_bodies(
-        quantization_algorithm, model, graphs, main_model_graph_id, calibration_dataset, subset_size, 1
-    )
+    calibration_device = advanced_parameters.calibration_device if advanced_parameters else None
+    with calibration_device_context(calibration_device):
+        quantized_model, _ = apply_algorithm_if_bodies(
+            quantization_algorithm, model, graphs, main_model_graph_id, calibration_dataset, subset_size, 1
+        )
 
     if is_weight_compression_needed(advanced_parameters):
         compress_quantize_weights_transformation(quantized_model)
@@ -168,7 +171,9 @@ def native_quantize_impl(
     )
     graph = GraphConverter.create_nncf_graph(model)
     warning_model_no_batchwise_support(graph, advanced_parameters, model_type, OPERATIONS_OUTPUT_HAS_NO_BATCH_AXIS)
-    quantized_model = quantization_algorithm.apply(model, graph, dataset=calibration_dataset)
+    calibration_device = advanced_parameters.calibration_device if advanced_parameters else None
+    with calibration_device_context(calibration_device):
+        quantized_model = quantization_algorithm.apply(model, graph, dataset=calibration_dataset)
 
     if is_weight_compression_needed(advanced_parameters):
         compress_quantize_weights_transformation(quantized_model)
@@ -296,15 +301,19 @@ def quantize_with_accuracy_control_impl(
             advanced_accuracy_restorer_parameters.num_ranking_workers,
             advanced_accuracy_restorer_parameters.restore_mode,
         )
-        quantized_model = accuracy_restorer.apply(
-            model,
-            initial_metric_results,
-            quantized_model,
-            quantized_metric_results,
-            validation_dataset,
-            validation_dataset_size,
-            evaluator,
+        calibration_device = (
+            advanced_quantization_parameters.calibration_device if advanced_quantization_parameters else None
         )
+        with calibration_device_context(calibration_device):
+            quantized_model = accuracy_restorer.apply(
+                model,
+                initial_metric_results,
+                quantized_model,
+                quantized_metric_results,
+                validation_dataset,
+                validation_dataset_size,
+                evaluator,
+            )
 
     if compress_weights:
         compress_quantize_weights_transformation(quantized_model)
@@ -402,12 +411,15 @@ def compress_weights_impl(
         advanced_parameters,
     )
 
+    calibration_device = advanced_parameters.calibration_device if advanced_parameters else None
+
     statistics_points = None
     if advanced_parameters and advanced_parameters.statistics_path:
         # If there is no such directory, then caches statistics
         statistics_path = Path(advanced_parameters.statistics_path)
         if not statistics_path.exists():
-            cache_weight_compression_statistics(model, graph, dataset, subset_size, statistics_path)
+            with calibration_device_context(calibration_device):
+                cache_weight_compression_statistics(model, graph, dataset, subset_size, statistics_path)
         statistics_aggregator = StatisticsAggregatorFactory.create(model, dataset)
         compression_algorithm.set_backend_entity(model)
         _, matmul_input_to_output_nodes_map = compression_algorithm.get_compression_nodes_info(graph)
@@ -421,4 +433,5 @@ def compress_weights_impl(
         statistics_aggregator.load_statistics_from_dir(statistics_path)
         statistics_points = statistics_aggregator.statistic_points
 
-    return compression_algorithm.apply(model, graph, statistics_points, dataset)
+    with calibration_device_context(calibration_device):
+        return compression_algorithm.apply(model, graph, statistics_points, dataset)

--- a/src/nncf/quantization/advanced_parameters.py
+++ b/src/nncf/quantization/advanced_parameters.py
@@ -252,6 +252,10 @@ class AdvancedQuantizationParameters:
     :type smooth_quant_alpha: float
     :param backend_params: Backend-specific parameters.
     :type backend_params: dict[str, Any]
+    :param calibration_device: OpenVINO device name to use for calibration inference
+        (e.g. "CPU", "GPU", "GPU.0", "AUTO:GPU,CPU"). If None, defaults to "CPU".
+        Only applicable to the OpenVINO backend.
+    :type calibration_device: Optional[str]
     """
 
     # General parameters
@@ -281,6 +285,9 @@ class AdvancedQuantizationParameters:
 
     # Backend specific parameters
     backend_params: dict[str, Any] = field(default_factory=dict)
+
+    # Calibration device
+    calibration_device: str | None = None
 
 
 @api()
@@ -427,6 +434,10 @@ class AdvancedCompressionParameters:
     :type lora_correction_params: AdvancedLoraCorrectionParameters
     :param backend_params: Backend-specific parameters.
     :type backend_params: dict[str, Any]
+    :param calibration_device: OpenVINO device name to use for calibration inference
+        (e.g. "CPU", "GPU", "GPU.0", "AUTO:GPU,CPU"). If None, defaults to "CPU".
+        Only applicable to the OpenVINO backend.
+    :type calibration_device: Optional[str]
     :param codebook: The codebook (LUT) for the weight compression.
         Applicable for vector quantization. Must be a numpy array or ov Tensor.
     :type codebook: TTensor
@@ -445,6 +456,7 @@ class AdvancedCompressionParameters:
     gptq_params: AdvancedGPTQParameters = field(default_factory=AdvancedGPTQParameters)
     lora_correction_params: AdvancedLoraCorrectionParameters = field(default_factory=AdvancedLoraCorrectionParameters)
     backend_params: dict[str, Any] = field(default_factory=dict)
+    calibration_device: str | None = None
     codebook: TTensor | None = None
     adaptive_codebook_params: AdvancedAdaptiveCodebookParameters = field(
         default_factory=AdvancedAdaptiveCodebookParameters

--- a/src/nncf/quantization/quantize_model.py
+++ b/src/nncf/quantization/quantize_model.py
@@ -201,6 +201,10 @@ def quantize(
     if backend == BackendType.ONNX:
         from nncf.onnx.quantization.quantize_model import quantize_impl
 
+        if advanced_parameters and advanced_parameters.calibration_device:
+            msg = "ONNX backend does not support the `calibration_device` option."
+            raise nncf.ParameterNotSupportedError(msg)
+
         return quantize_impl(  # type: ignore[no-any-return]
             model=model,
             calibration_dataset=calibration_dataset,
@@ -217,6 +221,10 @@ def quantize(
     if backend == BackendType.TORCH:
         from nncf.torch.function_hook.quantization.quantize_model import quantize_impl
 
+        if advanced_parameters and advanced_parameters.calibration_device:
+            msg = "Torch backend does not support the `calibration_device` option."
+            raise nncf.ParameterNotSupportedError(msg)
+
         return quantize_impl(  # type: ignore[no-any-return]
             model=model,
             calibration_dataset=calibration_dataset,
@@ -232,6 +240,10 @@ def quantize(
 
     if backend == BackendType.TORCH_FX:
         from nncf.experimental.torch.fx.quantization.quantize_model import quantize_impl
+
+        if advanced_parameters and advanced_parameters.calibration_device:
+            msg = "TorchFX backend does not support the `calibration_device` option."
+            raise nncf.ParameterNotSupportedError(msg)
 
         return quantize_impl(  # type: ignore[no-any-return]
             model=model,
@@ -371,6 +383,10 @@ def quantize_with_accuracy_control(
         )
     if backend == BackendType.ONNX:
         from nncf.onnx.quantization.quantize_model import quantize_with_accuracy_control_impl
+
+        if advanced_quantization_parameters and advanced_quantization_parameters.calibration_device:
+            msg = "ONNX backend does not support the `calibration_device` option."
+            raise nncf.ParameterNotSupportedError(msg)
 
         return quantize_with_accuracy_control_impl(  # type: ignore[no-any-return]
             model,
@@ -528,6 +544,10 @@ def compress_weights(
             msg = "Torch backend does not support statistics caching."
             raise nncf.ParameterNotSupportedError(msg)
 
+        if advanced_parameters and advanced_parameters.calibration_device:
+            msg = "Torch backend does not support the `calibration_device` option."
+            raise nncf.ParameterNotSupportedError(msg)
+
         if compression_format == CompressionFormat.FQ and group_size != -1:
             msg = "Torch backend does not support FQ compression format for group-wise quantization."
             raise nncf.ParameterNotSupportedError(msg)
@@ -576,6 +596,10 @@ def compress_weights(
 
         if advanced_parameters and advanced_parameters.statistics_path:
             msg = "TorchFX does not supports statistics caching."
+            raise nncf.ParameterNotSupportedError(msg)
+
+        if advanced_parameters and advanced_parameters.calibration_device:
+            msg = "TorchFX backend does not support the `calibration_device` option."
             raise nncf.ParameterNotSupportedError(msg)
 
         if compression_format in [CompressionFormat.FQ, CompressionFormat.FQ_LORA, CompressionFormat.FQ_LORA_NLS]:
@@ -648,6 +672,10 @@ def compress_weights(
 
         if advanced_parameters and advanced_parameters.statistics_path:
             msg = "ONNX does not supports statistics caching."
+            raise nncf.ParameterNotSupportedError(msg)
+
+        if advanced_parameters and advanced_parameters.calibration_device:
+            msg = "ONNX backend does not support the `calibration_device` option."
             raise nncf.ParameterNotSupportedError(msg)
         compression_weights_impl = onnx_compress_weights_impl
     if compression_weights_impl is None:

--- a/src/nncf/version.py
+++ b/src/nncf/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.2.0"
+__version__ = "3.2.0.dev0+00576e031"

--- a/tests/cross_fw/test_templates/template_test_quantize_api.py
+++ b/tests/cross_fw/test_templates/template_test_quantize_api.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from abc import ABC
+from abc import abstractmethod
+from typing import TypeVar
+
+import pytest
+
+import nncf
+from nncf.data.dataset import Dataset
+from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
+
+TModel = TypeVar("TModel")
+
+
+class TemplateTestQuantizeApi(ABC):
+    @staticmethod
+    @abstractmethod
+    def get_simple_model() -> TModel:
+        """Returns a minimal model for the backend."""
+
+    def test_quantize_calibration_device(self):
+        model = self.get_simple_model()
+        with pytest.raises(nncf.ParameterNotSupportedError):
+            nncf.quantize(
+                model,
+                Dataset([0]),
+                advanced_parameters=AdvancedQuantizationParameters(calibration_device="SOME_DEVICE"),
+            )

--- a/tests/cross_fw/test_templates/template_test_weights_compression.py
+++ b/tests/cross_fw/test_templates/template_test_weights_compression.py
@@ -983,3 +983,17 @@ class TemplateWeightCompression(ABC):
                 all_layers=True,
                 **kwargs,
             )
+
+    def test_compress_weights_calibration_device(self):
+        model = self.get_awq_model(non_mergable_pattern=False, is_3d_weights=False)
+        dataset = Dataset([self.to_tensor(np.ones([2, 8, 8]))])
+        with pytest.raises(nncf.ParameterNotSupportedError):
+            compress_weights(
+                model,
+                mode=CompressWeightsMode.INT4_SYM,
+                ratio=1.0,
+                group_size=2,
+                dataset=dataset,
+                awq=True,
+                advanced_parameters=CompressionParams(calibration_device="SOME_DEVICE"),
+            )

--- a/tests/onnx/quantization/test_quantize_api.py
+++ b/tests/onnx/quantization/test_quantize_api.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+import pytest
+
+import nncf
+from nncf import Dataset
+from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
+from tests.cross_fw.test_templates.template_test_quantize_api import TemplateTestQuantizeApi
+from tests.onnx.models import LinearModel
+
+INPUT_SHAPE = [1, 3, 32, 32]
+
+
+class TestONNXQuantizeApi(TemplateTestQuantizeApi):
+    @staticmethod
+    def get_simple_model():
+        return LinearModel().onnx_model
+
+    def test_quantize_with_accuracy_control_calibration_device(self):
+        model = self.get_simple_model()
+        dataset = Dataset([np.ones(INPUT_SHAPE, dtype=np.float32)])
+        with pytest.raises(nncf.ParameterNotSupportedError):
+            nncf.quantize_with_accuracy_control(
+                model,
+                dataset,
+                dataset,
+                lambda model, dataset: (1.0, None),
+                advanced_quantization_parameters=AdvancedQuantizationParameters(calibration_device="SOME_DEVICE"),
+            )

--- a/tests/openvino/native/quantization/test_quantize_api.py
+++ b/tests/openvino/native/quantization/test_quantize_api.py
@@ -35,3 +35,30 @@ def test_non_positive_subset_size():
     with pytest.raises(nncf.ValidationError) as e:
         nncf.quantize(model_to_test, Dataset(MockDataset(INPUT_SHAPE)), subset_size=0)
         assert "Subset size must be positive." in e.info
+
+
+def test_quantize_calibration_device(monkeypatch):
+    import numpy as np
+    import openvino as ov
+
+    from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
+    from tests.openvino.native.models import LinearModel
+
+    model_to_test = LinearModel().ov_model
+    input_shape = [inp.shape for inp in model_to_test.inputs][0]
+    dataset = Dataset([np.random.rand(*input_shape).astype(np.float32) for _ in range(2)])
+    captured_devices = []
+
+    original_compile = ov.Core.compile_model
+
+    def mock_compile(self, model, device_name="CPU", config=None):
+        captured_devices.append(device_name)
+        return original_compile(self, model, device_name="CPU", config=config)
+
+    monkeypatch.setattr(ov.Core, "compile_model", mock_compile)
+    nncf.quantize(
+        model_to_test,
+        dataset,
+        advanced_parameters=AdvancedQuantizationParameters(calibration_device="GPU"),
+    )
+    assert any(d == "GPU" for d in captured_devices)

--- a/tests/openvino/native/quantization/test_quantize_api.py
+++ b/tests/openvino/native/quantization/test_quantize_api.py
@@ -8,57 +8,67 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import numpy as np
+import openvino as ov
 import pytest
-from openvino import Model
-from openvino import Shape
-from openvino import Type
-from openvino import op
-from openvino import opset13 as opset
 
 import nncf
 from nncf import Dataset
-from tests.cross_fw.shared.datasets import MockDataset
+from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
+from tests.cross_fw.test_templates.template_test_quantize_api import TemplateTestQuantizeApi
+from tests.openvino.native.models import LinearModel
 
-INPUT_SHAPE = [2, 1, 1, 1]
-
-
-def get_mock_model() -> Model:
-    param_node = op.Parameter(Type.f32, Shape(INPUT_SHAPE))
-    softmax_axis = 1
-    softmax_node = opset.softmax(param_node, softmax_axis)
-    return Model(softmax_node, [param_node], "mock")
+LINEAR_MODEL_INPUT_SHAPE = [1, 3, 4, 2]
 
 
-def test_non_positive_subset_size():
-    model_to_test = get_mock_model()
+class TestOVQuantizeApi(TemplateTestQuantizeApi):
+    @staticmethod
+    def get_simple_model() -> ov.Model:
+        return LinearModel().ov_model
 
-    with pytest.raises(nncf.ValidationError) as e:
-        nncf.quantize(model_to_test, Dataset(MockDataset(INPUT_SHAPE)), subset_size=0)
-        assert "Subset size must be positive." in e.info
+    def test_quantize_calibration_device(self, monkeypatch):
+        model = self.get_simple_model()
+        dataset = Dataset([np.ones(LINEAR_MODEL_INPUT_SHAPE, dtype=np.float32)])
+        captured_devices = []
 
+        original_compile = ov.Core.compile_model
 
-def test_quantize_calibration_device(monkeypatch):
-    import numpy as np
-    import openvino as ov
+        def mock_compile(self, model, device_name="CPU", config=None):
+            captured_devices.append(device_name)
+            return original_compile(self, model, device_name="CPU", config=config)
 
-    from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
-    from tests.openvino.native.models import LinearModel
+        monkeypatch.setattr(ov.Core, "compile_model", mock_compile)
+        nncf.quantize(
+            model,
+            dataset,
+            advanced_parameters=AdvancedQuantizationParameters(calibration_device="SOME_DEVICE"),
+        )
+        assert all(d == "SOME_DEVICE" for d in captured_devices)
 
-    model_to_test = LinearModel().ov_model
-    input_shape = [inp.shape for inp in model_to_test.inputs][0]
-    dataset = Dataset([np.random.rand(*input_shape).astype(np.float32) for _ in range(2)])
-    captured_devices = []
+    def test_quantize_with_accuracy_control_calibration_device(self, monkeypatch):
+        model = self.get_simple_model()
+        dataset = Dataset([np.ones(LINEAR_MODEL_INPUT_SHAPE, dtype=np.float32)])
+        captured_devices = []
 
-    original_compile = ov.Core.compile_model
+        original_compile = ov.Core.compile_model
 
-    def mock_compile(self, model, device_name="CPU", config=None):
-        captured_devices.append(device_name)
-        return original_compile(self, model, device_name="CPU", config=config)
+        def mock_compile(self, model, device_name="CPU", config=None):
+            captured_devices.append(device_name)
+            return original_compile(self, model, device_name="CPU", config=config)
 
-    monkeypatch.setattr(ov.Core, "compile_model", mock_compile)
-    nncf.quantize(
-        model_to_test,
-        dataset,
-        advanced_parameters=AdvancedQuantizationParameters(calibration_device="GPU"),
-    )
-    assert any(d == "GPU" for d in captured_devices)
+        monkeypatch.setattr(ov.Core, "compile_model", mock_compile)
+        nncf.quantize_with_accuracy_control(
+            model,
+            dataset,
+            dataset,
+            lambda model, dataset: (1.0, None),
+            advanced_quantization_parameters=AdvancedQuantizationParameters(calibration_device="SOME_DEVICE"),
+        )
+        assert "SOME_DEVICE" in captured_devices
+
+    def test_non_positive_subset_size(self):
+        model_to_test = self.get_simple_model()
+
+        with pytest.raises(nncf.ValidationError) as e:
+            nncf.quantize(model_to_test, Dataset([np.ones(LINEAR_MODEL_INPUT_SHAPE, dtype=np.float32)]), subset_size=0)
+            assert "Subset size must be positive." in e.info

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -2767,3 +2767,27 @@ class TestOVTemplateWeightCompression(TemplateWeightCompression):
             group_size=-1,
         )
         assert self.get_num_int8_nodes(compressed_model) == 0
+
+
+def test_compress_weights_calibration_device(monkeypatch):
+    model = AWQMatmulModel().ov_model
+    dataset = Dataset([np.ones([2, 8, 8])])
+    captured_devices = []
+
+    original_compile = ov.Core.compile_model
+
+    def mock_compile(self, model, device_name="CPU", config=None):
+        captured_devices.append(device_name)
+        return original_compile(self, model, device_name="CPU", config=config)
+
+    monkeypatch.setattr(ov.Core, "compile_model", mock_compile)
+    compress_weights(
+        model,
+        mode=CompressWeightsMode.INT4_SYM,
+        ratio=1.0,
+        group_size=2,
+        dataset=dataset,
+        awq=True,
+        advanced_parameters=AdvancedCompressionParameters(calibration_device="GPU"),
+    )
+    assert any(d == "GPU" for d in captured_devices)

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -2768,26 +2768,26 @@ class TestOVTemplateWeightCompression(TemplateWeightCompression):
         )
         assert self.get_num_int8_nodes(compressed_model) == 0
 
+    def test_compress_weights_calibration_device(self, monkeypatch):
+        model = AWQMatmulModel().ov_model
+        dataset = Dataset([np.ones([2, 8, 8])])
+        captured_devices = []
 
-def test_compress_weights_calibration_device(monkeypatch):
-    model = AWQMatmulModel().ov_model
-    dataset = Dataset([np.ones([2, 8, 8])])
-    captured_devices = []
+        original_compile = ov.Core.compile_model
 
-    original_compile = ov.Core.compile_model
+        def mock_compile(self, model, device_name="CPU", config=None):
+            captured_devices.append(device_name)
+            return original_compile(self, model, device_name="CPU", config=config)
 
-    def mock_compile(self, model, device_name="CPU", config=None):
-        captured_devices.append(device_name)
-        return original_compile(self, model, device_name="CPU", config=config)
-
-    monkeypatch.setattr(ov.Core, "compile_model", mock_compile)
-    compress_weights(
-        model,
-        mode=CompressWeightsMode.INT4_SYM,
-        ratio=1.0,
-        group_size=2,
-        dataset=dataset,
-        awq=True,
-        advanced_parameters=AdvancedCompressionParameters(calibration_device="GPU"),
-    )
-    assert any(d == "GPU" for d in captured_devices)
+        monkeypatch.setattr(ov.Core, "compile_model", mock_compile)
+        monkeypatch.setenv("NNCF_DISABLE_OPTIMIZED_COMPRESSION", "1")
+        compress_weights(
+            model,
+            mode=CompressWeightsMode.INT4_SYM,
+            ratio=1.0,
+            group_size=2,
+            dataset=dataset,
+            awq=True,
+            advanced_parameters=AdvancedCompressionParameters(calibration_device="SOME_DEVICE"),
+        )
+        assert all(d == "SOME_DEVICE" for d in captured_devices)

--- a/tests/openvino/native/test_engine.py
+++ b/tests/openvino/native/test_engine.py
@@ -15,6 +15,7 @@ import pytest
 
 from nncf.definitions import NNCF_DATASET_RESET_STATE_KEY
 from nncf.openvino.engine import OVNativeEngine
+from nncf.openvino.engine import calibration_device_context
 from tests.openvino.native.models import ConvModel
 from tests.openvino.native.models import LinearModel
 from tests.openvino.native.models import QuantizedModel
@@ -123,3 +124,57 @@ def test_stateful_model_inference_with_controlled_resetting():
         "infer",
         "infer",
     ]
+
+
+def test_calibration_device_default(monkeypatch):
+    model = LinearModel().ov_model
+    captured_device = {}
+
+    import openvino as ov
+
+    original_compile = ov.Core.compile_model
+
+    def mock_compile(self, model, device_name="CPU", config=None):
+        captured_device["device_name"] = device_name
+        return original_compile(self, model, device_name="CPU", config=config)
+
+    monkeypatch.setattr(ov.Core, "compile_model", mock_compile)
+    OVNativeEngine(model)
+    assert captured_device["device_name"] == "CPU"
+
+
+def test_calibration_device_context(monkeypatch):
+    model = LinearModel().ov_model
+    captured_device = {}
+
+    import openvino as ov
+
+    original_compile = ov.Core.compile_model
+
+    def mock_compile(self, model, device_name="CPU", config=None):
+        captured_device["device_name"] = device_name
+        return original_compile(self, model, device_name="CPU", config=config)
+
+    monkeypatch.setattr(ov.Core, "compile_model", mock_compile)
+    with calibration_device_context("GPU"):
+        OVNativeEngine(model)
+    assert captured_device["device_name"] == "GPU"
+
+
+def test_calibration_device_context_resets(monkeypatch):
+    model = LinearModel().ov_model
+    captured_devices = []
+
+    import openvino as ov
+
+    original_compile = ov.Core.compile_model
+
+    def mock_compile(self, model, device_name="CPU", config=None):
+        captured_devices.append(device_name)
+        return original_compile(self, model, device_name="CPU", config=config)
+
+    monkeypatch.setattr(ov.Core, "compile_model", mock_compile)
+    with calibration_device_context("GPU"):
+        OVNativeEngine(model)
+    OVNativeEngine(model)
+    assert captured_devices == ["GPU", "CPU"]

--- a/tests/openvino/native/test_engine.py
+++ b/tests/openvino/native/test_engine.py
@@ -11,7 +11,10 @@
 from functools import wraps
 
 import numpy as np
+import openvino as ov
 import pytest
+from openvino import Type
+from openvino.properties.hint import inference_precision
 
 from nncf.definitions import NNCF_DATASET_RESET_STATE_KEY
 from nncf.openvino.engine import OVNativeEngine
@@ -126,55 +129,33 @@ def test_stateful_model_inference_with_controlled_resetting():
     ]
 
 
-def test_calibration_device_default(monkeypatch):
+def test_calibration_device(monkeypatch):
     model = LinearModel().ov_model
-    captured_device = {}
-
-    import openvino as ov
+    captured_device = None
+    captured_config = None
 
     original_compile = ov.Core.compile_model
 
     def mock_compile(self, model, device_name="CPU", config=None):
-        captured_device["device_name"] = device_name
+        nonlocal captured_device
+        nonlocal captured_config
+        captured_device = device_name
+        captured_config = config
         return original_compile(self, model, device_name="CPU", config=config)
 
     monkeypatch.setattr(ov.Core, "compile_model", mock_compile)
+    # Check default CPU
     OVNativeEngine(model)
-    assert captured_device["device_name"] == "CPU"
+    assert captured_device == "CPU"
+    assert captured_config == {inference_precision: Type.f32}
 
-
-def test_calibration_device_context(monkeypatch):
-    model = LinearModel().ov_model
-    captured_device = {}
-
-    import openvino as ov
-
-    original_compile = ov.Core.compile_model
-
-    def mock_compile(self, model, device_name="CPU", config=None):
-        captured_device["device_name"] = device_name
-        return original_compile(self, model, device_name="CPU", config=config)
-
-    monkeypatch.setattr(ov.Core, "compile_model", mock_compile)
-    with calibration_device_context("GPU"):
+    # Check with the context
+    with calibration_device_context("SOME_DEVICE"):
         OVNativeEngine(model)
-    assert captured_device["device_name"] == "GPU"
+    assert captured_device == "SOME_DEVICE"
+    assert captured_config is None
 
-
-def test_calibration_device_context_resets(monkeypatch):
-    model = LinearModel().ov_model
-    captured_devices = []
-
-    import openvino as ov
-
-    original_compile = ov.Core.compile_model
-
-    def mock_compile(self, model, device_name="CPU", config=None):
-        captured_devices.append(device_name)
-        return original_compile(self, model, device_name="CPU", config=config)
-
-    monkeypatch.setattr(ov.Core, "compile_model", mock_compile)
-    with calibration_device_context("GPU"):
-        OVNativeEngine(model)
+    # Check the context exit resets the device back
     OVNativeEngine(model)
-    assert captured_devices == ["GPU", "CPU"]
+    assert captured_device == "CPU"
+    assert captured_config == {inference_precision: Type.f32}

--- a/tests/post_training/conftest.py
+++ b/tests/post_training/conftest.py
@@ -39,6 +39,12 @@ def pytest_addoption(parser):
         help="Report memory using MemoryMonitor from tools/memory_monitor.py. "
         "Warning: currently, reported memory values are not always reproducible.",
     )
+    parser.addoption(
+        "--ov-calibration-device",
+        action="store",
+        default=None,
+        help="OpenVINO device to use for calibration during weight compression (e.g. CPU, GPU).",
+    )
 
 
 @pytest.fixture(scope="session", name="data_dir")
@@ -92,6 +98,11 @@ def fixture_extra_columns(pytestconfig):
 @pytest.fixture(scope="session", name="memory_monitor")
 def fixture_memory_monitor(pytestconfig):
     return pytestconfig.getoption("memory_monitor")
+
+
+@pytest.fixture(scope="session", name="ov_calibration_device")
+def fixture_ov_calibration_device(pytestconfig):
+    return pytestconfig.getoption("ov_calibration_device")
 
 
 @pytest.fixture(scope="session", name="forked")

--- a/tests/post_training/test_quantize_conformance.py
+++ b/tests/post_training/test_quantize_conformance.py
@@ -198,6 +198,7 @@ def run_pipeline(
     output_dir: Path,
     data_dir: Path | None,
     no_eval: bool,
+    ov_calibration_device: str | None,
     batch_size: int | None,
     run_fp32_backend: bool,
     run_torch_cuda_backend: bool,
@@ -216,6 +217,10 @@ def run_pipeline(
     maybe_skip_test_case(test_model_param, run_fp32_backend, run_torch_cuda_backend, batch_size)
     pipeline_cls = test_model_param["pipeline_cls"]
     pipeline_kwargs = create_pipeline_kwargs(test_model_param, subset_size, test_case_name, reference_data)
+    if ov_calibration_device:
+        compression_params = pipeline_kwargs["compression_params"]
+        advanced_params = compression_params.setdefault("advanced_parameters", nncf.AdvancedCompressionParameters())
+        advanced_params.calibration_device = ov_calibration_device
     pipeline_kwargs.update(
         {
             "output_dir": output_dir,
@@ -285,6 +290,7 @@ def test_ptq_quantization(
         output_dir,
         data_dir,
         no_eval,
+        None,
         batch_size,
         run_fp32_backend,
         run_torch_cuda_backend,
@@ -311,6 +317,7 @@ def test_weight_compression(
     capsys: pytest.CaptureFixture,
     extra_columns: bool,
     memory_monitor: bool,
+    ov_calibration_device: str | None,
     use_avx2: None,
 ):
     run_pipeline(
@@ -321,6 +328,7 @@ def test_weight_compression(
         output_dir,
         None,  # data_dir is not used in WC
         no_eval,
+        ov_calibration_device,
         batch_size,
         run_fp32_backend,
         run_torch_cuda_backend,

--- a/tests/torch/function_hook/quantization/test_quantize_api.py
+++ b/tests/torch/function_hook/quantization/test_quantize_api.py
@@ -8,5 +8,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from tests.cross_fw.test_templates.helpers import ConvTestModel
+from tests.cross_fw.test_templates.template_test_quantize_api import TemplateTestQuantizeApi
 
-__version__ = "3.2.0"
+
+class TestPTQuantizeApi(TemplateTestQuantizeApi):
+    @staticmethod
+    def get_simple_model():
+        return ConvTestModel()

--- a/tests/torch/fx/test_quantize_api.py
+++ b/tests/torch/fx/test_quantize_api.py
@@ -8,5 +8,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import torch
 
-__version__ = "3.2.0"
+from tests.cross_fw.test_templates.helpers import ConvTestModel
+from tests.cross_fw.test_templates.template_test_quantize_api import TemplateTestQuantizeApi
+
+
+class TestFXQuantizeApi(TemplateTestQuantizeApi):
+    @staticmethod
+    def get_simple_model():
+        model = ConvTestModel().eval()
+        example_input = torch.ones(ConvTestModel.INPUT_SIZE)
+        return torch.export.export(model, args=(example_input,)).module()


### PR DESCRIPTION
### Changes

Adds a `calibration_device` parameter to `AdvancedCompressionParameters` and `AdvancedQuantizationParameters` that allows users to specify which OpenVINO device to use for calibration inference (e.g. `"GPU"`, `"AUTO:GPU,CPU"`).

**Source changes:**
- `src/nncf/openvino/engine.py` — Added `calibration_device_context()` context manager using `contextvars.ContextVar`. `OVNativeEngine` reads the context variable to determine the compile device instead of hardcoding `"CPU"`. FP32 inference precision config is only applied for CPU device.
- `src/nncf/quantization/advanced_parameters.py` — Added `calibration_device: str | None = None` field to both `AdvancedQuantizationParameters` and `AdvancedCompressionParameters`.
- `src/nncf/openvino/quantization/quantize_model.py` — Wraps calibration calls in `calibration_device_context()` for `quantize_impl`, `quantize_with_accuracy_control_impl`, and `compress_weights_impl`.
- `src/nncf/quantization/quantize_model.py` — Added `ParameterNotSupportedError` guards for `calibration_device` in non-OV backends (Torch, TorchFX, ONNX) across `compress_weights`, `quantize`, and `quantize_with_accuracy_control`.

### Reason for changes

Up to 120x speed up for PI0.5 quantization calibration on Intel(R) Arc(TM) B580 Graphics 

Users need the ability to run calibration inference on a device other than CPU (e.g. GPU) for faster quantization/compression. This parameter is only meaningful for the OpenVINO backend; other backends now raise an explicit `ParameterNotSupportedError` instead of silently ignoring it.


### Related tickets
184686
### Tests

- `tests/openvino/native/test_engine.py` — Unit test for `calibration_device_context` and `OVNativeEngine` device propagation.


- `tests/cross_fw/test_templates/template_test_weights_compression.py` — Template test `test_compress_weights_calibration_device` verifying `ParameterNotSupportedError` is raised on non-OV backends.
- `tests/openvino/native/quantization/test_weights_compression.py` — OV override verifying the device is correctly passed through to `ov.Core.compile_model` via monkeypatch.

- `tests/cross_fw/test_templates/template_test_quantize_api.py` — New template `TemplateTestQuantizeApi` with `test_quantize_calibration_device` for non-OV backends.
- `tests/openvino/native/quantization/test_quantize_api.py` — OV overrides for `quantize` and `quantize_with_accuracy_control` verifying device propagation.

