### PR TITLE
Bump onnx-ir and onnxscript 

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -8,7 +8,7 @@ torchao==0.17.0
 
 # ONNX
 onnx==1.22.0
-onnx-ir==0.1.15
+onnx-ir==1.0.0
 onnxruntime==1.23.2; python_version < '3.11'
 onnxruntime==1.24.3; python_version >= '3.11'
 onnxscript==0.6.2

--- a/constraints.txt
+++ b/constraints.txt
@@ -11,7 +11,7 @@ onnx==1.22.0
 onnx-ir==1.0.0
 onnxruntime==1.23.2; python_version < '3.11'
 onnxruntime==1.24.3; python_version >= '3.11'
-onnxscript==0.6.2
+onnxscript==0.7.1
 
 # Tests and examples
 pytest==9.0.3

--- a/tests/executorch/requirements.txt
+++ b/tests/executorch/requirements.txt
@@ -27,4 +27,4 @@ onnx==1.22.0
 onnx-ir==1.0.0
 onnxruntime==1.23.2; python_version < '3.11'
 onnxruntime==1.24.3; python_version >= '3.11'
-onnxscript==0.5.7
+onnxscript==0.7.1

--- a/tests/executorch/requirements.txt
+++ b/tests/executorch/requirements.txt
@@ -24,7 +24,7 @@ fastprogress==1.0.5
 # This is because torch backend uses it and we import from torch
 # ONNX
 onnx==1.22.0
-onnx-ir==0.1.15
+onnx-ir==1.0.0
 onnxruntime==1.23.2; python_version < '3.11'
 onnxruntime==1.24.3; python_version >= '3.11'
 onnxscript==0.5.7


### PR DESCRIPTION
### Changes

Bump onnx-ir version to 1.0.0
Bump onnxscript version to 0.7.1

### Reason for changes

### Related tickets

### Tests


[Weight compression](https://github.com/openvinotoolkit/nncf/actions/runs/34206414848) - success