### PR TITLE
Bump optimum-intel==2.0.0

### DIFF
--- a/examples/llm_compression/onnx/tiny_llama/requirements.txt
+++ b/examples/llm_compression/onnx/tiny_llama/requirements.txt
@@ -2,7 +2,7 @@ transformers==4.53.0
 openvino==2026.2.0
 optimum-intel[openvino]==1.27.0
 optimum-onnx==0.1.0
-optimum==2.1.0
+optimum==2.2.0
 onnx==1.21.0
 onnxruntime==1.23.2; python_version < '3.11'
 onnxruntime==1.24.3; python_version >= '3.11'

--- a/examples/llm_compression/onnx/tiny_llama/requirements.txt
+++ b/examples/llm_compression/onnx/tiny_llama/requirements.txt
@@ -1,6 +1,6 @@
 transformers==4.53.0
 openvino==2026.2.0
-optimum-intel[openvino]==1.27.0
+optimum-intel[openvino]==2.0.0
 optimum-onnx==0.1.0
 optimum==2.2.0
 onnx==1.21.0

--- a/examples/llm_compression/onnx/tiny_llama/requirements.txt
+++ b/examples/llm_compression/onnx/tiny_llama/requirements.txt
@@ -1,7 +1,6 @@
 transformers==4.53.0
 openvino==2026.2.0
 optimum-intel[openvino]==2.0.0
-optimum-onnx==0.1.0
 optimum==2.2.0
 onnx==1.21.0
 onnxruntime==1.23.2; python_version < '3.11'

--- a/examples/llm_compression/onnx/tiny_llama/requirements.txt
+++ b/examples/llm_compression/onnx/tiny_llama/requirements.txt
@@ -2,6 +2,7 @@ transformers==4.53.0
 openvino==2026.2.0
 optimum-intel[openvino]==2.0.0
 optimum==2.2.0
+optimum-onnx @ git+https://github.com/AlexanderDokuchaev/optimum-onnx.git@b577399d0a6fe748af0ad2c776c7aab3adeec66d
 onnx==1.21.0
 onnxruntime==1.23.2; python_version < '3.11'
 onnxruntime==1.24.3; python_version >= '3.11'

--- a/examples/llm_compression/onnx/tiny_llama_scale_estimation/requirements.txt
+++ b/examples/llm_compression/onnx/tiny_llama_scale_estimation/requirements.txt
@@ -1,7 +1,7 @@
 torch==2.10.0
 transformers==4.53.0
 openvino==2026.2.0
-optimum-intel[openvino]==1.27.0
+optimum-intel[openvino]==2.0.0
 optimum-onnx==0.1.0
 optimum==2.2.0
 onnx==1.21.0

--- a/examples/llm_compression/onnx/tiny_llama_scale_estimation/requirements.txt
+++ b/examples/llm_compression/onnx/tiny_llama_scale_estimation/requirements.txt
@@ -3,7 +3,7 @@ transformers==4.53.0
 openvino==2026.2.0
 optimum-intel[openvino]==1.27.0
 optimum-onnx==0.1.0
-optimum==2.1.0
+optimum==2.2.0
 onnx==1.21.0
 onnxruntime==1.23.2; python_version < '3.11'
 onnxruntime==1.24.3; python_version >= '3.11'

--- a/examples/llm_compression/onnx/tiny_llama_scale_estimation/requirements.txt
+++ b/examples/llm_compression/onnx/tiny_llama_scale_estimation/requirements.txt
@@ -3,6 +3,7 @@ transformers==4.53.0
 openvino==2026.2.0
 optimum-intel[openvino]==2.0.0
 optimum==2.2.0
+optimum-onnx @ git+https://github.com/AlexanderDokuchaev/optimum-onnx.git@b577399d0a6fe748af0ad2c776c7aab3adeec66d
 onnx==1.21.0
 onnxruntime==1.23.2; python_version < '3.11'
 onnxruntime==1.24.3; python_version >= '3.11'

