### PR TITLE
Update OpenVINO version to 2026.2.1 in all requirements files

### DIFF
--- a/examples/quantization_aware_training/torch/anomalib/requirements.txt
+++ b/examples/quantization_aware_training/torch/anomalib/requirements.txt
@@ -1,6 +1,6 @@
 anomalib==2.2.0
 torch==2.10.0
-openvino==2025.3.0
+openvino==2026.2.1
 requests==2.33.0
 matplotlib==3.10.7
 numpy==2.2.6

--- a/tests/executorch/requirements.txt
+++ b/tests/executorch/requirements.txt
@@ -1,5 +1,5 @@
 # Openvino
-openvino==2026.0.0
+openvino==2026.2.1
 
 # Torch
 executorch==1.3.1


### PR DESCRIPTION
### Changes

Update OpenVINO version to 2026.2.1

### Reason for changes

https://github.com/openvinotoolkit/nncf/actions/runs/28832955049

### Related tickets

Out dates version in some requaremets

### Tests

[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/28848657874) - success
