### PR TITLE
[ci] Add xfail for ptq tests

### DIFF
--- a/tests/post_training/data/ptq_reference_data.yaml
+++ b/tests/post_training/data/ptq_reference_data.yaml
@@ -1,5 +1,9 @@
 hf/bert-base-uncased_backend_CUDA_TORCH:
   metric_value: null
+  exception_xfail_reason:
+    type: "RuntimeError"
+    error_message: "Couldn't get TorchScript module by tracing."
+    message: "Failed on converting to OV, after bump transformers to 5.5"
 hf/bert-base-uncased_backend_FP32:
   metric_value: null
 hf/bert-base-uncased_backend_ONNX:
@@ -10,6 +14,10 @@ hf/bert-base-uncased_backend_OV:
   metric_value: null
 hf/bert-base-uncased_backend_TORCH:
   metric_value: null
+  exception_xfail_reason:
+    type: "RuntimeError"
+    error_message: "Couldn't get TorchScript module by tracing."
+    message: "Failed on converting to OV, after bump transformers to 5.5"
 hf/hf-internal-testing/tiny-random-GPTNeoXForCausalLM_statefull_backend_FP32:
   metric_value: null
 hf/hf-internal-testing/tiny-random-GPTNeoXForCausalLM_stateless_backend_FP32:
@@ -26,6 +34,10 @@ hf/hf-internal-testing/tiny-random-gpt2_backend_OV:
   metric_value: null
 hf/hf-internal-testing/tiny-random-gpt2_backend_TORCH:
   metric_value: null
+  exception_xfail_reason:
+    type: "RuntimeError"
+    error_message: "Couldn't get TorchScript module by tracing."
+    message: "Failed on converting to OV, after bump transformers to 5.5"
 torchvision/resnet18_backend_FP32:
   metric_value: 0.6978
 torchvision/resnet18_backend_OV:

--- a/tests/post_training/pipelines/base.py
+++ b/tests/post_training/pipelines/base.py
@@ -596,7 +596,7 @@ def get_num_fq_int4_int8(model: ov.Model) -> tuple[int, int, int]:
 
 def _are_exceptions_matched(report: ErrorReport, reference_exception: dict[str, str]) -> bool:
     return (
-        reference_exception["error_message"] == report.msg.split(" | ")[1]
+        reference_exception["error_message"] in report.msg.split(" | ")[1]
         and reference_exception["type"] == report.msg.split(" | ")[0]
     )
 


### PR DESCRIPTION
### Changes

Add xfail to `hf/bert-base-uncased` and `hf/hf-internal-testing/tiny-random-gpt2`

### Reason for changes

Fall on converting original model to OV, after update transformers to 5.5

### Related tickets

### Tests

PTQ-888