--- a/examples/llm_compression/onnx/tiny_llama_scale_estimation/requirements.txt
+++ b/examples/llm_compression/onnx/tiny_llama_scale_estimation/requirements.txt
@@ -2,7 +2,6 @@ torch==2.10.0
 transformers==4.53.0
 openvino==2026.2.0
 optimum-intel[openvino]==2.0.0
-optimum-onnx==0.1.0
 optimum==2.2.0
 onnx==1.21.0
 onnxruntime==1.23.2; python_version < '3.11'

--- a/examples/llm_compression/openvino/smollm2_360m_adaptive_codebook/requirements.txt
+++ b/examples/llm_compression/openvino/smollm2_360m_adaptive_codebook/requirements.txt
@@ -1,7 +1,6 @@
 datasets==4.6.1
 openvino==2026.2.0
 optimum-intel[openvino]==2.0.0
-optimum-onnx==0.1.0
 optimum==2.2.0
 transformers==4.53.0
 onnx==1.21.0

--- a/examples/llm_compression/openvino/smollm2_360m_adaptive_codebook/requirements.txt
+++ b/examples/llm_compression/openvino/smollm2_360m_adaptive_codebook/requirements.txt
@@ -2,7 +2,7 @@ datasets==4.6.1
 openvino==2026.2.0
 optimum-intel[openvino]==1.27.0
 optimum-onnx==0.1.0
-optimum==2.1.0
+optimum==2.2.0
 transformers==4.53.0
 onnx==1.21.0
 torch==2.10.0

--- a/examples/llm_compression/openvino/smollm2_360m_adaptive_codebook/requirements.txt
+++ b/examples/llm_compression/openvino/smollm2_360m_adaptive_codebook/requirements.txt
@@ -1,6 +1,6 @@
 datasets==4.6.1
 openvino==2026.2.0
-optimum-intel[openvino]==1.27.0
+optimum-intel[openvino]==2.0.0
 optimum-onnx==0.1.0
 optimum==2.2.0
 transformers==4.53.0

--- a/examples/llm_compression/openvino/smollm2_360m_codebook/requirements.txt
+++ b/examples/llm_compression/openvino/smollm2_360m_codebook/requirements.txt
@@ -1,5 +1,5 @@
 openvino==2026.2.0
-optimum-intel[openvino]==1.27.0
+optimum-intel[openvino]==2.0.0
 optimum-onnx==0.1.0
 optimum==2.2.0
 transformers==4.53.0

--- a/examples/llm_compression/openvino/smollm2_360m_codebook/requirements.txt
+++ b/examples/llm_compression/openvino/smollm2_360m_codebook/requirements.txt
@@ -1,6 +1,5 @@
 openvino==2026.2.0
 optimum-intel[openvino]==2.0.0
-optimum-onnx==0.1.0
 optimum==2.2.0
 transformers==4.53.0
 onnx==1.21.0

--- a/examples/llm_compression/openvino/smollm2_360m_codebook/requirements.txt
+++ b/examples/llm_compression/openvino/smollm2_360m_codebook/requirements.txt
@@ -1,7 +1,7 @@
 openvino==2026.2.0
 optimum-intel[openvino]==1.27.0
 optimum-onnx==0.1.0
-optimum==2.1.0
+optimum==2.2.0
 transformers==4.53.0
 onnx==1.21.0
 torch==2.10.0

--- a/examples/llm_compression/openvino/smollm2_360m_fp8/requirements.txt
+++ b/examples/llm_compression/openvino/smollm2_360m_fp8/requirements.txt
@@ -1,7 +1,6 @@
 datasets==4.6.1
 openvino==2026.2.0
 optimum-intel[openvino]==2.0.0
-optimum-onnx==0.1.0
 optimum==2.2.0
 transformers==4.53.0
 onnx==1.21.0

--- a/examples/llm_compression/openvino/smollm2_360m_fp8/requirements.txt
+++ b/examples/llm_compression/openvino/smollm2_360m_fp8/requirements.txt
@@ -2,7 +2,7 @@ datasets==4.6.1
 openvino==2026.2.0
 optimum-intel[openvino]==1.27.0
 optimum-onnx==0.1.0
-optimum==2.1.0
+optimum==2.2.0
 transformers==4.53.0
 onnx==1.21.0
 torch==2.10.0

