### PR TITLE
[TorchFX] Stop using PT commands and migrate to FX commands

### DIFF
--- a/src/nncf/experimental/torch/fx/commands.py
+++ b/src/nncf/experimental/torch/fx/commands.py
@@ -35,3 +35,20 @@ class FXApplyTransformationCommand(Command):
         super().__init__(TransformationType.INSERT)
         self.transformation_fn = transformation_fn
         self.priority = priority
+
+
+class FXModelExtractionCommand(Command):
+    """
+    Extracts sub-graph based on the sub-model input and output names.
+    """
+
+    def __init__(self, input_ids: list[tuple[str, int]], output_ids: list[tuple[str, int]]):
+        """
+        :param input_ids: List of the input IDs: pairs of node names and corresponding input port ids.
+            Each pair denotes the sub-graph beginning.
+        :param output_ids: List of the output IDs: pairs of node names and corresponding output port ids.
+            Each pair denotes the sub-graph ending.
+        """
+        super().__init__(TransformationType.EXTRACT)
+        self.input_ids = input_ids
+        self.output_ids = output_ids

--- a/src/nncf/experimental/torch/fx/model_transformer.py
+++ b/src/nncf/experimental/torch/fx/model_transformer.py
@@ -16,17 +16,17 @@ import torch.fx
 from nncf.common.graph.model_transformer import ModelTransformer
 from nncf.common.graph.transformations.layout import TransformationLayout
 from nncf.experimental.torch.fx.commands import FXApplyTransformationCommand
+from nncf.experimental.torch.fx.commands import FXModelExtractionCommand
 from nncf.experimental.torch.fx.node_utils import get_graph_node_by_name
 from nncf.experimental.torch.fx.node_utils import get_node_args
 from nncf.experimental.torch.fx.node_utils import set_node_args
-from nncf.torch.graph.transformations.commands import PTModelExtractionCommand
 
 
 class FXModelTransformer(ModelTransformer):
     """
     Applies transformations upon Torch FX model.
     FXApplyTransformationCommands are made inplace,
-    PTModelExtractionCommands do not change the input model.
+    FXModelExtractionCommands do not change the input model.
     """
 
     def __init__(self, model: torch.fx.GraphModule):
@@ -34,7 +34,7 @@ class FXModelTransformer(ModelTransformer):
 
         self._command_transformation_ordered_pairs = [
             (FXApplyTransformationCommand, self._apply_transformation),
-            (PTModelExtractionCommand, self._apply_model_extraction),
+            (FXModelExtractionCommand, self._apply_model_extraction),
         ]
 
     def transform(self, transformation_layout: TransformationLayout) -> torch.fx.GraphModule:
@@ -91,7 +91,7 @@ class FXModelTransformer(ModelTransformer):
     @staticmethod
     def _apply_model_extraction(
         model: torch.fx.GraphModule,
-        transformations: list[PTModelExtractionCommand],
+        transformations: list[FXModelExtractionCommand],
     ) -> torch.fx.GraphModule:
         """
         Returns a submodel extracted from the given model by the given transformation.

--- a/src/nncf/quantization/algorithms/bias_correction/torch_fx_backend.py
+++ b/src/nncf/quantization/algorithms/bias_correction/torch_fx_backend.py
@@ -19,6 +19,7 @@ from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.tensor_statistics.builders import get_mean_statistic_collector
 from nncf.common.tensor_statistics.collectors import TensorCollector
 from nncf.experimental.torch.fx.commands import FXApplyTransformationCommand
+from nncf.experimental.torch.fx.commands import FXModelExtractionCommand
 from nncf.experimental.torch.fx.model_utils import get_target_point
 from nncf.experimental.torch.fx.model_utils import remove_fq_from_inputs
 from nncf.experimental.torch.fx.node_utils import get_bias_value
@@ -28,7 +29,6 @@ from nncf.experimental.torch.fx.transformations import constant_update_transform
 from nncf.experimental.torch.fx.transformations import output_insertion_transformation_builder
 from nncf.quantization.algorithms.bias_correction.backend import BiasCorrectionAlgoBackend
 from nncf.tensor import Tensor
-from nncf.torch.graph.transformations.commands import PTModelExtractionCommand
 from nncf.torch.graph.transformations.commands import PTTargetPoint
 from nncf.torch.model_graph_manager import is_quantized_weights
 
@@ -49,8 +49,8 @@ class FXBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
     @staticmethod
     def model_extraction_command(
         input_ids: set[tuple[str, int]], output_ids: set[tuple[str, int]]
-    ) -> PTModelExtractionCommand:
-        return PTModelExtractionCommand(list(input_ids), list(output_ids))
+    ) -> FXModelExtractionCommand:
+        return FXModelExtractionCommand(list(input_ids), list(output_ids))
 
     @staticmethod
     def output_insertion_command(nncf_graph: NNCFGraph, target_point: PTTargetPoint) -> FXApplyTransformationCommand:

--- a/src/nncf/quantization/algorithms/fast_bias_correction/torch_fx_backend.py
+++ b/src/nncf/quantization/algorithms/fast_bias_correction/torch_fx_backend.py
@@ -20,13 +20,13 @@ from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.tensor_statistics.builders import get_mean_statistic_collector
 from nncf.common.tensor_statistics.collectors import TensorCollector
 from nncf.experimental.torch.fx.commands import FXApplyTransformationCommand
+from nncf.experimental.torch.fx.commands import FXModelExtractionCommand
 from nncf.experimental.torch.fx.model_utils import get_target_point
 from nncf.experimental.torch.fx.node_utils import get_bias_value
 from nncf.experimental.torch.fx.node_utils import is_node_with_bias
 from nncf.experimental.torch.fx.transformations import constant_update_transformation_builder
 from nncf.quantization.algorithms.fast_bias_correction.backend import FastBiasCorrectionAlgoBackend
 from nncf.tensor import Tensor
-from nncf.torch.graph.transformations.commands import PTModelExtractionCommand
 from nncf.torch.graph.transformations.commands import PTTargetPoint
 from nncf.torch.model_graph_manager import is_quantized_weights
 
@@ -47,8 +47,8 @@ class FXFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
     @staticmethod
     def model_extraction_command(
         input_ids: list[tuple[str, int]], output_ids: list[tuple[str, int]]
-    ) -> PTModelExtractionCommand:
-        return PTModelExtractionCommand([input_ids[0]], [output_ids[0]])
+    ) -> FXModelExtractionCommand:
+        return FXModelExtractionCommand([input_ids[0]], [output_ids[0]])
 
     @staticmethod
     def mean_statistic_collector(

--- a/tests/torch/fx/test_model_transformer.py
+++ b/tests/torch/fx/test_model_transformer.py
@@ -26,6 +26,7 @@ import nncf.torch.graph.operator_metatypes as om
 from nncf.common.graph.transformations.commands import TargetType
 from nncf.common.graph.transformations.layout import TransformationLayout
 from nncf.common.quantization.structs import QuantizationScheme as QuantizationMode
+from nncf.experimental.torch.fx.commands import FXModelExtractionCommand
 from nncf.experimental.torch.fx.constant_folding import constant_fold
 from nncf.experimental.torch.fx.model_transformer import FXModelTransformer
 from nncf.experimental.torch.fx.nncf_graph_builder import GraphConverter
@@ -42,7 +43,6 @@ from nncf.experimental.torch.fx.transformations import node_removal_transformati
 from nncf.experimental.torch.fx.transformations import output_insertion_transformation_builder
 from nncf.experimental.torch.fx.transformations import qdq_insertion_transformation_builder
 from nncf.experimental.torch.fx.transformations import remove_split_getitem_nodes
-from nncf.torch.graph.transformations.commands import PTModelExtractionCommand
 from nncf.torch.graph.transformations.commands import PTTargetPoint
 from nncf.torch.utils import get_model_device
 from tests.cross_fw.shared.nx_graph import compare_nx_graph_with_reference
@@ -70,42 +70,42 @@ TRANSFORMED_GRAPH_DIR_NAME = REF_DIR / "transformed"
 class ModelExtractionTestCase:
     model: torch.nn.Module
     input_shape: tuple[int, ...]
-    command: PTModelExtractionCommand
+    command: FXModelExtractionCommand
 
 
 MODEL_EXTRACTION_CASES = (
     ModelExtractionTestCase(
-        ConvolutionWithNotTensorBiasModel, (1, 1, 3, 3), PTModelExtractionCommand([("conv2d", 0)], [("conv2d", 0)])
+        ConvolutionWithNotTensorBiasModel, (1, 1, 3, 3), FXModelExtractionCommand([("conv2d", 0)], [("conv2d", 0)])
     ),
     ModelExtractionTestCase(
-        ConvolutionWithAllConstantInputsModel, (1, 1, 3, 3), PTModelExtractionCommand([("conv2d", 0)], [("conv2d", 0)])
+        ConvolutionWithAllConstantInputsModel, (1, 1, 3, 3), FXModelExtractionCommand([("conv2d", 0)], [("conv2d", 0)])
     ),
     ModelExtractionTestCase(
-        MultiBranchesConnectedModel, (1, 3, 3, 3), PTModelExtractionCommand([("conv2d_1", 0)], [("add__1", 0)])
+        MultiBranchesConnectedModel, (1, 3, 3, 3), FXModelExtractionCommand([("conv2d_1", 0)], [("add__1", 0)])
     ),
     ModelExtractionTestCase(
-        MultiBranchesConnectedModel, (1, 3, 3, 3), PTModelExtractionCommand([("conv2d", 0)], [("add_", 0), ("add", 0)])
+        MultiBranchesConnectedModel, (1, 3, 3, 3), FXModelExtractionCommand([("conv2d", 0)], [("add_", 0), ("add", 0)])
     ),
     ModelExtractionTestCase(
         MultiBranchesConnectedModel,
         (1, 3, 3, 3),
-        PTModelExtractionCommand([("conv2d", 0), ("conv2d_1", 0)], [("add_", 0), ("add__1", 0)]),
+        FXModelExtractionCommand([("conv2d", 0), ("conv2d_1", 0)], [("add_", 0), ("add__1", 0)]),
     ),
     ModelExtractionTestCase(
-        MultiBranchesConnectedModel, (1, 3, 3, 3), PTModelExtractionCommand([("conv2d", 0)], [("conv2d_2", 0)])
+        MultiBranchesConnectedModel, (1, 3, 3, 3), FXModelExtractionCommand([("conv2d", 0)], [("conv2d_2", 0)])
     ),
     ModelExtractionTestCase(
-        MultiBranchesConnectedModel, (1, 3, 3, 3), PTModelExtractionCommand([("conv2d", 0)], [("add__1", 0)])
+        MultiBranchesConnectedModel, (1, 3, 3, 3), FXModelExtractionCommand([("conv2d", 0)], [("add__1", 0)])
     ),
     ModelExtractionTestCase(
         ConcatWithInput,
         ConcatWithInput.INPUT_SIZE,
-        PTModelExtractionCommand([("cat", 1), ("conv2d", 0)], [("cat", 0)]),
+        FXModelExtractionCommand([("cat", 1), ("conv2d", 0)], [("cat", 0)]),
     ),
     ModelExtractionTestCase(
         ConcatWithReluInput,
         ConcatWithReluInput.INPUT_SIZE,
-        PTModelExtractionCommand([("cat", 1), ("conv2d", 0)], [("cat", 0)]),
+        FXModelExtractionCommand([("cat", 1), ("conv2d", 0)], [("cat", 0)]),
     ),
 )
 
@@ -146,7 +146,7 @@ def test_model_extraction(test_case: ModelExtractionTestCase):
             ModelExtractionTestCase(
                 ConvolutionWithNotTensorBiasModel,
                 (1, 1, 3, 3),
-                PTModelExtractionCommand([("conv2d", 0)], [("output", 0)]),
+                FXModelExtractionCommand([("conv2d", 0)], [("output", 0)]),
             ),
             False,
             "(conv2d,)",
@@ -155,14 +155,14 @@ def test_model_extraction(test_case: ModelExtractionTestCase):
             ModelExtractionTestCase(
                 ConvolutionWithNotTensorBiasModel,
                 (1, 1, 3, 3),
-                PTModelExtractionCommand([("conv2d", 0)], [("conv2d", 0), ("output", 0), ("conv2d", 0)]),
+                FXModelExtractionCommand([("conv2d", 0)], [("conv2d", 0), ("output", 0), ("conv2d", 0)]),
             ),
             False,
             "(conv2d, conv2d, conv2d)",
         ),
         (
             ModelExtractionTestCase(
-                ConvolutionWithSeveralOutputs, (1, 1, 3, 3), PTModelExtractionCommand([("conv2d", 0)], [("output", 0)])
+                ConvolutionWithSeveralOutputs, (1, 1, 3, 3), FXModelExtractionCommand([("conv2d", 0)], [("output", 0)])
             ),
             False,
             "([conv2d, add],)",
@@ -171,7 +171,7 @@ def test_model_extraction(test_case: ModelExtractionTestCase):
             ModelExtractionTestCase(
                 ConvolutionWithSeveralOutputs,
                 (1, 1, 3, 3),
-                PTModelExtractionCommand([("conv2d", 0)], [("conv2d", 0), ("output", 0), ("conv2d", 0)]),
+                FXModelExtractionCommand([("conv2d", 0)], [("conv2d", 0), ("output", 0), ("conv2d", 0)]),
             ),
             False,
             "(conv2d, [conv2d, add], conv2d)",
@@ -180,7 +180,7 @@ def test_model_extraction(test_case: ModelExtractionTestCase):
             ModelExtractionTestCase(
                 ConvolutionWithNotTensorBiasModel,
                 (1, 1, 3, 3),
-                PTModelExtractionCommand([("conv2d", 0)], [("output", 0)]),
+                FXModelExtractionCommand([("conv2d", 0)], [("output", 0)]),
             ),
             True,
             "(conv2d,)",
@@ -189,7 +189,7 @@ def test_model_extraction(test_case: ModelExtractionTestCase):
             ModelExtractionTestCase(
                 ConvolutionWithNotTensorBiasModel,
                 (1, 1, 3, 3),
-                PTModelExtractionCommand([("conv2d", 0)], [("conv2d", 0), ("output", 0), ("conv2d", 0)]),
+                FXModelExtractionCommand([("conv2d", 0)], [("conv2d", 0), ("output", 0), ("conv2d", 0)]),
             ),
             True,
             "(conv2d, conv2d, conv2d)",
@@ -198,7 +198,7 @@ def test_model_extraction(test_case: ModelExtractionTestCase):
             ModelExtractionTestCase(
                 ConcatWithReluInput,
                 ConcatWithReluInput.INPUT_SIZE,
-                PTModelExtractionCommand([("cat", 1)], [("output", 0)]),
+                FXModelExtractionCommand([("cat", 1)], [("output", 0)]),
             ),
             False,
             "(conv2d_1,)",


### PR DESCRIPTION
### Changes

* Added `FXModelExtractionCommand` to the TorchFX command layer (`nncf.experimental.torch.fx.commands`)
* Migrated `FXModelTransformer` to dispatch model extraction using `FXModelExtractionCommand`
* Updated `FXBiasCorrectionAlgoBackend` and `FXFastBiasCorrectionAlgoBackend` to create and return `FXModelExtractionCommand`
* Updated `tests/torch/fx/test_model_transformer.py` to use `FXModelExtractionCommand`

### Reason for changes

To separate the PT and FX backends and stop using native PyTorch commands (`PTModelExtractionCommand` / `PTCommand`) in TorchFX. This is a follow-up to #2882.

### Related tickets

#2928

### Tests

* `pytest tests/torch/fx/test_model_transformer.py -k test_model_extraction`
* `pytest tests/torch/fx/test_bias_correction.py tests/torch/fx/test_fast_bias_correction.py`
* `pre-commit run -a`

[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/35600599219) - success

[Weight compression](https://github.com/openvinotoolkit/nncf/actions/runs/35600606246) - failure