### PR TITLE
[Fix] Avoid accessing parents_node_mapping[tensor_name] when the tensor is a model input and has no parent node

### DIFF
--- a/src/nncf/onnx/graph/nncf_graph_builder.py
+++ b/src/nncf/onnx/graph/nncf_graph_builder.py
@@ -229,9 +229,13 @@ def _get_bias_attr(
                 port_id = i
                 break
 
-        # Ensure that `tensor_name` is the output of a `Constant` node or an initializer.
         initializer = {x.name: x for x in model.graph.initializer}
-        if tensor_name in initializer or parents_node_mapping[tensor_name].op_type == "Constant":
+        parent_node = parents_node_mapping.get(tensor_name)
+
+        # Ensure that `tensor_name` is the output of a `Constant` node or an initializer.
+        # We should check that `parent_node` is not None here, because `tensor_name` can be a model input,
+        # in which case `parent_node` does not exist.
+        if tensor_name in initializer or (parent_node is not None and parent_node.op_type == "Constant"):
             return {"node": add_node.name, "name": tensor_name, "port_id": port_id}
         return {}
 

--- a/tests/onnx/test_nncf_graph_builder.py
+++ b/tests/onnx/test_nncf_graph_builder.py
@@ -19,6 +19,9 @@ import torch
 from nncf.onnx.graph.metatypes.onnx_metatypes import ONNXMatMulMetatype
 from nncf.onnx.graph.model_transformer import ONNXModelTransformer
 from nncf.onnx.graph.nncf_graph_builder import GraphConverter
+from nncf.onnx.graph.nncf_graph_builder import _get_bias_attr
+from nncf.onnx.graph.onnx_helper import get_children_node_mapping
+from nncf.onnx.graph.onnx_helper import get_parents_node_mapping
 from tests.cross_fw.shared.nx_graph import compare_nx_graph_with_reference
 from tests.cross_fw.shared.paths import TEST_ROOT
 from tests.onnx.common import ModelBuilder
@@ -165,3 +168,19 @@ def test_multiedge_nncf_graph():
     assert len(edges) == 2
     assert edges[0].to_node.node_id == edges[1].to_node.node_id
     assert edges[0].input_port_id != edges[1].input_port_id
+
+
+def test_get_bias_attr():
+    mb = ModelBuilder()
+    x = mb.add_input("x", (4, 3))
+    y = mb.add_input("y", (4, 2))
+    matmul = mb.add_matmul(x, (3, 2))
+    add = mb.add_add(y, matmul)
+    mb.add_output(add, (4, 2))
+    model = mb.build(opset_version=21, ir_version=10)
+
+    children_node_mapping = get_children_node_mapping(model)
+    parents_node_mapping = get_parents_node_mapping(model)
+
+    matmul_node = next(x for x in model.graph.node if x.name == "MatMul_0")
+    assert _get_bias_attr(matmul_node, model, parents_node_mapping, children_node_mapping) == {}


### PR DESCRIPTION
### Changes
In the `_get_bias_attr()` function, we access `parents_node_mapping[tensor_name]` to get the parent node that produces the tensor with the given `tensor_name`. However, the tensor can also be a model input, in which case it does not have a parent node. This results in a `KeyError`.

The fix handles this case correctly by checking whether a parent node exists before accessing its op_type.

### Reason for changes
A `KeyError` was raised when `tensor_name` referred to a model input that did not have a corresponding entry in `parents_node_mapping`.

### Related tickets

CVS-192069

### Tests

test_get_bias_attr

[Weight compression](https://github.com/openvinotoolkit/nncf/actions/runs/31476097989) - success

[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/31476225917) - success