### PR TITLE
requirements: allow pydot 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "openvino-telemetry>=2023.2.0",
     "packaging>=20.0",
     "psutil",
-    "pydot>=1.4.1, <=3.0.4",
+    "pydot>=1.4.1, <=4.0.1",
     "rich>=13.5.2",
     "safetensors>=0.4.1",
     "scikit-learn>=0.24.0",


### PR DESCRIPTION
NNCF currently caps pydot at 3.0.4, but the graph visualization implementation uses APIs that remain available in pydot 4. This prevents NNCF from resolving with current distributions despite the exercised code path being compatible. This is a Python dependency constraint failure, not a C++ build failure.

NNCF's production use is limited to the Dot, Node, Edge, add_node, and add_edge APIs, all of which retain compatible behavior in 4.0.1. Extend the supported range to pydot 4.