### PR TITLE
[ci] Remove disable_tf32_precision fixture from torch/conftest.py

### DIFF
--- a/tests/torch/conftest.py
+++ b/tests/torch/conftest.py
@@ -22,13 +22,6 @@ from nncf import set_log_level
 from nncf.common.quantization.structs import QuantizationScheme
 
 
-@pytest.fixture(scope="session", autouse=True)
-def disable_tf32_precision():
-    if torch:
-        torch.backends.cuda.matmul.fp32_precision = "ieee"
-        torch.backends.cudnn.conv.fp32_precision = "ieee"
-
-
 def pytest_addoption(parser: Parser):
     parser.addoption(
         "--regen-ref-data",


### PR DESCRIPTION
### Changes

Removed `disable_tf32_precision`  fixture 

### Reason for changes

torch.backends.cudnn.conv.fp32_precision is deprecated 
Not affect on tests

### Related tickets

### Tests

