### PR TITLE
Add pack int2 functions

### DIFF
--- a/src/nncf/torch/quantization/quantize_functions.py
+++ b/src/nncf/torch/quantization/quantize_functions.py
@@ -471,3 +471,80 @@ def unpack_int4(packed_tensor: torch.Tensor) -> torch.Tensor:
     """
     t = unpack_uint4(packed_tensor)
     return t.type(torch.int8) - 8
+
+
+def pack_uint2(tensor: torch.Tensor) -> torch.Tensor:
+    """
+    Packs a tensor containing uint2 values (in the range [0, 3]) into a tensor with uint8 values,
+    where each element stores four uint2 values.
+
+    :param tensor: A tensor of dtype `torch.uint8` where each element represents a uint2 value.
+        The tensor should contain values in the range [0, 3].
+    :return: A packed tensor of dtype `torch.uint8` where each element packs four uint2 values.
+    """
+    if tensor.dtype != torch.uint8:
+        msg = f"Invalid tensor dtype {tensor.type}. torch.uint8 type is supported."
+        raise ValidationError(msg)
+    if torch.any((tensor < 0) | (tensor > 3)):
+        msg = "Tensor values are not in [0, 3]."
+        raise ValueError(msg)
+    packed_tensor = tensor.contiguous().reshape(-1, 4)
+    packed_tensor = (
+        torch.bitwise_and(packed_tensor[..., 0], 3)
+        | (torch.bitwise_and(packed_tensor[..., 1], 3) << 2)
+        | (torch.bitwise_and(packed_tensor[..., 2], 3) << 4)
+        | (torch.bitwise_and(packed_tensor[..., 3], 3) << 6)
+    )
+    return packed_tensor
+
+
+def unpack_uint2(packed_tensor: torch.Tensor) -> torch.Tensor:
+    """
+    Unpacks a tensor, where each uint8 element stores four uint2 values, back into a tensor with
+    individual uint2 values.
+
+    :param packed_tensor: A tensor of dtype `torch.uint8` where each element packs four uint2 values.
+    :return: A tensor of dtype `torch.uint8` where each element represents a uint2 value.
+    """
+    unpacked_tensor = torch.stack(
+        (
+            torch.bitwise_and(packed_tensor, 3),
+            torch.bitwise_and(torch.bitwise_right_shift(packed_tensor, 2), 3),
+            torch.bitwise_and(torch.bitwise_right_shift(packed_tensor, 4), 3),
+            torch.bitwise_and(torch.bitwise_right_shift(packed_tensor, 6), 3),
+        ),
+        dim=-1,
+    )
+    return unpacked_tensor
+
+
+def pack_int2(tensor: torch.Tensor) -> torch.Tensor:
+    """
+    Packs a tensor containing int2 values (in the range [-2, 1]) into a tensor with uint8 values,
+    where each element stores four int2 values.
+
+    :param tensor: A tensor of dtype `torch.int8` where each element represents an int2 value.
+        The tensor should contain values in the range [-2, 1].
+    :return: A packed tensor of dtype `torch.uint8` where each element packs four int2 values.
+    :raises nncf.errors.ValidationError: If the input tensor is not of type `torch.int8`.
+    """
+    if tensor.dtype != torch.int8:
+        msg = f"Invalid tensor dtype {tensor.type}. torch.int8 type is supported."
+        raise ValidationError(msg)
+    if torch.any((tensor < -2) | (tensor > 1)):
+        msg = "Tensor values are not in [-2, 1]."
+        raise ValueError(msg)
+    tensor = tensor + 2
+    return pack_uint2(tensor.type(torch.uint8))
+
+
+def unpack_int2(packed_tensor: torch.Tensor) -> torch.Tensor:
+    """
+    Unpacks a tensor, where each uint8 element stores four int2 values, back into a tensor with
+    individual int2 values.
+
+    :param packed_tensor: A tensor of dtype `torch.uint8` where each element packs four int2 values.
+    :return: A tensor of dtype `torch.int8` where each element represents an int2 value.
+    """
+    t = unpack_uint2(packed_tensor)
+    return t.type(torch.int8) - 2

--- a/src/nncf/torch/quantization/quantize_functions.py
+++ b/src/nncf/torch/quantization/quantize_functions.py
@@ -419,6 +419,16 @@ def pack_uint4(tensor: torch.Tensor) -> torch.Tensor:
     Packs a tensor containing uint4 values (in the range [0, 15]) into a tensor with uint8 values,
     where each element stores two uint4 values.
 
+    Elements are packed in groups of two into a single uint8 byte. The element with the lower index
+    is stored in the least significant bits, and the element with the higher index in the most
+    significant bits::
+
+        index:     0       1
+        value:  [ 0xA ] [ 0xB ]          (only low 4 bits used)
+
+        bits:    7 6 5 4 | 3 2 1 0
+        byte 0: [  0xB   |  0xA  ]  = 0xBA
+
     :param tensor: A tensor of dtype `torch.uint8` where each element represents a uint4 value.
         The tensor should contain values in the range [0, 15].
     :return: A packed tensor of dtype `torch.uint8` where each element packs two uint4 values.
@@ -449,6 +459,17 @@ def pack_int4(tensor: torch.Tensor) -> torch.Tensor:
     Packs a tensor containing int4 values (in the range [-8, 7]) into a tensor with uint8 values,
     where each element stores two int4 values.
 
+    Each int4 value is first shifted by +8 into the uint4 range [0, 15], then packed in groups of
+    two into a single uint8 byte. The element with the lower index is stored in the least
+    significant bits, and the element with the higher index in the most significant bits::
+
+        index:     0       1
+        value:  [  -8 ] [   7 ]
+        +8:     [   0 ] [  15 ]
+
+        bits:    7 6 5 4 | 3 2 1 0
+        byte 0: [  15    |   0   ]  = 0xF0
+
     :param tensor: A tensor of dtype `torch.int8` where each element represents an int4 value.
         The tensor should contain values in the range [-8, 7].
     :return: A packed tensor of dtype `torch.uint8` where each element packs two int4 values.
@@ -478,9 +499,21 @@ def pack_uint2(tensor: torch.Tensor) -> torch.Tensor:
     Packs a tensor containing uint2 values (in the range [0, 3]) into a tensor with uint8 values,
     where each element stores four uint2 values.
 
+    Elements are packed in groups of four into a single uint8 byte. The element with the lowest
+    index is stored in the least significant bits, and elements with higher indices in
+    progressively more significant bits::
+
+        index:    0     1     2     3
+        value:  [ 1 ] [ 2 ] [ 3 ] [ 0 ]    (only low 2 bits used)
+
+        bits:     7 6 | 5 4 | 3 2 | 1 0
+        byte 0:  [ 0  |  3  |  2  |  1 ]  = 0b00_11_10_01
+
     :param tensor: A tensor of dtype `torch.uint8` where each element represents a uint2 value.
         The tensor should contain values in the range [0, 3].
     :return: A packed tensor of dtype `torch.uint8` where each element packs four uint2 values.
+    :raises nncf.errors.ValidationError: If the input tensor is not of type `torch.uint8`.
+    :raises ValueError: If the tensor values are not in the range [0, 3].
     """
     if tensor.dtype != torch.uint8:
         msg = f"Invalid tensor dtype {tensor.type}. torch.uint8 type is supported."
