### PR TITLE
[PT] Replace deprecated export_for_training

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ def transform_fn(data_item):
 calibration_dataset = nncf.Dataset(dataset_loader, transform_fn)
 
 # Step 3: Export model to TorchFX
-input_shape = (1, 3, 224, 224)
+ex_input = torch.randn(1, 3, 224, 224)
 fx_model = torch.export.export(model, args=(ex_input,)).module()
 
 # Step 4: Run the quantization pipeline

--- a/README.md
+++ b/README.md
@@ -164,9 +164,7 @@ calibration_dataset = nncf.Dataset(dataset_loader, transform_fn)
 
 # Step 3: Export model to TorchFX
 input_shape = (1, 3, 224, 224)
-fx_model = torch.export.export_for_training(model, args=(ex_input,)).module()
-# or
-# fx_model = torch.export.export(model, args=(ex_input,)).module()
+fx_model = torch.export.export(model, args=(ex_input,)).module()
 
 # Step 4: Run the quantization pipeline
 quantized_fx_model = nncf.quantize(fx_model, calibration_dataset)

--- a/examples/llm_compression/torch_fx/tiny_llama/modelling.py
+++ b/examples/llm_compression/torch_fx/tiny_llama/modelling.py
@@ -106,7 +106,7 @@ def convert_and_export_with_cache(model: PreTrainedModel) -> tuple[ExportedProgr
 
     dynamic_shapes = {"input_ids": {1: torch.export.Dim.DYNAMIC}, "cache_position": {0: torch.export.Dim.DYNAMIC}}
 
-    exported_program = torch.export.export_for_training(
+    exported_program = torch.export.export(
         model,
         args=(
             example_input_ids,

--- a/tests/post_training/pipelines/fx_modelling.py
+++ b/tests/post_training/pipelines/fx_modelling.py
@@ -93,7 +93,7 @@ def convert_and_export_with_cache(model: PreTrainedModel):
 
     dynamic_shapes = {"input_ids": {1: torch.export.Dim.DYNAMIC}, "cache_position": {0: torch.export.Dim.DYNAMIC}}
 
-    exported_program = torch.export.export_for_training(
+    exported_program = torch.export.export(
         model,
         args=(
             example_input_ids,

--- a/tests/post_training/pipelines/image_classification_torchvision.py
+++ b/tests/post_training/pipelines/image_classification_torchvision.py
@@ -24,10 +24,6 @@ from tests.post_training.pipelines.base import BackendType
 from tests.post_training.pipelines.image_classification_base import ImageClassificationBase
 
 
-def _torch_export_for_training(model: torch.nn.Module, args: tuple[Any, ...]) -> torch.fx.GraphModule:
-    return torch.export.export_for_training(model, args, strict=True).module(check_guards=False)
-
-
 def _torch_export(model: torch.nn.Module, args: tuple[Any, ...]) -> torch.fx.GraphModule:
     return torch.export.export(model, args, strict=True).module(check_guards=False)
 
@@ -43,19 +39,17 @@ class ImageClassificationTorchvision(ImageClassificationBase):
     """Pipeline for Image Classification model from torchvision repository"""
 
     models_vs_model_params = {
-        models.resnet18: VisionModelParams(models.ResNet18_Weights.DEFAULT, _torch_export_for_training),
-        models.mobilenet_v3_small: VisionModelParams(
-            models.MobileNet_V3_Small_Weights.DEFAULT, _torch_export_for_training
-        ),
+        models.resnet18: VisionModelParams(models.ResNet18_Weights.DEFAULT, _torch_export),
+        models.mobilenet_v3_small: VisionModelParams(models.MobileNet_V3_Small_Weights.DEFAULT, _torch_export),
         models.vit_b_16: VisionModelParams(
             models.ViT_B_16_Weights.DEFAULT,
-            _torch_export_for_training,
-            export_torch_before_ov_convert=False,  # OV convert of exported model has issues Issue-162009
+            _torch_export,
+            export_torch_before_ov_convert=False,
         ),
         models.swin_v2_s: VisionModelParams(
             models.Swin_V2_S_Weights.DEFAULT,
             _torch_export,
-            export_torch_before_ov_convert=False,  # OV convert of exported model has issues Issue-162009
+            export_torch_before_ov_convert=False,
         ),
     }
 

--- a/tests/torch/fx/helpers.py
+++ b/tests/torch/fx/helpers.py
@@ -54,13 +54,9 @@ def get_torch_fx_model(
         device_ex_input.append(inp.to(device))
     device_ex_input = tuple(device_ex_input)
 
-    # Temporary workaround for executorch tests. Can be removed once torch>=2.11.0
-    export_fn = (
-        torch.export.export_for_training if hasattr(torch.export, "export_for_training") else torch.export.export
-    )
     model.eval()
     with torch.no_grad():
-        return export_fn(model, args=device_ex_input, dynamic_shapes=dynamic_shapes, strict=True).module(
+        return torch.export.export(model, args=device_ex_input, dynamic_shapes=dynamic_shapes, strict=True).module(
             check_guards=False
         )
 


### PR DESCRIPTION
### Changes

Replace deprecated `export_for_training` to `export` 

### Reason for changes

Deprecated function

### Related tickets

### Tests


[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/34221277084) - success