### PR TITLE
[Example] Add TorchAO to GPTQModel Test Requirement

### DIFF
--- a/examples/llm_compression/torch/gptq_model_convertor/requirements.txt
+++ b/examples/llm_compression/torch/gptq_model_convertor/requirements.txt
@@ -1,4 +1,5 @@
 torch==2.9.0
+torchao==0.17.0 # Was installed transitively before https://github.com/openvinotoolkit/nncf/actions/runs/30928990933/job/92221632392
 # TODO(AlexanderDokuchaev): remove transformers next release gptqmodel https://github.com/ModelCloud/GPTQModel/issues/2328
 transformers==4.57.6
 numpy==2.2.6

--- a/examples/llm_compression/torch/gptq_model_convertor/requirements.txt
+++ b/examples/llm_compression/torch/gptq_model_convertor/requirements.txt
@@ -1,5 +1,5 @@
 torch==2.9.0
-torchao==0.17.0 # Was installed transitively before https://github.com/openvinotoolkit/nncf/actions/runs/30928990933/job/92221632392
+torchao==0.17.0
 # TODO(AlexanderDokuchaev): remove transformers next release gptqmodel https://github.com/ModelCloud/GPTQModel/issues/2328
 transformers==4.57.6
 numpy==2.2.6

--- a/examples/llm_compression/torch/gptq_model_convertor/requirements_extra.txt
+++ b/examples/llm_compression/torch/gptq_model_convertor/requirements_extra.txt
@@ -1,5 +1,6 @@
 gptqmodel==5.6.12
 torch==2.9.0
+torchao==0.17.0 # Was installed transitively before https://github.com/openvinotoolkit/nncf/actions/runs/30928990933/job/92221632392
 # TODO(AlexanderDokuchaev): remove transformers next release gptqmodel https://github.com/ModelCloud/GPTQModel/issues/2328
 transformers==4.57.6
 huggingface_hub==0.36.2

--- a/examples/llm_compression/torch/gptq_model_convertor/requirements_extra.txt
+++ b/examples/llm_compression/torch/gptq_model_convertor/requirements_extra.txt
@@ -1,6 +1,6 @@
 gptqmodel==5.6.12
 torch==2.9.0
-torchao==0.17.0 # Was installed transitively before https://github.com/openvinotoolkit/nncf/actions/runs/30928990933/job/92221632392
+torchao==0.17.0
 # TODO(AlexanderDokuchaev): remove transformers next release gptqmodel https://github.com/ModelCloud/GPTQModel/issues/2328
 transformers==4.57.6
 huggingface_hub==0.36.2

--- a/tests/integration/gptq_model/requirements.txt
+++ b/tests/integration/gptq_model/requirements.txt
@@ -1,3 +1,4 @@
 torch==2.9.0
+torchao==0.17.0 # Was installed transitively before https://github.com/openvinotoolkit/nncf/actions/runs/30928990933/job/92221632392
 transformers==4.57.6
 pytest==9.0.3

--- a/tests/integration/gptq_model/requirements.txt
+++ b/tests/integration/gptq_model/requirements.txt
@@ -1,4 +1,4 @@
 torch==2.9.0
-torchao==0.17.0 # Was installed transitively before https://github.com/openvinotoolkit/nncf/actions/runs/30928990933/job/92221632392
+torchao==0.17.0
 transformers==4.57.6
 pytest==9.0.3


### PR DESCRIPTION
### Changes

Add TorchAO to GPTQModel Test Requirement and pin it to `0.17.0`

### Reason for changes

It was installed transitively before with torch. Recent release of torchao(`0.18.0`) was being installed this way which caused unexpected error. (Failing action: https://github.com/openvinotoolkit/nncf/actions/runs/30928990933/job/92221632392)

### Related tickets

<!--- Post the numerical ID of the ticket, if available -->

### Tests

<!--- How was the correctness of changes tested and whether new tests were added -->

[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/30984266172) - success