### PR TITLE
[tests] Get rid of pkg_resources that is deprecated

### DIFF
--- a/tests/openvino/tools/calibrate.py
+++ b/tests/openvino/tools/calibrate.py
@@ -23,12 +23,12 @@ from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import replace
 from enum import Enum
+from importlib import metadata as importlib_metadata
 from itertools import islice
 from typing import Any, Iterable, TypeVar
 
 import numpy as np
 import openvino as ov
-import pkg_resources
 from config import Config
 from openvino import Dimension
 from openvino import PartialShape
@@ -1115,8 +1115,8 @@ class EnvInfo:
     @staticmethod
     def _get_nncf_version() -> str:
         try:
-            version = pkg_resources.get_distribution("nncf").version
-        except pkg_resources.DistributionNotFound:
+            version = importlib_metadata.version("nncf")
+        except importlib_metadata.PackageNotFoundError:
             version = "Unknown"
         return version
 


### PR DESCRIPTION
### Changes

Need to get rid of deprecated `import pkg_resources`

### Reason for changes

- since newer setuptools (e.g. 84) we are getting following error in validation:
```
Traceback (most recent call last):
  File "/home/jenkins/agent/workspace/DL-Benchmark/precommit_pnp/PR-7296/W_calibr_public-default_small/nncf/tests/openvino/tools/calibrate.py", line 31, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

It was a warning for a long time now:
```
[2026-09-04T13:16:38.133Z] ForkPoolWorker-17: /home/jenkins/agent/workspace/DL-Benchmark/precommit_pnp/master_942046a7/W_calibr_public-default_small/nncf/tests/openvino/tools/calibrate.py:31: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```
