### PR TITLE
Bump numpy to <2.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 dependencies = [
     "networkx>=2.6, <=3.6.1",
     "ninja>=1.10.0.post2, <1.14",
-    "numpy>=1.24.0, <2.5.0",
+    "numpy>=1.24.0, <2.6.0",
     "openvino-telemetry>=2023.2.0",
     "packaging>=20.0",
     "psutil",

--- a/src/nncf/tensor/functions/numpy_io.py
+++ b/src/nncf/tensor/functions/numpy_io.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from numpy.typing import NDArray
 from safetensors.numpy import load_file as np_load_file
 from safetensors.numpy import save_file as np_save_file
 
@@ -22,7 +21,7 @@ from nncf.tensor.definitions import TensorDeviceType
 from nncf.tensor.functions import io as io
 from nncf.tensor.functions.numpy_numeric import validate_device
 
-T_NUMPY_ARRAY = NDArray[Any]
+T_NUMPY_ARRAY = np.ndarray[Any, np.dtype[Any]]
 T_NUMPY = T_NUMPY_ARRAY | np.generic  # type: ignore[type-arg]
 
 

--- a/src/nncf/tensor/functions/numpy_linalg.py
+++ b/src/nncf/tensor/functions/numpy_linalg.py
@@ -12,13 +12,12 @@
 from typing import Any, Literal
 
 import numpy as np
-from numpy.typing import NDArray
 from scipy.linalg import lstsq
 
 from nncf.tensor.definitions import T_AXIS
 from nncf.tensor.functions import linalg
 
-T_NUMPY_ARRAY = NDArray[Any]
+T_NUMPY_ARRAY = np.ndarray[Any, np.dtype[Any]]
 
 
 @linalg.norm.register

--- a/src/nncf/tensor/functions/numpy_numeric.py
+++ b/src/nncf/tensor/functions/numpy_numeric.py
@@ -12,7 +12,6 @@
 from typing import Any, Callable, Literal, Sequence
 
 import numpy as np
-from numpy.typing import NDArray
 
 from nncf.tensor.definitions import T_AXIS
 from nncf.tensor.definitions import T_NUMBER
@@ -25,7 +24,7 @@ from nncf.tensor.definitions import TypeInfo
 from nncf.tensor.functions import numeric as numeric
 from nncf.tensor.tensor import TTensor
 
-T_NUMPY_ARRAY = NDArray[Any]
+T_NUMPY_ARRAY = np.ndarray[Any, np.dtype[Any]]
 T_NUMPY = T_NUMPY_ARRAY | np.generic  # type: ignore[type-arg]
 
 DTYPE_MAP: dict[TensorDataType, np.dtype] = {  # type: ignore[type-arg]

--- a/src/nncf/tensor/functions/openvino_numeric.py
+++ b/src/nncf/tensor/functions/openvino_numeric.py
@@ -10,8 +10,8 @@
 # limitations under the License.
 from typing import Any
 
+import numpy as np
 import openvino as ov  # type: ignore
-from numpy.typing import NDArray
 
 from nncf.tensor import Tensor
 from nncf.tensor import TensorDataType
@@ -55,7 +55,7 @@ NATIVE_OV_CAST_DTYPES = [
 DTYPE_MAP_REV = {v: k for k, v in DTYPE_MAP.items()}
 
 
-def from_numpy(a: NDArray[Any]) -> ov.Tensor:
+def from_numpy(a: np.ndarray[Any, np.dtype[Any]]) -> ov.Tensor:
     """
     Convert a numpy array to an OpenVINO tensor.
 
@@ -100,7 +100,7 @@ def _(a: ov.Tensor, shape: int | tuple[int, ...]) -> ov.Tensor:
 
 
 @numeric.as_numpy_tensor.register
-def _(a: ov.Tensor) -> NDArray[Any]:
+def _(a: ov.Tensor) -> np.ndarray[Any, np.dtype[Any]]:
     # Cannot convert bfloat16, uint4, int4, nf4, f4e2m1, f8e8m0, f8e4m3, f8e5m2 to numpy directly
     a_dtype = DTYPE_MAP_REV[a.get_element_type()]
     if a_dtype in NATIVE_OV_CAST_DTYPES:

--- a/src/nncf/tensor/functions/torch_numeric.py
+++ b/src/nncf/tensor/functions/torch_numeric.py
@@ -13,7 +13,6 @@ from typing import Any, Callable, Literal, Sequence
 
 import numpy as np
 import torch
-from numpy.typing import NDArray
 
 from nncf.tensor import TensorDataType
 from nncf.tensor import TensorDeviceType
@@ -536,7 +535,7 @@ def arange(
     return torch.arange(start, end, step, dtype=pt_dtype, device=pt_device)
 
 
-def from_numpy(ndarray: NDArray[Any]) -> torch.Tensor:
+def from_numpy(ndarray: np.ndarray[Any, np.dtype[Any]]) -> torch.Tensor:
     return torch.from_numpy(ndarray)
 
 
@@ -562,7 +561,7 @@ def tensor(
 
 
 @numeric.as_numpy_tensor.register
-def _(a: torch.Tensor) -> NDArray[Any]:
+def _(a: torch.Tensor) -> np.ndarray[Any, np.dtype[Any]]:
     return a.cpu().detach().numpy()
 
 


### PR DESCRIPTION
### Changes

Set `numpy>=1.24.0, <2.6.0` for requarements
Replaced `NDArray` to `np.ndarray[Any, np.dtype[Any]]` 

### Reason for changes

New release of numpy 

### Related tickets

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/35595737581
