### PR TITLE
Add FP8 support for the ONNX backend

### DIFF
--- a/examples/llm_compression/onnx/smollm2_360m_fp8/README.md
+++ b/examples/llm_compression/onnx/smollm2_360m_fp8/README.md
@@ -1,0 +1,34 @@
+# Large Language Models FP8 Compression Example
+
+This example demonstrates how to apply static FP8 quantization to [HuggingFaceTB/SmolLM2-360M-Instruct](https://huggingface.co/HuggingFaceTB/SmolLM2-360M-Instruct) model. It can be useful for evaluation and early HW enablement purposes.
+
+## Prerequisites
+
+Before running this example, ensure you have Python 3.10+ installed and set up your environment:
+
+### 1. Create and activate a virtual environment
+
+```bash
+python3 -m venv nncf_env
+source nncf_env/bin/activate  # On Windows: nncf_env\Scripts\activate.bat
+```
+
+### 2. Install NNCF and other dependencies
+
+```bash
+python3 -m pip install ../../../../ -r requirements.txt
+```
+
+## Run Example
+
+To run example:
+
+```bash
+python main.py
+```
+
+This will automatically:
+
+- Download the SmolLM2 model and dataset
+- Apply weight compression using NNCF
+- Save the optimized model

--- a/examples/llm_compression/onnx/smollm2_360m_fp8/main.py
+++ b/examples/llm_compression/onnx/smollm2_360m_fp8/main.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+from pathlib import Path
+
+import numpy as np
+import onnx
+from datasets import load_dataset
+from optimum.intel.openvino import OVModelForCausalLM
+from optimum.onnxruntime import ORTModelForCausalLM
+from transformers import AutoTokenizer
+
+import nncf
+
+
+def transform_fn(data, tokenizer):
+    tokenized_text = tokenizer(data["text"], return_tensors="np")
+    input_ids = tokenized_text["input_ids"]
+    attention_mask = tokenized_text["attention_mask"]
+
+    inputs = {}
+    inputs["input_ids"] = input_ids
+    inputs["attention_mask"] = tokenized_text["attention_mask"]
+    position_ids = np.cumsum(attention_mask, axis=1) - 1
+    position_ids[attention_mask == 0] = 1
+    inputs["position_ids"] = position_ids
+
+    return inputs
+
+
+def generate_answers(questions, model, tokenizer, max_new_tokens=50):
+    messages = [
+        {"role": "system", "content": "You are a chatbot who always responds as short as possible."},
+        {"role": "user", "content": "What is the capital of Spain?"},
+        {"role": "assistant", "content": "Madrid."},
+    ]
+    answers_by_questions = {}
+    model.request = None
+
+    for question in questions:
+        messages.append({"role": "user", "content": question})
+        input_ids = tokenizer.apply_chat_template(
+            messages, tokenize=True, add_generation_prompt=True, return_tensors="pt"
+        ).to(device=model.device)
+        input_len = len(input_ids[0])
+
+        output = model.generate(input_ids, max_new_tokens=max_new_tokens, do_sample=False)[0]
+        answer = tokenizer.decode(output[input_len:], skip_special_tokens=True)
+        answers_by_questions[question] = answer
+        messages.append({"role": "assistant", "content": answer})
+
+    model.request = None
+    return answers_by_questions
+
+
+def main():
+    ROOT = Path(__file__).parent.resolve()
+    MODEL_ID = "HuggingFaceTB/SmolLM2-360M-Instruct"
+    OUTPUT_DIR = ROOT / "smollm2_360m_compressed"
+
+    dataset = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split="test")
+    # Filtering to remove empty samples from the dataset
+    dataset = dataset.filter(lambda example: len(example["text"]) > 1)
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+    model = ORTModelForCausalLM.from_pretrained(MODEL_ID, export=True, use_cache=False)
+    model.save_pretrained(OUTPUT_DIR)
+
+    questions = [
+        "What is the capital of France?",
+        "What is the highest peak in the Alps?",
+        "What is the largest city in Canada?",
+        "What is the most visited city in Japan?",
+    ]
+
+    answers_by_questions = generate_answers(questions, model, tokenizer)
+    print(f"Non-optimized model outputs:\n{answers_by_questions}\n")
+
+    quantization_dataset = nncf.Dataset(dataset, partial(transform_fn, tokenizer=tokenizer))
+
+    onnx_model = onnx.load(OUTPUT_DIR / "model.onnx", load_external_data=False)
+    target_version = 21
+    if onnx_model.opset_import[0].version != target_version:
+        onnx_model = onnx.version_converter.convert_version(onnx_model, target_version)
+
+    compressed_onnx_model = nncf.quantize(
+        onnx_model,
+        calibration_dataset=quantization_dataset,
+        # Only PERFORMANCE preset supports in combination with FP8 quantization mode
+        preset=nncf.QuantizationPreset.PERFORMANCE,
+        mode=nncf.QuantizationMode.FP8_E4M3,
+        model_type=nncf.ModelType.TRANSFORMER,
+        # SmoothQuant algorithm is not needed for FP8 quantization
+        advanced_parameters=nncf.AdvancedQuantizationParameters(
+            smooth_quant_alphas=nncf.AdvancedSmoothQuantParameters(matmul=-1)
+        ),
+        ignored_scope=nncf.IgnoredScope(
+            names=[
+                "/model/rotary_emb/MatMul",
+                "/model/layers.0/self_attn/MatMul_1",
+                "/model/layers.1/self_attn/MatMul_1",
+                "/model/layers.2/self_attn/MatMul_1",
+                "/model/layers.3/self_attn/MatMul_1",
+                "/model/layers.4/self_attn/MatMul_1",
+                "/model/layers.5/self_attn/MatMul_1",
+                "/model/layers.6/self_attn/MatMul_1",
+                "/model/layers.7/self_attn/MatMul_1",
+                "/model/layers.8/self_attn/MatMul_1",
+                "/model/layers.9/self_attn/MatMul_1",
+                "/model/layers.10/self_attn/MatMul_1",
+                "/model/layers.11/self_attn/MatMul_1",
+                "/model/layers.12/self_attn/MatMul_1",
+                "/model/layers.13/self_attn/MatMul_1",
+                "/model/layers.14/self_attn/MatMul_1",
+                "/model/layers.15/self_attn/MatMul_1",
+                "/model/layers.16/self_attn/MatMul_1",
+                "/model/layers.17/self_attn/MatMul_1",
+                "/model/layers.18/self_attn/MatMul_1",
+                "/model/layers.19/self_attn/MatMul_1",
+                "/model/layers.20/self_attn/MatMul_1",
+                "/model/layers.21/self_attn/MatMul_1",
+                "/model/layers.22/self_attn/MatMul_1",
+                "/model/layers.23/self_attn/MatMul_1",
+                "/model/layers.24/self_attn/MatMul_1",
+                "/model/layers.25/self_attn/MatMul_1",
+                "/model/layers.26/self_attn/MatMul_1",
+                "/model/layers.27/self_attn/MatMul_1",
+                "/model/layers.28/self_attn/MatMul_1",
+                "/model/layers.29/self_attn/MatMul_1",
+                "/model/layers.30/self_attn/MatMul_1",
+                "/model/layers.31/self_attn/MatMul_1",
+            ],
+        ),
+    )
+
+    # Replace the original model with the compressed model.
+    onnx.save(compressed_onnx_model, OUTPUT_DIR / "model.onnx", save_as_external_data=True)
+    tokenizer.save_pretrained(OUTPUT_DIR)
+
+    model = OVModelForCausalLM.from_pretrained(
+        OUTPUT_DIR, ov_config={"INFERENCE_PRECISION_HINT": "f32"}, from_onnx=True, use_cache=False
+    )
+    answers_by_questions = generate_answers(questions, model, tokenizer)
+    print(f"Optimized model outputs:\n{answers_by_questions}\n")
+    return answers_by_questions
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/llm_compression/onnx/smollm2_360m_fp8/requirements.txt
+++ b/examples/llm_compression/onnx/smollm2_360m_fp8/requirements.txt
@@ -1,0 +1,10 @@
+datasets==5.0.0
+openvino==2026.2.0
+optimum-intel[openvino]==2.0.0
+optimum==2.2.0
+optimum-onnx @ git+https://github.com/AlexanderDokuchaev/optimum-onnx.git@b577399d0a6fe748af0ad2c776c7aab3adeec66d
+transformers==4.53.0
+onnx==1.22.0
+onnxruntime==1.23.2; python_version < '3.11'
+onnxruntime==1.24.3; python_version >= '3.11'
+torch==2.10.0