--- a/examples/llm_compression/openvino/smollm2_360m_fp8/requirements.txt
+++ b/examples/llm_compression/openvino/smollm2_360m_fp8/requirements.txt
@@ -1,6 +1,6 @@
 datasets==4.6.1
 openvino==2026.2.0
-optimum-intel[openvino]==1.27.0
+optimum-intel[openvino]==2.0.0
 optimum-onnx==0.1.0
 optimum==2.2.0
 transformers==4.53.0

--- a/examples/llm_compression/openvino/tiny_llama/requirements.txt
+++ b/examples/llm_compression/openvino/tiny_llama/requirements.txt
@@ -1,7 +1,7 @@
 datasets==4.6.1
 onnx==1.21.0
 openvino==2026.2.0
-optimum-intel[openvino]==1.27.0
+optimum-intel[openvino]==2.0.0
 optimum-onnx==0.1.0
 optimum==2.2.0
 torch==2.10.0

--- a/examples/llm_compression/openvino/tiny_llama/requirements.txt
+++ b/examples/llm_compression/openvino/tiny_llama/requirements.txt
@@ -3,6 +3,6 @@ onnx==1.21.0
 openvino==2026.2.0
 optimum-intel[openvino]==1.27.0
 optimum-onnx==0.1.0
-optimum==2.1.0
+optimum==2.2.0
 torch==2.10.0
 transformers==4.53.0

--- a/examples/llm_compression/openvino/tiny_llama/requirements.txt
+++ b/examples/llm_compression/openvino/tiny_llama/requirements.txt
@@ -2,7 +2,6 @@ datasets==4.6.1
 onnx==1.21.0
 openvino==2026.2.0
 optimum-intel[openvino]==2.0.0
-optimum-onnx==0.1.0
 optimum==2.2.0
 torch==2.10.0
 transformers==4.53.0

--- a/examples/llm_compression/openvino/tiny_llama_find_hyperparams/requirements.txt
+++ b/examples/llm_compression/openvino/tiny_llama_find_hyperparams/requirements.txt
@@ -1,7 +1,7 @@
 whowhatbench @ git+https://github.com/AlexanderDokuchaev/openvino.genai@light_req#subdirectory=tools/who_what_benchmark
 numpy==1.26.4
 openvino==2026.2.0
-optimum-intel==1.27.0
+optimum-intel==2.0.0
 optimum-onnx==0.1.0
 optimum==2.1.0
 transformers==4.53.0

--- a/examples/llm_compression/openvino/tiny_llama_find_hyperparams/requirements.txt
+++ b/examples/llm_compression/openvino/tiny_llama_find_hyperparams/requirements.txt
@@ -2,7 +2,6 @@ whowhatbench @ git+https://github.com/AlexanderDokuchaev/openvino.genai@light_re
 numpy==1.26.4
 openvino==2026.2.0
 optimum-intel==2.0.0
-optimum-onnx==0.1.0
 optimum==2.2.0
 transformers==4.53.0
 onnx==1.21.0

--- a/examples/llm_compression/openvino/tiny_llama_find_hyperparams/requirements.txt
+++ b/examples/llm_compression/openvino/tiny_llama_find_hyperparams/requirements.txt
@@ -3,7 +3,7 @@ numpy==1.26.4
 openvino==2026.2.0
 optimum-intel==2.0.0
 optimum-onnx==0.1.0
-optimum==2.1.0
+optimum==2.2.0
 transformers==4.53.0
 onnx==1.21.0
 torch==2.10.0

--- a/examples/llm_compression/openvino/tiny_llama_synthetic_data/requirements.txt
+++ b/examples/llm_compression/openvino/tiny_llama_synthetic_data/requirements.txt
@@ -4,6 +4,6 @@ numpy>=1.23.5,<2
 openvino==2026.2.0
 optimum-intel==2.0.0
 optimum-onnx==0.1.0
-optimum==2.1.0
+optimum==2.2.0
 transformers==4.53.0
 onnx==1.21.0

