### PR TITLE
[ci] Update PyTorch test configuration to exclude long tests

### DIFF
--- a/.github/workflows/call_precommit.yml
+++ b/.github/workflows/call_precommit.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Print installed modules
         run: pip list
       - name: Run torch precommit test scope
-        run: pytest -ra -n2 --durations=30 tests/torch -m "not cuda"
+        run: pytest -ra -n2 --durations=30 tests/torch -m "not cuda and not long"
 
   pytorch-cuda:
     timeout-minutes: 40
@@ -197,4 +197,4 @@ jobs:
           python -c "import torch; print(torch.cuda.is_available())"
       - name: Run PyTorch precommit test scope
         run: |
-          pytest -ra --durations=30 tests/torch -m cuda
+          pytest -ra --durations=30 tests/torch -m "cuda and not long"

--- a/tests/torch/pytest.ini
+++ b/tests/torch/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
     cuda
+    long
 python_files = test_*
 xfail_strict = true

--- a/tests/torch/quantization/test_functions.py
+++ b/tests/torch/quantization/test_functions.py
@@ -608,7 +608,7 @@ class TestParametrizedFast(BaseParametrized):
     pass
 
 
-@pytest.mark.nightly
+@pytest.mark.long
 @pytest.mark.parametrize(
     "input_size",
     [[1, 48, 112, 112], [1, 96, 28, 28], [1, 288, 14, 14], [16, 96, 112, 112], [16, 192, 28, 28], [16, 576, 14, 14]],


### PR DESCRIPTION
### Changes

Disable long tests
Rename `nightly` marker to `long`

### Reason for changes

Speedup tests

### Related tickets


### Tests

