### PR TITLE
Bump torchao version to 0.18.0

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,7 @@ openvino==2026.3.1
 # Pytorch
 torch==2.10.0
 torchvision==0.25.0
-torchao==0.17.0
+torchao==0.18.0
 
 # ONNX
 onnx==1.22.0

--- a/examples/llm_compression/torch/distillation_qat_with_lora/requirements.txt
+++ b/examples/llm_compression/torch/distillation_qat_with_lora/requirements.txt
@@ -1,6 +1,6 @@
 tensorboard==2.20.0
 torch==2.10.0
-torchao==0.17.0
+torchao==0.18.0
 numpy>=1.23.5,<2
 openvino==2026.3.1
 optimum-intel==2.0.0

--- a/examples/llm_compression/torch/downstream_qat_with_nls/requirements.txt
+++ b/examples/llm_compression/torch/downstream_qat_with_nls/requirements.txt
@@ -6,4 +6,4 @@ optimum-intel==2.0.0
 optimum==2.2.0
 transformers==5.0.0
 lm_eval[hf]==0.4.12
-torchao==0.17.0
+torchao==0.18.0

--- a/examples/llm_compression/torch_fx/tiny_llama/requirements.txt
+++ b/examples/llm_compression/torch_fx/tiny_llama/requirements.txt
@@ -4,4 +4,4 @@ openvino==2026.3.1
 optimum==2.2.0
 torch==2.10.0
 torchvision==0.25.0
-torchao==0.17.0
+torchao==0.18.0

--- a/examples/post_training_quantization/torch_fx/resnet18/requirements.txt
+++ b/examples/post_training_quantization/torch_fx/resnet18/requirements.txt
@@ -4,4 +4,4 @@ fastcore==1.11.5
 openvino==2026.3.1
 torch==2.10.0
 torchvision==0.25.0
-torchao==0.17.0
+torchao==0.18.0


### PR DESCRIPTION
### Changes

Bump torchao version to 0.18.0

### Reason for changes

### Related tickets

### Tests

[Test examples](https://github.com/openvinotoolkit/nncf/actions/runs/34224397534) - success

[Weight compression](https://github.com/openvinotoolkit/nncf/actions/runs/34224411828) - success