### PR TITLE
[ci] Avoid fail of "Add Job Link to PR" action

### DIFF
--- a/.github/workflows/helper_add_job_link.yml
+++ b/.github/workflows/helper_add_job_link.yml
@@ -6,7 +6,6 @@ on:
       - "Weight compression"
     types:
       - requested
-      - in_progress
       - completed
 
 permissions:
@@ -44,7 +43,7 @@ jobs:
           echo "Workflow name: $WORKFLOW_NAME"
 
           # 2. Extract the number following 'PR#'
-          PR_NUM=$(echo "$DISPLAY_TITLE" | grep -oP 'PR#\K\d+')
+          PR_NUM=$(echo "$DISPLAY_TITLE" | grep -oP 'PR#\K\d+' || echo "")
 
           if [ -z "$PR_NUM" ]; then
             echo "Could not find PR number in display title '$DISPLAY_TITLE'. Skipping."


### PR DESCRIPTION
### Changes

Remove `in_progress` trigger to limit number of runs (in most cases in_progress imediatrly triggered after requesting).
Fix exit with return code 1 on grep by adding `| echo ""` 

### Reason for changes

Failing jobs if run without set `pr_num`
https://github.com/openvinotoolkit/nncf/actions/runs/26210650427/job/77120477410

### Related tickets


### Tests
