### PR TITLE
[ci] Disable ci for gptqmodel convertor

### DIFF
--- a/.github/workflows/gptqmodel.yml
+++ b/.github/workflows/gptqmodel.yml
@@ -4,11 +4,11 @@ permissions: read-all
 
 on:
   workflow_call:
-  pull_request:
-    paths:
-      - .github/workflows/gptqmodel.yml
-      - src/nncf/experimental/torch/gptqmodel/**
-      - tests/integration/gptq_model/**
+  # pull_request:
+  #   paths:
+  #     - .github/workflows/gptqmodel.yml
+  #     - src/nncf/experimental/torch/gptqmodel/**
+  #     - tests/integration/gptq_model/**
 
 jobs:
   pytorch-cuda:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,6 +43,6 @@ jobs:
       python_version: "3.12"
       gpu_enabled: true
 
-  gptqmodel:
-    if: github.repository_owner == 'openvinotoolkit'
-    uses: ./.github/workflows/gptqmodel.yml
+  # gptqmodel:
+  #   if: github.repository_owner == 'openvinotoolkit'
+  #   uses: ./.github/workflows/gptqmodel.yml

--- a/examples/llm_compression/torch/gptq_model_convertor/requirements.txt
+++ b/examples/llm_compression/torch/gptq_model_convertor/requirements.txt
@@ -1,5 +1,4 @@
-torch==2.9.0
-torchao==0.17.0
-# TODO(AlexanderDokuchaev): remove transformers next release gptqmodel https://github.com/ModelCloud/GPTQModel/issues/2328
-transformers==4.57.6
+torch
+torchao
+transformers
 numpy==2.2.6

--- a/examples/llm_compression/torch/gptq_model_convertor/requirements_extra.txt
+++ b/examples/llm_compression/torch/gptq_model_convertor/requirements_extra.txt
@@ -1,8 +1,8 @@
-gptqmodel==5.6.12
-torch==2.9.0
-torchao==0.17.0
-# TODO(AlexanderDokuchaev): remove transformers next release gptqmodel https://github.com/ModelCloud/GPTQModel/issues/2328
-transformers==4.57.6
+
+gptqmodel
+torch
+torchao
+transformers
 huggingface_hub==0.36.2
 numpy==2.2.6
 kernels==0.12.3

--- a/tests/cross_fw/examples/example_scope.json
+++ b/tests/cross_fw/examples/example_scope.json
@@ -356,14 +356,5 @@
         "accuracy_metrics": {
             "acc1": 54.96
         }
-    },
-    "llm_compression_torch_gptqmodel_convertor": {
-        "backend": "torch",
-        "device": "cuda",
-        "requirements": "examples/llm_compression/torch/gptq_model_convertor/requirements.txt",
-        "extra_requirements": "examples/llm_compression/torch/gptq_model_convertor/requirements_extra.txt",
-        "accuracy_metrics": {
-            "word_count": 28
-        }
     }
 }


### PR DESCRIPTION
### Changes

Temporary disable all tests with gptqmodel

### Reason for changes

Unavalible host to validate on actual versions

### Related tickets

CVS-194364

### Tests


[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/34200441461) - success