### PR TITLE
Added int2 and int3 symmetric compression types for OV backend.

### DIFF
--- a/src/nncf/parameters.py
+++ b/src/nncf/parameters.py
@@ -104,6 +104,8 @@ class CompressWeightsMode(StrEnum):
     INT8_ASYM = "int8_asym"
     INT4_SYM = "int4_sym"
     INT4_ASYM = "int4_asym"
+    INT3_SYM = "int3_sym"
+    INT2_SYM = "int2_sym"
     NF4 = "nf4"
     CB4 = "cb4"
     MXFP4 = "mxfp4"

--- a/src/nncf/parameters.py
+++ b/src/nncf/parameters.py
@@ -88,6 +88,10 @@ class CompressWeightsMode(StrEnum):
     :param INT4_ASYM: The same as INT4_SYM mode, but weights are quantized to a primary precision asymmetrically
         with a typical non-fixed zero point.
         https://github.com/openvinotoolkit/nncf/blob/develop/docs/usage/training_time_compression/other_algorithms/LegacyQuantization.md#asymmetric-quantization
+    :param INT3_SYM: Stands for a mixed-precision weights quantization with 3-bit integer as a primary precision.
+        Weights are quantized to a primary precision symmetrically without zero point.
+    :param INT2_SYM: Stands for a mixed-precision weights quantization with 2-bit integer as a primary precision.
+        Weights are quantized to a primary precision symmetrically without zero point.
     :param NF4: The the same as INT4_SYM mode, but primary precision is NF4 data type without zero point.
     :param MXFP4: MX-compliant FP4 format with E2M1 values sharing group-level E8M0 scale. The size of group is 32.
     :param MXFP8_E4M3: MX-compliant FP8 format with E4M3 values sharing group-level E8M0 scale. The size of group is 32.

--- a/src/nncf/quantization/algorithms/weight_compression/config.py
+++ b/src/nncf/quantization/algorithms/weight_compression/config.py
@@ -61,14 +61,22 @@ class WeightCompressionConfig:
                 return 8
             return 16
 
-        if self.mode in [
-            CompressWeightsMode.INT8_SYM,
-            CompressWeightsMode.INT8_ASYM,
-            CompressWeightsMode.FP8_E4M3,
-            CompressWeightsMode.MXFP8_E4M3,
-        ]:
-            return 8
-        return 4
+        mode_to_bits_map = {
+            CompressWeightsMode.INT8_ASYM: 8,
+            CompressWeightsMode.INT8_SYM: 8,
+            CompressWeightsMode.INT4_SYM: 4,
+            CompressWeightsMode.INT4_ASYM: 4,
+            CompressWeightsMode.NF4: 4,
+            CompressWeightsMode.FP4: 4,
+            CompressWeightsMode.MXFP4: 4,
+            CompressWeightsMode.NVFP4: 4,
+            CompressWeightsMode.FP8_E4M3: 8,
+            CompressWeightsMode.MXFP8_E4M3: 8,
+            CompressWeightsMode.INT3_SYM: 3,
+            CompressWeightsMode.INT2_SYM: 2,
+        }
+
+        return mode_to_bits_map[self.mode]
 
     @property
     def is_asym_mode(self) -> bool:
@@ -118,6 +126,8 @@ class WeightCompressionConfig:
                 return TensorDataType.uint8
             return TensorDataType.uint16
         dtype_per_mode = {
+            CompressWeightsMode.INT2_SYM: TensorDataType.int2,
+            CompressWeightsMode.INT3_SYM: TensorDataType.int3,
             CompressWeightsMode.INT4_SYM: TensorDataType.int4,
             CompressWeightsMode.INT4_ASYM: TensorDataType.uint4,
             CompressWeightsMode.INT8_ASYM: TensorDataType.uint8,
@@ -130,6 +140,16 @@ class WeightCompressionConfig:
             CompressWeightsMode.MXFP8_E4M3: TensorDataType.f8e4m3,
         }
         return dtype_per_mode[self.mode]
