### PR TITLE
Bump netwrokx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "networkx>=2.6, <3.5.0",
+    "networkx>=2.6, <=3.7.0",
     "ninja>=1.10.0.post2, <1.14",
     "numpy>=1.24.0, <2.5.0",
     "openvino-telemetry>=2023.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "networkx>=2.6, <=3.7.0",
+    "networkx>=2.6, <=3.6.1",
     "ninja>=1.10.0.post2, <1.14",
     "numpy>=1.24.0, <2.5.0",
     "openvino-telemetry>=2023.2.0",


### PR DESCRIPTION
### Changes

`networkx>=2.6, <=3.6.1"` 

### Reason for changes

3.4.1 is out-date

### Related tickets

### Tests

