### PR TITLE
[Bug Fix] Fix Aggregator For HAWQ Sensitivity Metric

### DIFF
--- a/src/nncf/common/tensor_statistics/collectors.py
+++ b/src/nncf/common/tensor_statistics/collectors.py
@@ -928,8 +928,6 @@ class HAWQAggregator(AggregatorBase):
 
     def _register_reduced_input_impl(self, x: Tensor) -> None:
         trace = fns.sum(fns.multiply(x, x))
-        # NOTE: average trace?? divide by number of diagonal elements
-        # TODO(dlyakhov): revise this formula as possibly it is with an error; adopted from previous HAWQ implementation
         # We normalize the trace by the number of elements in the tensor so that larger matrices do not dominate
         # the sensitivity scores
         self._container += trace / x.size

--- a/src/nncf/common/tensor_statistics/collectors.py
+++ b/src/nncf/common/tensor_statistics/collectors.py
@@ -934,6 +934,10 @@ class HAWQAggregator(AggregatorBase):
         # the sensitivity scores
         self._container += trace / x.size
 
+    def reset(self) -> None:
+        self._collected_samples = 0
+        self._container: Tensor = Tensor(0.0)  # type: ignore[assignment]
+
     def _aggregate_impl(self) -> Tensor:
         return self._container * 2 / self._collected_samples
 

--- a/src/nncf/common/tensor_statistics/collectors.py
+++ b/src/nncf/common/tensor_statistics/collectors.py
@@ -930,7 +930,9 @@ class HAWQAggregator(AggregatorBase):
         trace = fns.sum(fns.multiply(x, x))
         # NOTE: average trace?? divide by number of diagonal elements
         # TODO(dlyakhov): revise this formula as possibly it is with an error; adopted from previous HAWQ implementation
-        self._container = (self._container + trace) / x.size
+        # We normalize the trace by the number of elements in the tensor so that larger matrices do not dominate
+        # the sensitivity scores
+        self._container += trace / x.size
 
     def _aggregate_impl(self) -> Tensor:
         return self._container * 2 / self._collected_samples

--- a/src/nncf/common/tensor_statistics/collectors.py
+++ b/src/nncf/common/tensor_statistics/collectors.py
@@ -936,7 +936,7 @@ class HAWQAggregator(AggregatorBase):
 
     def reset(self) -> None:
         self._collected_samples = 0
-        self._container: Tensor = Tensor(0.0)  # type: ignore[assignment]
+        self._container = Tensor(0.0)
 
     def _aggregate_impl(self) -> Tensor:
         return self._container * 2 / self._collected_samples

--- a/tests/common/test_reducers_and_aggregators.py
+++ b/tests/common/test_reducers_and_aggregators.py
@@ -714,8 +714,8 @@ class TemplateTestReducersAggregators:
 
     HAWQ_AGGREGATOR_REFERENCE_VALUES = [
         ([np.arange(10)], 57.0),
-        ([np.arange(12).reshape((2, 6)), np.arange(24).reshape((4, 6))], 181.92361111111111),
-        ([np.arange(8 * i).reshape((1, 8, i)) for i in range(1, 5)], 165.61627197265625),
+        ([np.arange(12).reshape((2, 6)), np.arange(24).reshape((4, 6))], 222.33333333333331),
+        ([np.arange(8 * i).reshape((1, 8, i)) for i in range(1, 5)], 300.3333333333333),
     ]
 
     @pytest.mark.parametrize("inputs,reference_output", HAWQ_AGGREGATOR_REFERENCE_VALUES)


### PR DESCRIPTION
### Changes

Change the formula for HAWQ aggregator

### Reason for changes

Possibly not the right method.

### Related tickets

186588

### Tests
**Ratio: 0.5; INT4_ASYM; GS128**

| Model         | Variant | Strict | Flexible | Size      |
|---------------|---------|--------|----------|-----------|
| Qwen3-8B      | buggy   | 84.91% | 85.22%   | 6.665 GB  |
| Qwen3-8B      | fixed   | 85.82% | 86.28%   | 6.663 GB  |
| Qwen3-0.6B    | buggy   | 29.57% | 29.64%   | 0.500 GB  |
| Qwen3-0.6B    | fixed   | 31.84% | 31.84%   | 0.500 GB  |
| Llama-3.1-8B  | buggy   | 72.10% | 73.09%   | 6.503 GB  |
| Llama-3.1-8B  | fixed   | 72.63% | 73.46%   | 6.503 GB  |
| Llama-3.2-3B  | buggy   | 57.62% | 63.61%   | 2.594 GB  |
| Llama-3.2-3B  | fixed   | 57.62% | 63.61%   | 2.594 GB  |
| Gemma4-E4B    | buggy   | 61.79% | 60.96%   | 6.650 GB  |
| Gemma4-E4B    | fixed   | 61.94% | 61.18%   | 6.650 GB  |