+
+    @property
+    def is_symmetric_represented_by_unsigned(self) -> bool:
+        """
+        True if compression type is symmetric and represented by unsigned integer, else False.
+        """
+        return self.mode in [
+            CompressWeightsMode.INT2_SYM,
+            CompressWeightsMode.INT3_SYM,
+        ]
 
     def __hash__(self) -> int:
         return hash((self.mode.value, self.group_size))

--- a/src/nncf/quantization/algorithms/weight_compression/config.py
+++ b/src/nncf/quantization/algorithms/weight_compression/config.py
@@ -76,7 +76,11 @@ class WeightCompressionConfig:
             CompressWeightsMode.INT2_SYM: 2,
         }
 
-        return mode_to_bits_map[self.mode]
+        try:
+            return mode_to_bits_map[self.mode]
+        except KeyError as e:
+            msg = f"Unsupported compression mode for num_bits: {self.mode}"
+            raise InternalError(msg) from e
 
     @property
     def is_asym_mode(self) -> bool:

--- a/src/nncf/quantization/algorithms/weight_compression/openvino_backend.py
+++ b/src/nncf/quantization/algorithms/weight_compression/openvino_backend.py
@@ -255,6 +255,18 @@ class OVWeightCompressionAlgoBackend(WeightCompressionAlgoBackend):
                 dtype=compression_dtype,
                 name=const_node_name,
             )
