### PR TITLE
Enhance type alias handling in dispatcher functions

### DIFF
--- a/src/nncf/tensor/functions/dispatcher.py
+++ b/src/nncf/tensor/functions/dispatcher.py
@@ -209,6 +209,10 @@ def _get_register_types(type_alias: Any) -> list[type]:
         """
         Recursively find types.
         """
+        # Resolve PEP 695 type aliases (e.g. numpy.typing.NDArray on NumPy 2.5+) via their `__value__`
+        # attribute; duck typing avoids the distinct `typing` vs `typing_extensions` TypeAliasType classes.
+        if hasattr(t, "__value__"):
+            return _unpack_types(t.__value__)
         origin = get_origin(t)
         if origin is types.UnionType or origin is Union or origin is list or origin is tuple or origin is SequenceABC:
             ret = []

--- a/tests/common/tensor/test_disaptcher.py
+++ b/tests/common/tensor/test_disaptcher.py
@@ -9,9 +9,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import deque
-from typing import Union
+from typing import Any, Union
 
+import numpy as np
 import pytest
+from numpy.typing import NDArray
+
+try:
+    from typing_extensions import TypeAliasType
+except ImportError:
+    from typing import TypeAliasType
 
 from nncf.tensor import Tensor
 from nncf.tensor.functions.dispatcher import _get_arg_type
@@ -79,6 +86,10 @@ def test_get_arg_type(data, ref):
         (list[float | str], [float, str]),
         (dict[str, int], [int]),
         (dict[str, float | int], [float, int]),
+        (NDArray[Any], [np.ndarray]),
+        (NDArray[Any] | np.generic, [np.ndarray, np.generic]),
+        (TypeAliasType("array_alias", np.ndarray), [np.ndarray]),
+        (TypeAliasType("array_alias", np.ndarray | np.generic), [np.ndarray, np.generic]),
     ),
 )
 def test_get_register_types(data, ref):


### PR DESCRIPTION
### Changes

Improves tensor dispatcher to register function with using TypeAliasType in signature.

### Reason for changes

To support numpy 2.5

```
        for key in registry:
>           if issubclass(type_, key):
               ^^^^^^^^^^^^^^^^^^^^^^
E           TypeError: issubclass() arg 2 must be a class, a tuple of classes,or a union
```

`key` is `[NDArray]` instead of `[nd.array]`

### Related tickets

CVS-190904

### Tests
