### PR TITLE
[wc] Ignored scope by name of constant node

### DIFF
--- a/src/nncf/quantization/algorithms/weight_compression/algorithm.py
+++ b/src/nncf/quantization/algorithms/weight_compression/algorithm.py
@@ -885,7 +885,7 @@ class WeightCompression(Algorithm):
 
         :param weight_dtype: The data type of the weights to be compressed.
         :param compression_mode: The compression mode to be applied.
-        :return: True if the combination of wgit eight_dtype and compression_mode is supported for compression,
+        :return: True if the combination of weight_dtype and compression_mode is supported for compression,
             False otherwise. Specifically, returns False if the data type is one of the supported
             float8 types and the mode is an INT8 mode (i.e., same-bit compression is not supported).
         """
@@ -1009,7 +1009,11 @@ class WeightCompression(Algorithm):
                 reduction_axes = self._backend_entity.get_reduction_axes(node, weight_port_id, graph)
 
                 wc_config = None
-                if is_target_node and self.is_weight_compression_supported(weight_dtype, self._mode):
+                if (
+                    is_target_node
+                    and weight_name not in ignored_names
+                    and self.is_weight_compression_supported(weight_dtype, self._mode)
+                ):
                     if (
                         self._group_size != -1
                         and self._all_layers

--- a/tests/onnx/quantization/test_weights_compression.py
+++ b/tests/onnx/quantization/test_weights_compression.py
@@ -1012,7 +1012,7 @@ class ParamIgnoredScope:
     ),
     ids=str,
 )
-def test_ignored_scope(param: ParamIgnoredScope, model_for_ignored_scope_test: onnx.ModelProto):
+def test_weight_compress_with_ignored_scope(param: ParamIgnoredScope, model_for_ignored_scope_test: onnx.ModelProto):
     model = deepcopy(model_for_ignored_scope_test)
 
     compressed_model = compress_weights(

--- a/tests/onnx/quantization/test_weights_compression.py
+++ b/tests/onnx/quantization/test_weights_compression.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 from collections import defaultdict
+from copy import deepcopy
 from dataclasses import dataclass
 from functools import reduce
 from operator import mul
@@ -19,6 +20,7 @@ import numpy as np
 import onnx
 import onnxruntime
 import pytest
+import torch
 from onnx import TensorProto
 from onnx import helper
 from onnx import numpy_helper
@@ -39,6 +41,7 @@ from nncf.onnx.graph.onnx_helper import get_tensor_value
 from nncf.onnx.graph.transformations.commands import ONNXOutputInsertionCommand
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
 from nncf.quantization import compress_weights
+from nncf.scopes import IgnoredScope
 from nncf.tensor import Tensor
 from nncf.tensor import TensorDataType
 from tests.cross_fw.test_templates.template_test_weights_compression import TemplateWeightCompression
@@ -958,3 +961,67 @@ class TestONNXTemplateWeightCompression(TemplateWeightCompression):
     @pytest.mark.skip("RoPE pattern is invalid for the ONNX backend, ticket 183208")
     def test_rope_weight_compression():
         pass
+
+
+class LinearModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        weight = torch.arange(0, 8 * 16, dtype=torch.float32).reshape(16, 8)
+        self.linear = torch.nn.Linear(weight.shape[0], weight.shape[1], False)
+        self.linear.weight = torch.nn.Parameter(weight)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+@pytest.fixture(name="model_for_ignored_scope_test", scope="module")
+def get_model_for_ignored_scope_test(tmp_path_factory) -> onnx.ModelProto:
+    pt_model = LinearModel().eval()
+    onnx_path = tmp_path_factory.mktemp("onnx_models") / "LinearModel.onnx"
+    torch.onnx.export(
+        pt_model, torch.randn(1, 8), onnx_path, input_names=["input"], output_names=["output"], external_data=False
+    )
+    model = onnx.load(onnx_path)
+    return model
+
+
+@dataclass
+class ParamIgnoredScope:
+    name: str
+    ignored_scope: IgnoredScope
+    ref: int
+
+    def __str__(self):
+        return self.name
+
+
+@pytest.mark.parametrize(
+    "param",
+    (
+        ParamIgnoredScope("empty", IgnoredScope(), {"linear.weight_quantized"}),
+        pytest.param(
+            ParamIgnoredScope("name_const", IgnoredScope(names=["linear.weight"]), set()),
+            marks=pytest.mark.xfail(reason="See ticket 186262"),
+        ),
+        ParamIgnoredScope("name_op", IgnoredScope(names=["node_linear"]), set()),
+        pytest.param(
+            ParamIgnoredScope("pattern_const", IgnoredScope(patterns=[".*weight"]), set()),
+            marks=pytest.mark.xfail(reason="See ticket 186262"),
+        ),
+        ParamIgnoredScope("pattern_op", IgnoredScope(patterns=["node_li.*"]), set()),
+    ),
+    ids=str,
+)
+def test_ignored_scope(param: ParamIgnoredScope, model_for_ignored_scope_test: onnx.ModelProto):
+    model = deepcopy(model_for_ignored_scope_test)
+
+    compressed_model = compress_weights(
+        model,
+        mode=CompressWeightsMode.INT4_SYM,
+        group_size=-1,
+        all_layers=True,
+        ignored_scope=param.ignored_scope,
+    )
+
+    names = {i.name for i in compressed_model.graph.initializer if i.data_type == onnx.TensorProto.INT4}
+    assert names == param.ref

--- a/tests/onnx/quantization/test_weights_compression.py
+++ b/tests/onnx/quantization/test_weights_compression.py
@@ -967,10 +967,10 @@ class LinearModel(torch.nn.Module):
     def __init__(self):
         super().__init__()
         weight = torch.arange(0, 8 * 16, dtype=torch.float32).reshape(16, 8)
-        self.linear = torch.nn.Linear(weight.shape[0], weight.shape[1], False)
+        self.linear = torch.nn.Linear(weight.shape[1], weight.shape[0], False)
         self.linear.weight = torch.nn.Parameter(weight)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.linear(x)
 
 
@@ -989,9 +989,9 @@ def get_model_for_ignored_scope_test(tmp_path_factory) -> onnx.ModelProto:
 class ParamIgnoredScope:
     name: str
     ignored_scope: IgnoredScope
-    ref: int
+    ref: set[str]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 

--- a/tests/onnx/requirements.txt
+++ b/tests/onnx/requirements.txt
@@ -1,6 +1,7 @@
 -c ../../constraints.txt
 onnx
 onnxruntime
+onnxscript
 openvino
 pandas
 pytest-cov

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -119,7 +119,8 @@ class LMLinearModel(OVReferenceModel):
         input_1 = opset.parameter(self._input_shape, name="Input")
         weight_shape = self.get_weight_shape(transpose_b)
         data = self._rng.random(weight_shape).astype(np.float32)
-        matmul = opset.matmul(input_1, data, transpose_a=transpose_a, transpose_b=transpose_b, name="MatMul")
+        opset_constant = opset.constant(data, name="Weights")
+        matmul = opset.matmul(input_1, opset_constant, transpose_a=transpose_a, transpose_b=transpose_b, name="MatMul")
         result = opset.result(matmul, name="Result")
         result.get_output_tensor(0).set_names(set(["Result"]))
         model = ov.Model([result], [input_1])
@@ -2767,3 +2768,41 @@ class TestOVTemplateWeightCompression(TemplateWeightCompression):
             group_size=-1,
         )
         assert self.get_num_int8_nodes(compressed_model) == 0
+
+
+@dataclass
+class ParamIgnoredScope:
+    name: str
+    ignored_scope: IgnoredScope
+    ref: int
+
+    def __str__(self):
+        return self.name
+
+
+@pytest.mark.parametrize(
+    "param",
+    (
+        ParamIgnoredScope(name="empty", ignored_scope=IgnoredScope(), ref={"Weights"}),
+        ParamIgnoredScope(name="name_const", ignored_scope=IgnoredScope(names=["Weights"]), ref=set()),
+        ParamIgnoredScope(name="name_op", ignored_scope=IgnoredScope(names=["MatMul"]), ref=set()),
+        ParamIgnoredScope(name="pattern_const", ignored_scope=IgnoredScope(patterns=["Wei.*"]), ref=set()),
+        ParamIgnoredScope(name="pattern_op", ignored_scope=IgnoredScope(patterns=["Mat.*"]), ref=set()),
+    ),
+    ids=str,
+)
+def test_ignored_scope(param: ParamIgnoredScope):
+    model = LMLinearModel().ov_model
+    compressed_model = compress_weights(
+        model,
+        mode=CompressWeightsMode.INT4_SYM,
+        group_size=-1,
+        all_layers=True,
+        ignored_scope=param.ignored_scope,
+    )
+
+    compressed = set()
+    for op in compressed_model.get_ops():
+        if op.get_type_name() == "Constant" and op.get_element_type() in [ov.Type.i4, ov.Type.u4]:
+            compressed.add(op.get_friendly_name())
+    assert compressed == set(param.ref)

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -2774,9 +2774,9 @@ class TestOVTemplateWeightCompression(TemplateWeightCompression):
 class ParamIgnoredScope:
     name: str
     ignored_scope: IgnoredScope
-    ref: int
+    ref: set[str]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -830,18 +830,31 @@ CALCULATE_SCALE_DESCS = [
 ]
 
 
+@dataclass
+class ParamIgnoredScope:
+    name: str
+    ignored_scope: IgnoredScope
+    ref: set[str]
+
+    def __str__(self) -> str:
+        return self.name
+
+
 @pytest.mark.parametrize(
-    ("ignored_scope", "num_compressed"),
+    "param",
     (
-        (IgnoredScope(types=["MatMul"]), 1),
-        (IgnoredScope(types=["Gather"]), 2),
-        (IgnoredScope(names=["MatMul_1"]), 2),
-        (IgnoredScope(patterns=["MatMul_\\d"]), 1),
+        ParamIgnoredScope(name="empty", ignored_scope=IgnoredScope(), ref=3),
+        ParamIgnoredScope(name="type", ignored_scope=IgnoredScope(types=["Gather"]), ref=2),
+        ParamIgnoredScope(name="name_const", ignored_scope=IgnoredScope(names=["matmul_1_data"]), ref=2),
+        ParamIgnoredScope(name="name_op", ignored_scope=IgnoredScope(names=["MatMul_1"]), ref=2),
+        ParamIgnoredScope(name="pattern_const", ignored_scope=IgnoredScope(patterns=[".*data"]), ref=0),
+        ParamIgnoredScope(name="pattern_op", ignored_scope=IgnoredScope(patterns=["Mat.*"]), ref=1),
     ),
+    ids=str,
 )
-def test_weight_compress_with_ignored_scope(ignored_scope, num_compressed):
+def test_weight_compress_with_ignored_scope(param: ParamIgnoredScope):
     model = IntegerModel(positive_w=False).ov_model
-    compressed_model = compress_weights(model, ignored_scope=ignored_scope)
+    compressed_model = compress_weights(model, ignored_scope=param.ignored_scope)
     ref_compressed_weights = TEST_MODELS[IntegerModel]
     act_num = 0
     for op in compressed_model.get_ops():
@@ -851,7 +864,7 @@ def test_weight_compress_with_ignored_scope(ignored_scope, num_compressed):
             and op.get_element_type() == ov.Type.u8
         ):
             act_num += 1
-    assert act_num == num_compressed
+    assert act_num == param.ref
 
 
 @pytest.mark.parametrize("desc", CALCULATE_SCALE_DESCS)
@@ -2768,41 +2781,3 @@ class TestOVTemplateWeightCompression(TemplateWeightCompression):
             group_size=-1,
         )
         assert self.get_num_int8_nodes(compressed_model) == 0
-
-
-@dataclass
-class ParamIgnoredScope:
-    name: str
-    ignored_scope: IgnoredScope
-    ref: set[str]
-
-    def __str__(self) -> str:
-        return self.name
-
-
-@pytest.mark.parametrize(
-    "param",
-    (
-        ParamIgnoredScope(name="empty", ignored_scope=IgnoredScope(), ref={"Weights"}),
-        ParamIgnoredScope(name="name_const", ignored_scope=IgnoredScope(names=["Weights"]), ref=set()),
-        ParamIgnoredScope(name="name_op", ignored_scope=IgnoredScope(names=["MatMul"]), ref=set()),
-        ParamIgnoredScope(name="pattern_const", ignored_scope=IgnoredScope(patterns=["Wei.*"]), ref=set()),
-        ParamIgnoredScope(name="pattern_op", ignored_scope=IgnoredScope(patterns=["Mat.*"]), ref=set()),
-    ),
-    ids=str,
-)
-def test_ignored_scope(param: ParamIgnoredScope):
-    model = LMLinearModel().ov_model
-    compressed_model = compress_weights(
-        model,
-        mode=CompressWeightsMode.INT4_SYM,
-        group_size=-1,
-        all_layers=True,
-        ignored_scope=param.ignored_scope,
-    )
-
-    compressed = set()
-    for op in compressed_model.get_ops():
-        if op.get_type_name() == "Constant" and op.get_element_type() in [ov.Type.i4, ov.Type.u4]:
-            compressed.add(op.get_friendly_name())
-    assert compressed == set(param.ref)

--- a/tests/torch/function_hook/quantization/test_weights_compression.py
+++ b/tests/torch/function_hook/quantization/test_weights_compression.py
@@ -11,6 +11,7 @@
 
 
 from collections import defaultdict
+from dataclasses import dataclass
 
 import pytest
 import torch
@@ -27,6 +28,7 @@ from nncf.parameters import CompressionFormat
 from nncf.quantization import compress_weights
 from nncf.quantization.advanced_parameters import AdvancedCompressionParameters
 from nncf.quantization.algorithms.smooth_quant.torch_backend import SQMultiply
+from nncf.scopes import IgnoredScope
 from nncf.tensor import Tensor
 from nncf.tensor import TensorDataType
 from nncf.torch.function_hook import get_hook_storage
@@ -113,8 +115,9 @@ class MatMulModel(torch.nn.Module):
 
 
 class LinearModel(torch.nn.Module):
-    def __init__(self, weight: torch.Tensor = torch.ones(size=(256, 256), dtype=torch.float32)):
+    def __init__(self):
         super().__init__()
+        weight = torch.arange(0, 8 * 16, dtype=torch.float32).reshape(16, 8)
         self.linear = torch.nn.Linear(weight.shape[0], weight.shape[1], False)
         self.linear.weight = torch.nn.Parameter(weight)
 
@@ -588,7 +591,7 @@ class TestPTTemplateWeightCompression(TemplateWeightCompression):
 
     @staticmethod
     def get_model_for_test_scale_estimation():
-        return LinearModel(torch.arange(0, 8 * 16, dtype=torch.float32).reshape(16, 8))
+        return LinearModel()
 
     @staticmethod
     def get_moe_model_for_test_scale_estimation():
@@ -931,3 +934,39 @@ def test_half_precision_models(dtype):
         awq=True,
         dataset=nncf.Dataset([dict(inputs)]),
     )
+
+
+@dataclass
+class ParamIgnoredScope:
+    name: str
+    ignored_scope: IgnoredScope
+    ref: int
+
+    def __str__(self):
+        return self.name
+
+
+@pytest.mark.parametrize(
+    "param",
+    (
+        ParamIgnoredScope("empty", IgnoredScope(), {"post_hooks.linear:weight__0.0"}),
+        ParamIgnoredScope("name_const", IgnoredScope(names=["linear.weight"]), set()),
+        ParamIgnoredScope("name_op", IgnoredScope(names=["linear/linear/0"]), set()),
+        ParamIgnoredScope("pattern_const", IgnoredScope(patterns=[".*weight"]), set()),
+        ParamIgnoredScope("pattern_op", IgnoredScope(patterns=["linear/*"]), set()),
+    ),
+    ids=str,
+)
+def test_ignored_scope(param: ParamIgnoredScope):
+    model = wrap_model(LinearModel())
+    example_input = torch.rand(8, 8)
+    wrapped_model = GraphModelWrapper(model, example_input=example_input)
+    compressed_model = compress_weights(
+        wrapped_model,
+        mode=CompressWeightsMode.INT4_SYM,
+        group_size=-1,
+        all_layers=True,
+        ignored_scope=param.ignored_scope,
+    )
+    hooks = {n for n, _ in get_hook_storage(compressed_model).named_hooks()}
+    assert hooks == param.ref

--- a/tests/torch/function_hook/quantization/test_weights_compression.py
+++ b/tests/torch/function_hook/quantization/test_weights_compression.py
@@ -957,7 +957,7 @@ class ParamIgnoredScope:
     ),
     ids=str,
 )
-def test_ignored_scope(param: ParamIgnoredScope):
+def test_weight_compress_with_ignored_scope(param: ParamIgnoredScope):
     model = wrap_model(LinearModel())
     example_input = torch.rand(8, 8)
     wrapped_model = GraphModelWrapper(model, example_input=example_input)

--- a/tests/torch/function_hook/quantization/test_weights_compression.py
+++ b/tests/torch/function_hook/quantization/test_weights_compression.py
@@ -118,11 +118,11 @@ class LinearModel(torch.nn.Module):
     def __init__(self):
         super().__init__()
         weight = torch.arange(0, 8 * 16, dtype=torch.float32).reshape(16, 8)
-        self.linear = torch.nn.Linear(weight.shape[0], weight.shape[1], False)
+        self.linear = torch.nn.Linear(weight.shape[1], weight.shape[0], False)
         self.linear.weight = torch.nn.Parameter(weight)
 
-    def forward(self, input):
-        return self.linear(input)
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
 
 
 class SimpleMoEModel(nn.Module):
@@ -940,9 +940,9 @@ def test_half_precision_models(dtype):
 class ParamIgnoredScope:
     name: str
     ignored_scope: IgnoredScope
-    ref: int
+    ref: set[str]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 

--- a/tests/torch/fx/test_weights_compression.py
+++ b/tests/torch/fx/test_weights_compression.py
@@ -758,7 +758,7 @@ class ParamIgnoredScope:
     ignored_scope: IgnoredScope
     ref: int
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 

--- a/tests/torch/fx/test_weights_compression.py
+++ b/tests/torch/fx/test_weights_compression.py
@@ -355,7 +355,7 @@ class TestFXTemplateWeightCompression(TemplateWeightCompression):
 
     @staticmethod
     def get_model_for_test_scale_estimation():
-        model = LinearModel(torch.arange(0, 8 * 16, dtype=torch.float32).reshape(16, 8))
+        model = LinearModel()
         ex_input = torch.ones([1, 4, 8], dtype=torch.float32)
         exported_model = get_torch_fx_model(model, ex_input)
         return exported_model

--- a/tests/torch/fx/test_weights_compression.py
+++ b/tests/torch/fx/test_weights_compression.py
@@ -773,7 +773,7 @@ class ParamIgnoredScope:
     ),
     ids=str,
 )
-def test_ignored_scope(param: ParamIgnoredScope):
+def test_weight_compress_with_ignored_scope(param: ParamIgnoredScope):
     example_input = torch.rand(8, 8)
     model = get_torch_fx_model(LinearModel(), example_input)
     compressed_model = compress_weights(

--- a/tests/torch/fx/test_weights_compression.py
+++ b/tests/torch/fx/test_weights_compression.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import defaultdict
+from dataclasses import dataclass
 
 import pytest
 import torch
@@ -23,6 +24,7 @@ from nncf.parameters import CompressionFormat
 from nncf.quantization import compress_weights
 from nncf.quantization.advanced_parameters import AdvancedCompressionParameters
 from nncf.quantization.algorithms.weight_compression.torch_fx_backend import FXAWQMultiply
+from nncf.scopes import IgnoredScope
 from nncf.tensor import Tensor
 from nncf.tensor import TensorDataType
 from nncf.torch.quantization.layers import BaseWeightsDecompressor
@@ -748,3 +750,39 @@ class TestFXTemplateWeightCompression(TemplateWeightCompression):
     @pytest.mark.skip("RoPE pattern is invalid for the TorchFX backend, ticket 183208")
     def test_rope_weight_compression():
         pass
+
+
+@dataclass
+class ParamIgnoredScope:
+    name: str
+    ignored_scope: IgnoredScope
+    ref: int
+
+    def __str__(self):
+        return self.name
+
+
+@pytest.mark.parametrize(
+    "param",
+    (
+        ParamIgnoredScope("empty", IgnoredScope(), 1),
+        ParamIgnoredScope("name_const", IgnoredScope(names=["linear_weight"]), 0),
+        ParamIgnoredScope("name_op", IgnoredScope(names=["linear"]), 0),
+        ParamIgnoredScope("pattern_const", IgnoredScope(patterns=[".*weight"]), 0),
+        ParamIgnoredScope("pattern_op", IgnoredScope(patterns=["linear*"]), 0),
+    ),
+    ids=str,
+)
+def test_ignored_scope(param: ParamIgnoredScope):
+    example_input = torch.rand(8, 8)
+    model = get_torch_fx_model(LinearModel(), example_input)
+    compressed_model = compress_weights(
+        model,
+        mode=CompressWeightsMode.INT4_SYM,
+        group_size=-1,
+        all_layers=True,
+        ignored_scope=param.ignored_scope,
+    )
+
+    num_int4 = TestFXTemplateWeightCompression.get_num_int4_nodes(compressed_model)
+    assert num_int4 == param.ref


### PR DESCRIPTION
### Changes

Add a check for ignored names to each compressed weight, rather than applying the check only at the operation node level.

### Reason for changes


### Related tickets

https://github.com/openvinotoolkit/nncf/issues/4033

### Tests


[Weight compression](https://github.com/openvinotoolkit/nncf/actions/runs/25424539107) - success

[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/25424551853) - success