### PR TITLE
[Example] [TorchFX] Fix TorchFX Example for Transformers Version Upgrade

### DIFF
--- a/examples/llm_compression/torch_fx/tiny_llama/main.py
+++ b/examples/llm_compression/torch_fx/tiny_llama/main.py
@@ -72,6 +72,8 @@ def main() -> str:
         input_ids = tokenizer.apply_chat_template(
             messages, tokenize=True, add_generation_prompt=True, return_tensors="pt"
         )
+        if not isinstance(input_ids, torch.Tensor):
+            input_ids = input_ids["input_ids"]
 
         print("Warmup...")
         output = compressed_model_hf.generate(input_ids)

--- a/examples/llm_compression/torch_fx/tiny_llama/modelling.py
+++ b/examples/llm_compression/torch_fx/tiny_llama/modelling.py
@@ -17,7 +17,6 @@ from transformers import GenerationConfig
 from transformers import GenerationMixin
 from transformers import PretrainedConfig
 from transformers import PreTrainedModel
-from transformers.cache_utils import StaticCacheConfig
 from transformers.integrations.executorch import TorchExportableModuleWithStaticCache
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.models.llama.configuration_llama import LlamaConfig
@@ -97,8 +96,9 @@ def convert_and_export_with_cache(model: PreTrainedModel) -> tuple[ExportedProgr
     example_cache_position = torch.arange(0, 8, dtype=torch.long)
     model_config = None
     gen_config = None
+    model.generation_config.use_cache = True
     model.generation_config.cache_implementation = "static"
-    model.generation_config.cache_config = StaticCacheConfig(batch_size=1, max_cache_len=512)
+    model.generation_config.cache_config = {"batch_size": 1, "max_cache_len": 512}
     model.generation_config.max_new_tokens = 100
     gen_config = model.generation_config
     model_config = model.config

--- a/examples/llm_compression/torch_fx/tiny_llama/requirements.txt
+++ b/examples/llm_compression/torch_fx/tiny_llama/requirements.txt
@@ -1,4 +1,4 @@
-transformers==4.53.0
+transformers==5.0.0rc3
 datasets==5.0.0
 openvino==2026.2.0
 optimum==2.2.0


### PR DESCRIPTION
### Changes

Remove static cache object from the torch fx example. 

### Reason for changes

Transformers 5.0.0 doesn't have static cache object but instead expects a dict.

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->

[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/27675116515) - success