### PR TITLE
fix weekly for python 3.11

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -27,3 +27,4 @@ matplotlib==3.10.9
 pandas==2.3.3
 fastprogress==1.0.5
 fastcore==1.11.5
+typing_extensions==4.16.0; python_version < '3.12'

--- a/tests/common/requirements.txt
+++ b/tests/common/requirements.txt
@@ -3,3 +3,4 @@ pytest
 pytest-cov
 pytest-mock
 pytest-xdist
+typing_extensions; python_version < '3.12'


### PR DESCRIPTION
### Changes

Install the missing package only for Python < 3.12.

### Reason for changes

Weekly tests failed.
```
ERROR tests/common/tensor/test_disaptcher.py - ImportError while importing test module '/home/runner/work/nncf/nncf/tests/common/tensor/test_disaptcher.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/common/tensor/test_disaptcher.py:19: in <module>
    from typing_extensions import TypeAliasType
E   ModuleNotFoundError: No module named 'typing_extensions'
```

### Related tickets

N/A