--- a/examples/llm_compression/openvino/tiny_llama_synthetic_data/requirements.txt
+++ b/examples/llm_compression/openvino/tiny_llama_synthetic_data/requirements.txt
@@ -2,7 +2,7 @@ torch==2.10.0
 datasets==4.6.1
 numpy>=1.23.5,<2
 openvino==2026.2.0
-optimum-intel==1.27.0
+optimum-intel==2.0.0
 optimum-onnx==0.1.0
 optimum==2.1.0
 transformers==4.53.0

--- a/examples/llm_compression/openvino/tiny_llama_synthetic_data/requirements.txt
+++ b/examples/llm_compression/openvino/tiny_llama_synthetic_data/requirements.txt
@@ -3,7 +3,6 @@ datasets==4.6.1
 numpy>=1.23.5,<2
 openvino==2026.2.0
 optimum-intel==2.0.0
-optimum-onnx==0.1.0
 optimum==2.2.0
 transformers==4.53.0
 onnx==1.21.0

--- a/examples/llm_compression/torch/distillation_qat_with_lora/requirements.txt
+++ b/examples/llm_compression/torch/distillation_qat_with_lora/requirements.txt
@@ -4,7 +4,6 @@ torchao==0.17.0
 numpy>=1.23.5,<2
 openvino==2026.2.0
 optimum-intel==2.0.0
-optimum-onnx==0.1.0
 optimum==2.2.0
 transformers==4.53.0
 lm_eval==0.4.8

--- a/examples/llm_compression/torch/distillation_qat_with_lora/requirements.txt
+++ b/examples/llm_compression/torch/distillation_qat_with_lora/requirements.txt
@@ -5,6 +5,6 @@ numpy>=1.23.5,<2
 openvino==2026.2.0
 optimum-intel==2.0.0
 optimum-onnx==0.1.0
-optimum==2.1.0
+optimum==2.2.0
 transformers==4.53.0
 lm_eval==0.4.8

--- a/examples/llm_compression/torch/distillation_qat_with_lora/requirements.txt
+++ b/examples/llm_compression/torch/distillation_qat_with_lora/requirements.txt
@@ -3,7 +3,7 @@ torch==2.10.0
 torchao==0.17.0
 numpy>=1.23.5,<2
 openvino==2026.2.0
-optimum-intel==1.27.0
+optimum-intel==2.0.0
 optimum-onnx==0.1.0
 optimum==2.1.0
 transformers==4.53.0

--- a/examples/llm_compression/torch/downstream_qat_with_nls/requirements.txt
+++ b/examples/llm_compression/torch/downstream_qat_with_nls/requirements.txt
@@ -3,7 +3,6 @@ torch==2.10.0
 numpy>=1.23.5,<2
 openvino==2026.2.0
 optimum-intel==2.0.0
-optimum-onnx==0.1.0
 optimum==2.2.0
 transformers==4.53.0
 lm_eval==0.4.8

--- a/examples/llm_compression/torch/downstream_qat_with_nls/requirements.txt
+++ b/examples/llm_compression/torch/downstream_qat_with_nls/requirements.txt
@@ -2,7 +2,7 @@ tensorboard==2.20.0
 torch==2.10.0
 numpy>=1.23.5,<2
 openvino==2026.2.0
-optimum-intel==1.27.0
+optimum-intel==2.0.0
 optimum-onnx==0.1.0
 optimum==2.1.0
 transformers==4.53.0

--- a/examples/llm_compression/torch/downstream_qat_with_nls/requirements.txt
+++ b/examples/llm_compression/torch/downstream_qat_with_nls/requirements.txt
@@ -4,7 +4,7 @@ numpy>=1.23.5,<2
 openvino==2026.2.0
 optimum-intel==2.0.0
 optimum-onnx==0.1.0
-optimum==2.1.0
+optimum==2.2.0
 transformers==4.53.0
 lm_eval==0.4.8
 torchao==0.17.0

--- a/examples/llm_compression/torch_fx/tiny_llama/requirements.txt
+++ b/examples/llm_compression/torch_fx/tiny_llama/requirements.txt
@@ -1,7 +1,7 @@
 transformers==4.53.0
 datasets==4.6.1
 openvino==2026.2.0
