### PR TITLE
[FBC] Support models without the batch dimension

### DIFF
--- a/src/nncf/common/tensor_statistics/builders.py
+++ b/src/nncf/common/tensor_statistics/builders.py
@@ -23,7 +23,7 @@ from nncf.common.tensor_statistics.statistics import RawTensorStatistic
 
 
 def get_mean_statistic_collector(
-    num_samples: int, channel_axis: int, window_size: int | None = None
+    num_samples: int, channel_axis: int, window_size: int | None = None, input_rank: int | None = None
 ) -> TensorCollector:
     """
     Mean statistic collector builder.
@@ -33,11 +33,16 @@ def get_mean_statistic_collector(
     :param window_size: Number of samples from the end of the list of collected samples to aggregate.
         Aggregates all available collected statistics in case parameter is None.
     :param inplace: Whether the mean reducer should be calculated inplace or out of place.
+    :param input_rank: Rank of the input tensor of the target node, if known.
     :return: Mean statistic collector.
     """
     inplace = False
     reducer: TensorReducerBase
-    if channel_axis == 0:
+    if input_rank == 1:
+        # A 1D activation has no batch dimension: its elements are already the per-channel
+        # values, so they are collected as is and averaged across samples by the aggregator.
+        reducer = RawReducer()
+    elif channel_axis == 0:
         reducer = BatchMeanReducer(inplace)
     else:
         reducer = MeanPerChReducer(channel_axis=channel_axis, inplace=inplace)

--- a/src/nncf/openvino/statistics/builders.py
+++ b/src/nncf/openvino/statistics/builders.py
@@ -12,6 +12,7 @@
 
 from nncf.common.tensor_statistics.collectors import MeanAggregator
 from nncf.common.tensor_statistics.collectors import NoopAggregator
+from nncf.common.tensor_statistics.collectors import RawReducer
 from nncf.common.tensor_statistics.collectors import TensorCollector
 from nncf.common.tensor_statistics.statistics import MeanTensorStatistic
 from nncf.openvino.statistics.collectors import OVBatchMeanReducer
@@ -20,7 +21,11 @@ from nncf.openvino.statistics.collectors import OVShapeReducer
 
 
 def get_mean_statistic_collector(
-    num_samples: int, channel_axis: int, window_size: int | None = None, inplace: bool = True
+    num_samples: int,
+    channel_axis: int,
+    window_size: int | None = None,
+    inplace: bool = True,
+    input_rank: int | None = None,
 ) -> TensorCollector:
     """
     Mean statistic collector builder.
@@ -30,9 +35,14 @@ def get_mean_statistic_collector(
     :param window_size: Number of samples from the end of the list of collected samples to aggregate.
         Aggregates all available collected statistics in case parameter is None.
     :param inplace: Whether the mean reducer should be calculated inplace or out of place.
+    :param input_rank: Rank of the input tensor of the target node, if known.
     :return: Mean statistic collector.
     """
-    if channel_axis == 0:
+    if input_rank == 1:
+        # A 1D activation has no batch dimension: its elements are already the per-channel
+        # values, so they are collected as is and averaged across samples by the aggregator.
+        reducer = RawReducer()
+    elif channel_axis == 0:
         reducer = OVBatchMeanReducer(inplace)
     else:
         reducer = OVMeanPerChanelReducer(channel_axis=channel_axis, inplace=inplace)

--- a/src/nncf/quantization/algorithms/fast_bias_correction/algorithm.py
+++ b/src/nncf/quantization/algorithms/fast_bias_correction/algorithm.py
@@ -286,16 +286,19 @@ class FastBiasCorrection(Algorithm):
             output_fp.extend(tensor_collector.get_statistics().mean_values)
         return output_fp
 