+        elif compression_config.is_symmetric_represented_by_unsigned:
+            offset = 2 ** (compression_config.num_bits - 1)
+            compressed_tensor = compressed_weight.tensor + offset
+            compressed_const = create_ov_const_from_tensor(compressed_tensor, compression_dtype, name=const_node_name)
+            converted_const = opset.convert(compressed_const, ov.Type.f16)
+
+            zero_point_const = opset.constant(offset, dtype=ov.Type.i8, name=f"{const_node_name}/zero_point")
+            zero_point_const = opset.convert(zero_point_const, ov.Type.f16)
+
+            converted_const = opset.subtract(
+                converted_const, zero_point_const, name=f"{const_node_name}/zero_point/subtract"
+            )
         else:
             compressed_const = create_ov_const_from_tensor(
                 compressed_weight.tensor, compression_dtype, name=const_node_name

--- a/src/nncf/tensor/definitions.py
+++ b/src/nncf/tensor/definitions.py
@@ -53,6 +53,8 @@ class TensorDataType(StrEnum):
     uint8 = auto()
     uint4 = auto()
     int4 = auto()
+    int3 = auto()
+    int2 = auto()
 
     def is_float(self) -> bool:
         """
@@ -78,6 +80,8 @@ class TensorDataType(StrEnum):
             TensorDataType.nf4: 4,
             TensorDataType.uint4: 4,
             TensorDataType.int4: 4,
+            TensorDataType.int3: 3,
+            TensorDataType.int2: 2,
             TensorDataType.f8e4m3: 8,
             TensorDataType.f8e5m2: 8,
             TensorDataType.int8: 8,

--- a/src/nncf/tensor/functions/openvino_numeric.py
+++ b/src/nncf/tensor/functions/openvino_numeric.py
@@ -22,6 +22,8 @@ from nncf.tensor.functions import numeric
 from nncf.tensor.functions.numpy_numeric import DTYPE_MAP_REV as DTYPE_MAP_REV_NUMPY
 
 DTYPE_MAP: dict[TensorDataType, ov.Type] = {
+    TensorDataType.int2: ov.Type.u2,
+    TensorDataType.int3: ov.Type.u3,
     TensorDataType.nf4: ov.Type.nf4,
     TensorDataType.f4e2m1: ov.Type.f4e2m1,
     TensorDataType.f8e8m0: ov.Type.f8e8m0,
@@ -43,6 +45,8 @@ DTYPE_MAP: dict[TensorDataType, ov.Type] = {
 
 NATIVE_OV_CAST_DTYPES = [
     TensorDataType.bfloat16,
+    TensorDataType.int2,
+    TensorDataType.int3,
     TensorDataType.int4,
     TensorDataType.uint4,
     TensorDataType.nf4,

--- a/tests/cross_fw/test_templates/template_test_nncf_tensor.py
+++ b/tests/cross_fw/test_templates/template_test_nncf_tensor.py
@@ -2155,6 +2155,8 @@ class TemplateTestNNCFTensorOperators:
                 and dtype == TensorDataType.bfloat16
                 or dtype
                 in [
+                    TensorDataType.int2,
+                    TensorDataType.int3,
                     TensorDataType.int4,
                     TensorDataType.uint4,
                     TensorDataType.nf4,
@@ -2189,6 +2191,8 @@ class TemplateTestNNCFTensorOperators:
                 and dtype == TensorDataType.bfloat16
                 or dtype
                 in [
+                    TensorDataType.int2,
+                    TensorDataType.int3,
                     TensorDataType.int4,
                     TensorDataType.uint4,
                     TensorDataType.uint16,

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -1497,6 +1497,8 @@ def test_codebook(codebook, n_layers, dst_type, group_size):
             CompressWeightsMode.INT4_SYM,
             [-8.0, -7.0, -6.0, -5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
         ),
+        (CompressWeightsMode.INT3_SYM, [-4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0]),
+        (CompressWeightsMode.INT2_SYM, [-2.0, -1.0, 0.0, 1.0]),
     ),
 )
 def test_int_compressed_weighs_range(mode, data):
@@ -1660,6 +1662,10 @@ def test_codebook_weights_range(data):
         (WeightCompressionConfig(CompressWeightsMode.INT8_SYM), False, False, False),
         (WeightCompressionConfig(CompressWeightsMode.INT4_SYM), True, False, False),
         (WeightCompressionConfig(CompressWeightsMode.INT4_SYM), False, False, False),
+        (WeightCompressionConfig(CompressWeightsMode.INT3_SYM), True, False, False),
+        (WeightCompressionConfig(CompressWeightsMode.INT3_SYM), False, False, False),
+        (WeightCompressionConfig(CompressWeightsMode.INT2_SYM), True, False, False),
+        (WeightCompressionConfig(CompressWeightsMode.INT2_SYM), False, False, False),
     ],
 )
 def test_int_quantization_with_precomputed_parameters(config, precompute_scale, precompute_zero_point, raises):

--- a/tests/openvino/native/quantization/test_weights_compression.py
+++ b/tests/openvino/native/quantization/test_weights_compression.py
@@ -103,6 +103,7 @@ ALL_SENSITIVITY_METRICS = DATA_BASED_SENSITIVITY_METRICS + (SensitivityMetric.WE
 INT8_MODES = (CompressWeightsMode.INT8_SYM, CompressWeightsMode.INT8_ASYM)
 INT4_NF4_MODES = (CompressWeightsMode.INT4_SYM, CompressWeightsMode.INT4_ASYM, CompressWeightsMode.NF4)
 INT4_MODES = (CompressWeightsMode.INT4_SYM, CompressWeightsMode.INT4_ASYM)
+INT2_3_MODES = (CompressWeightsMode.INT2_SYM, CompressWeightsMode.INT3_SYM)
 
 
 class LMLinearModel(OVReferenceModel):
@@ -908,7 +909,7 @@ def test_raise_error_with_unsupported_params_for_int8(mode, params):
         compress_weights(ov.Model([], []), mode=mode, **params)
 
 
-@pytest.mark.parametrize("mode", INT4_NF4_MODES)
+@pytest.mark.parametrize("mode", INT4_NF4_MODES + INT2_3_MODES)
 @pytest.mark.parametrize(
     "params",
     (
@@ -1023,7 +1024,7 @@ def test_call_max_var_criterion_with_dataset_by_default(mocker, mode):
     scores_spy.assert_called()
 
 
-@pytest.mark.parametrize("mode", INT4_MODES)
+@pytest.mark.parametrize("mode", INT4_MODES + INT2_3_MODES)
 def test_call_max_var_criterion_with_dataset_by_default_awq(mode):
     model = AWQMatmulModel().ov_model
     dataset = Dataset([np.ones([2, 8, 8])])
@@ -1031,7 +1032,7 @@ def test_call_max_var_criterion_with_dataset_by_default_awq(mode):
     compress_weights(model, mode=mode, ratio=1.0, group_size=2, dataset=dataset, awq=True)
 
 
-@pytest.mark.parametrize("mode", INT4_NF4_MODES)
+@pytest.mark.parametrize("mode", INT4_NF4_MODES + INT2_3_MODES)
 def test_call_max_var_criterion_with_dataset_awq_for_compressed_model(mode):
     model = AWQMatmulModel(is_int8=True).ov_model
     dataset = Dataset([np.ones([2, 8, 8])])
@@ -1039,7 +1040,7 @@ def test_call_max_var_criterion_with_dataset_awq_for_compressed_model(mode):
     compress_weights(model, mode=mode, ratio=1.0, group_size=2, dataset=dataset, awq=True)
 
 
-@pytest.mark.parametrize("mode", INT4_NF4_MODES)
+@pytest.mark.parametrize("mode", INT4_NF4_MODES + INT2_3_MODES)
 def test_call_max_var_criterion_with_dataset_awq_neg_group_size(mode):
     model = AWQMatmulModel().ov_model
     dataset = Dataset([np.ones([2, 8, 8])])
@@ -1250,7 +1251,7 @@ def test_call_max_var_criterion_with_dataset_by_default_scale_estimation(mode, c
     assert tzm_spy.call_args_list[0][0][0].dtype == compressed_weight_dtype
 
 
-@pytest.mark.parametrize("mode", INT4_NF4_MODES)
+@pytest.mark.parametrize("mode", INT4_NF4_MODES + INT2_3_MODES)
 def test_call_max_var_criterion_with_dataset_scale_estimation_for_compressed_model(mode):
     model = AWQMatmulModel(is_int8=True).ov_model
     dataset = Dataset([np.ones([1, 8, 8])])
@@ -1258,7 +1259,7 @@ def test_call_max_var_criterion_with_dataset_scale_estimation_for_compressed_mod
     compress_weights(model, mode=mode, ratio=1.0, group_size=2, dataset=dataset, scale_estimation=True)
 
 
-@pytest.mark.parametrize("mode", INT4_NF4_MODES)
+@pytest.mark.parametrize("mode", INT4_NF4_MODES + INT2_3_MODES)
 def test_call_max_var_criterion_with_dataset_scale_estimation_neg_group_size(mode):
     model = AWQMatmulModel().ov_model
     dataset = Dataset([np.ones([1, 8, 8])])
@@ -1266,7 +1267,7 @@ def test_call_max_var_criterion_with_dataset_scale_estimation_neg_group_size(mod
     compress_weights(model, mode=mode, ratio=1.0, group_size=-1, dataset=dataset, scale_estimation=True)
 
 
-@pytest.mark.parametrize("mode", INT4_NF4_MODES)
+@pytest.mark.parametrize("mode", INT4_NF4_MODES + INT2_3_MODES)
 def test_call_gptq(mode):
     model = AWQMatmulModel().ov_model
     dataset = Dataset([np.ones([1, 8, 8])])
@@ -1274,7 +1275,7 @@ def test_call_gptq(mode):
     compress_weights(model, mode=mode, ratio=1.0, group_size=2, dataset=dataset, gptq=True)
 
 
-@pytest.mark.parametrize("mode", INT4_NF4_MODES)
+@pytest.mark.parametrize("mode", INT4_NF4_MODES + INT2_3_MODES)
 def test_call_gptq_with_dataset_scale_estimation_neg_group_size(mode):
     model = AWQMatmulModel().ov_model
     dataset = Dataset([np.ones([1, 8, 8])])


### PR DESCRIPTION
### Changes

<!--- What was changed (briefly), how to reproduce (if applicable), what the reviewers should focus on -->

### Reason for changes

<!--- Why should the change be applied -->

### Related tickets

<!--- Post the numerical ID of the ticket, if available -->

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->
