### PR TITLE
Fix Makefile and documentation paths left behind by moved files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ install-openvino-test:
 install-openvino-dev: install-openvino-test install-pre-commit
 	pip install -r examples/post_training_quantization/openvino/mobilenet_v2/requirements.txt
 	pip install -r examples/post_training_quantization/openvino/anomaly_stfpm_quantize_with_accuracy_control/requirements.txt
-	pip install -r examples/post_training_quantization/openvino/yolov8/requirements.txt
+	pip install -r examples/post_training_quantization/openvino/yolo26/requirements.txt
 	pip install -r examples/post_training_quantization/openvino/yolov8_quantize_with_accuracy_control/requirements.txt
 
 test-openvino:
@@ -163,4 +163,4 @@ install-fuzz-test: install-common-test
 	pip install -r tests/cross_fw/sdl/fuzz/requirements.txt
 
 test-fuzz:
-	python tests/cross_fw/sdl/fuzz/quantize_api.py
+	python tests/cross_fw/sdl/fuzz/fuzz_target.py

--- a/docs/usage/IgnoredScope.md
+++ b/docs/usage/IgnoredScope.md
@@ -45,5 +45,5 @@ graph.dump_graph("model.dot")
 ### Convert dot to svg file
 
 ```sh
-python tools/render_dot_to_svg.py -m model.dot
+python tools/other/render_dot_to_svg.py -i model.dot
 ```

--- a/tests/docs/test_makefile_paths.py
+++ b/tests/docs/test_makefile_paths.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+from tests.cross_fw.shared.paths import PROJECT_ROOT
+
+MAKEFILE = PROJECT_ROOT / "Makefile"
+
+# A literal Python path written out in a recipe, e.g. `python tests/.../fuzz_target.py`.
+# Deliberately literal-only: a path assembled from a Make variable, reached after a `cd`,
+# or run as `python -m package.module` is not matched and not claimed to be.
+SCRIPT_RE = re.compile(r"(?<![\w/.-])((?:tests|tools|examples|src|docs|scripts)/[\w/.-]+\.py)")
+
+
+def _referenced_scripts() -> list[tuple[int, str]]:
+    """Literal Python script paths written out in Makefile recipes, with line numbers."""
+    found = []
+    for lineno, line in enumerate(MAKEFILE.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.startswith("\t") or line.lstrip().startswith("#"):
+            continue  # not a recipe command
+        for match in SCRIPT_RE.finditer(line):
+            found.append((lineno, match.group(1)))
+    return found
+
+
+def test_makefile_scripts_exist():
+    """Every Python script written out literally in a Makefile recipe must exist.
+
+    This is narrow on purpose. It does not check requirements files, paths built from
+    Make variables, or `python -m` invocations, so a green run here is not a claim that
+    every Makefile target works. It catches one recurring mistake: a file is moved or
+    renamed and the recipe that runs it keeps the old path, which makes the target fail
+    the moment anyone invokes it.
+    """
+    missing = [
+        f"Makefile:{lineno}: {path}" for lineno, path in _referenced_scripts() if not (PROJECT_ROOT / path).is_file()
+    ]
+    assert not missing, "Makefile invokes scripts that do not exist:\n" + "\n".join(missing)

--- a/tests/post_training/README.md
+++ b/tests/post_training/README.md
@@ -66,7 +66,7 @@ Additional arguments:
 - `--batch-size=N` to use batch_size for calibration. Some of the models do not support --batch-size > 1. For such models, please, use --batch-size=1.
 - `--benchmark` to collect throughput statistics, add `FPS` column to result.csv
 - `--extra-columns` to add additional columns to reports.csv, like time for each algorithms
-- `--memory-monitor` to using MemoryMonitor from tools/memory_monitor.py
+- `--memory-monitor` to using MemoryMonitor from tools/memory_monitor/memory_monitor.py
 
 ### Examples
 

--- a/tests/post_training/conftest.py
+++ b/tests/post_training/conftest.py
@@ -36,7 +36,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--memory-monitor",
         action="store_true",
-        help="Report memory using MemoryMonitor from tools/memory_monitor.py. "
+        help="Report memory using MemoryMonitor from tools/memory_monitor/memory_monitor.py. "
         "Warning: currently, reported memory values are not always reproducible.",
     )
 


### PR DESCRIPTION
### Changes

Repoint five references left pointing at files that were renamed or removed by merged refactors:

- `Makefile`, `test-fuzz` — invoked `quantize_api.py`; #3695 removed it and added `fuzz_target.py` in the same commit. Filename only: both call `atheris.Setup(sys.argv, ...)`, behaviour unchanged.
- `Makefile`, `install-openvino-dev` — installs from `openvino/yolov8/`, renamed `yolo26` in #3844.
- `docs/usage/IgnoredScope.md`, `tests/post_training/README.md`, a `--memory-monitor` help string — `tools/` paths moved in #3939. `render_dot_to_svg.py` takes `-i`, not `-m`.

Adds `tests/docs/test_makefile_paths.py`: scripts named in Makefile recipes must exist.

`install-models-hub-torch` installs from `tests/torch/models_hub_test/`, deleted in #3553; removing a target seemed like your call.

### Reason for changes

`make test-fuzz` fails on its only line; `make install-openvino-dev` on its third, a requirements file that no longer exists. No CI job runs the fuzz target, so nothing caught it.

### Related tickets

None; no issue or PR covers these paths.

### Tests

Test fails on `develop` naming `Makefile:166`, passes after. `pytest tests/docs` green (14), `tests/common` unchanged, Ruff v0.15.18 check and format clean. The `memory_monitor` edits are text, checked by inspection.