-    def _add_statistic_point(self, container: StatisticPointsContainer, point: TargetPoint, axis: int) -> None:
+    def _add_statistic_point(
+        self, container: StatisticPointsContainer, point: TargetPoint, axis: int, input_rank: int | None = None
+    ) -> None:
         """
         Adds specific statistic point.
 
         :param container: StatisticPointsContainer instance.
         :param point: TargetPoint for statistic collection.
         :param axis: Channel axis for the statistics calculation.
+        :param input_rank: Rank of the statistics collection target tensor, if known.
         """
         stat_collector = self._backend_entity.mean_statistic_collector(
-            channel_axis=axis, num_samples=self.subset_size, inplace=self.inplace_statistics
+            channel_axis=axis, num_samples=self.subset_size, inplace=self.inplace_statistics, input_rank=input_rank
         )
         container.add_statistic_point(
             StatisticPoint(target_point=point, tensor_collector=stat_collector, algorithm=self._algorithm_key)
@@ -323,7 +326,9 @@ class FastBiasCorrection(Algorithm):
         engine = EngineFactory.create(model)
         raw_output = engine.infer(input_blob)
         q_outputs = self._backend_entity.process_model_output(raw_output, output_name)
-        q_outputs = mean_per_channel(q_outputs, output_channel_axis)
+        # A 1D output has no batch dimension to reduce: it is already the per-channel data.
+        if q_outputs.ndim > 1:
+            q_outputs = mean_per_channel(q_outputs, output_channel_axis)
         bias_shift = fns.stack(output_fp) - q_outputs
         return bias_shift
 
@@ -346,10 +351,14 @@ class FastBiasCorrection(Algorithm):
             )
             input_shape = graph.get_input_edges(node)[input_port_id].tensor_shape
             input_channel_axis = self._backend_entity.get_activation_channel_axis(node, input_port_id, input_shape)
+            output_edges = graph.get_output_edges_by_port_id(node, output_port_id)
+            output_rank = len(output_edges[0].tensor_shape) if output_edges else None
 
-            self._add_statistic_point(statistic_container, pre_layer_statistic_point, input_channel_axis)
             self._add_statistic_point(
-                statistic_container, post_layer_statistic_point, node.metatype.output_channel_axis
+                statistic_container, pre_layer_statistic_point, input_channel_axis, len(input_shape)
+            )
+            self._add_statistic_point(
+                statistic_container, post_layer_statistic_point, node.metatype.output_channel_axis, output_rank
             )
 
         return statistic_container

--- a/src/nncf/quantization/algorithms/fast_bias_correction/backend.py
+++ b/src/nncf/quantization/algorithms/fast_bias_correction/backend.py
@@ -77,6 +77,7 @@ class FastBiasCorrectionAlgoBackend(ABC):
         inplace: bool,
         num_samples: int | None = None,
         window_size: int | None = None,
+        input_rank: int | None = None,
     ) -> TensorCollector:
         """
         Returns backend-specific mean statistic collector.
@@ -85,6 +86,7 @@ class FastBiasCorrectionAlgoBackend(ABC):
         :param inplace: Whether to calculate statistic inplace or not.
         :param num_samples: Maximum number of samples to collect.
         :param window_size: The maximum size of the samples queue.
+        :param input_rank: Rank of the input tensor of the target node, if known.
         :return: Backend-specific TensorCollector for the statistics calculation.
         """
 

--- a/src/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
+++ b/src/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
@@ -55,8 +55,9 @@ class ONNXFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         inplace: bool,
         num_samples: int | None = None,
         window_size: int | None = None,
+        input_rank: int | None = None,
     ) -> TensorCollector:
-        return get_mean_statistic_collector(num_samples, channel_axis, window_size)
+        return get_mean_statistic_collector(num_samples, channel_axis, window_size, input_rank=input_rank)
 
     @staticmethod
     def get_sub_input_output_names(subgraph: onnx.ModelProto) -> tuple[str, str]:

--- a/src/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
+++ b/src/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
@@ -60,8 +60,9 @@ class OVFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         inplace: bool,
         num_samples: int | None = None,
         window_size: int | None = None,
+        input_rank: int | None = None,
     ) -> TensorCollector:
-        return get_mean_statistic_collector(num_samples, channel_axis, window_size)
+        return get_mean_statistic_collector(num_samples, channel_axis, window_size, input_rank=input_rank)
 
     @staticmethod
     def get_sub_input_output_names(subgraph: ov.Model) -> tuple[str, str]:

--- a/src/nncf/quantization/algorithms/fast_bias_correction/torch_backend.py
+++ b/src/nncf/quantization/algorithms/fast_bias_correction/torch_backend.py
@@ -67,8 +67,9 @@ class PTFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         inplace: bool,
         num_samples: int | None = None,
         window_size: int | None = None,
+        input_rank: int | None = None,
     ) -> TensorCollector:
-        return get_mean_statistic_collector(num_samples, channel_axis, window_size)
+        return get_mean_statistic_collector(num_samples, channel_axis, window_size, input_rank=input_rank)
 
     @staticmethod
     def get_sub_input_output_names(subgraph: nn.Module) -> tuple[str | None, str | None]:

--- a/src/nncf/quantization/algorithms/fast_bias_correction/torch_fx_backend.py
+++ b/src/nncf/quantization/algorithms/fast_bias_correction/torch_fx_backend.py
@@ -56,8 +56,9 @@ class FXFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         inplace: bool,
         num_samples: int | None = None,
         window_size: int | None = None,
+        input_rank: int | None = None,
     ) -> TensorCollector:
-        return get_mean_statistic_collector(num_samples, channel_axis, window_size)
+        return get_mean_statistic_collector(num_samples, channel_axis, window_size, input_rank=input_rank)
 
     @staticmethod
     def get_sub_input_output_names(subgraph: torch.fx.GraphModule) -> tuple[int | None, int]:

--- a/tests/cross_fw/test_templates/test_fast_bias_correction.py
+++ b/tests/cross_fw/test_templates/test_fast_bias_correction.py
@@ -25,6 +25,7 @@ from nncf.quantization.algorithms.post_training.algorithm import PostTrainingQua
 from tests.cross_fw.test_templates.helpers import ConvBNTestModel
 from tests.cross_fw.test_templates.helpers import ConvTestModel
 from tests.cross_fw.test_templates.helpers import FCTestModel
+from tests.cross_fw.test_templates.helpers import OneDimMM
 from tests.cross_fw.test_templates.helpers import get_static_dataset
 
 TModel = TypeVar("TModel")
@@ -121,6 +122,7 @@ class TemplateTestFBCAlgorithm:
             TestCase(ConvTestModel, [0.0288348, 1.0838453]),
             TestCase(ConvBNTestModel, [0.08396978, 1.1676897]),
             TestCase(FCTestModel, [0.9999, 1.9989]),
+            TestCase(OneDimMM, [0.95773065, 1.3218939, 0.81694865]),
         ),
         ids=str,
     )


### PR DESCRIPTION
### Changes

- `get_mean_statistic_collector` (common and OpenVINO builders) accepts an optional `input_rank` argument. For `input_rank == 1` the mean branch uses `RawReducer`, since a 1D activation has no batch dimension and its elements are already the per channel values; the `MeanAggregator` then averages them across samples. The default `None` keeps the current reducer selection for every existing caller.
- `FastBiasCorrection.get_statistic_points` passes the statically known input and output ranks to the collectors, forwarded by `mean_statistic_collector` in all four backends.
- `FastBiasCorrection._get_bias_shift` skips `mean_per_channel` for 1D outputs of the extracted submodel, since they are already per channel data.
- The `OneDimMM` case from #3479 is enabled in the FBC test template, which parametrizes it across the OpenVINO, Torch, Torch FX and ONNX backend tests.

### Reason for changes

FastBiasCorrection crashes for models without the batch dimension. On current develop the crash happens in `_get_fp_outputs` (`TypeError: iteration over a 0-d tensor`), and behind it sits the `IndexError` from the issue in `create_input_data`. The root cause is that the statistics pipeline treats axis 0 as the batch axis, so a 1D activation gets its only axis averaged away and the per channel statistics collapse to a scalar. Selecting the reducer by rank where the collectors are built fixes the statistics at the source and keeps BiasCorrection and all other users of the builders unchanged.

### Related tickets

#3481

### Tests

- `test_update_bias[OneDimMM]` passes on all four backends against the reference biases introduced with #3479
- Full FastBiasCorrection and BiasCorrection suites pass on OpenVINO, Torch, Torch FX and ONNX; BiasCorrection results are unchanged
- tests/common and the statistics collector suites pass; pre-commit checks pass