-optimum==2.1.0
+optimum==2.2.0
 torch==2.10.0
 torchvision==0.25.0
 torchao==0.17.0

--- a/tests/openvino/requirements.txt
+++ b/tests/openvino/requirements.txt
@@ -16,6 +16,6 @@ timm==0.9.2
 efficientnet_pytorch==0.7.1
 datasets
 transformers==4.53.0
-optimum-intel==1.27.0
+optimum-intel==2.0.0
 optimum-onnx==0.1.0
 optimum==2.1.0

--- a/tests/openvino/requirements.txt
+++ b/tests/openvino/requirements.txt
@@ -17,5 +17,4 @@ efficientnet_pytorch==0.7.1
 datasets
 transformers==4.53.0
 optimum-intel==2.0.0
-optimum-onnx==0.1.0
 optimum==2.2.0

--- a/tests/openvino/requirements.txt
+++ b/tests/openvino/requirements.txt
@@ -18,4 +18,4 @@ datasets
 transformers==4.53.0
 optimum-intel==2.0.0
 optimum-onnx==0.1.0
-optimum==2.1.0
+optimum==2.2.0

--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -17,7 +17,6 @@ pytest-split
 librosa==0.10.0
 memory-profiler==0.61.0
 optimum-intel==2.0.0
-optimum-onnx==0.1.0
 optimum==2.2.0
 scikit-learn>=1.2.2,<=1.5.0
 soundfile==0.12.1

--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -16,7 +16,7 @@ pytest-split
 
 librosa==0.10.0
 memory-profiler==0.61.0
-optimum-intel==1.27.0
+optimum-intel==2.0.0
 optimum-onnx==0.1.0
 optimum==2.1.0
 scikit-learn>=1.2.2,<=1.5.0

--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -18,7 +18,7 @@ librosa==0.10.0
 memory-profiler==0.61.0
 optimum-intel==2.0.0
 optimum-onnx==0.1.0
-optimum==2.1.0
+optimum==2.2.0
 scikit-learn>=1.2.2,<=1.5.0
 soundfile==0.12.1
 tensorboard==2.20.0

--- a/tests/post_training/requirements.txt
+++ b/tests/post_training/requirements.txt
@@ -18,6 +18,7 @@ librosa==0.10.0
 memory-profiler==0.61.0
 optimum-intel==2.0.0
 optimum==2.2.0
+optimum-onnx @ git+https://github.com/AlexanderDokuchaev/optimum-onnx.git@b577399d0a6fe748af0ad2c776c7aab3adeec66d
 scikit-learn>=1.2.2,<=1.5.0
 soundfile==0.12.1
 tensorboard==2.20.0

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -18,7 +18,6 @@ transformers==4.53.0
 
 sentence-transformers==4.1.0
 optimum-intel==2.0.0
-optimum-onnx==0.1.0
 optimum==2.2.0
 accelerate==1.9.0
 fastdownload==0.0.7

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -17,7 +17,7 @@ efficientnet_pytorch==0.7.1
 transformers==4.53.0
 
 sentence-transformers==4.1.0
-optimum-intel==1.27.0
+optimum-intel==2.0.0
 optimum-onnx==0.1.0
 optimum==2.1.0
 accelerate==1.9.0

--- a/tests/torch/requirements.txt
+++ b/tests/torch/requirements.txt
@@ -19,6 +19,6 @@ transformers==4.53.0
 sentence-transformers==4.1.0
 optimum-intel==2.0.0
 optimum-onnx==0.1.0
-optimum==2.1.0
+optimum==2.2.0
 accelerate==1.9.0
 fastdownload==0.0.7


### PR DESCRIPTION
### Changes

- Bump `optimum==2.2.0`
- Bump `optimum-intel==2.0.0`
- Use [fork](https://github.com/AlexanderDokuchaev/optimum-onnx/commit/b577399d0a6fe748af0ad2c776c7aab3adeec66d) of `optimum-onnx` to avoid dependence conflicts 

### Reason for changes


### Related tickets


### Tests

[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/27282017490) - success
[Weight compression](https://github.com/openvinotoolkit/nncf/actions/runs/27280794218) - success
PTQ-869