@@ -523,10 +556,22 @@ def pack_int2(tensor: torch.Tensor) -> torch.Tensor:
     Packs a tensor containing int2 values (in the range [-2, 1]) into a tensor with uint8 values,
     where each element stores four int2 values.
 
+    Each int2 value is first shifted by +2 into the uint2 range [0, 3], then packed in groups of
+    four into a single uint8 byte. The element with the lowest index is stored in the least
+    significant bits, and elements with higher indices in progressively more significant bits::
+
+        index:    0     1     2     3
+        value: [ -2 ] [ -1 ] [ 0 ] [ 1 ]
+        +2:    [  0 ] [  1 ] [ 2 ] [ 3 ]
+
+        bits:    7 6 | 5 4 | 3 2 | 1 0
+        byte 0: [ 3  |  2  |  1  |  0 ]  = 0b11_10_01_00
+
     :param tensor: A tensor of dtype `torch.int8` where each element represents an int2 value.
         The tensor should contain values in the range [-2, 1].
     :return: A packed tensor of dtype `torch.uint8` where each element packs four int2 values.
     :raises nncf.errors.ValidationError: If the input tensor is not of type `torch.int8`.
+    :raises ValueError: If the tensor values are not in the range [-2, 1].
     """
     if tensor.dtype != torch.int8:
         msg = f"Invalid tensor dtype {tensor.type}. torch.int8 type is supported."

--- a/src/nncf/torch/quantization/quantize_functions.py
+++ b/src/nncf/torch/quantization/quantize_functions.py
@@ -432,7 +432,6 @@ def pack_uint4(tensor: torch.Tensor) -> torch.Tensor:
     :param tensor: A tensor of dtype `torch.uint8` where each element represents a uint4 value.
         The tensor should contain values in the range [0, 15].
     :return: A packed tensor of dtype `torch.uint8` where each element packs two uint4 values.
-    :raises nncf.errors.ValidationError: If the input tensor is not of type `torch.uint8`.
     """
     if tensor.dtype != torch.uint8:
         msg = f"Invalid tensor dtype {tensor.dtype}. torch.uint8 type is supported."
