### PR TITLE
Fix for safetensors >=0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "psutil",
     "pydot>=1.4.1, <=3.0.4",
     "rich>=13.5.2",
-    "safetensors>=0.4.1, <8.0.0",
+    "safetensors>=0.4.1, <0.8.0",
     "scikit-learn>=0.24.0",
     "scipy>=1.3.2",
     "tabulate>=0.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "psutil",
     "pydot>=1.4.1, <=3.0.4",
     "rich>=13.5.2",
-    "safetensors>=0.4.1, <0.8.0",
+    "safetensors>=0.4.1",
     "scikit-learn>=0.24.0",
     "scipy>=1.3.2",
     "tabulate>=0.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "psutil",
     "pydot>=1.4.1, <=3.0.4",
     "rich>=13.5.2",
-    "safetensors>=0.4.1",
+    "safetensors>=0.4.1, <8.0.0",
     "scikit-learn>=0.24.0",
     "scipy>=1.3.2",
     "tabulate>=0.9.0",

--- a/src/nncf/tensor/functions/numpy_io.py
+++ b/src/nncf/tensor/functions/numpy_io.py
@@ -34,4 +34,14 @@ def load_file(file_path: str, *, device: TensorDeviceType | None = None) -> dict
 @io.save_file.register
 def _(data: dict[str, T_NUMPY], file_path: Path) -> None:
     fail_if_symlink(file_path)
-    np_save_file(data, file_path)  # type: ignore [arg-type]
+
+    normalized_data: dict[str, T_NUMPY_ARRAY] = {}
+    for key, value in data.items():
+        if isinstance(value, np.generic):
+            # Safetensors >= 0.8.0 requires np.array(scalar) instead of raw NumPy scalars.
+            # Note: This only changes the container type; functional behavior remains identical.
+            normalized_data[key] = np.asarray(value)
+        else:
+            normalized_data[key] = value
+
+    np_save_file(normalized_data, file_path)


### PR DESCRIPTION
### Changes

Convert numpy scalars to array befor save by safetensors
Functional behavior after loading remains identical.

### Reason for changes

Safetensors >= 0.8.0 requires np.array(scalar) instead of raw NumPy scalars.

https://github.com/openvinotoolkit/nncf/actions/runs/27194077393/job/80281175625
```
FAILED tests/openvino/native/quantization/test_weights_compression_statistics_caching.py::test_weight_compression_statistics_caching - AttributeError: 'numpy.float32' object has no attribute 'ctypes'. Did you mean: 'dtype'?
```

### Related tickets

CVS-188352

### Tests


[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/27334546713) - success