### PR TITLE
[ci] Rename nightly and weekly schedule workflows

### DIFF
--- a/.github/workflows/schedule_nightly.yml
+++ b/.github/workflows/schedule_nightly.yml
@@ -1,4 +1,4 @@
-name: nightly
+name: "[Schedule] Nightly"
 permissions: read-all
 
 on:

--- a/.github/workflows/schedule_weekly.yml
+++ b/.github/workflows/schedule_weekly.yml
@@ -1,4 +1,4 @@
-name: weekly
+name: "[Schedule] Weekly"
 permissions: read-all
 
 on:


### PR DESCRIPTION
### Changes

Rename nightly and weekly schedule workflows

### Reason for changes

Test the theory that a notification is sent to the user who committed the workflow file.
Improve organization of GitHub workflows.

### Related tickets

### Tests