@@ -476,7 +475,6 @@ def pack_int4(tensor: torch.Tensor) -> torch.Tensor:
     :param tensor: A tensor of dtype `torch.int8` where each element represents an int4 value.
         The tensor should contain values in the range [-8, 7].
     :return: A packed tensor of dtype `torch.uint8` where each element packs two int4 values.
-    :raises nncf.errors.ValidationError: If the input tensor is not of type `torch.int8`.
     """
     if tensor.dtype != torch.int8:
         msg = f"Invalid tensor dtype {tensor.dtype}. torch.int8 type is supported."
@@ -518,11 +516,9 @@ def pack_uint2(tensor: torch.Tensor) -> torch.Tensor:
     :param tensor: A tensor of dtype `torch.uint8` where each element represents a uint2 value.
         The tensor should contain values in the range [0, 3].
     :return: A packed tensor of dtype `torch.uint8` where each element packs four uint2 values.
-    :raises nncf.errors.ValidationError: If the input tensor is not of type `torch.uint8`.
-    :raises ValueError: If the tensor values are not in the range [0, 3].
     """
     if tensor.dtype != torch.uint8:
-        msg = f"Invalid tensor dtype {tensor.type}. torch.uint8 type is supported."
+        msg = f"Invalid tensor dtype {tensor.dtype}. torch.uint8 type is supported."
         raise ValidationError(msg)
     if torch.any((tensor < 0) | (tensor > 3)):
         msg = "Tensor values are not in [0, 3]."
@@ -576,11 +572,9 @@ def pack_int2(tensor: torch.Tensor) -> torch.Tensor:
     :param tensor: A tensor of dtype `torch.int8` where each element represents an int2 value.
         The tensor should contain values in the range [-2, 1].
     :return: A packed tensor of dtype `torch.uint8` where each element packs four int2 values.
-    :raises nncf.errors.ValidationError: If the input tensor is not of type `torch.int8`.
-    :raises ValueError: If the tensor values are not in the range [-2, 1].
     """
     if tensor.dtype != torch.int8:
-        msg = f"Invalid tensor dtype {tensor.type}. torch.int8 type is supported."
+        msg = f"Invalid tensor dtype {tensor.dtype}. torch.int8 type is supported."
         raise ValidationError(msg)
     if torch.any((tensor < -2) | (tensor > 1)):
         msg = "Tensor values are not in [-2, 1]."

--- a/src/nncf/torch/quantization/quantize_functions.py
+++ b/src/nncf/torch/quantization/quantize_functions.py
@@ -435,8 +435,11 @@ def pack_uint4(tensor: torch.Tensor) -> torch.Tensor:
     :raises nncf.errors.ValidationError: If the input tensor is not of type `torch.uint8`.
     """
     if tensor.dtype != torch.uint8:
