### PR TITLE
fix(quantization): compare quantizer setup groups in both directions

### DIFF
--- a/src/nncf/common/quantization/quantizer_setup.py
+++ b/src/nncf/common/quantization/quantizer_setup.py
@@ -356,8 +356,13 @@ class QuantizerSetupBase:
 
     def equivalent_to(self, other: "QuantizerSetupBase") -> bool:
         this_qp_id_to_other_qp_id_dict: dict[QuantizationPointId, QuantizationPointId] = {}
+        other_qp_id_to_this_qp_id_dict: dict[QuantizationPointId, QuantizationPointId] = {}
 
-        def _compare_qps(first: "QuantizerSetupBase", second: "QuantizerSetupBase") -> bool:
+        def _compare_qps(
+            first: "QuantizerSetupBase",
+            second: "QuantizerSetupBase",
+            id_map: dict[QuantizationPointId, QuantizationPointId],
+        ) -> bool:
             for this_qp_id, this_qp in first.quantization_points.items():
                 matches: list[QuantizationPointId] = []
                 for other_qp_id, other_qp in second.quantization_points.items():
@@ -366,14 +371,16 @@ class QuantizerSetupBase:
                 if len(matches) == 0:
                     return False
                 assert len(matches) == 1  # separate quantization points should not compare equal to each other
-                this_qp_id_to_other_qp_id_dict[this_qp_id] = matches[0]
+                id_map[this_qp_id] = matches[0]
             return True
 
-        def _compare_shared_input_groups(first: "QuantizerSetupBase", second: "QuantizerSetupBase") -> bool:
+        def _compare_shared_input_groups(
+            first: "QuantizerSetupBase",
+            second: "QuantizerSetupBase",
+            id_map: dict[QuantizationPointId, QuantizationPointId],
+        ) -> bool:
             for this_same_input_group_set in first.shared_input_operation_set_groups.values():
-                translated_id_set = set(
-                    this_qp_id_to_other_qp_id_dict[this_qp_id] for this_qp_id in this_same_input_group_set
-                )
+                translated_id_set = set(id_map[this_qp_id] for this_qp_id in this_same_input_group_set)
                 matches = []
 
                 for other_shared_inputs_group in second.shared_input_operation_set_groups.values():
@@ -384,11 +391,13 @@ class QuantizerSetupBase:
                 assert len(matches) == 1  # shared inputs group entries should be present in only one group
             return True
 
-        def _compare_unified_scale_groups(first: "QuantizerSetupBase", second: "QuantizerSetupBase") -> bool:
+        def _compare_unified_scale_groups(
+            first: "QuantizerSetupBase",
+            second: "QuantizerSetupBase",
+            id_map: dict[QuantizationPointId, QuantizationPointId],
+        ) -> bool:
             for this_unified_scales_group in first.unified_scale_groups.values():
-                translated_id_set = set(
-                    this_qp_id_to_other_qp_id_dict[this_qp_id] for this_qp_id in this_unified_scales_group
-                )
+                translated_id_set = set(id_map[this_qp_id] for this_qp_id in this_unified_scales_group)
                 matches = []
                 for other_unified_scales_group in second.unified_scale_groups.values():
                     if translated_id_set == other_unified_scales_group:
@@ -399,12 +408,12 @@ class QuantizerSetupBase:
             return True
 
         return (
-            _compare_qps(self, other)
-            and _compare_qps(other, self)
-            and _compare_shared_input_groups(self, other)
-            and _compare_shared_input_groups(self, other)
-            and _compare_unified_scale_groups(self, other)
-            and _compare_unified_scale_groups(self, other)
+            _compare_qps(self, other, this_qp_id_to_other_qp_id_dict)
+            and _compare_qps(other, self, other_qp_id_to_this_qp_id_dict)
+            and _compare_shared_input_groups(self, other, this_qp_id_to_other_qp_id_dict)
+            and _compare_shared_input_groups(other, self, other_qp_id_to_this_qp_id_dict)
+            and _compare_unified_scale_groups(self, other, this_qp_id_to_other_qp_id_dict)
+            and _compare_unified_scale_groups(other, self, other_qp_id_to_this_qp_id_dict)
         )
 
 


### PR DESCRIPTION
### What

`QuantizerSetupBase.equivalent_to` calls two of its three helpers twice in the **same** direction:

```python
return (
    _compare_qps(self, other)
    and _compare_qps(other, self)
    and _compare_shared_input_groups(self, other)
    and _compare_shared_input_groups(self, other)   # <- (other, self)
    and _compare_unified_scale_groups(self, other)
    and _compare_unified_scale_groups(self, other)  # <- (other, self)
)
```

`_compare_qps` is already checked both ways; the two group comparisons are not. Each of them only asserts that *every group of `first` has a match in `second`*, so running it twice in the same direction leaves the subset case unchecked: a setup whose grouping is a strict subset of the other's compares equal.

### Why the id map has to be split too

Simply flipping the arguments is not enough. All three helpers read the shared `this_qp_id_to_other_qp_id_dict`, which `_compare_qps(other, self)` overwrites with the *other → this* mapping. A `(other, self)` group comparison needs exactly that map, while the `(self, other)` one needs the *this → other* map. So `_compare_qps` now writes into a caller-supplied dict and each direction is given its own; the translation logic itself is unchanged.

### Reproduction

Two setups with identical quantization points, where `other` has one extra shared-input group:

```python
qps = {0: qp_a, 1: qp_b, 2: qp_c}
a = setup(qps, shared_input_operation_set_groups={0: {0, 1}})
b = setup(qps, shared_input_operation_set_groups={0: {0, 1}, 1: {2}})
a.equivalent_to(b)   # True   <- wrong, b groups qp_c and a does not
b.equivalent_to(a)   # False  <- the direction that is already checked
```

Running `equivalent_to` extracted from `develop` against duck-typed setups, before and after the patch:

```
extra shared-input group in `other`     current=True    patched=False   expected=False  OK
extra unified-scale group in `other`    current=True    patched=False   expected=False  OK
[control] equivalent setups             current=True    patched=True    expected=True   OK
[control] extra group in `self`         current=False   patched=False   expected=False  OK
[control] differing QPs                 current=False   patched=False   expected=False  OK
[control] no groups                     current=True    patched=True    expected=True   OK
```

Every control keeps its previous result; only the previously-unchecked direction changes.

`ruff check` and `ruff format --check` pass with the pinned `v0.15.18` and the repo's `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
