### PR TITLE
[ci] Set extra url for install tests

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -8,7 +8,6 @@ on:
       pull_request_number:
         description: 'The pull request number'
         default: ''
-  pull_request:
 
 jobs:
   install-cpu:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -8,6 +8,7 @@ on:
       pull_request_number:
         description: 'The pull request number'
         default: ''
+  pull_request:
 
 jobs:
   install-cpu:
@@ -85,3 +86,5 @@ jobs:
       - name: Run install test scope
         run: |
           pytest tests/cross_fw/install -rA -s --host-configuration gpu --backend torch
+        env:
+          PIP_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cu126"


### PR DESCRIPTION
### Changes

Set extra url for install tests
```
PIP_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cu126"
```

### Reason for changes

https://github.com/openvinotoolkit/nncf/actions/runs/34419753245/job/102692387071
https://github.com/openvinotoolkit/nncf/pull/4197

### Related tickets

### Tests

https://github.com/openvinotoolkit/nncf/actions/runs/34449183486/job/102780700993?pr=4204
