### PR TITLE
[pruning] Ignored scope by name of constant node

### DIFF
--- a/src/nncf/torch/function_hook/pruning/magnitude/algo.py
+++ b/src/nncf/torch/function_hook/pruning/magnitude/algo.py
@@ -27,7 +27,7 @@ TModel = TypeVar("TModel", bound=nn.Module)
 
 def apply_magnitude_pruning(
     model: TModel,
-    parameters: list[str],
+    parameters: set[str],
     mode: PruneMode,
     ratio: float,
 ) -> TModel:
@@ -43,8 +43,7 @@ def apply_magnitude_pruning(
     :param ratio: The ratio of parameters to prune.
     :returns: The pruned model with hooks registered for the specified parameters.
     """
-    # Insert hooks
-    for param_name in set(parameters):
+    for param_name in parameters:
         param_data = get_const_data_by_name(param_name, model)
         hook_module = UnstructuredPruningMask(tuple(param_data.shape)).to(device=param_data.device)
         register_post_function_hook(
@@ -54,7 +53,6 @@ def apply_magnitude_pruning(
             hook=hook_module,
         )
 
-    # Set ratio
     update_pruning_ratio(model, mode, ratio)
 
     return model
@@ -65,11 +63,11 @@ def get_pruned_modules(model: nn.Module) -> dict[str, UnstructuredPruningMask]:
     Retrieves a mapping of operation names to their corresponding
     UnstructuredPruningMask hooks from the given model.
 
-    :param model: The model from which to retrieve the sparsity modules.
-    :return: A dictionary mapping tensor names to their corresponding MagnitudeSparsityBinaryMask instances.
+    :param model: The model from which to retrieve the prunable modules.
+    :return: A dictionary mapping tensor names to their corresponding UnstructuredPruningMask instances.
     """
     hook_storage = get_hook_storage(model)
-    sparsity_module_map: dict[str, UnstructuredPruningMask] = dict()
+    pruned_modules: dict[str, UnstructuredPruningMask] = dict()
 
     for name, hook in hook_storage.named_hooks():
         if not isinstance(hook, UnstructuredPruningMask):
@@ -79,9 +77,9 @@ def get_pruned_modules(model: nn.Module) -> dict[str, UnstructuredPruningMask]:
         if hook_type != "post_hooks" or port_id != 0:
             msg = f"Unexpected place of SparsityBinaryMask: {hook_type=}, {op_name=}, {port_id=}"
             raise nncf.InternalError(msg)
-        sparsity_module_map[op_name] = hook
+        pruned_modules[op_name] = hook
 
-    return sparsity_module_map
+    return pruned_modules
 
 
 @torch.no_grad()
@@ -104,7 +102,7 @@ def update_pruning_ratio(
     pruned_modules_map = get_pruned_modules(model)
 
     if not pruned_modules_map:
-        msg = "No Sparsity modules found in the model"
+        msg = "No pruned tensors found in the model"
         raise nncf.InternalError(msg)
 
     if mode == PruneMode.UNSTRUCTURED_MAGNITUDE_LOCAL:

--- a/src/nncf/torch/function_hook/pruning/magnitude/algo.py
+++ b/src/nncf/torch/function_hook/pruning/magnitude/algo.py
@@ -38,7 +38,7 @@ def apply_magnitude_pruning(
     for unstructured pruning based and update the specified ratio.
 
     :param model: The neural network model to be pruned.
-    :param parameters: A list of parameter names to be pruned.
+    :param parameters: A set of parameter names to be pruned.
     :param mode: The mode of pruning to be applied.
     :param ratio: The ratio of parameters to prune.
     :returns: The pruned model with hooks registered for the specified parameters.
@@ -75,7 +75,7 @@ def get_pruned_modules(model: nn.Module) -> dict[str, UnstructuredPruningMask]:
 
         hook_type, op_name, port_id = decode_hook_name(name)
         if hook_type != "post_hooks" or port_id != 0:
-            msg = f"Unexpected place of SparsityBinaryMask: {hook_type=}, {op_name=}, {port_id=}"
+            msg = f"Unexpected place of UnstructuredPruningMask: {hook_type=}, {op_name=}, {port_id=}"
             raise nncf.InternalError(msg)
         pruned_modules[op_name] = hook
 

--- a/src/nncf/torch/function_hook/pruning/prune_model.py
+++ b/src/nncf/torch/function_hook/pruning/prune_model.py
@@ -23,6 +23,7 @@ from nncf.torch.function_hook.nncf_graph.nncf_graph_builder import build_nncf_gr
 from nncf.torch.function_hook.pruning.magnitude.algo import apply_magnitude_pruning
 from nncf.torch.function_hook.pruning.rb.algo import apply_regularization_based_pruning
 from nncf.torch.function_hook.wrapper import wrap_model
+from nncf.torch.graph.graph import PTNNCFGraph
 from nncf.torch.model_graph_manager import get_const_node
 
 TModel = TypeVar("TModel", bound=nn.Module)
@@ -57,14 +58,39 @@ def prune(
 
     model = wrap_model(model)
     graph = build_nncf_graph(model, examples_inputs)
+    parameters_to_sparsity = get_prunable_parameters(graph, ignored_scope)
 
+    # Select and apply the pruning algorithm by mode
+    if mode in [PruneMode.UNSTRUCTURED_MAGNITUDE_GLOBAL, PruneMode.UNSTRUCTURED_MAGNITUDE_LOCAL]:
+        if ratio is None:
+            msg = f"`ratio` parameter should be specified for {mode} mode in nncf.prune function"
+            raise nncf.InternalError(msg)
+        model = apply_magnitude_pruning(model, parameters_to_sparsity, mode, ratio)
+    elif mode == PruneMode.UNSTRUCTURED_REGULARIZATION_BASED:
+        if ratio is not None:
+            nncf_logger.warning(
+                f"`ratio` parameter is ignored for {mode} mode in nncf.prune function. "
+                "Target pruning ratio should be set by RBLoss."
+            )
+        model = apply_regularization_based_pruning(model, parameters_to_sparsity)
+    else:
+        msg = f"Pruning mode {mode} is not implemented for Torch backend"
+        raise nncf.InternalError(msg)
+    return model
+
+
+def get_prunable_parameters(graph: PTNNCFGraph, ignored_scope: IgnoredScope | None) -> set[str]:
+    """
+    Retrieves the names of constant nodes that are associated with prunable parameters in the given graph.
+
+    :param graph: The NNCFGraph to analyze.
+    :param ignored_scope: The IgnoredScope to filter out nodes.
+    :return: A set of names of constant nodes that are associated with prunable parameters.
+    """
     ignored_names: set[str] = set()
     if ignored_scope is not None:
         ignored_names = get_ignored_node_names_from_ignored_scope(ignored_scope, graph)
 
-    # 1. Find all operation nodes with weights
-    # 2. Filter by ignored names
-    # 3. Collect unique names of parameters
     nodes_with_weights = graph.get_nodes_by_metatypes(OPERATORS_WITH_WEIGHTS_METATYPES)
     parameters_to_sparsity: set[str] = set()
     for node in nodes_with_weights:
@@ -82,23 +108,7 @@ def prune(
 
         for port in weights_ports:
             const_node = get_const_node(node, port, graph)
-            if const_node is not None:
+            if const_node is not None and const_node.node_name not in ignored_names:
                 parameters_to_sparsity.add(const_node.node_name)
 
-    # Select and apply the pruning algorithm by mode
-    if mode in [PruneMode.UNSTRUCTURED_MAGNITUDE_GLOBAL, PruneMode.UNSTRUCTURED_MAGNITUDE_LOCAL]:
-        if ratio is None:
-            msg = f"`ratio` parameter should be specified for {mode} mode in nncf.prune function"
-            raise nncf.InternalError(msg)
-        model = apply_magnitude_pruning(model, list(parameters_to_sparsity), mode, ratio)
-    elif mode == PruneMode.UNSTRUCTURED_REGULARIZATION_BASED:
-        if ratio is not None:
-            nncf_logger.warning(
-                f"`ratio` parameter is ignored for {mode} mode in nncf.prune function. "
-                "Target pruning ratio should be set by RBLoss."
-            )
-        model = apply_regularization_based_pruning(model, list(parameters_to_sparsity))
-    else:
-        msg = f"Pruning mode {mode} is not implemented for Torch backend"
-        raise nncf.InternalError(msg)
-    return model
+    return parameters_to_sparsity

--- a/src/nncf/torch/function_hook/pruning/rb/algo.py
+++ b/src/nncf/torch/function_hook/pruning/rb/algo.py
@@ -25,7 +25,7 @@ TModel = TypeVar("TModel", bound=nn.Module)
 
 def apply_regularization_based_pruning(
     model: TModel,
-    parameters: list[str],
+    parameters: set[str],
 ) -> TModel:
     """
     :param model: The neural network model to be pruned.
@@ -33,8 +33,7 @@ def apply_regularization_based_pruning(
     :param ratio: The ratio of parameters to prune.
     :returns: The pruned model with hooks registered for the specified parameters.
     """
-    # Insert hooks
-    for param_name in set(parameters):
+    for param_name in parameters:
         param_data = get_const_data_by_name(param_name, model)
         hook_module = RBPruningMask(shape=tuple(param_data.shape)).to(device=param_data.device)
 

--- a/src/nncf/torch/function_hook/pruning/rb/algo.py
+++ b/src/nncf/torch/function_hook/pruning/rb/algo.py
@@ -29,8 +29,7 @@ def apply_regularization_based_pruning(
 ) -> TModel:
     """
     :param model: The neural network model to be pruned.
-    :param parameters: A list of parameter names to be pruned.
-    :param ratio: The ratio of parameters to prune.
+    :param parameters: A set of parameter names to be pruned.
     :returns: The pruned model with hooks registered for the specified parameters.
     """
     for param_name in parameters:
@@ -64,7 +63,7 @@ def get_pruned_modules(model: nn.Module) -> dict[str, RBPruningMask]:
 
         hook_type, op_name, port_id = decode_hook_name(name)
         if hook_type != "post_hooks" or port_id != 0:
-            msg = f"Unexpected place of SparsityBinaryMask: {hook_type=}, {op_name=}, {port_id=}"
+            msg = f"Unexpected place of RBPruningMask: {hook_type=}, {op_name=}, {port_id=}"
             raise nncf.InternalError(msg)
         sparsity_module_map[op_name] = hook
 

--- a/tests/torch/function_hook/pruning/magnitude/test_algo.py
+++ b/tests/torch/function_hook/pruning/magnitude/test_algo.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -17,8 +18,11 @@ from torch import nn
 
 import nncf
 from nncf.parameters import PruneMode
+from nncf.scopes import IgnoredScope
 from nncf.torch.function_hook.pruning.magnitude.modules import UnstructuredPruningMask
+from nncf.torch.function_hook.pruning.prune_model import get_prunable_parameters
 from nncf.torch.function_hook.wrapper import get_hook_storage
+from nncf.torch.graph.graph import PTNNCFGraph
 from tests.torch.function_hook.pruning.helpers import ConvModel
 from tests.torch.function_hook.pruning.helpers import MatMulLeft
 from tests.torch.function_hook.pruning.helpers import MatMulRight
@@ -168,3 +172,53 @@ def test_statistic():
     txt = str(stat)
     assert "conv.weight" in txt
     assert "All parameters" in txt
+
+
+@pytest.fixture(scope="session")
+def two_conv_graph() -> PTNNCFGraph:
+    model = TwoConvModel()
+    return nncf.build_graph(model, example_input=model.get_example_inputs())
+
+
+@dataclass
+class IgnoredScopeParam:
+    test_name: str
+    ignored_scope: IgnoredScope
+    expected_params: set[str]
+
+    def __str__(self):
+        return self.test_name
+
+
+@pytest.mark.parametrize(
+    "param",
+    (
+        IgnoredScopeParam(
+            test_name="none",
+            ignored_scope=None,
+            expected_params={"conv1.weight", "conv2.weight"},
+        ),
+        IgnoredScopeParam(
+            test_name="weight_name_1",
+            ignored_scope=IgnoredScope(names=["conv1.weight"]),
+            expected_params={"conv2.weight"},
+        ),
+        IgnoredScopeParam(
+            test_name="weight_name_2",
+            ignored_scope=IgnoredScope(names=["conv2.weight"]),
+            expected_params={"conv1.weight"},
+        ),
+        IgnoredScopeParam(
+            test_name="op_name", ignored_scope=IgnoredScope(names=["conv1/conv2d/0"]), expected_params={"conv2.weight"}
+        ),
+        IgnoredScopeParam(
+            test_name="pattern_conv",
+            ignored_scope=IgnoredScope(patterns=["^conv1/conv2d/.*"]),
+            expected_params={"conv2.weight"},
+        ),
+    ),
+    ids=str,
+)
+def test_ignore_scope_for_prunable_parameters(param: IgnoredScopeParam, two_conv_graph: PTNNCFGraph):
+    prunable_parameters = get_prunable_parameters(two_conv_graph, param.ignored_scope)
+    assert prunable_parameters == param.expected_params

--- a/tests/torch/function_hook/pruning/magnitude/test_algo.py
+++ b/tests/torch/function_hook/pruning/magnitude/test_algo.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -18,11 +17,8 @@ from torch import nn
 
 import nncf
 from nncf.parameters import PruneMode
-from nncf.scopes import IgnoredScope
 from nncf.torch.function_hook.pruning.magnitude.modules import UnstructuredPruningMask
-from nncf.torch.function_hook.pruning.prune_model import get_prunable_parameters
 from nncf.torch.function_hook.wrapper import get_hook_storage
-from nncf.torch.graph.graph import PTNNCFGraph
 from tests.torch.function_hook.pruning.helpers import ConvModel
 from tests.torch.function_hook.pruning.helpers import MatMulLeft
 from tests.torch.function_hook.pruning.helpers import MatMulRight
@@ -172,53 +168,3 @@ def test_statistic():
     txt = str(stat)
     assert "conv.weight" in txt
     assert "All parameters" in txt
-
-
-@pytest.fixture(scope="session")
-def two_conv_graph() -> PTNNCFGraph:
-    model = TwoConvModel()
-    return nncf.build_graph(model, example_input=model.get_example_inputs())
-
-
-@dataclass
-class IgnoredScopeParam:
-    test_name: str
-    ignored_scope: IgnoredScope
-    expected_params: set[str]
-
-    def __str__(self):
-        return self.test_name
-
-
-@pytest.mark.parametrize(
-    "param",
-    (
-        IgnoredScopeParam(
-            test_name="none",
-            ignored_scope=None,
-            expected_params={"conv1.weight", "conv2.weight"},
-        ),
-        IgnoredScopeParam(
-            test_name="weight_name_1",
-            ignored_scope=IgnoredScope(names=["conv1.weight"]),
-            expected_params={"conv2.weight"},
-        ),
-        IgnoredScopeParam(
-            test_name="weight_name_2",
-            ignored_scope=IgnoredScope(names=["conv2.weight"]),
-            expected_params={"conv1.weight"},
-        ),
-        IgnoredScopeParam(
-            test_name="op_name", ignored_scope=IgnoredScope(names=["conv1/conv2d/0"]), expected_params={"conv2.weight"}
-        ),
-        IgnoredScopeParam(
-            test_name="pattern_conv",
-            ignored_scope=IgnoredScope(patterns=["^conv1/conv2d/.*"]),
-            expected_params={"conv2.weight"},
-        ),
-    ),
-    ids=str,
-)
-def test_ignore_scope_for_prunable_parameters(param: IgnoredScopeParam, two_conv_graph: PTNNCFGraph):
-    prunable_parameters = get_prunable_parameters(two_conv_graph, param.ignored_scope)
-    assert prunable_parameters == param.expected_params

--- a/tests/torch/function_hook/pruning/test_prune.py
+++ b/tests/torch/function_hook/pruning/test_prune.py
@@ -27,51 +27,27 @@ def two_conv_graph() -> PTNNCFGraph:
 
 
 @dataclass
-class IgnoredScopeParam:
-    test_name: str
+class ParamIgnoredScope:
+    name: str
     ignored_scope: IgnoredScope
     expected_params: set[str]
 
-    def __str__(self):
-        return self.test_name
+    def __str__(self) -> str:
+        return self.name
 
 
 @pytest.mark.parametrize(
     "param",
     (
-        IgnoredScopeParam(
-            test_name="none",
-            ignored_scope=None,
-            expected_params={"conv1.weight", "conv2.weight"},
-        ),
-        IgnoredScopeParam(
-            test_name="weight_name_1",
-            ignored_scope=IgnoredScope(names=["conv1.weight"]),
-            expected_params={"conv2.weight"},
-        ),
-        IgnoredScopeParam(
-            test_name="weight_name_2",
-            ignored_scope=IgnoredScope(names=["conv2.weight"]),
-            expected_params={"conv1.weight"},
-        ),
-        IgnoredScopeParam(
-            test_name="op_name",
-            ignored_scope=IgnoredScope(names=["conv1/conv2d/0"]),
-            expected_params={"conv2.weight"},
-        ),
-        IgnoredScopeParam(
-            test_name="pattern_conv",
-            ignored_scope=IgnoredScope(patterns=["^conv1/conv2d/.*"]),
-            expected_params={"conv2.weight"},
-        ),
-        IgnoredScopeParam(
-            test_name="pattern_const",
-            ignored_scope=IgnoredScope(patterns=[".*2.weight"]),
-            expected_params={"conv1.weight"},
-        ),
+        ParamIgnoredScope("empty", IgnoredScope(), {"conv1.weight", "conv2.weight"}),
+        ParamIgnoredScope("weight_name_1", IgnoredScope(names=["conv1.weight"]), {"conv2.weight"}),
+        ParamIgnoredScope("weight_name_2", IgnoredScope(names=["conv2.weight"]), {"conv1.weight"}),
+        ParamIgnoredScope("op_name", IgnoredScope(names=["conv1/conv2d/0"]), {"conv2.weight"}),
+        ParamIgnoredScope("pattern_conv", IgnoredScope(patterns=["^conv1/conv2d/.*"]), {"conv2.weight"}),
+        ParamIgnoredScope("pattern_const", IgnoredScope(patterns=[".*2.weight"]), {"conv1.weight"}),
     ),
     ids=str,
 )
-def test_ignore_scope_for_prunable_parameters(param: IgnoredScopeParam, two_conv_graph: PTNNCFGraph):
+def test_ignore_scope_for_prunable_parameters(param: ParamIgnoredScope, two_conv_graph: PTNNCFGraph):
     prunable_parameters = get_prunable_parameters(two_conv_graph, param.ignored_scope)
     assert prunable_parameters == param.expected_params

--- a/tests/torch/function_hook/pruning/test_prune.py
+++ b/tests/torch/function_hook/pruning/test_prune.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+import pytest
+
+import nncf
+from nncf.scopes import IgnoredScope
+from nncf.torch.function_hook.pruning.prune_model import get_prunable_parameters
+from nncf.torch.graph.graph import PTNNCFGraph
+from tests.torch.function_hook.pruning.helpers import TwoConvModel
+
+
+@pytest.fixture(scope="session")
+def two_conv_graph() -> PTNNCFGraph:
+    model = TwoConvModel()
+    return nncf.build_graph(model, example_input=model.get_example_inputs())
+
+
+@dataclass
+class IgnoredScopeParam:
+    test_name: str
+    ignored_scope: IgnoredScope
+    expected_params: set[str]
+
+    def __str__(self):
+        return self.test_name
+
+
+@pytest.mark.parametrize(
+    "param",
+    (
+        IgnoredScopeParam(
+            test_name="none",
+            ignored_scope=None,
+            expected_params={"conv1.weight", "conv2.weight"},
+        ),
+        IgnoredScopeParam(
+            test_name="weight_name_1",
+            ignored_scope=IgnoredScope(names=["conv1.weight"]),
+            expected_params={"conv2.weight"},
+        ),
+        IgnoredScopeParam(
+            test_name="weight_name_2",
+            ignored_scope=IgnoredScope(names=["conv2.weight"]),
+            expected_params={"conv1.weight"},
+        ),
+        IgnoredScopeParam(
+            test_name="op_name",
+            ignored_scope=IgnoredScope(names=["conv1/conv2d/0"]),
+            expected_params={"conv2.weight"},
+        ),
+        IgnoredScopeParam(
+            test_name="pattern_conv",
+            ignored_scope=IgnoredScope(patterns=["^conv1/conv2d/.*"]),
+            expected_params={"conv2.weight"},
+        ),
+        IgnoredScopeParam(
+            test_name="pattern_const",
+            ignored_scope=IgnoredScope(patterns=[".*2.weight"]),
+            expected_params={"conv1.weight"},
+        ),
+    ),
+    ids=str,
+)
+def test_ignore_scope_for_prunable_parameters(param: IgnoredScopeParam, two_conv_graph: PTNNCFGraph):
+    prunable_parameters = get_prunable_parameters(two_conv_graph, param.ignored_scope)
+    assert prunable_parameters == param.expected_params


### PR DESCRIPTION
### Changes

Add a check for ignored names to each pruned weight, rather than applying the check only at the operation node level.
Moved some logic to `get_prunable_parameters` function to easy validate ignored scope.

### Reason for changes

### Related tickets

https://github.com/openvinotoolkit/nncf/issues/4033

### Tests

[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/25376728927) - success