-        msg = f"Invalid tensor dtype {tensor.type}. torch.uint8 type is supported."
+        msg = f"Invalid tensor dtype {tensor.dtype}. torch.uint8 type is supported."
         raise ValidationError(msg)
+    if torch.any((tensor < 0) | (tensor > 15)):
+        msg = "Tensor values are not in [0, 15]."
+        raise ValueError(msg)
     packed_tensor = tensor.contiguous()
     packed_tensor = packed_tensor.reshape(-1, 2)
     packed_tensor = torch.bitwise_and(packed_tensor[..., ::2], 15) | packed_tensor[..., 1::2] << 4
@@ -476,8 +479,11 @@ def pack_int4(tensor: torch.Tensor) -> torch.Tensor:
     :raises nncf.errors.ValidationError: If the input tensor is not of type `torch.int8`.
     """
     if tensor.dtype != torch.int8:
-        msg = f"Invalid tensor dtype {tensor.type}. torch.int8 type is supported."
+        msg = f"Invalid tensor dtype {tensor.dtype}. torch.int8 type is supported."
         raise ValidationError(msg)
+    if torch.any((tensor < -8) | (tensor > 7)):
+        msg = "Tensor values are not in [-8, 7]."
+        raise ValueError(msg)
     tensor = tensor + 8
     return pack_uint4(tensor.type(torch.uint8))
 

--- a/tests/torch/function_hook/quantization/test_weights_compression.py
+++ b/tests/torch/function_hook/quantization/test_weights_compression.py
@@ -39,10 +39,6 @@ from nncf.torch.quantization.layers import INT4AsymmetricWeightsDecompressor
 from nncf.torch.quantization.layers import INT4SymmetricWeightsDecompressor
 from nncf.torch.quantization.layers import INT8AsymmetricWeightsDecompressor
 from nncf.torch.quantization.layers import INT8SymmetricWeightsDecompressor
-from nncf.torch.quantization.quantize_functions import pack_int4
-from nncf.torch.quantization.quantize_functions import pack_uint4
-from nncf.torch.quantization.quantize_functions import unpack_int4
-from nncf.torch.quantization.quantize_functions import unpack_uint4
 from tests.cross_fw.test_templates.helpers import RoPEModel
 from tests.cross_fw.test_templates.helpers import SAMPEModel
 from tests.cross_fw.test_templates.template_test_weights_compression import TemplateWeightCompression
@@ -552,24 +548,6 @@ def test_model_devices_and_precisions(use_cuda, dtype):
     assert compressed_model.state_dict()["__nncf_hooks.post_hooks.w__0.0._scale"].dtype == torch.float16
     # Result should be in the precision of the model
     assert result.dtype == dtype
-
-
-def test_pack_uint4():
-    w_uint8 = torch.randint(0, 15, (4, 4), dtype=torch.uint8)
-    packed_w = pack_uint4(w_uint8)
-    assert packed_w.dtype == torch.uint8
-    assert packed_w.numel() * 2 == w_uint8.numel()
-    unpacked_w = unpack_uint4(packed_w).reshape(w_uint8.shape)
-    assert torch.all(unpacked_w == w_uint8)
-
-
-def test_pack_int4():
-    w_int8 = torch.randint(-8, 7, (4, 4), dtype=torch.int8)
-    packed_w = pack_int4(w_int8)
-    assert packed_w.dtype == torch.uint8
-    assert packed_w.numel() * 2 == w_int8.numel()
-    unpacked_w = unpack_int4(packed_w).reshape(w_int8.shape)
-    assert torch.all(unpacked_w == w_int8)
 
 
 class TestPTTemplateWeightCompression(TemplateWeightCompression):

--- a/tests/torch/quantization/test_functions.py
+++ b/tests/torch/quantization/test_functions.py
@@ -880,6 +880,18 @@ def test_pack_invalid_dtype_raises(desc: PackUnpackDesc):
         desc.pack_fn(tensor)
 
 
+@pytest.mark.parametrize("desc", PACK_UNPACK_DESCS, ids=str)
+def test_pack_invalid_value(desc: PackUnpackDesc):
+    tensor = torch.tensor([desc.max_value + 1, 0, 0, 0], dtype=desc.input_dtype)
+    with pytest.raises(ValueError, match=r"Tensor values are not in"):
+        desc.pack_fn(tensor)
+
+    if desc.input_dtype.is_signed:
+        tensor = torch.tensor([desc.min_value - 1, 0, 0, 0], dtype=desc.input_dtype)
+        with pytest.raises(ValueError, match=r"Tensor values are not in"):
+            desc.pack_fn(tensor)
+
+
 def test_pack_uint4_layout():
     tensor = torch.tensor([1, 2, 3, 4], dtype=torch.uint8)
     # Two consecutive values [low, high] are packed into one byte as: low | (high << 4).

--- a/tests/torch/quantization/test_functions.py
+++ b/tests/torch/quantization/test_functions.py
@@ -8,6 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from dataclasses import dataclass
 from typing import Callable
 
 import numpy as np
@@ -18,11 +19,20 @@ from torch.distributions.uniform import Uniform
 
 from nncf.common.quantization.structs import QuantizationScheme as QuantizationMode
 from nncf.common.utils.os import is_windows
+from nncf.errors import ValidationError
 from nncf.torch.quantization.extensions import QuantizedFunctionsCPU
 from nncf.torch.quantization.extensions import QuantizedFunctionsCUDA
 from nncf.torch.quantization.quantize_functions import asymmetric_quantize
 from nncf.torch.quantization.quantize_functions import get_scale_zp_from_input_low_input_high
+from nncf.torch.quantization.quantize_functions import pack_int2
+from nncf.torch.quantization.quantize_functions import pack_int4
+from nncf.torch.quantization.quantize_functions import pack_uint2
+from nncf.torch.quantization.quantize_functions import pack_uint4
 from nncf.torch.quantization.quantize_functions import symmetric_quantize
+from nncf.torch.quantization.quantize_functions import unpack_int2
+from nncf.torch.quantization.quantize_functions import unpack_int4
+from nncf.torch.quantization.quantize_functions import unpack_uint2
+from nncf.torch.quantization.quantize_functions import unpack_uint4
 from nncf.torch.quantization.reference import ReferenceBackendType
 from nncf.torch.quantization.reference import ReferenceQuantize
 from nncf.torch.quantization.reference import ReferenceQuantizedFunctions
@@ -814,3 +824,88 @@ def test_cuda_extension_reference_compatibility(desc):
     assert torch.allclose(bwd_grad_input, ref_grad_input)
     assert torch.allclose(bwd_grad_low, ref_grad_low)
     assert torch.allclose(bwd_grad_range, ref_grad_range, atol=1e-7)
+
+
+@dataclass
+class PackUnpackDesc:
+    name: str
+    pack_fn: Callable[[torch.Tensor], torch.Tensor]
+    unpack_fn: Callable[[torch.Tensor], torch.Tensor]
+    input_dtype: torch.dtype
+    min_value: int
+    max_value: int
+    values_per_byte: int
+    wrong_dtype: torch.dtype
+
+    def __str__(self) -> str:
+        return self.name
+
+
+PACK_UNPACK_DESCS = [
+    PackUnpackDesc("uint4", pack_uint4, unpack_uint4, torch.uint8, 0, 15, 2, torch.int8),
+    PackUnpackDesc("int4", pack_int4, unpack_int4, torch.int8, -8, 7, 2, torch.uint8),
+    PackUnpackDesc("uint2", pack_uint2, unpack_uint2, torch.uint8, 0, 3, 4, torch.int8),
+    PackUnpackDesc("int2", pack_int2, unpack_int2, torch.int8, -2, 1, 4, torch.uint8),
+]
+
+
+@pytest.mark.parametrize("desc", PACK_UNPACK_DESCS, ids=str)
+def test_pack_unpack_round_trip(desc: PackUnpackDesc):
+    # Exhaustively cover every representable value of the range, including the boundaries, tiled into a 2D tensor.
+    values = torch.arange(desc.min_value, desc.max_value + 1, dtype=desc.input_dtype)
+    tensor = values.unsqueeze(0).repeat(8, 1)
+
+    packed = desc.pack_fn(tensor)
+    unpacked = desc.unpack_fn(packed).reshape(tensor.shape)
+
+    assert unpacked.dtype == desc.input_dtype
+    assert torch.equal(unpacked, tensor)
+
+
+@pytest.mark.parametrize("desc", PACK_UNPACK_DESCS, ids=str)
+def test_pack_output_dtype_and_compression_ratio(desc: PackUnpackDesc):
+    values = torch.arange(desc.min_value, desc.max_value + 1, dtype=desc.input_dtype)
+    tensor = values.unsqueeze(0).repeat(8, 1)
+
+    packed = desc.pack_fn(tensor)
+
+    assert packed.dtype == torch.uint8
+    assert packed.numel() * desc.values_per_byte == tensor.numel()
+
+
+@pytest.mark.parametrize("desc", PACK_UNPACK_DESCS, ids=str)
+def test_pack_invalid_dtype_raises(desc: PackUnpackDesc):
+    tensor = torch.zeros(desc.values_per_byte, dtype=desc.wrong_dtype)
+    with pytest.raises(ValidationError, match="Invalid tensor dtype"):
+        desc.pack_fn(tensor)
+
+
+def test_pack_uint4_layout():
+    tensor = torch.tensor([1, 2, 3, 4], dtype=torch.uint8)
+    # Two consecutive values [low, high] are packed into one byte as: low | (high << 4).
+    expected = torch.tensor([1 | (2 << 4), 3 | (4 << 4)], dtype=torch.uint8)  # [33, 67]
+    assert torch.equal(pack_uint4(tensor).flatten(), expected)
+
+
+def test_pack_uint2_layout():
+    tensor = torch.tensor([1, 2, 3, 0, 3, 2, 1, 0], dtype=torch.uint8)
+    # Four consecutive values are packed into one byte as: v0 | v1 << 2 | v2 << 4 | v3 << 6
+    expected = torch.tensor(
+        [1 | (2 << 2) | (3 << 4) | (0 << 6), 3 | (2 << 2) | (1 << 4) | (0 << 6)],  # [57, 27]
+        dtype=torch.uint8,
+    )
+    assert torch.equal(pack_uint2(tensor).flatten(), expected)
+
+
+def test_pack_int4_layout():
+    # Signed values are mapped to the unsigned range with a +8 offset before packing.
+    tensor = torch.tensor([-8, -7, 0, 7], dtype=torch.int8)
+    expected = torch.tensor([(-8 + 8) | ((-7 + 8) << 4), (0 + 8) | ((7 + 8) << 4)], dtype=torch.uint8)  # [16, 248]
+    assert torch.equal(pack_int4(tensor).flatten(), expected)
+
+
+def test_pack_int2_layout():
+    # Signed values are mapped to the unsigned range with a +2 offset before packing.
+    tensor = torch.tensor([-2, -1, 0, 1], dtype=torch.int8)
+    expected = torch.tensor([(-2 + 2) | ((-1 + 2) << 2) | ((0 + 2) << 4) | ((1 + 2) << 6)], dtype=torch.uint8)  # [228]
+    assert torch.equal(pack_int2(tensor).flatten(), expected)


### PR DESCRIPTION
### Changes

Add functions for compression to int2: `pack_uint2`, `pack_int2`, `unpack_uint2`, `unpack_int2`\
Move all tests for int4 compression to corresponding file `tests/torch/quantization/test_functions.py` 

### Reason for changes

### Related tickets

### Tests