--- a/src/nncf/onnx/graph/model_transformer.py
+++ b/src/nncf/onnx/graph/model_transformer.py
@@ -285,13 +285,17 @@ class ONNXModelTransformer(ModelTransformer[onnx.ModelProto]):
         dims = scale.shape if per_channel else []
         onnx_scale = [scale.tolist()] if not per_channel else scale
         onnx_zero_point = [zero_point.tolist()] if not per_channel else zero_point
+
         if tensor_type == np.uint8:
             onnx_tensor_type = onnx.TensorProto.UINT8
         elif tensor_type == np.int8:
             onnx_tensor_type = onnx.TensorProto.INT8
+        elif tensor_type in (onnx.TensorProto.FLOAT8E5M2, onnx.TensorProto.FLOAT8E4M3FN):
+            onnx_tensor_type = tensor_type
         else:
             msg = f"Incorrect tensor type - {tensor_type}."
             raise nncf.ValidationError(msg)
+
         assert quantizer.input[1] == dequantizer.input[1] and quantizer.input[2] == dequantizer.input[2]
         scale_tensor_name = quantizer.input[1]
         zero_point_tensor_name = quantizer.input[2]

--- a/src/nncf/onnx/quantization/quantize_model.py
+++ b/src/nncf/onnx/quantization/quantize_model.py
@@ -139,13 +139,14 @@ def quantize_impl(
     if target_device == TargetDevice.CPU_SPR:
         msg = "target_device == CPU_SPR is not supported."
         raise nncf.ValidationError(msg)
-    if mode is not None:
-        msg = f"mode={mode} is not supported"
-        raise ValueError(msg)
-    if model.opset_import[0].version < 10:
+
+    opset_version = model.opset_import[0].version
+    if opset_version < 21 and mode is not None:
+        msg = f"FP8 quantization requires opset >= 21, got {opset_version}"
+    if opset_version < 10:
         msg = "ONNX models with opset version < 10 do not support quantization."
         raise nncf.ValidationError(msg)
-    if model.opset_import[0].version < 13:
+    if opset_version < 13:
         nncf_logger.warning(
             "ONNX models with 10 < opset version < 13 do not support per-channel quantization."
             " Per-tensor quantization will be applied."
@@ -163,6 +164,7 @@ def quantize_impl(
     model = apply_preprocess_passes(model)
 
     quantization_algorithm = PostTrainingQuantization(
+        mode=mode,
         preset=preset,
         target_device=target_device,
         subset_size=subset_size,

--- a/src/nncf/onnx/quantization/quantizer_parameters.py
+++ b/src/nncf/onnx/quantization/quantizer_parameters.py
@@ -12,7 +12,10 @@
 from dataclasses import dataclass
 
 import numpy as np
+import onnx
 
+from nncf.quantization.advanced_parameters import FP8Type
+from nncf.quantization.fake_quantize import FakeConvertParameters
 from nncf.quantization.fake_quantize import FakeQuantizeParameters
 from nncf.quantization.fake_quantize import calculate_scale_zero_point
 from nncf.tensor import functions as fns
@@ -31,8 +34,42 @@ class ONNXQuantizerLayerParameters:
 
     scale: np.ndarray
     zero_point: np.ndarray
-    tensor_type: np.dtype
+    tensor_type: onnx.TensorProto.DataType | np.dtype
     axis: int | None = None
+
+
+def convert_fc_params_to_onnx_params(
+    parameters: FakeConvertParameters, axis: int | None
+) -> ONNXQuantizerLayerParameters:
+    """
+    Converts common FakeConvertParameters to ONNXQuantizerLayerParameters.
+
+    :param parameters: FakeConvertParameters representation.
+    :param axis: Axis for per-channel quantization.
+    :return: Quantizer layer attributes.
+    """
+    if parameters.destination_type == FP8Type.E4M3:
+        tensor_type = onnx.TensorProto.FLOAT8E4M3FN
+    elif parameters.destination_type == FP8Type.E5M2:
+        tensor_type = onnx.TensorProto.FLOAT8E5M2
+    else:
+        msg = f"Unsupported FP8type: {parameters.destination_type}. Expected FP8Type.E4M3 or FP8Type.E5M2"
+        raise ValueError(msg)
+
+    scale = parameters.scale
+    zero_point = parameters.shift
+
+    # TODO(andrey-churkin): Check that scale and zero_point are calculated correctly.
+
+    # NOTE: adding machine epsilon to avoid division by zero
+    eps = fns.finfo(scale).eps
+    scale = fns.where(fns.abs(scale) < eps, eps, scale)
+    scale = 1.0 / scale
+    # ONNX demands parameters to be a scalar or 1-D Tensor.
+    scale = fns.squeeze(scale)
+    zero_point = fns.squeeze(zero_point)
+
+    return ONNXQuantizerLayerParameters(scale.data, zero_point.data, tensor_type, axis)
 
 
 def convert_fq_params_to_onnx_params(

--- a/src/nncf/onnx/quantization/quantizer_parameters.py
+++ b/src/nncf/onnx/quantization/quantizer_parameters.py
@@ -59,8 +59,6 @@ def convert_fc_params_to_onnx_params(
     scale = parameters.scale
     zero_point = parameters.shift
 
-    # TODO(andrey-churkin): Check that scale and zero_point are calculated correctly.
-
     # NOTE: adding machine epsilon to avoid division by zero
     eps = fns.finfo(scale).eps
     scale = fns.where(fns.abs(scale) < eps, eps, scale)

--- a/src/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/src/nncf/quantization/algorithms/min_max/algorithm.py
@@ -1030,7 +1030,9 @@ class MinMaxQuantization(Algorithm):
                 )
                 for quantization_target_point in unified_scale_group:
                     transformation_layout.register(
-                        self._backend_entity.create_convert_insertion_command(quantization_target_point, parameters)
+                        self._backend_entity.create_convert_insertion_command(
+                            graph, quantization_target_point, qconfig, parameters
+                        )
                     )
                     unified_ops_list.add(quantization_target_point)
                 continue
@@ -1069,7 +1071,7 @@ class MinMaxQuantization(Algorithm):
                         statistics, is_per_channel=qconfig.per_channel, destination_type=destination_type
                     )
                     command = self._backend_entity.create_convert_insertion_command(
-                        quantization_target_point, parameters
+                        graph, quantization_target_point, qconfig, parameters
                     )
                 else:
                     parameters = calculate_quantizer_parameters(statistics, qconfig, quant_group, half_range)

--- a/src/nncf/quantization/algorithms/min_max/backend.py
+++ b/src/nncf/quantization/algorithms/min_max/backend.py
@@ -198,13 +198,17 @@ class MinMaxAlgoBackend(ABC):
     @staticmethod
     @abstractmethod
     def create_convert_insertion_command(
+        nncf_graph: NNCFGraph,
         target_point: TargetPoint,
+        quantizer_config: QuantizerConfig,
         parameters: FakeConvertParameters,
     ) -> Command:
         """
         Returns backend-specific convert insertion command.
 
+        :param nncf_graph: NNCFGraph to get input/output shapes for the target point.
         :param target_point: Target location for the correction.
+        :param quantizer_config: QuantizerConfig instance for the current layer.
         :param parameters: FakeConvertParameters to calculate activation quantization parameters.
         :return: Backend-specific Command for the quantizer insertion operation.
         """

--- a/src/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/src/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -12,7 +12,6 @@
 
 import numpy as np
 
-import nncf
 from nncf.common.graph.graph import NNCFGraph
 from nncf.common.graph.graph import NNCFNode
 from nncf.common.graph.operator_metatypes import OperatorMetatype
@@ -33,6 +32,7 @@ from nncf.onnx.graph.transformations.commands import ONNXQuantizerInsertionComma
 from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
 from nncf.onnx.hardware.config import ONNXHWConfig
 from nncf.onnx.quantization.default_quantization import DEFAULT_ONNX_QUANT_TRAIT_TO_OP_DICT
+from nncf.onnx.quantization.quantizer_parameters import convert_fc_params_to_onnx_params
 from nncf.onnx.quantization.quantizer_parameters import convert_fq_params_to_onnx_params
 from nncf.parameters import ModelType
 from nncf.parameters import TargetDevice
@@ -158,11 +158,20 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
 
     @staticmethod
     def create_convert_insertion_command(
+        nncf_graph: NNCFGraph,
         target_point: ONNXTargetPoint,
+        quantizer_config: QuantizerConfig,
         parameters: FakeConvertParameters,
     ) -> TransformationCommand:
-        msg = "FakeConvert insertion not implemented in ONNX backend!"
-        raise nncf.InternalError(msg)
+        axis = None
+        if quantizer_config.per_channel:
+            node = nncf_graph.get_node_by_name(target_point.target_node_name)
+            axis = (
+                get_weight_quantization_axis(node, target_point.port_id) if target_point.is_weight_target_point() else 1
+            )
+        onnx_parameters = convert_fc_params_to_onnx_params(parameters, axis)
+        nncf_input_node_next_nodes = ONNXMinMaxAlgoBackend._get_input_edges_mapping(nncf_graph)
+        return ONNXQuantizerInsertionCommand(target_point, nncf_input_node_next_nodes, onnx_parameters)
 
     @staticmethod
     def _get_input_edges_mapping(nncf_graph: NNCFGraph):

--- a/src/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/src/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -170,6 +170,8 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
                 get_weight_quantization_axis(node, target_point.port_id) if target_point.is_weight_target_point() else 1
             )
         onnx_parameters = convert_fc_params_to_onnx_params(parameters, axis)
+        # TODO(andrey-churkin): Investigate why the nncf_input_node_next_nodes parameter is passed directly to the
+        # command rather than being created within ModelTransformer, as it is for the OpenVINO backend.
         nncf_input_node_next_nodes = ONNXMinMaxAlgoBackend._get_input_edges_mapping(nncf_graph)
         return ONNXQuantizerInsertionCommand(target_point, nncf_input_node_next_nodes, onnx_parameters)
 

--- a/src/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/src/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -136,7 +136,9 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
 
     @staticmethod
     def create_convert_insertion_command(
+        nncf_graph: NNCFGraph,
         target_point: OVTargetPoint,
+        quantizer_config: QuantizerConfig,
         parameters: FakeConvertParameters,
     ) -> OVQuantizerInsertionCommand:
         return OVConvertInsertionCommand(target_point, parameters)

--- a/src/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/src/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -149,7 +149,9 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
 
     @staticmethod
     def create_convert_insertion_command(
+        nncf_graph: NNCFGraph,
         target_point: PTTargetPoint,
+        quantizer_config: QuantizerConfig,
         parameters: FakeConvertParameters,
     ) -> TransformationCommand:
         msg = "FakeConvert insertion not implemented in PyTorch backend!"

--- a/src/nncf/quantization/algorithms/min_max/torch_fx_backend.py
+++ b/src/nncf/quantization/algorithms/min_max/torch_fx_backend.py
@@ -137,7 +137,9 @@ class FXMinMaxAlgoBackend(MinMaxAlgoBackend):
 
     @staticmethod
     def create_convert_insertion_command(
+        nncf_graph: NNCFGraph,
         target_point: PTTargetPoint,
+        quantizer_config: QuantizerConfig,
         parameters: FakeConvertParameters,
     ) -> TransformationCommand:
         msg = "FakeConvert insertion not implemented in PyTorch backend!"

--- a/src/nncf/quantization/algorithms/weight_compression/onnx_backend.py
+++ b/src/nncf/quantization/algorithms/weight_compression/onnx_backend.py
@@ -71,6 +71,7 @@ class ONNXWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
         CompressWeightsMode.INT8_ASYM: onnx.TensorProto.UINT8,
         CompressWeightsMode.INT4_SYM: onnx.TensorProto.INT4,
         CompressWeightsMode.INT4_ASYM: onnx.TensorProto.UINT4,
+        CompressWeightsMode.FP8_E4M3: onnx.TensorProto.FLOAT8E4M3FN,
     }
 
     def __init__(self, model: onnx.ModelProto):
@@ -363,8 +364,14 @@ class ONNXWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                 zero_point = pack_4_bits(zero_point)
 
         # Create initializers for the quantized weights, scale, and zero point
+        if weight_dtype == onnx.TensorProto.FLOAT8E4M3FN:
+            np_dtype = helper.tensor_dtype_to_np_dtype(weight_dtype)
+            vals = onnx.numpy_helper.saturate_cast(np.asarray(quantized_weights), np_dtype).flatten()
+        else:
+            vals = quantized_weights
+
         quantized_weights_initializer = onnx.helper.make_tensor(
-            quantized_weight_name, weight_dtype, orig_shape, quantized_weights.tobytes(), raw=True
+            quantized_weight_name, weight_dtype, orig_shape, vals.tobytes(), raw=True
         )
         scale_initializer = numpy_helper.from_array(
             np.array(scale, dtype=helper.tensor_dtype_to_np_dtype(scale_dtype)), name=scale_name
@@ -374,8 +381,15 @@ class ONNXWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
 
         if zero_point is not None:
             deq_inputs.append(weight_name + "_zero_point")
+
+            if weight_dtype == onnx.TensorProto.FLOAT8E4M3FN:
+                np_dtype = helper.tensor_dtype_to_np_dtype(weight_dtype)
+                vals = onnx.numpy_helper.saturate_cast(np.asarray(zero_point), np_dtype).flatten()
+            else:
+                vals = zero_point
+
             zero_point_initializer = onnx.helper.make_tensor(
-                weight_name + "_zero_point", weight_dtype, orig_zero_point_shape, zero_point.tobytes(), raw=True
+                weight_name + "_zero_point", weight_dtype, orig_zero_point_shape, vals.tobytes(), raw=True
             )
             new_initializers.append(zero_point_initializer)
 

--- a/src/nncf/quantization/algorithms/weight_compression/onnx_backend.py
+++ b/src/nncf/quantization/algorithms/weight_compression/onnx_backend.py
@@ -364,11 +364,10 @@ class ONNXWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                 zero_point = pack_4_bits(zero_point)
 
         # Create initializers for the quantized weights, scale, and zero point
+        vals = quantized_weights
         if weight_dtype == onnx.TensorProto.FLOAT8E4M3FN:
             np_dtype = helper.tensor_dtype_to_np_dtype(weight_dtype)
             vals = onnx.numpy_helper.saturate_cast(np.asarray(quantized_weights), np_dtype).flatten()
-        else:
-            vals = quantized_weights
 
         quantized_weights_initializer = onnx.helper.make_tensor(
             quantized_weight_name, weight_dtype, orig_shape, vals.tobytes(), raw=True
@@ -382,11 +381,10 @@ class ONNXWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
         if zero_point is not None:
             deq_inputs.append(weight_name + "_zero_point")
 
+            vals = zero_point
             if weight_dtype == onnx.TensorProto.FLOAT8E4M3FN:
                 np_dtype = helper.tensor_dtype_to_np_dtype(weight_dtype)
                 vals = onnx.numpy_helper.saturate_cast(np.asarray(zero_point), np_dtype).flatten()
-            else:
-                vals = zero_point
 
             zero_point_initializer = onnx.helper.make_tensor(
                 weight_name + "_zero_point", weight_dtype, orig_zero_point_shape, vals.tobytes(), raw=True

--- a/src/nncf/quantization/quantize_model.py
+++ b/src/nncf/quantization/quantize_model.py
@@ -629,7 +629,6 @@ def compress_weights(
             CompressWeightsMode.NF4,
             CompressWeightsMode.MXFP4,
             CompressWeightsMode.MXFP8_E4M3,
-            CompressWeightsMode.FP8_E4M3,
             CompressWeightsMode.FP4,
             CompressWeightsMode.NVFP4,
             CompressWeightsMode.CODEBOOK,

--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -283,6 +283,19 @@
             ]
         }
     },
+    "fp8_llm_quantization_onnx": {
+        "backend": "onnx",
+        "requirements": "examples/llm_compression/onnx/smollm2_360m_fp8/requirements.txt",
+        "cpu": "Intel(R) Core(TM) i9-10980XE CPU @ 3.00GHz",
+        "accuracy_metrics": {
+            "answers": [
+                "Paris.",
+                "Mont Blanc.",
+                "Toronto.",
+                "Tokyo."
+            ]
+        }
+    },
     "codebook_llm_compression": {
         "backend": "openvino",
         "requirements": "examples/llm_compression/openvino/smollm2_360m_codebook/requirements.txt",

--- a/tests/cross_fw/examples/run_example.py
+++ b/tests/cross_fw/examples/run_example.py
@@ -204,6 +204,14 @@ def fp8_llm_quantization() -> dict[str, float]:
     return {"answers": list(result.values())}
 
 
+def fp8_llm_quantization_onnx() -> dict[str, float]:
+    from examples.llm_compression.onnx.smollm2_360m_fp8.main import main as fp8_llm_quantization_main
+
+    result = fp8_llm_quantization_main()
+
+    return {"answers": list(result.values())}
+
+
 def codebook_llm_compression() -> list[str]:
     from examples.llm_compression.openvino.smollm2_360m_codebook.main import main as codebook_llm_compression_main
 

--- a/tests/cross_fw/examples/test_durations.json
+++ b/tests/cross_fw/examples/test_durations.json
@@ -2,6 +2,7 @@
     "tests/cross_fw/examples/test_examples.py::test_examples[adaptive_codebook_llm_compression]": 512,
     "tests/cross_fw/examples/test_examples.py::test_examples[codebook_llm_compression]": 184,
     "tests/cross_fw/examples/test_examples.py::test_examples[fp8_llm_quantization]": 229,
+    "tests/cross_fw/examples/test_examples.py::test_examples[fp8_llm_quantization_onnx]": 532,
     "tests/cross_fw/examples/test_examples.py::test_examples[llm_compression_distillation_qat_with_lora]": 665,
     "tests/cross_fw/examples/test_examples.py::test_examples[llm_compression_fx]": 394,
     "tests/cross_fw/examples/test_examples.py::test_examples[llm_compression_onnx]": 404,

--- a/tests/onnx/quantization/test_qdq_params_calculation.py
+++ b/tests/onnx/quantization/test_qdq_params_calculation.py
@@ -15,8 +15,12 @@ import pytest
 
 from nncf.common.quantization.structs import QuantizationPreset
 from nncf.onnx.graph.onnx_helper import get_tensor_value
+from nncf.onnx.quantization.quantizer_parameters import convert_fc_params_to_onnx_params
 from nncf.quantization.advanced_parameters import AdvancedQuantizationParameters
+from nncf.quantization.advanced_parameters import FP8Type
 from nncf.quantization.advanced_parameters import OverflowFix
+from nncf.quantization.fake_quantize import FakeConvertParameters
+from nncf.tensor import Tensor
 from tests.cross_fw.shared.comparator import compare_stats
 from tests.cross_fw.shared.json import load_json
 from tests.onnx.conftest import ONNX_TEST_ROOT
@@ -113,3 +117,55 @@ def test_scales(model, preset):
 
     ref_nodes_params = load_json(ref_stats_path)
     compare_stats(ref_nodes_params, q_nodes_params)
+
+
+@pytest.mark.parametrize(
+    "scale,shift,destination_type,axis,expected",
+    [
+        (
+            np.array(2, dtype=np.float32),
+            np.array(0, dtype=np.float32),
+            FP8Type.E4M3,
+            None,
+            (np.array(0.5, dtype=np.float32), np.array(0, dtype=np.float32), onnx.TensorProto.FLOAT8E4M3FN),
+        ),
+        (
+            np.array(2, dtype=np.float32),
+            np.array(0, dtype=np.float32),
+            FP8Type.E5M2,
+            None,
+            (np.array(0.5, dtype=np.float32), np.array(0, dtype=np.float32), onnx.TensorProto.FLOAT8E5M2),
+        ),
+        (
+            np.array(0, dtype=np.float32),
+            np.array(0, dtype=np.float32),
+            FP8Type.E5M2,
+            None,
+            (np.array(8388608, dtype=np.float32), np.array(0, dtype=np.float32), onnx.TensorProto.FLOAT8E5M2),
+        ),
+        (
+            np.array([2, 4, 8], dtype=np.float32).reshape(3, 1, 1, 1),
+            np.array([0, 0, 0], dtype=np.float32).reshape(3, 1, 1, 1),
+            FP8Type.E4M3,
+            0,
+            (
+                np.array([0.5, 0.25, 0.125], dtype=np.float32),
+                np.array([0, 0, 0], dtype=np.float32),
+                onnx.TensorProto.FLOAT8E4M3FN,
+            ),
+        ),
+    ],
+)
+def test_convert_fc_params_to_onnx_params(scale, shift, destination_type, axis, expected):
+    fc_params = FakeConvertParameters(Tensor(scale), Tensor(shift), destination_type)
+    onnx_params = convert_fc_params_to_onnx_params(fc_params, axis)
+    expected_scale, expected_zp, expected_type = expected
+
+    assert expected_scale.shape == onnx_params.scale.shape
+    assert np.allclose(expected_scale, onnx_params.scale, atol=1e-5)
+
+    assert expected_zp.shape == onnx_params.zero_point.shape
+    assert np.allclose(expected_zp, onnx_params.zero_point, atol=1e-5)
+
+    assert expected_type == onnx_params.tensor_type
+    assert axis == onnx_params.axis

--- a/tests/onnx/quantization/test_weights_compression.py
+++ b/tests/onnx/quantization/test_weights_compression.py
@@ -52,7 +52,6 @@ UNSUPPORTED_MODES = (
     CompressWeightsMode.NVFP4,
     CompressWeightsMode.MXFP4,
     CompressWeightsMode.MXFP8_E4M3,
-    CompressWeightsMode.FP8_E4M3,
     CompressWeightsMode.FP4,
 )
 


### PR DESCRIPTION
### Changes

- Add support for `nncf.CompressWeightsMode.FP8_E4M3` mode in the `nncf.compress_weights()` method for the ONNX backend.
- Add support for quantization using `nncf.QuantizationMode.FP8_E4M3` and `nncf.QuantizationMode.FP8_E5M2` modes in the `nncf.quantize()` method for the ONNX backend. 
- Add an example `‎examples/llm_compression/onnx/smollm2_360m_fp8`
### Reason for changes

Add support for FP8 quantization and weight compression in the ONNX backend.

### Related tickets

- CVS-180789

### Tests

[Weight compression](https://github.com/openvinotoolkit/nncf/actions/runs/25908094808) - success

[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/28224288278) - success